### PR TITLE
[hack] if there is no ingress, have traffic gen use productpage route

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -377,6 +377,9 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
   echo "Installing Traffic Generator"
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     INGRESS_ROUTE=$(${CLIENT_EXE} get route istio-ingressgateway -o jsonpath='{.spec.host}{"\n"}' -n ${ISTIO_NAMESPACE})
+    if [ -z "${INGRESS_ROUTE}" ]; then
+      INGRESS_ROUTE=$(${CLIENT_EXE} get route productpage -o jsonpath='{.spec.host}{"\n"}' -n ${NAMESPACE})
+    fi
     echo "Traffic Generator will use the OpenShift ingress route of: ${INGRESS_ROUTE}"
   else
     # Important note for minikube users


### PR DESCRIPTION
There may not be an ingress installed in istio-system - if not, have bookinfo demo traffic gen go directly to the productpage route on openshift