### PR TITLE
[hack] on OpenShift when no ingress gateway is installed, wait for productpage route

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -376,10 +376,14 @@ fi
 if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
   echo "Installing Traffic Generator"
   if [ "${IS_OPENSHIFT}" == "true" ]; then
+    echo -n "Determining the route to send traffic to"
     INGRESS_ROUTE=$(${CLIENT_EXE} get route istio-ingressgateway -o jsonpath='{.spec.host}{"\n"}' -n ${ISTIO_NAMESPACE})
-    if [ -z "${INGRESS_ROUTE}" ]; then
+    while [ -z "${INGRESS_ROUTE}" ]; do
+      sleep 1
+      echo -n "."
       INGRESS_ROUTE=$(${CLIENT_EXE} get route productpage -o jsonpath='{.spec.host}{"\n"}' -n ${NAMESPACE})
-    fi
+    done
+    echo
     echo "Traffic Generator will use the OpenShift ingress route of: ${INGRESS_ROUTE}"
   else
     # Important note for minikube users


### PR DESCRIPTION
Note that this fixes a bug in the hack script - it was trying to expose the openshift routes before the services even existed. This also fixes that problem.