### PR TITLE
Fixed graph node decorators in PF5

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -38,7 +38,7 @@ import { PFColors } from 'components/Pf/PfColors';
 import { getEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
 import { Span } from 'types/TracingInfo';
 import { IconType } from 'config/Icons';
-import { TrafficDecorator } from './components/TrafficDecorator';
+import { NodeDecorator } from './components/NodeDecorator';
 
 // Utilities for working with PF Topology
 // - most of these add cytoscape-like functions
@@ -153,7 +153,7 @@ export const getNodeShape = (data: NodeData): NodeShape => {
 };
 
 const getDecorator = (element: Node, quadrant: TopologyQuadrant, icon: IconType, tooltip?: string): React.ReactNode => {
-  return <TrafficDecorator element={element} quadrant={quadrant} icon={icon} tooltip={tooltip} />;
+  return <NodeDecorator element={element} quadrant={quadrant} icon={icon} tooltip={tooltip} />;
 };
 
 export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSettings): void => {

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -40,7 +40,7 @@ import _ from 'lodash';
 import { PFColors } from 'components/Pf/PfColors';
 import { getEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
 import { Span } from 'types/TracingInfo';
-import { Tooltip } from '@patternfly/react-core';
+//import { Tooltip } from '@patternfly/react-core';
 import { IconType } from 'config/Icons';
 
 // Utilities for working with PF Topology
@@ -155,13 +155,17 @@ export const getNodeShape = (data: NodeData): NodeShape => {
   }
 };
 
-const getDecorator = (element: Node, quadrant: TopologyQuadrant, icon: IconType, tooltip?: string): React.ReactNode => {
+const getDecorator = (
+  element: Node,
+  quadrant: TopologyQuadrant,
+  icon: IconType,
+  _tooltip?: string
+): React.ReactNode => {
   const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
-
   return (
-    <Tooltip content={!!tooltip ? tooltip : icon.text}>
-      <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={React.createElement(icon.icon)} />
-    </Tooltip>
+    //<Tooltip content={!!tooltip ? tooltip : icon.text}>
+    <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={React.createElement(icon.icon)} />
+    //</Tooltip>
   );
 };
 

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -2,12 +2,9 @@ import * as React from 'react';
 import {
   BadgeLocation,
   Controller,
-  Decorator,
-  DEFAULT_DECORATOR_RADIUS,
   Edge,
   EdgeModel,
   EdgeTerminalType,
-  getDefaultShapeDecoratorCenter,
   GraphElement,
   isEdge,
   isNode,
@@ -40,8 +37,8 @@ import _ from 'lodash';
 import { PFColors } from 'components/Pf/PfColors';
 import { getEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
 import { Span } from 'types/TracingInfo';
-//import { Tooltip } from '@patternfly/react-core';
 import { IconType } from 'config/Icons';
+import { TrafficDecorator } from './components/TrafficDecorator';
 
 // Utilities for working with PF Topology
 // - most of these add cytoscape-like functions
@@ -155,18 +152,8 @@ export const getNodeShape = (data: NodeData): NodeShape => {
   }
 };
 
-const getDecorator = (
-  element: Node,
-  quadrant: TopologyQuadrant,
-  icon: IconType,
-  _tooltip?: string
-): React.ReactNode => {
-  const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
-  return (
-    //<Tooltip content={!!tooltip ? tooltip : icon.text}>
-    <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={React.createElement(icon.icon)} />
-    //</Tooltip>
-  );
+const getDecorator = (element: Node, quadrant: TopologyQuadrant, icon: IconType, tooltip?: string): React.ReactNode => {
+  return <TrafficDecorator element={element} quadrant={quadrant} icon={icon} tooltip={tooltip} />;
 };
 
 export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSettings): void => {

--- a/frontend/src/pages/GraphPF/components/NodeDecorator.tsx
+++ b/frontend/src/pages/GraphPF/components/NodeDecorator.tsx
@@ -1,0 +1,24 @@
+import { Tooltip } from '@patternfly/react-core';
+import { DEFAULT_DECORATOR_RADIUS, Decorator, Node, TopologyQuadrant, getDefaultShapeDecoratorCenter, observer } from '@patternfly/react-topology';
+import { IconType } from 'config/Icons';
+import React from 'react';
+
+interface Props {
+  element: Node,
+  quadrant: TopologyQuadrant,
+  icon: IconType,
+  tooltip?: string
+}
+
+const NodeDecoratorInner: React.FC<Props> = ({element, quadrant, icon, tooltip}) => {
+  const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
+  const decoratorRef = React.useRef<SVGAElement | null>(null);
+
+  return (
+    <Tooltip triggerRef={decoratorRef} content={!!tooltip ? tooltip : icon.text}>
+      <Decorator innerRef={decoratorRef} x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={React.createElement(icon.icon)} />
+    </Tooltip>
+  );
+};
+
+export const NodeDecorator = observer(NodeDecoratorInner);


### PR DESCRIPTION
Fixes #6926 

A fix is introduced because decorators were failing due to a change introduced in PF5. 