### PR TITLE
Add separate cluster for configured kiali instance

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -81,8 +81,8 @@ func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 // NewWithBackends creates the business layer using the passed k8sClients and prom clients.
 // Note that the client passed here should *not* be the Kiali ServiceAccount client.
 // It should be the user client based on the logged in user's token.
-func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface) *Layer {
-	return newLayer(userClients, kialiSAClients, prom, tracingClient, kialiCache, poller, config.Get())
+func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, traceClient tracing.ClientInterface) *Layer {
+	return newLayer(userClients, kialiSAClients, prom, traceClient, kialiCache, poller, config.Get())
 }
 
 func newLayer(
@@ -124,12 +124,12 @@ func newLayer(
 // NewLayer creates the business layer using the passed k8sClients and prom clients.
 // Note that the client passed here should *not* be the Kiali ServiceAccount client.
 // It should be the user client based on the logged in user's token.
-func NewLayer(conf *config.Config, cache cache.KialiCache, cf kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm ControlPlaneMonitor, authInfo *api.AuthInfo) (*Layer, error) {
+func NewLayer(conf *config.Config, cache cache.KialiCache, cf kubernetes.ClientFactory, prom prometheus.ClientInterface, traceClient tracing.ClientInterface, cpm ControlPlaneMonitor, authInfo *api.AuthInfo) (*Layer, error) {
 	userClients, err := cf.GetClients(authInfo)
 	if err != nil {
 		return nil, err
 	}
 
 	kialiSAClients := cf.GetSAClients()
-	return newLayer(userClients, kialiSAClients, prom, tracingClient, cache, cpm, conf), nil
+	return newLayer(userClients, kialiSAClients, prom, traceClient, cache, cpm, conf), nil
 }

--- a/business/layer.go
+++ b/business/layer.go
@@ -81,30 +81,55 @@ func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 // NewWithBackends creates the business layer using the passed k8sClients and prom clients.
 // Note that the client passed here should *not* be the Kiali ServiceAccount client.
 // It should be the user client based on the logged in user's token.
-func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, traceClient tracing.ClientInterface) *Layer {
+func NewWithBackends(userClients map[string]kubernetes.ClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface) *Layer {
+	return newLayer(userClients, kialiSAClients, prom, tracingClient, kialiCache, poller, config.Get())
+}
+
+func newLayer(
+	userClients map[string]kubernetes.ClientInterface,
+	kialiSAClients map[string]kubernetes.ClientInterface,
+	prom prometheus.ClientInterface,
+	traceClient tracing.ClientInterface,
+	cache cache.KialiCache,
+	cpm ControlPlaneMonitor,
+	conf *config.Config,
+) *Layer {
 	temporaryLayer := &Layer{}
-	conf := config.Get()
 
 	homeClusterName := conf.KubernetesConfig.ClusterName
+
 	// TODO: Modify the k8s argument to other services to pass the whole k8s map if needed
 	temporaryLayer.App = AppService{prom: prom, userClients: userClients, businessLayer: temporaryLayer}
 	temporaryLayer.Health = HealthService{prom: prom, businessLayer: temporaryLayer, userClients: userClients}
-	temporaryLayer.IstioConfig = IstioConfigService{config: *conf, userClients: userClients, kialiCache: kialiCache, businessLayer: temporaryLayer, controlPlaneMonitor: poller}
+	temporaryLayer.IstioConfig = IstioConfigService{config: *conf, userClients: userClients, kialiCache: cache, businessLayer: temporaryLayer, controlPlaneMonitor: poller}
 	temporaryLayer.IstioStatus = NewIstioStatusService(userClients, temporaryLayer, poller)
 	temporaryLayer.IstioCerts = IstioCertsService{k8s: userClients[homeClusterName], businessLayer: temporaryLayer}
-	temporaryLayer.Namespace = NewNamespaceService(userClients, kialiSAClients, kialiCache, *conf)
-	temporaryLayer.Mesh = NewMeshService(kialiSAClients, kialiCache, temporaryLayer.Namespace, *conf)
+	temporaryLayer.Namespace = NewNamespaceService(userClients, kialiSAClients, cache, *conf)
+	temporaryLayer.Mesh = NewMeshService(kialiSAClients, cache, temporaryLayer.Namespace, *conf)
 	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: userClients[homeClusterName], kialiSAClient: kialiSAClients[homeClusterName]}
-	temporaryLayer.ProxyStatus = ProxyStatusService{kialiSAClients: kialiSAClients, kialiCache: kialiCache, businessLayer: temporaryLayer}
+	temporaryLayer.ProxyStatus = ProxyStatusService{kialiSAClients: kialiSAClients, kialiCache: cache, businessLayer: temporaryLayer}
 	// Out of order because it relies on ProxyStatus
 	temporaryLayer.ProxyLogging = ProxyLoggingService{userClients: userClients, proxyStatus: &temporaryLayer.ProxyStatus}
-	temporaryLayer.RegistryStatus = RegistryStatusService{kialiCache: kialiCache}
-	temporaryLayer.TLS = TLSService{userClients: userClients, kialiCache: kialiCache, businessLayer: temporaryLayer}
-	temporaryLayer.Svc = SvcService{config: *conf, kialiCache: kialiCache, businessLayer: temporaryLayer, prom: prom, userClients: userClients}
+	temporaryLayer.RegistryStatus = RegistryStatusService{kialiCache: cache}
+	temporaryLayer.TLS = TLSService{userClients: userClients, kialiCache: cache, businessLayer: temporaryLayer}
+	temporaryLayer.Svc = SvcService{config: *conf, kialiCache: cache, businessLayer: temporaryLayer, prom: prom, userClients: userClients}
 	temporaryLayer.TokenReview = NewTokenReview(userClients[homeClusterName])
 	temporaryLayer.Validations = IstioValidationsService{userClients: userClients, businessLayer: temporaryLayer}
-	temporaryLayer.Workload = *NewWorkloadService(userClients, prom, kialiCache, temporaryLayer, conf)
-	temporaryLayer.Tracing = NewTracingService(conf, traceClient, &temporaryLayer.Svc, &temporaryLayer.Workload)
+	temporaryLayer.Workload = *NewWorkloadService(userClients, prom, cache, temporaryLayer, conf)
 
+	temporaryLayer.Tracing = NewTracingService(conf, traceClient, &temporaryLayer.Svc, &temporaryLayer.Workload)
 	return temporaryLayer
+}
+
+// NewLayer creates the business layer using the passed k8sClients and prom clients.
+// Note that the client passed here should *not* be the Kiali ServiceAccount client.
+// It should be the user client based on the logged in user's token.
+func NewLayer(conf *config.Config, cache cache.KialiCache, cf kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm ControlPlaneMonitor, authInfo *api.AuthInfo) (*Layer, error) {
+	userClients, err := cf.GetClients(authInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	kialiSAClients := cf.GetSAClients()
+	return newLayer(userClients, kialiSAClients, prom, tracingClient, cache, cpm, conf), nil
 }

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -18,7 +19,6 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
-	"github.com/kiali/kiali/util/httputil"
 )
 
 const (
@@ -118,7 +118,7 @@ func (in *MeshService) GetMesh(ctx context.Context) (*Mesh, error) {
 	)
 	defer end()
 
-	clusters, err := in.GetClusters(nil)
+	clusters, err := in.GetClusters()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get mesh clusters: %w", err)
 	}
@@ -126,15 +126,23 @@ func (in *MeshService) GetMesh(ctx context.Context) (*Mesh, error) {
 	mesh := &Mesh{}
 	var remoteClusters []*kubernetes.Cluster
 	for _, cluster := range clusters {
+		// We can't get anything from an inaccessible cluster.
+		if !cluster.Accessible {
+			continue
+		}
+
 		cluster := cluster
 		kubeCache, err := in.kialiCache.GetKubeCache(cluster.Name)
 		if err != nil {
 			return nil, err
 		}
 
-		if isRemoteCluster, err := in.IsRemoteCluster(cluster.Name); err != nil {
+		isRemoteCluster, err := in.IsRemoteCluster(cluster.Name)
+		if err != nil {
 			return nil, err
-		} else if isRemoteCluster {
+		}
+
+		if isRemoteCluster {
 			log.Debugf("Cluster [%s] is a remote cluster. Skipping adding a controlplane.", cluster.Name)
 			remoteClusters = append(remoteClusters, &cluster)
 		} else {
@@ -270,17 +278,19 @@ func NewMeshService(kialiSAClients map[string]kubernetes.ClientInterface, cache 
 
 // GetClusters resolves the Kubernetes clusters that are hosting the mesh. Resolution
 // is done as best-effort using the resources that are present in the cluster.
-func (in *MeshService) GetClusters(r *http.Request) ([]kubernetes.Cluster, error) {
+func (in *MeshService) GetClusters() ([]kubernetes.Cluster, error) {
 	if clusters := in.kialiCache.GetClusters(); clusters != nil {
 		return clusters, nil
 	}
 
 	// Even if somehow there are no clusters found, which there should always be at least the homecluster,
 	// setting this to an empty slice will prevent us from trying to resolve again.
-	clusters := []kubernetes.Cluster{}
+	clustersByName := map[string]kubernetes.Cluster{}
 	for cluster, client := range in.kialiSAClients {
 		info := client.ClusterInfo()
 		meshCluster := kubernetes.Cluster{
+			// If there's a client for this cluster then it's accessible.
+			Accessible: true,
 			Name:       cluster,
 			SecretName: info.SecretName,
 		}
@@ -288,13 +298,35 @@ func (in *MeshService) GetClusters(r *http.Request) ([]kubernetes.Cluster, error
 			meshCluster.ApiEndpoint = info.ClientConfig.Host
 		}
 
-		meshCluster.KialiInstances = in.discoverKiali(context.TODO(), cluster, r)
 		meshCluster.Network = in.resolveNetwork(cluster)
 
 		if cluster == in.conf.KubernetesConfig.ClusterName {
 			meshCluster.IsKialiHome = true
 		}
-		clusters = append(clusters, meshCluster)
+		clustersByName[cluster] = meshCluster
+	}
+
+	// Add clusters from config.
+	for _, cluster := range in.conf.Clustering.Clusters {
+		if _, found := clustersByName[cluster.Name]; !found {
+			clustersByName[cluster.Name] = kubernetes.Cluster{
+				Name:       cluster.Name,
+				Accessible: cluster.Accessible,
+			}
+		}
+	}
+
+	clusters := maps.Values(clustersByName)
+
+	// TODO: Separate KialiInstance from Cluster model.
+	for idx := range clusters {
+		cluster := &clusters[idx]
+		instances, err := in.getKialiInstances(*cluster)
+		if err != nil {
+			log.Warningf("Unable to get Kiali instances for cluster [%s]: %v", cluster.Name, err)
+			continue
+		}
+		cluster.KialiInstances = instances
 	}
 
 	in.kialiCache.SetClusters(clusters)
@@ -302,9 +334,26 @@ func (in *MeshService) GetClusters(r *http.Request) ([]kubernetes.Cluster, error
 	return clusters, nil
 }
 
+func (in *MeshService) getKialiInstances(cluster kubernetes.Cluster) ([]kubernetes.KialiInstance, error) {
+	kialiConfigURLsForCluster := []config.KialiURL{}
+	for _, cfgurl := range in.conf.Clustering.KialiURLs {
+		if cfgurl.ClusterName == cluster.Name {
+			kialiConfigURLsForCluster = append(kialiConfigURLsForCluster, cfgurl)
+		}
+	}
+
+	var instances []kubernetes.KialiInstance
+	instances = append(instances, in.discoverKiali(cluster)...)
+	for _, cfgURL := range kialiConfigURLsForCluster {
+		instances = appendKialiInstancesFromConfig(instances, cfgURL)
+	}
+
+	return instances, nil
+}
+
 // convertKialiServiceToInstance converts a svc Service data structure of the
 // Kubernetes client to a KialiInstance data structure.
-func convertKialiServiceToInstance(svc *core_v1.Service) kubernetes.KialiInstance {
+func convertKialiServiceToInstance(svc *core_v1.Service, cluster kubernetes.Cluster) kubernetes.KialiInstance {
 	return kubernetes.KialiInstance{
 		ServiceName:      svc.Name,
 		Namespace:        svc.Namespace,
@@ -315,74 +364,111 @@ func convertKialiServiceToInstance(svc *core_v1.Service) kubernetes.KialiInstanc
 }
 
 // discoverKiali tries to find a Kiali installation on the cluster.
-func (in *MeshService) discoverKiali(ctx context.Context, clusterName string, r *http.Request) []kubernetes.KialiInstance {
+func (in *MeshService) discoverKiali(cluster kubernetes.Cluster) []kubernetes.KialiInstance {
+	clusterName := cluster.Name
 	kubeCache, err := in.kialiCache.GetKubeCache(clusterName)
 	if err != nil {
 		log.Warningf("Discovery for Kiali instances in cluster [%s] failed. Unable to find kube cache for cluster [%s]", clusterName, clusterName)
-		// But still the Kiali instance can be configured to show the instance and the URL in Mesh page
-		return in.appendKialiInstancesFromConfig([]kubernetes.KialiInstance{}, clusterName)
+		return nil
 	}
 
 	// The operator and the helm charts set this fixed label. It's also
 	// present in the Istio addon manifest of Kiali.
-	kialiAppLabel := map[string]string{"app.kubernetes.io/part-of": "kiali"}
-	// TODO: getting services will fail spectacularly if cluster wide mode is not enabled - only call when in cluster-wide mode
-	if !config.Get().Deployment.ClusterWideAccess {
-		return in.appendKialiInstancesFromConfig([]kubernetes.KialiInstance{}, clusterName)
-	}
-	services, err := kubeCache.GetServices("", kialiAppLabel)
+	kialiAppLabel := "app.kubernetes.io/part-of=kiali"
+	services, err := kubeCache.GetServices(metav1.NamespaceAll, kialiAppLabel)
 	if err != nil {
 		log.Warningf("Discovery for Kiali instances in cluster [%s] failed: %s", clusterName, err.Error())
-		// But still the Kiali instance can be configured to show the instance and the URL in Mesh page
-		return in.appendKialiInstancesFromConfig([]kubernetes.KialiInstance{}, clusterName)
+		return nil
 	}
 
 	var instances []kubernetes.KialiInstance
 	for _, d := range services {
-		kiali := convertKialiServiceToInstance(&d)
+		kiali := convertKialiServiceToInstance(&d, cluster)
 		// If URL is already populated (because of an annotation), trust that because it's user configuration.
 		// But if Kiali URL configured per cluster name, instance name and namespace, then use that URL.
-		for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
+		for _, cfgurl := range in.conf.Clustering.KialiURLs {
 			if cfgurl.ClusterName == clusterName && cfgurl.InstanceName == kiali.ServiceName && cfgurl.Namespace == kiali.Namespace {
 				kiali.Url = cfgurl.URL
-				break
 			}
-		}
-		// If URL is still empty, only guess ourselves on our own cluster.
-		if kiali.Url == "" && clusterName == in.conf.KubernetesConfig.ClusterName {
-			kiali.Url = httputil.GuessKialiURL(r)
 		}
 		instances = append(instances, kiali)
 	}
-	// Read the rest of Kiali instances configured
-	instances = in.appendKialiInstancesFromConfig(instances, clusterName)
 	return instances
 }
 
 // appendKialiInstancesFromConfig appends the rest of Kiali instances which are configured in KialiFeatureFlags.Clustering.KialiURLs into existing list of instances.
-func (in *MeshService) appendKialiInstancesFromConfig(instances []kubernetes.KialiInstance, clusterName string) []kubernetes.KialiInstance {
-	for _, cfgurl := range config.Get().KialiFeatureFlags.Clustering.KialiURLs {
-		if cfgurl.ClusterName != clusterName {
-			continue
-		}
-		found := false
-		for _, kiali := range instances {
-			if cfgurl.InstanceName == kiali.ServiceName && cfgurl.Namespace == kiali.Namespace {
-				found = true
-				// skip already appended instance
-				break
-			}
-		}
-		// When configured Kiali is not found, still show that instance.
-		if !found {
-			instances = append(instances, kubernetes.KialiInstance{
-				ServiceName: cfgurl.InstanceName,
-				Namespace:   cfgurl.Namespace,
-				Url:         cfgurl.URL,
-			})
+func appendKialiInstancesFromConfig(instances []kubernetes.KialiInstance, cfgurl config.KialiURL) []kubernetes.KialiInstance {
+	found := false
+	for _, kiali := range instances {
+		if cfgurl.InstanceName == kiali.ServiceName && cfgurl.Namespace == kiali.Namespace {
+			found = true
+			// skip already appended instance
+			break
 		}
 	}
+	// When configured Kiali is not found, still show that instance.
+	if !found {
+		instances = append(instances, kubernetes.KialiInstance{
+			ServiceName: cfgurl.InstanceName,
+			Namespace:   cfgurl.Namespace,
+			Url:         cfgurl.URL,
+		})
+	}
 	return instances
+}
+
+func (in *MeshService) getNetworkFromSidecarInejctorConfigMap(kubeCache cache.KubeCache) string {
+	// Try to resolve the logical Istio's network ID of the cluster where
+	// Kiali is installed. This assumes that the mesh Control Plane is installed in the same
+	// cluster as Kiali.
+	// TODO: This doesn't take into account revisions.
+	istioSidecarConfig, err := kubeCache.GetConfigMap(in.conf.IstioNamespace, in.conf.ExternalServices.Istio.IstioSidecarInjectorConfigMapName)
+	if err != nil {
+		// Don't return an error, as this may mean that Kiali is not installed along the control plane.
+		// This setup is OK, it's just that it's not within our multi-cluster assumptions.
+		log.Warningf("Cannot resolve the network ID of the cluster where Kiali is hosted: cannot get the sidecar injector config map :%v", err)
+		return ""
+	}
+
+	parsedConfig := make(map[string]interface{})
+	err = json.Unmarshal([]byte(istioSidecarConfig.Data["values"]), &parsedConfig)
+	if err != nil {
+		// This does not return an error, because it's probably valid that the configmap does not have the "values" key.
+		// So, tell that the network wasn't found by returning blank values
+		log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: no configuration found for the sidecar injector. Err: %v", err)
+		return ""
+	}
+
+	globalConfig, ok := parsedConfig["global"]
+	if !ok {
+		// This does not return an error, because it's probably valid that the configmap does not have the "values.global" key.
+		// So, tell that the network wasn't found by returning blank values
+		log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: no global configuration found for the sidecar injector.")
+		return ""
+	}
+
+	typedGlobalConfig, ok := globalConfig.(map[string]interface{})
+	if !ok {
+		log.Debug("cannot parse the config map of the Istio sidecar injector")
+		return ""
+	}
+
+	networkConfig, ok := typedGlobalConfig["network"]
+	if !ok {
+		// This does not return an error, because it's valid that the configmap does not have the "values.global.network" key, which most
+		// likely means that Istio is not setup for multi-clustering.
+		// So, tell that the network wasn't found by returning blank values
+		log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: multi-cluster is probably turned off.")
+		return ""
+	}
+
+	typedNetworkConfig, ok := networkConfig.(string)
+	if !ok {
+		// It's probably invalid that the network id is not a string
+		return ""
+	}
+
+	return typedNetworkConfig
 }
 
 // resolveNetwork tries to resolve the NETWORK_ID (as known by the Control Plane) of the
@@ -393,80 +479,34 @@ func (in *MeshService) appendKialiInstancesFromConfig(instances []kubernetes.Kia
 // No errors are returned because we don't want to block processing of other clusters if
 // one fails. So, errors are only logged to let processing continue.
 func (in *MeshService) resolveNetwork(clusterName string) string {
-	var network string
-	if clusterName == in.conf.KubernetesConfig.ClusterName {
-		// Home Cluster
+	kubeCache, err := in.kialiCache.GetKubeCache(clusterName)
+	if err != nil {
+		log.Warningf("Cannot resolve the network ID of the cluster [%s]: cannot get the kube cache: %v", clusterName, err)
+		return ""
+	}
 
-		// Try to resolve the logical Istio's network ID of the cluster where
-		// Kiali is installed. This assumes that the mesh Control Plane is installed in the same
-		// cluster as Kiali.
-		istioSidecarConfig, err := in.kialiCache.GetConfigMap(in.conf.IstioNamespace, in.conf.ExternalServices.Istio.IstioSidecarInjectorConfigMapName)
-		if err != nil {
-			// Don't return an error, as this may mean that Kiali is not installed along the control plane.
-			// This setup is OK, it's just that it's not within our multi-cluster assumptions.
-			log.Warningf("Cannot resolve the network ID of the cluster where Kiali is hosted: cannot get the sidecar injector config map :%v", err)
-			return ""
-		}
+	if network := in.getNetworkFromSidecarInejctorConfigMap(kubeCache); network != "" {
+		return network
+	}
 
-		parsedConfig := make(map[string]interface{})
-		err = json.Unmarshal([]byte(istioSidecarConfig.Data["values"]), &parsedConfig)
-		if err != nil {
-			// This does not return an error, because it's probably valid that the configmap does not have the "values" key.
-			// So, tell that the network wasn't found by returning blank values
-			log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: no configuration found for the sidecar injector. Err: %v", err)
-			return ""
-		}
+	// Network id wasn't found in the config. Try to find it on the istio namespace.
 
-		globalConfig, ok := parsedConfig["global"]
-		if !ok {
-			// This does not return an error, because it's probably valid that the configmap does not have the "values.global" key.
-			// So, tell that the network wasn't found by returning blank values
-			log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: no global configuration found for the sidecar injector.")
-			return ""
-		}
+	// Let's assume that the istio namespace has the same name on all clusters in the mesh.
+	istioNamespace, err := in.namespaceService.GetClusterNamespace(context.TODO(), in.conf.IstioNamespace, clusterName)
+	if err != nil {
+		log.Warningf("Cannot describe the [%s] namespace on cluster [%s]: %v", in.conf.IstioNamespace, clusterName, err)
+		return ""
+	}
 
-		typedGlobalConfig, ok := globalConfig.(map[string]interface{})
-		if !ok {
-			log.Debug("cannot parse the config map of the Istio sidecar injector")
-			return ""
-		}
-
-		networkConfig, ok := typedGlobalConfig["network"]
-		if !ok {
-			// This does not return an error, because it's valid that the configmap does not have the "values.global.network" key, which most
-			// likely means that Istio is not setup for multi-clustering.
-			// So, tell that the network wasn't found by returning blank values
-			log.Debugf("Cannot resolve the network ID of the cluster where Kiali is hosted: multi-cluster is probably turned off.")
-			return ""
-		}
-
-		typedNetworkConfig, ok := networkConfig.(string)
-		if !ok {
-			// It's probably invalid that the network id is not a string
-			return ""
-		}
-
-		network = typedNetworkConfig
-	} else {
-		// Let's assume that the istio namespace has the same name on all clusters in the mesh.
-		istioNamespace, err := in.namespaceService.GetClusterNamespace(context.TODO(), in.conf.IstioNamespace, clusterName)
-		if err != nil {
-			log.Warningf("Cannot describe the [%s] namespace on cluster [%s]: %v", in.conf.IstioNamespace, clusterName, err)
-			return ""
-		}
-
-		// For Kiali's control plane, we used the istio sidecar injector config map to fetch the network ID. This
-		// approach is probably more accurate, because that's what is injected along the sidecar. However,
-		// in remote clusters, we don't have privileges to query config maps, so it's not possible to fetch
-		// the sidecar injector config map. However, Istio docs say that the Istio namespace must be labeled with
-		// the network ID. We use that label to retrieve the network ID.
-		networkName, ok := istioNamespace.Labels["topology.istio.io/network"]
-		if !ok {
-			log.Debugf("Istio namespace [%s] in cluster [%s] does not have network label", in.conf.IstioNamespace, clusterName)
-			return ""
-		}
-
-		network = networkName
+	// For Kiali's control plane, we used the istio sidecar injector config map to fetch the network ID. This
+	// approach is probably more accurate, because that's what is injected along the sidecar. However,
+	// in remote clusters, we don't have privileges to query config maps, so it's not possible to fetch
+	// the sidecar injector config map. However, Istio docs say that the Istio namespace must be labeled with
+	// the network ID. We use that label to retrieve the network ID.
+	network, ok := istioNamespace.Labels["topology.istio.io/network"]
+	if !ok {
+		log.Debugf("Istio namespace [%s] in cluster [%s] does not have network label", in.conf.IstioNamespace, clusterName)
+		return ""
 	}
 
 	return network

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -307,11 +307,10 @@ func (in *MeshService) GetClusters() ([]kubernetes.Cluster, error) {
 	}
 
 	// Add clusters from config.
-	for _, cluster := range in.conf.Clustering.Clusters {
+	for _, cluster := range in.conf.Clustering.InaccessibleClusters {
 		if _, found := clustersByName[cluster.Name]; !found {
 			clustersByName[cluster.Name] = kubernetes.Cluster{
-				Name:       cluster.Name,
-				Accessible: cluster.Accessible,
+				Name: cluster.Name,
 			}
 		}
 	}

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -1120,9 +1120,8 @@ func TestGetClustersShowsConfiguredKialiInstances(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	conf := config.NewConfig()
-	conf.Clustering.Clusters = []config.Cluster{{
-		Name:       "west",
-		Accessible: false,
+	conf.Clustering.InaccessibleClusters = []config.Cluster{{
+		Name: "west",
 	}}
 	conf.Clustering.KialiURLs = []config.KialiURL{{
 		InstanceName: "kiali",

--- a/business/services.go
+++ b/business/services.go
@@ -142,7 +142,7 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 				log.Warningf("Services not filtered. Selector %s not valid", criteria.ServiceSelector)
 			}
 		}
-		svcs, err2 = kubeCache.GetServices(criteria.Namespace, selectorLabels)
+		svcs, err2 = kubeCache.GetServicesBySelectorLabels(criteria.Namespace, selectorLabels)
 		if err2 != nil {
 			log.Errorf("Error fetching Services per namespace %s: %s", criteria.Namespace, err2)
 			errChan <- err2

--- a/config/config.go
+++ b/config/config.go
@@ -523,7 +523,7 @@ type Clustering struct {
 
 type FeatureFlagClustering struct {
 	// TODO: Deprecate this in favor of Clustering.Clusters.
-	Clustering
+	Clustering         `yaml:",inline"`
 	EnableExecProvider bool `yaml:"enable_exec_provider,omitempty" json:"enable_exec_provider"`
 }
 
@@ -1051,6 +1051,10 @@ func Unmarshal(yamlString string) (conf *Config, err error) {
 	// TODO: Remove when we no longer support the old format.
 	if conf.Clustering.Clusters == nil && conf.KialiFeatureFlags.Clustering.Clusters != nil {
 		conf.Clustering.Clusters = conf.KialiFeatureFlags.Clustering.Clusters
+	}
+
+	if conf.Clustering.KialiURLs == nil && conf.KialiFeatureFlags.Clustering.KialiURLs != nil {
+		conf.Clustering.KialiURLs = conf.KialiFeatureFlags.Clustering.KialiURLs
 	}
 
 	return

--- a/config/config.go
+++ b/config/config.go
@@ -116,14 +116,6 @@ var overrideSecretsDir = "/kiali-override-secrets"
 type Cluster struct {
 	// Name of the cluster. Must be unique and match what is in telemetry.
 	Name string `yaml:"name,omitempty"`
-	// Accessible whether or not the kiali server can access this cluster.
-	// Only manually specified clusters that kiali cannot access should
-	// be marked as inaccessible. For example, with two clusters A and B
-	// and two Kialis A and B where kiali A is on cluster A and kiali B
-	// is on cluster B, without access to the other cluster, Kiali A should
-	// add a config for Cluster B and mark it as inaccessbile and Kiali B
-	// should add a config for Cluster A and mark it as inaccessible.
-	Accessible bool `yaml:"accessible"`
 }
 
 // Metrics provides metrics configuration for the Kiali server.
@@ -515,10 +507,9 @@ type CertificatesInformationIndicators struct {
 
 // Clustering defines configuration around multi-cluster functionality.
 type Clustering struct {
-	// Clusters represents clusters that are part of the mesh but that Kiali may not have access to.
-	// For this reason it is not an exhaustive list of clusters and shouldn't be relied on for that.
-	Clusters  []Cluster  `yaml:"clusters,omitempty" json:"clusters,omitempty"`
-	KialiURLs []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
+	// InaccessibleClusters represents clusters that are part of the mesh but that Kiali may not have access to.
+	InaccessibleClusters []Cluster  `yaml:"inaccessible_clusters,omitempty" json:"inaccessible_clusters,omitempty"`
+	KialiURLs            []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
 }
 
 type FeatureFlagClustering struct {
@@ -1049,8 +1040,8 @@ func Unmarshal(yamlString string) (conf *Config, err error) {
 
 	// Copy over feature flags that have been upgraded to the new format.
 	// TODO: Remove when we no longer support the old format.
-	if conf.Clustering.Clusters == nil && conf.KialiFeatureFlags.Clustering.Clusters != nil {
-		conf.Clustering.Clusters = conf.KialiFeatureFlags.Clustering.Clusters
+	if conf.Clustering.InaccessibleClusters == nil && conf.KialiFeatureFlags.Clustering.InaccessibleClusters != nil {
+		conf.Clustering.InaccessibleClusters = conf.KialiFeatureFlags.Clustering.InaccessibleClusters
 	}
 
 	if conf.Clustering.KialiURLs == nil && conf.KialiFeatureFlags.Clustering.KialiURLs != nil {

--- a/frontend/src/actions/__tests__/ClusterAction.test.ts
+++ b/frontend/src/actions/__tests__/ClusterAction.test.ts
@@ -1,7 +1,16 @@
 import { ClusterActions } from '../ClusterAction';
+import { MeshCluster } from '../../types/Mesh';
 
 describe('ClusterActions', () => {
-  const cluster = { name: 'east', isKialiHome: true, kialiInstances: [], secretName: '', apiEndpoint: '', network: '' };
+  const cluster: MeshCluster = {
+    name: 'east',
+    isKialiHome: true,
+    kialiInstances: [],
+    secretName: '',
+    apiEndpoint: '',
+    network: '',
+    accessible: true
+  };
 
   it('should set active clusters', () => {
     expect(ClusterActions.setActiveClusters([cluster]).payload).toEqual([cluster]);

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -13,11 +13,11 @@ function getHomeCluster(cfg: ServerConfig): MeshCluster | undefined {
   return Object.values(cfg.clusters).find(cluster => cluster.isKialiHome);
 }
 
-export const humanDurations = (cfg: ComputedServerConfig, prefix?: string, suffix?: string) =>
+export const humanDurations = (cfg: ComputedServerConfig, prefix?: string, suffix?: string): Durations =>
   _.mapValues(cfg.durations, v => _.reject([prefix, v, suffix], _.isEmpty).join(' '));
 
 const toDurations = (tupleArray: [number, string][]): Durations => {
-  const obj = {};
+  const obj: Duration = {};
   tupleArray.forEach(tuple => {
     obj[tuple[0]] = tuple[1];
   });
@@ -39,7 +39,7 @@ const durationsTuples: [number, string][] = [
   [2592000, '30d']
 ];
 
-const computeValidDurations = (cfg: ComputedServerConfig) => {
+const computeValidDurations = (cfg: ComputedServerConfig): void => {
   const tsdbRetention = cfg.prometheus.storageTsdbRetention;
   const scrapeInterval = cfg.prometheus.globalScrapeInterval;
   let filtered = durationsTuples.filter(
@@ -151,7 +151,7 @@ export const toValidDuration = (duration: number): number => {
   return validDurations[0][0];
 };
 
-export const setServerConfig = (cfg: ServerConfig) => {
+export const setServerConfig = (cfg: ServerConfig): void => {
   serverConfig = {
     ...defaultServerConfig,
     ...cfg
@@ -181,5 +181,10 @@ export const isConfiguredCluster = (cluster: string): boolean => {
 };
 
 function isMC(): boolean {
-  return Object.keys(serverConfig.clusters).length > 1;
+  // If there is only one cluster, it is not a multi-cluster deployment.
+  // If there are multiple clusters but only one is accessible, it is not a multi-cluster deployment.
+  return (
+    Object.keys(serverConfig.clusters).length > 1 &&
+    Object.values(serverConfig.clusters).filter(c => c.accessible).length > 1
+  );
 }

--- a/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/SummaryLink.test.tsx
@@ -21,6 +21,7 @@ describe('renderBadgedLink', () => {
 
     serverConfig.clusters = {
       'cluster-default': {
+        accessible: true,
         apiEndpoint: '',
         isKialiHome: true,
         kialiInstances: [],

--- a/frontend/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/frontend/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -48,6 +48,7 @@ describe('SummaryPanelNodeComponent', () => {
 
     serverConfig.clusters = {
       'cluster-default': {
+        accessible: true,
         apiEndpoint: '',
         isKialiHome: true,
         kialiInstances: [],

--- a/frontend/src/types/Mesh.ts
+++ b/frontend/src/types/Mesh.ts
@@ -1,4 +1,5 @@
 export interface MeshCluster {
+  accessible: boolean;
   apiEndpoint: string;
   isKialiHome: boolean;
   kialiInstances: KialiInstance[];
@@ -8,9 +9,9 @@ export interface MeshCluster {
 }
 
 export interface KialiInstance {
-  serviceName: string;
   namespace: string;
   operatorResource: string;
+  serviceName: string;
   url: string;
   version: string;
 }

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -463,7 +463,7 @@ type servicesError struct {
 	errorMsg string
 }
 
-func (s *servicesError) GetServices(namespace string, selectorLabels map[string]string) ([]core_v1.Service, error) {
+func (s *servicesError) GetServicesBySelectorLabels(namespace string, selectorLabels map[string]string) ([]core_v1.Service, error) {
 	return nil, fmt.Errorf(s.errorMsg)
 }
 

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -121,7 +121,7 @@ func Config(w http.ResponseWriter, r *http.Request) {
 
 		// Fetch the list of all clusters in the mesh
 		// One usage of this data is to cross-link Kiali instances, when possible.
-		clusters, err := layer.Mesh.GetClusters(r)
+		clusters, err := layer.Mesh.GetClusters()
 		if err != nil {
 			return fmt.Errorf("failure while listing clusters in the mesh: %w", err)
 		}

--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -4,27 +4,40 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 )
 
 // GetClusters writes to the HTTP response a JSON document with the
 // list of clusters that are part of the mesh when multi-cluster is enabled. If
 // multi-cluster is not enabled in the control plane, this handler may provide
 // erroneous data.
-func GetClusters(w http.ResponseWriter, r *http.Request) {
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Business layer initialization error: "+err.Error())
-		return
-	}
+func GetClusters(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm business.ControlPlaneMonitor) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authInfo, err := getAuthInfo(r)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 
-	meshClusters, err := business.Mesh.GetClusters(r)
-	if err != nil {
-		RespondWithError(w, http.StatusServiceUnavailable, "Cannot fetch mesh clusters: "+err.Error())
-		return
-	}
+		layer, err := business.NewLayer(conf, kialiCache, clientFactory, prom, tracingClient, cpm, authInfo)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 
-	RespondWithJSON(w, http.StatusOK, meshClusters)
+		meshClusters, err := layer.Mesh.GetClusters()
+		if err != nil {
+			RespondWithError(w, http.StatusServiceUnavailable, "Cannot fetch mesh clusters: "+err.Error())
+			return
+		}
+
+		RespondWithJSON(w, http.StatusOK, meshClusters)
+	}
 }
 
 func OutboundTrafficPolicyMode(w http.ResponseWriter, r *http.Request) {

--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -16,7 +16,7 @@ import (
 // list of clusters that are part of the mesh when multi-cluster is enabled. If
 // multi-cluster is not enabled in the control plane, this handler may provide
 // erroneous data.
-func GetClusters(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm business.ControlPlaneMonitor) http.HandlerFunc {
+func GetClusters(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, traceClientLoader func() tracing.ClientInterface, cpm business.ControlPlaneMonitor) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		authInfo, err := getAuthInfo(r)
 		if err != nil {
@@ -24,7 +24,7 @@ func GetClusters(conf *config.Config, kialiCache cache.KialiCache, clientFactory
 			return
 		}
 
-		layer, err := business.NewLayer(conf, kialiCache, clientFactory, prom, tracingClient, cpm, authInfo)
+		layer, err := business.NewLayer(conf, kialiCache, clientFactory, prom, traceClientLoader(), cpm, authInfo)
 		if err != nil {
 			RespondWithError(w, http.StatusInternalServerError, err.Error())
 			return

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -50,7 +50,7 @@ func NamespaceValidationSummary(w http.ResponseWriter, r *http.Request) {
 	var errValidations error
 
 	// If cluster is not set, is because we need a unified validations view (E.g. in the Summary graph)
-	clusters, _ := business.Mesh.GetClusters(r)
+	clusters, _ := business.Mesh.GetClusters()
 	if len(clusters) == 1 {
 		istioConfigValidationResults, errValidations = business.Validations.GetValidations(r.Context(), cluster, namespace, "", "")
 	} else {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -73,7 +73,6 @@ func GetOldestNamespace(namespaces []models.Namespace) *models.Namespace {
 }
 
 func createMetricsServiceForNamespace(w http.ResponseWriter, r *http.Request, promSupplier promClientSupplier, ns models.Namespace) (*business.MetricsService, *models.Namespace) {
-
 	metrics, infoMap := createMetricsServiceForNamespaces(w, r, promSupplier, []models.Namespace{ns})
 	if result, ok := infoMap[ns.Name]; ok {
 		if result.err != nil {

--- a/kiali.go
+++ b/kiali.go
@@ -163,7 +163,7 @@ func main() {
 	}
 
 	// Start listening to requests
-	server := server.NewServer(cpm, clientFactory, cache, *cfg, prom, tracingLoader)
+	server := server.NewServer(cpm, clientFactory, cache, cfg, prom, tracingLoader)
 	server.Start()
 
 	// wait forever, or at least until we are told to exit

--- a/kubernetes/cluster_secret.go
+++ b/kubernetes/cluster_secret.go
@@ -197,6 +197,11 @@ type Cluster struct {
 
 	// SecretName is the name of the kubernetes "remote cluster secret" that was mounted to the file system and where data of this cluster was resolved
 	SecretName string `json:"secretName"`
+
+	// Accessible specifies if the cluster is accessible or not. Clusters that are manually specified in the Kiali config
+	// but do not have an associated remote cluster secret are considered not accessible. This is helpful when you have
+	// two disconnected Kialis and want to link them without giving them access to each other.
+	Accessible bool `json:"accessible"`
 }
 
 // KialiInstance represents a Kiali installation. It holds some data about

--- a/routing/router.go
+++ b/routing/router.go
@@ -24,7 +24,7 @@ import (
 )
 
 // NewRouter creates the router with all API routes and the static files handler
-func NewRouter(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom kialiprometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm business.ControlPlaneMonitor) *mux.Router {
+func NewRouter(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom kialiprometheus.ClientInterface, traceClientLoader func() tracing.ClientInterface, cpm business.ControlPlaneMonitor) *mux.Router {
 	webRoot := conf.Server.WebRoot
 	webRootWithSlash := webRoot + "/"
 
@@ -74,7 +74,7 @@ func NewRouter(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 	appRouter = appRouter.StrictSlash(true)
 
 	// Build our API server routes and install them.
-	apiRoutes := NewRoutes(conf, kialiCache, clientFactory, prom, tracingClient, cpm)
+	apiRoutes := NewRoutes(conf, kialiCache, clientFactory, prom, traceClientLoader, cpm)
 	authenticationHandler, _ := handlers.NewAuthenticationHandler()
 	for _, route := range apiRoutes.Routes {
 		handlerFunction := metricHandler(route.HandlerFunc, route)

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -17,19 +17,18 @@ import (
 
 func TestDrawPathProperly(t *testing.T) {
 	conf := new(config.Config)
-	config.Set(conf)
-	router := NewRouter()
+	router := NewRouter(conf, nil, nil, nil, nil, nil)
 	testRoute(router, "Root", "GET", t)
 }
 
 func testRoute(router *mux.Router, name string, method string, t *testing.T) {
-	var path = router.Get(name)
+	path := router.Get(name)
 
 	if path == nil {
 		t.Error("path is not registered into router")
 	}
 
-	var methods, err = path.GetMethods()
+	methods, err := path.GetMethods()
 	if err != nil {
 		t.Error(err)
 	}
@@ -40,14 +39,10 @@ func testRoute(router *mux.Router, name string, method string, t *testing.T) {
 }
 
 func TestWebRootRedirect(t *testing.T) {
-	oldConfig := config.Get()
-	defer config.Set(oldConfig)
-
 	conf := new(config.Config)
 	conf.Server.WebRoot = "/test"
-	config.Set(conf)
 
-	router := NewRouter()
+	router := NewRouter(conf, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -68,9 +63,8 @@ func TestWebRootRedirect(t *testing.T) {
 
 func TestSimpleRoute(t *testing.T) {
 	conf := new(config.Config)
-	config.Set(conf)
 
-	router := NewRouter()
+	router := NewRouter(conf, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -85,20 +79,16 @@ func TestSimpleRoute(t *testing.T) {
 }
 
 func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
-	oldConfig := config.Get()
-	defer config.Set(oldConfig)
-
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
 	_ = os.Chdir(os.TempDir())
-	_ = os.MkdirAll("./console", 0777)
+	_ = os.MkdirAll("./console", 0o777)
 	_, _ = os.Create("./console/index.html")
 
 	conf := new(config.Config)
 	conf.Server.WebRoot = "/test"
-	config.Set(conf)
 
-	router := NewRouter()
+	router := NewRouter(conf, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -126,7 +116,7 @@ func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 }
 
 func TestMetricHandlerAPIFailures(t *testing.T) {
-	var errcodes = []struct {
+	errcodes := []struct {
 		Name string
 		Code int
 	}{

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -28,7 +28,7 @@ type Routes struct {
 }
 
 // NewRoutes creates and returns all the API routes
-func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm business.ControlPlaneMonitor) (r *Routes) {
+func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, traceClientLoader func() tracing.ClientInterface, cpm business.ControlPlaneMonitor) (r *Routes) {
 	r = new(Routes)
 
 	r.Routes = []Route{
@@ -1423,7 +1423,7 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 			"GetClusters",
 			"GET",
 			"/api/clusters",
-			handlers.GetClusters(conf, kialiCache, clientFactory, prom, tracingClient, cpm),
+			handlers.GetClusters(conf, kialiCache, clientFactory, prom, traceClientLoader, cpm),
 			true,
 		},
 		// swagger:route GET /api/mesh/outbound_traffic_policy/mode

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -3,7 +3,13 @@ package routing
 import (
 	"net/http"
 
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 )
 
 // Route describes a single route
@@ -22,7 +28,7 @@ type Routes struct {
 }
 
 // NewRoutes creates and returns all the API routes
-func NewRoutes() (r *Routes) {
+func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface, tracingClient tracing.ClientInterface, cpm business.ControlPlaneMonitor) (r *Routes) {
 	r = new(Routes)
 
 	r.Routes = []Route{
@@ -1417,7 +1423,7 @@ func NewRoutes() (r *Routes) {
 			"GetClusters",
 			"GET",
 			"/api/clusters",
-			handlers.GetClusters,
+			handlers.GetClusters(conf, kialiCache, clientFactory, prom, tracingClient, cpm),
 			true,
 		},
 		// swagger:route GET /api/mesh/outbound_traffic_policy/mode

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ type Server struct {
 	prom                prometheus.ClientInterface
 	router              *mux.Router
 	tracer              *sdktrace.TracerProvider
-	tracingClientLoader func() tracing.ClientInterface
+	traceClientLoader   func() tracing.ClientInterface
 }
 
 // NewServer creates a new server configured with the given settings.
@@ -41,10 +41,10 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 	cache cache.KialiCache,
 	conf *config.Config,
 	prom prometheus.ClientInterface,
-	tracingClientLoader func() tracing.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
 ) *Server {
 	// create a router that will route all incoming API server requests to different handlers
-	router := routing.NewRouter(conf, cache, clientFactory, prom, tracingClient, controlPlaneMonitor)
+	router := routing.NewRouter(conf, cache, clientFactory, prom, traceClientLoader, controlPlaneMonitor)
 	var tracingProvider *sdktrace.TracerProvider
 	if conf.Server.Observability.Tracing.Enabled {
 		log.Infof("Tracing Enabled. Initializing tracer with collector url: %s", conf.Server.Observability.Tracing.CollectorURL)
@@ -96,7 +96,7 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 		kialiCache:          cache,
 		prom:                prom,
 		router:              router,
-		tracingClientLoader: tracingClientLoader,
+		traceClientLoader:   traceClientLoader,
 	}
 	if conf.Server.Observability.Tracing.Enabled && tracingProvider != nil {
 		s.tracer = tracingProvider
@@ -106,7 +106,7 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 
 // Start HTTP server asynchronously. TLS may be active depending on the global configuration.
 func (s *Server) Start() {
-	business.Start(s.clientFactory, s.controlPlaneMonitor, s.kialiCache, s.prom, s.tracingClientLoader)
+	business.Start(s.clientFactory, s.controlPlaneMonitor, s.kialiCache, s.prom, s.traceClientLoader)
 
 	log.Infof("Server endpoint will start at [%v%v]", s.httpServer.Addr, s.conf.Server.WebRoot)
 	log.Infof("Server endpoint will serve static content from [%v]", s.conf.Server.StaticContentRootDirectory)

--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Server struct {
-	conf                config.Config
+	conf                *config.Config
 	controlPlaneMonitor business.ControlPlaneMonitor
 	clientFactory       kubernetes.ClientFactory
 	httpServer          *http.Server
@@ -39,12 +39,12 @@ type Server struct {
 func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 	clientFactory kubernetes.ClientFactory,
 	cache cache.KialiCache,
-	conf config.Config,
+	conf *config.Config,
 	prom prometheus.ClientInterface,
 	tracingClientLoader func() tracing.ClientInterface,
 ) *Server {
 	// create a router that will route all incoming API server requests to different handlers
-	router := routing.NewRouter()
+	router := routing.NewRouter(conf, cache, clientFactory, prom, tracingClient, controlPlaneMonitor)
 	var tracingProvider *sdktrace.TracerProvider
 	if conf.Server.Observability.Tracing.Enabled {
 		log.Infof("Tracing Enabled. Initializing tracer with collector url: %s", conf.Server.Observability.Tracing.CollectorURL)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -67,7 +67,7 @@ func TestRootContextPath(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server := NewServer(cpm, cf, cache, *conf, nil, nil)
+	server := NewServer(cpm, cf, cache, conf, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -131,7 +131,7 @@ func TestAnonymousMode(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server := NewServer(cpm, cf, cache, *conf, nil, nil)
+	server := NewServer(cpm, cf, cache, conf, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -222,7 +222,7 @@ func TestSecureComm(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server := NewServer(cpm, cf, cache, *conf, nil, nil)
+	server := NewServer(cpm, cf, cache, conf, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -318,7 +318,7 @@ func TestTracingConfigured(t *testing.T) {
 
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server := NewServer(cpm, cf, cache, *conf, nil, nil)
+	server := NewServer(cpm, cf, cache, conf, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {

--- a/tests/integration/tests/clusters_test.go
+++ b/tests/integration/tests/clusters_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/tests/integration/utils/kiali"
+	"github.com/kiali/kiali/tests/integration/utils/kube"
+)
+
+func TestRemoteKialiShownInClustersResponse(t *testing.T) {
+	require := require.New(t)
+
+	// Get the number of clusters before we start.
+	originalClusters, err := kiali.Clusters()
+	require.NoError(err)
+
+	ctx := contextWithTestingDeadline(t)
+	dynamicClient := kube.NewDynamicClient(t)
+	kubeClient := kube.NewKubeClient(t)
+	instance, err := kiali.NewInstance(ctx, kubeClient, dynamicClient)
+	require.NoError(err)
+
+	// Add an inaccessible cluster/kiali instance to the kiali config and restart kiali.
+	conf, err := instance.GetConfig(ctx)
+	require.NoError(err)
+	originalConf := *conf
+
+	conf.Clustering.Clusters = []config.Cluster{{Name: "inaccessible", Accessible: false}}
+	conf.Clustering.KialiURLs = []config.KialiURL{{ClusterName: "inaccessible", URL: "http://inaccessible:20001", InstanceName: "kiali", Namespace: "istio-system"}}
+
+	t.Cleanup(func() {
+		log.Debugf("Updating kiali config to original state")
+		require.NoError(instance.UpdateConfig(ctx, &originalConf))
+		require.NoError(instance.Restart(ctx))
+	})
+
+	require.NoError(instance.UpdateConfig(ctx, conf))
+	require.NoError(instance.Restart(ctx))
+
+	clusters, err := kiali.Clusters()
+	require.NoError(err)
+
+	// Ensure the inaccessible cluster/kiali instance is shown in the clusters response.
+	require.Greater(len(clusters), len(originalClusters))
+
+	inaccessibleIdx := slices.IndexFunc(clusters, func(c kubernetes.Cluster) bool { return c.Name == "inaccessible" })
+	require.NotEqualf(-1, inaccessibleIdx, "inaccessible cluster not found in clusters response")
+}

--- a/tests/integration/tests/clusters_test.go
+++ b/tests/integration/tests/clusters_test.go
@@ -31,7 +31,7 @@ func TestRemoteKialiShownInClustersResponse(t *testing.T) {
 	require.NoError(err)
 	originalConf := *conf
 
-	conf.Clustering.Clusters = []config.Cluster{{Name: "inaccessible", Accessible: false}}
+	conf.Clustering.InaccessibleClusters = []config.Cluster{{Name: "inaccessible"}}
 	conf.Clustering.KialiURLs = []config.KialiURL{{ClusterName: "inaccessible", URL: "http://inaccessible:20001", InstanceName: "kiali", Namespace: "istio-system"}}
 
 	t.Cleanup(func() {

--- a/tests/integration/tests/testing.go
+++ b/tests/integration/tests/testing.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"context"
+	"testing"
+)
+
+/*
+	Contains helper utils and functions for integration tests.
+*/
+
+// contextWithTestingDeadline returns a context with a deadline set to the test's deadline.
+// The context is canceled when the test ends.
+// If the test does not have a deadline, then a context.Background() is returned.
+func contextWithTestingDeadline(t *testing.T) context.Context {
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+	}
+	return ctx
+}

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -224,12 +224,12 @@ func waitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface,
 		}
 
 		if deployment.Generation != deployment.Status.ObservedGeneration {
-			log.Debug("The deployment has not observed the latest spec updated yet.\n")
+			log.Debug("The deployment has not observed the latest spec updated yet.")
 			return false, nil
 		}
 
 		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
-			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)\n", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
+			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
 			return false, nil
 		}
 

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -1,0 +1,253 @@
+package kiali
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v2"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+)
+
+var kialiGroupVersionResource = schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
+
+// NewInstance finds the kiali instance deployed in the cluster and creates an Instance out of it.
+// Assumes there's only a single Kiali deployed to the cluster.
+func NewInstance(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) (*Instance, error) {
+	log.Debug("Finding Kiali Instance")
+
+	var kialiCRDExists bool
+	if _, err := kubeClient.Discovery().RESTClient().Get().AbsPath("/apis/kiali.io").DoRaw(ctx); err != nil {
+		// If it's an error other than NotFound then we should return it since we can't determine if the CRD exists.
+		if !kubeerrors.IsNotFound(err) {
+			return nil, err
+		}
+		// Otherwise we know the CRD doesn't exist because it's a not found error so keep the default of false.
+		log.Debug("Kiali CRD does not exist. Kiali must be deployed with helm.")
+	} else {
+		log.Debug("Kiali CRD exists. Kiali must be deployed with the operator.")
+		kialiCRDExists = true
+	}
+
+	instance := &Instance{
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+		useKialiCR:    kialiCRDExists,
+	}
+
+	if kialiCRDExists {
+		kialiCRs, err := dynamicClient.Resource(kialiGroupVersionResource).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(kialiCRs.Items) > 1 {
+			return nil, fmt.Errorf("Expecting only one Kiali CR but found %d", len(kialiCRs.Items))
+		}
+
+		kialiCR := kialiCRs.Items[0]
+		instance.Name = kialiCR.GetName()
+		instance.Namespace = kialiCR.GetNamespace()
+		instance.ResourceNamespace = instance.Namespace
+
+		// If the CR has a spec.deployment.namespace then all the kiali resources will be deployed
+		// in that namespace rather than the namespace of the CR.
+		if spec, ok := kialiCR.Object["spec"].(map[string]interface{}); ok {
+			if deployment, ok := spec["deployment"].(map[string]interface{}); ok {
+				if namespace, ok := deployment["namespace"].(string); ok {
+					instance.ResourceNamespace = namespace
+				}
+			}
+		}
+		log.Debugf("Found Kiali CR: [%s] in namespace: [%s]. All Kiali CR resources are in namespace: [%s].", instance.Name, instance.Namespace, instance.ResourceNamespace)
+	} else {
+		kialiDeployments, err := kubeClient.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(kialiDeployments.Items) > 1 {
+			return nil, fmt.Errorf("Expecting only one Kiali deployment but found %d", len(kialiDeployments.Items))
+		}
+
+		kialiDeployment := kialiDeployments.Items[0]
+		instance.Name = kialiDeployment.Name
+		instance.Namespace = kialiDeployment.Namespace
+		instance.ResourceNamespace = instance.Namespace
+
+		log.Debugf("Found Kiali deployment: [%s] in namespace: [%s]. All Kiali resources are in namespace: [%s].", instance.Name, instance.Namespace, instance.ResourceNamespace)
+	}
+
+	return instance, nil
+}
+
+// Instance is a single deployment of Kiali. It abstracts away the differences between
+// Kiali deployed with the operator and Kiali deployed with helm and provides an interface
+// for interacting with the Kiali instance for actions like updating the Kiali config.
+type Instance struct {
+	dynamicClient dynamic.Interface
+	kubeClient    kubernetes.Interface
+
+	// Name of the kiali instance. Either the name of the CR or the name of the deployment.
+	Name string
+
+	// Namespace of the kiali instance. Either the namespace of the CR or the namespace of the deployment.
+	Namespace string
+
+	// ResourceNamespace is the namespace where the Kiali resources are deployed aka spec.deployment.namespace.
+	ResourceNamespace string
+
+	useKialiCR bool
+}
+
+// GetConfig fetches the kiali configuration from the kiali configmap.
+func (in *Instance) GetConfig(ctx context.Context) (*config.Config, error) {
+	cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var currentConfig config.Config
+	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig); err != nil {
+		return nil, err
+	}
+
+	return &currentConfig, nil
+}
+
+// UpdateConfig will update the Kiali instance with the new config. It will ensure
+// that the underlying configmap is actually updated before returning.
+func (in *Instance) UpdateConfig(ctx context.Context, conf *config.Config) error {
+	log.Debug("Updating Kiali config")
+	// Update the configmap directly by getting the configmap and patching it.
+	if in.useKialiCR {
+		// Before we patch the Kiali CR, get the current configmap so that later we can ensure the configmap is updated.
+		cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Fetch the Kiali CR and update the config on it.
+		// Update the Kiali CR
+		newConfig, err := yaml.Marshal(conf)
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("Diff between old config and new config: %s\n", cmp.Diff(cm.Data["config.yaml"], string(newConfig)))
+
+		mergePatch := []byte(fmt.Sprintf(`{"spec": %s}`, string(newConfig)))
+		_, err = in.dynamicClient.Resource(kialiGroupVersionResource).Namespace(in.Namespace).Patch(ctx, in.Name, types.MergePatchType, mergePatch, metav1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Need to know when the kiali operator has seen the CR change and finished updating
+		// the configmap. There's no ObservedGeneration on the Kiali CR so just checking the configmap itself.
+		timeout := 5 * time.Minute
+		pollInterval := 10 * time.Second
+
+		return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			log.Debug("Waiting for kiali configmap to update")
+			currentConfigMap, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			return currentConfigMap.Generation > cm.Generation, nil
+		})
+	} else {
+		// Update the configmap directly. It's important to use yaml.Marshal because the config struct
+		// doesn't have json tags.
+		newConfig, err := yaml.Marshal(conf)
+		if err != nil {
+			return err
+		}
+
+		cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("Diff between old config and new config: %s\n", cmp.Diff(cm.Data["config.yaml"], string(newConfig)))
+
+		cm.Data["config.yaml"] = string(newConfig)
+
+		_, err = in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func restartDeployment(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Update the pod template annotation to trigger a rolling restart
+		if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+			deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+		_, err = clientset.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+		return err
+	})
+
+	return retryErr
+}
+
+func waitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) error {
+	timeout := 5 * time.Minute
+	pollInterval := 10 * time.Second
+
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			log.Debug("The deployment has not observed the latest spec updated yet.\n")
+			return false, nil
+		}
+
+		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)\n", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// Restart will recreate the Kiali pod and wait for it to be ready.
+func (in *Instance) Restart(ctx context.Context) error {
+	log.Debug("Restarting Kiali deployment")
+	if err := restartDeployment(ctx, in.kubeClient, in.ResourceNamespace, in.Name); err != nil {
+		return err
+	}
+
+	log.Debug("Waiting for Kiali deployment to be ready")
+	if err := waitForDeploymentReady(ctx, in.kubeClient, in.ResourceNamespace, in.Name); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v2"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 )

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph/config/cytoscape"
 	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/status"
@@ -614,6 +615,26 @@ func Grafana() (*models.GrafanaInfo, int, error) {
 	} else {
 		return nil, code, err
 	}
+}
+
+func Clusters() ([]kubernetes.Cluster, error) {
+	url := fmt.Sprintf("%s/api/clusters", client.kialiURL)
+	body, code, _, err := httpGETWithRetry(url, client.GetAuth(), TIMEOUT, nil, client.kialiCookies)
+	if err != nil {
+		return nil, err
+	}
+
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("Non 200 response code: %d when getting clusters. Body: %s", code, body)
+	}
+
+	clusters := []kubernetes.Cluster{}
+	err = json.Unmarshal(body, &clusters)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal body into clusters. Body: %s", body)
+	}
+
+	return clusters, nil
 }
 
 func IstioApiEnabled() (bool, error) {

--- a/tests/integration/utils/kube/kube_client.go
+++ b/tests/integration/utils/kube/kube_client.go
@@ -65,7 +65,6 @@ func DeleteKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namesp
 
 // Waits for old kiali pod to terminate and for the new one to be ready
 func RestartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, currentKialiPod string) error {
-
 	return wait.PollUntilContextTimeout(ctx, time.Second*5, time.Minute*4, true, func(ctx context.Context) (bool, error) {
 		log.Debugf("Waiting for kiali pod %s in %s namespace to be ready", currentKialiPod, namespace)
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
@@ -96,7 +95,6 @@ func RestartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, names
 // Returns the name of the Kiali pod
 // It expects to find just one Kiali pod
 func GetKialiPodName(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, t *testing.T) string {
-
 	require := require.New(t)
 	pods, err := kubeClient.CoreV1().Pods(kialiNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
 	require.NoError(err)
@@ -107,7 +105,6 @@ func GetKialiPodName(ctx context.Context, kubeClient kubernetes.Interface, kiali
 
 // Get Kiali config map
 func GetKialiConfigMap(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, kialiName string, t *testing.T) (*config.Config, *v1.ConfigMap) {
-
 	require := require.New(t)
 
 	// Update the configmap directly by getting the configmap and patching it.
@@ -121,7 +118,8 @@ func GetKialiConfigMap(ctx context.Context, kubeClient kubernetes.Interface, kia
 }
 
 func UpdateKialiCR(ctx context.Context, dynamicClient dynamic.Interface, kubeClient kubernetes.Interface,
-	kialiNamespace string, check string, registryPatch []byte, t *testing.T) {
+	kialiNamespace string, check string, registryPatch []byte, t *testing.T,
+) {
 	require := require.New(t)
 	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
 	// Find the Kiali CR and override some settings if they're set on the CR.
@@ -158,7 +156,6 @@ func UpdateKialiCR(ctx context.Context, dynamicClient dynamic.Interface, kubeCli
 
 // Update Kiali config map
 func UpdateKialiConfigMap(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, currentConfig *config.Config, cm *v1.ConfigMap, t *testing.T) {
-
 	require := require.New(t)
 
 	newConfig, err := yaml.Marshal(currentConfig)


### PR DESCRIPTION
** Describe the change **

This change lets you manually specify a cluster in the kiali config that there is no remote secret for. This cluster is considered "inaccessible" meaning that Kiali won't try to connect to it and the frontend won't consider it for the "multi-cluster mode" e.g. there won't be a cluster column when there's one accessible cluster and one inaccessible cluster.

To test:
1. Create two clusters. You can use: `hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`.
2. Deploy kiali on both clusters including the "west" cluster. `./hack/istio/multicluster/deploy-kiali.sh --single-kiali false --cluster1-context kind-east --cluster2-context kind-west --kiali-auth-strategy anonymous --manage-kind true --kiali-use-dev-image true`
3. Add the "east" cluster to the "west" kiali config by editing the "west" kiali configmap (`kubectl --context kind-west edit cm kiali -n istio-system`):
    ```
    clustering:
      clusters:
        - name: east
          accessible: false
      kiali_urls:
        - cluster_name: east
          url: http://<kiali_url>/kiali
          instance_name: kiali
          namespace: istio-system
    ```
4. Restart the west kiali: `kubectl --context kind-west delete pod -n istio-system -l app=kiali`
5. Navigate to the west kiali's "mesh" page (you can port-forward to it via `hack/kiali-port-forward.sh -kc kind-west`).
  You should see two kiali instances on the mesh page and a link to the "east" kiali:
![Screenshot from 2023-12-20 13-31-19](https://github.com/kiali/kiali/assets/6226732/e3dc7efe-667e-4700-8ace-a056e69100e0)
  You should _not_ see a cluster column on any of the app/service/istio/workload pages for the "west" kiali.

** Issue reference **

Fixes #6243 