### PR TITLE
[OSSM-5306][OSSM-5307] Add building tests images workflow into pipeline

### DIFF
--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -1,0 +1,115 @@
+name: Build and push test suite images
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: Branch to release
+        default: master
+        type: string
+        required: true
+      quay_org:
+        description: Quay organization
+        type: string
+        default: kiali
+        required: true
+      images_tag:
+        description: Images tag
+        type: string
+        default: dev
+        required: true
+      build_mode:
+        type: choice
+        description: Which images should be built
+        default: both
+        options: 
+        - integration
+        - cypress
+        - both
+  workflow_call:
+    inputs:
+      release_branch:
+        description: Branch to release
+        type: string
+        required: true
+      quay_org:
+        description: Quay organization
+        type: string
+        required: true
+      images_tag:
+        description: Images tag
+        type: string
+        required: true
+      build_mode:
+        description: Which images should be built (integration/cypress/both)
+        type: string
+        required: true
+    secrets:
+      QUAY_USER:
+        description: 'A quay user secret passed from the caller workflow'
+        required: true
+      QUAY_PASSWORD:
+        description: 'A quay user password passed from the caller workflow'
+        required: true
+    
+
+jobs:
+  build_and_push_integration_tests:
+    name: Generate and push integration test docker images
+    if: ${{ inputs.build_mode == 'integration' || inputs.build_mode == 'both' }}
+    runs-on: ubuntu-latest
+    env:
+      # These ENVs are expected in Make file!
+      IMAGE_ORG: ${{ inputs.quay_org }}
+      INT_TESTS_CONTAINER_VERSION: ${{ inputs.images_tag }}
+      CYPRESS_TESTS_CONTAINER_VERSION: ${{ inputs.images_tag }}
+    steps:
+      - name: Log information
+        run: |
+          echo "Branch": ${{ inputs.release_branch }}
+          echo "Quay organization": ${{ inputs.quay_org }}
+          echo "Images tag": ${{ inputs.images_tag }}
+          echo "Builde mode": ${{ inputs.build_mode }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: "Build integration test image"
+        run: |
+          make container-build-int-tests container-push-int-tests-quay
+
+  build_and_push_cypress_tests:
+    name: Generate and push cypress test docker images
+    if: ${{ inputs.build_mode == 'cypress' || inputs.build_mode == 'both' }}
+    runs-on: ubuntu-latest
+    env:
+      # These ENVs are expected in Make file!
+      IMAGE_ORG: ${{ inputs.quay_org }}
+      INT_TESTS_CONTAINER_VERSION: ${{ inputs.images_tag }}
+      CYPRESS_TESTS_CONTAINER_VERSION: ${{ inputs.images_tag }}
+    steps:
+      - name: Log information
+        run: |
+          echo "Branch": ${{ inputs.release_branch }}
+          echo "Quay organization": ${{ inputs.quay_org }}
+          echo "Images tag": ${{ inputs.images_tag }}
+          echo "Builde mode": ${{ inputs.build_mode }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: "Build cypress test image"
+        run: |
+          make container-build-cypress-tests container-push-cypress-tests-quay

--- a/.github/workflows/test-images-release.yml
+++ b/.github/workflows/test-images-release.yml
@@ -1,0 +1,70 @@
+name: Release test suite images
+
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-20.04
+    outputs:
+      quay_org: 'kiali'
+      images_tag: ${{ steps.images_tag.outputs.images_tag }}
+    steps:
+    - name: Determine Image tag without Z version
+      id: images_tag
+      run: |
+        major=$(echo ${{ github.ref_name }} | cut -d. -f1)
+        minor=$(echo ${{ github.ref_name }} | cut -d. -f2)
+
+        echo "images_tag=$major.$minor" >> $GITHUB_OUTPUT
+    - name: Log information
+      run: |
+        echo "Github tag": ${{ github.ref_name }}
+        echo "Quay main version tag": ${{ steps.images_tag.outputs.images_tag }}
+
+  push_test_images:
+    name: Build and push images with full tag
+    uses: ./.github/workflows/test-images-creator.yml
+    needs: [initialize]
+    with:
+      release_branch: ${{ github.ref_name }}
+      images_tag: ${{ github.ref_name }}
+      quay_org: ${{ needs.initialize.outputs.quay_org }}
+      build_mode: 'both'
+    secrets:
+      QUAY_USER: ${{ secrets.QUAY_USER }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  update_latest_test_images:
+    name: Update images under major.minor version tag
+    runs-on: ubuntu-20.04
+    needs: [initialize, push_test_images]
+    steps:
+    - name: Login to Quay.io
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Pull new integration test image
+      run: |
+        docker pull quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-int-tests:${{ github.ref_name }}
+    - name: Use major.minor version tag
+      run: |
+        docker tag quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-int-tests:${{ github.ref_name }} quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-int-tests:${{ needs.initialize.outputs.images_tag }}
+    - name: Update integration test image in quay
+      run: |
+        docker push quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-int-tests:${{ needs.initialize.outputs.images_tag }}
+    
+    - name: Pull new cypress test image
+      run: |
+        docker pull quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-cypress-tests:${{ github.ref_name }}
+    - name: Use major.minor version tag
+      run: |
+        docker tag quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-cypress-tests:${{ github.ref_name }} quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-cypress-tests:${{ needs.initialize.outputs.images_tag }}
+    - name: Update cypress test image in quay
+      run: |
+        docker push quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-cypress-tests:${{ needs.initialize.outputs.images_tag }}

--- a/.github/workflows/test-images-update-latest.yml
+++ b/.github/workflows/test-images-update-latest.yml
@@ -1,0 +1,65 @@
+name: Update latest test suite images
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'hack/**'
+      - 'frontend/**'
+      # ignore src folder 
+      - '!frontend/src/**'
+      - 'deploy/docker/Dockerfile-cypress'
+      - 'tests/integration/**'
+
+jobs:
+  determine_change:
+    name: Determine which images are affected by the change
+    runs-on: ubuntu-latest
+    outputs:
+      build_mode: ${{ steps.determine.outputs.build_mode }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2.11.1
+      id: filter
+      with:
+        filters: |
+          integration:
+            - 'hack/**'
+            - 'tests/integration/**'
+          cypress:
+            - 'hack/**'
+            - 'frontend/**'
+            - 'deploy/docker/Dockerfile-cypress'
+    - name: Determine what needs to be rebuilt
+      id: determine
+      run: |
+        if ${{ steps.filter.outputs.integration }} && ${{ steps.filter.outputs.cypress }}; then
+          MODE="both"
+        elif ${{ steps.filter.outputs.integration }}; then
+          MODE="integration"
+        elif ${{ steps.filter.outputs.cypress }}; then
+          MODE="cypress"
+        else
+          echo "Unknown change. A change in watched folders was detected, but the folder is not related to any test image. Review the workflow file and add that folder to the related test image in the filter step!"          exit 1
+        fi
+        
+        echo "build_mode=$MODE" >> $GITHUB_OUTPUT
+    - name: Log information
+      run: |
+        echo "Change in folders related to int tests": ${{ steps.filter.outputs.integration }}
+        echo "Change in folders related to cypress tests": ${{ steps.filter.outputs.cypress }}
+        echo "Determined mode": ${{ steps.determine.outputs.build_mode }}
+  
+  push_test_images:
+    name: Build and push test images
+    needs: [determine_change]
+    uses: ./.github/workflows/test-images-creator.yml
+    with:
+      release_branch: ${{ github.ref_name }}
+      images_tag: 'latest'
+      quay_org: 'kiali'
+      build_mode: ${{ needs.determine_change.outputs.build_mode }}
+    secrets:
+      QUAY_USER: ${{ secrets.QUAY_USER }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ INT_TESTS_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
 INT_TESTS_QUAY_NAME ?= quay.io/${INT_TESTS_CONTAINER_NAME}
 INT_TESTS_QUAY_TAG ?= ${INT_TESTS_QUAY_NAME}:${INT_TESTS_CONTAINER_VERSION}
 
+# Identifies the Kiali cypress tests container image that will be built
+CYPRESS_TESTS_CONTAINER_NAME ?= ${IMAGE_ORG}/kiali-cypress-tests
+CYPRESS_TESTS_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
+CYPRESS_TESTS_QUAY_NAME ?= quay.io/${CYPRESS_TESTS_CONTAINER_NAME}
+CYPRESS_TESTS_QUAY_TAG ?= ${CYPRESS_TESTS_QUAY_NAME}:${CYPRESS_TESTS_CONTAINER_VERSION}
+
 # Where the control plane is
 ISTIO_NAMESPACE ?= istio-system
 # Declares the namespace/project where the objects are to be deployed.

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -44,6 +44,16 @@ else
 	podman build --pull -t ${INT_TESTS_QUAY_TAG} -f tests/integration/Dockerfile .
 endif
 
+## container-build-cypress-tests: Build Kiali cypress tests container image
+container-build-cypress-tests:
+ifeq ($(DORP),docker)
+	@echo Building container image for Kiali cypress tests using docker
+	docker build --pull -t ${CYPRESS_TESTS_QUAY_TAG} -f deploy/docker/Dockerfile-cypress .
+else
+	@echo Building container image for Kiali cypress tests using podman
+	podman build --pull -t ${CYPRESS_TESTS_QUAY_TAG} -f deploy/docker/Dockerfile-cypress .
+endif
+
 ## container-push-kiali-quay: Pushes the Kiali image to quay.
 container-push-kiali-quay:
 ifeq ($(DORP),docker)
@@ -61,14 +71,24 @@ container-push-operator-quay:
 ## container-push: Pushes all container images to quay
 container-push: container-push-kiali-quay container-push-operator-quay
 
-## container-push-int-tests-quay: Pushes the Kiali integration tests image to quay.
+## container-push-int-tests-quay: Pushes the Kiali integration test image to quay.
 container-push-int-tests-quay:
 ifeq ($(DORP),docker)
-	@echo Pushing Kiali integration tests image to ${INT_TESTS_QUAY_TAG} using docker
+	@echo Pushing Kiali integration test image to ${INT_TESTS_QUAY_TAG} using docker
 	docker push ${INT_TESTS_QUAY_TAG}
 else
-	@echo Pushing Kiali integration tests image to ${INT_TESTS_QUAY_TAG} using podman
+	@echo Pushing Kiali integration test image to ${INT_TESTS_QUAY_TAG} using podman
 	podman push ${INT_TESTS_QUAY_TAG}
+endif
+
+## container-push-cypress-tests-quay: Pushes the Kiali cypress test image to quay.
+container-push-cypress-tests-quay:
+ifeq ($(DORP),docker)
+	@echo Pushing Kiali cypress test image to ${CYPRESS_TESTS_QUAY_TAG} using docker
+	docker push ${CYPRESS_TESTS_QUAY_TAG}
+else
+	@echo Pushing Kiali cypress test image to ${CYPRESS_TESTS_QUAY_TAG} using podman
+	podman push ${CYPRESS_TESTS_QUAY_TAG}
 endif
 
 # Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md


### PR DESCRIPTION
**Describe the change**

Adding a workflow (`tests-images-creator.yml`) for building and pushing integration and cypress test images (both at once or a particular one). The workflow can be run from a different workflow or manually (e.g. for manually rebuilding a particular tag).
![image](https://github.com/kiali/kiali/assets/16251792/db557700-a1d3-45a6-9144-61adee4f826a)


1. The workflow is called from `tests-images-update-latest.yml` job, which is watching folders related to tests. If something is pushed into those folders, the job detects in which folders the changes were done and rebuilds the cypress, integration, or both test images accordingly. So the `latest` tag will always contain the latest changes in test suites.

2 In addition, the workflow is called whenever a new tag is created (e.g. after release) by `tests-images-release.yml`. In that case, the new integration and cypress test images are created in Quay under the released tag version, e.g. `1.65.12`. Also, the images under the tag `1.65` are updated to point to the latest Z version (other words, the X.Y tag will contain always the latest X.Y.Z released version).


**Issue reference**
Ref:
https://issues.redhat.com/browse/OSSM-5306
https://issues.redhat.com/browse/OSSM-5307
https://issues.redhat.com/browse/OSSM-5356

**Examples**

- Manual trigger 
  - both: https://github.com/mkralik3/kiali/actions/runs/7183479032
  - integration tests only: https://github.com/mkralik3/kiali/actions/runs/7183520056
  - cypress tests only: https://github.com/mkralik3/kiali/actions/runs/7183525511
- Update master with update in
  - hack folder, which is related for both: https://github.com/mkralik3/kiali/actions/runs/7183511121
  - readme in integration, only int is rebuilt: https://github.com/mkralik3/kiali/actions/runs/7183607891
  - frontend/package.json, only cypress is rebuilt: https://github.com/mkralik3/kiali/actions/runs/7183629336
- After tag creation: https://github.com/mkralik3/kiali/actions/runs/7183109197 
  - I have created three tags, `v1.65.30`, `v1.65.31` and `v1.65.32`. So after that, the Quay repo contains `v1.65.30`, `v1.65.31`, `v1.65.32` and `v1.65` [same as v1.65.32] images


**Additional info**
I will backport this to the master and other necessary branches[which are maintained]. [This](https://github.com/kiali/kiali/commit/887d4100a4ef5a37664823e346ee84593009e9bb) needs to be backported as well (+ update cypress docker file), that is why firstly I want to add all these changes to 1.65 which is ready for it.