### PR TITLE
Include FQDN in error list for K8s HTTPRoute backend ref service name.

### DIFF
--- a/business/checkers/k8shttproutes/no_host_checker.go
+++ b/business/checkers/k8shttproutes/no_host_checker.go
@@ -2,6 +2,7 @@ package k8shttproutes
 
 import (
 	"fmt"
+	"strings"
 
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -29,7 +30,8 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 				namespace = string(*ref.Namespace)
 			}
 			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
-			if !n.checkDestination(fqdn.String(), namespace) {
+			//service name should not be set in fqdn format
+			if strings.Contains(string(ref.Name), ".") || !n.checkDestination(fqdn.String(), namespace) {
 				path := fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)
 				validation := models.Build("k8shttproutes.nohost.namenotfound", path)
 				validations = append(validations, &validation)

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -222,7 +222,7 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"k8shttproutes.nohost.namenotfound": {
 		Code:     "KIA1402",
-		Message:  "BackendRef on rule doesn't have a valid service (host not found)",
+		Message:  "BackendRef on rule doesn't have a valid service (Service name not found)",
 		Severity: ErrorSeverity,
 	},
 	"k8shttproutes.nok8sgateway": {

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -187,7 +187,7 @@ func TestK8sHTTPRoutesServicesError(t *testing.T) {
 	require.Equal("k8shttproute", config.IstioValidation.ObjectType)
 	require.NotEmpty(config.IstioValidation.Checks)
 	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	require.Equal("BackendRef on rule doesn't have a valid service (host not found)", config.IstioValidation.Checks[0].Message)
+	require.Equal("BackendRef on rule doesn't have a valid service (Service name not found)", config.IstioValidation.Checks[0].Message)
 }
 
 func getConfigDetails(namespace, name, configType string, skipReferences bool, require *require.Assertions) (*models.IstioConfigDetails, error) {


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6948

Before: Kiali was accepting FQDN in K8sHTTPRoute config's 'backendRef.name' as a Service name, but Gateway API expects it to be 'name' only. A bug!

Now: Error `KIA1402` will be extended to be shown also in FQDN formatted Service name (even if FQDN is correct). Error message is changed to be more clear that not a `host` is expected but `Service name`.

However, Kiali requires `istio_identity_domain: svc.cluster.local` set in `kiali` configmap, or not set that property at all to take the default.