### PR TITLE
K8sReferenceGrants support in Istio Config List/Details pages

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -733,7 +733,8 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 		istioConfigDetail.K8sHTTPRoute, err = userClient.GatewayAPI().GatewayV1().HTTPRoutes(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
 	case kubernetes.K8sReferenceGrants:
 		istioConfigDetail.K8sReferenceGrant = &k8s_networking_v1beta1.ReferenceGrant{}
-		istioConfigDetail.K8sReferenceGrant, err = userClient.GatewayAPI().GatewayV1beta1().ReferenceGrants(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
+		fixedPatch := strings.Replace(jsonPatch, "\"group\":null", "\"group\":\"\"", -1)
+		istioConfigDetail.K8sReferenceGrant, err = userClient.GatewayAPI().GatewayV1beta1().ReferenceGrants(namespace).Patch(ctx, name, patchType, []byte(fixedPatch), patchOpts)
 	case kubernetes.ServiceEntries:
 		istioConfigDetail.ServiceEntry = &networking_v1beta1.ServiceEntry{}
 		istioConfigDetail.ServiceEntry, err = userClient.Istio().NetworkingV1beta1().ServiceEntries(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -264,6 +264,8 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, httpRouteChecker}
 		referenceChecker = references.K8sHTTPRouteReferences{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: namespaces}
+	case kubernetes.K8sReferenceGrants:
+		// TODO
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)
 	}
@@ -401,6 +403,7 @@ func (in *IstioValidationsService) fetchIstioConfigList(ctx context.Context, rVa
 		IncludePeerAuthentications:    true,
 		IncludeK8sHTTPRoutes:          true,
 		IncludeK8sGateways:            true,
+		IncludeK8sReferenceGrants:     true,
 	}
 	istioConfigMap, err := in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, criteria)
 	if err != nil {

--- a/business/services.go
+++ b/business/services.go
@@ -186,15 +186,16 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 	// References MAY have visibility for a user but not access if they are not allowed to access to the namespace
 	if criteria.IncludeIstioResources {
 		criteria := IstioConfigCriteria{
-			AllNamespaces:           true,
-			Cluster:                 cluster,
-			Namespace:               criteria.Namespace,
-			IncludeDestinationRules: true,
-			IncludeGateways:         true,
-			IncludeK8sGateways:      true,
-			IncludeK8sHTTPRoutes:    true,
-			IncludeServiceEntries:   true,
-			IncludeVirtualServices:  true,
+			AllNamespaces:             true,
+			Cluster:                   cluster,
+			Namespace:                 criteria.Namespace,
+			IncludeDestinationRules:   true,
+			IncludeGateways:           true,
+			IncludeK8sGateways:        true,
+			IncludeK8sHTTPRoutes:      true,
+			IncludeK8sReferenceGrants: true,
+			IncludeServiceEntries:     true,
+			IncludeVirtualServices:    true,
 		}
 		go func() {
 			defer wg.Done()
@@ -558,11 +559,12 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 			Namespace:               namespace,
 			IncludeDestinationRules: true,
 			// TODO the frontend is merging the Gateways per ServiceDetails but it would be a clean design to locate it here
-			IncludeGateways:        true,
-			IncludeK8sGateways:     true,
-			IncludeK8sHTTPRoutes:   true,
-			IncludeServiceEntries:  true,
-			IncludeVirtualServices: true,
+			IncludeGateways:           true,
+			IncludeK8sGateways:        true,
+			IncludeK8sHTTPRoutes:      true,
+			IncludeK8sReferenceGrants: true,
+			IncludeServiceEntries:     true,
+			IncludeVirtualServices:    true,
 		}
 		istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(ctx, criteria)
 		if err2 != nil {

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -37,6 +37,7 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
   HTTPRoute: { badge: 'HTTP', tt: 'HTTPRoute' } as PFBadgeType,
   K8sGateway: { badge: 'G', tt: 'Gateway (K8s)' } as PFBadgeType,
   K8sHTTPRoute: { badge: 'HTTP', tt: 'HTTPRoute (K8s)' } as PFBadgeType,
+  K8sReferenceGrant: { badge: 'RG', tt: 'ReferenceGrant (K8s)' } as PFBadgeType,
   Handler: { badge: 'H', tt: 'Handler' },
   Host: { badge: 'H', tt: 'Host' },
   Instance: { badge: 'I', tt: 'Instance' },

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -238,6 +238,8 @@ export const IstioTypes: { [type: string]: IstioConfigType } = {
     url: 'requestauthentications',
     badge: PFBadges.RequestAuthentication
   },
+  // TODO should be merged with k8sreferencegrant
+  referencegrant: { name: 'ReferenceGrant (K8s)', url: 'k8sreferencegrants', badge: PFBadges.K8sReferenceGrant },
   rule: { name: 'Rule', url: 'rules', badge: PFBadges.Rule },
   serviceentry: { name: 'ServiceEntry', url: 'serviceentries', badge: PFBadges.ServiceEntry },
   servicerole: { name: 'ServiceRole', url: 'serviceroles', badge: PFBadges.ServiceRole },

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -224,6 +224,7 @@ export const IstioTypes: { [type: string]: IstioConfigType } = {
   instance: { name: 'Instance', url: 'instances', badge: PFBadges.Instance },
   k8sgateway: { name: 'Gateway (K8s)', url: 'k8sgateways', badge: PFBadges.K8sGateway },
   k8shttproute: { name: 'HTTPRoute (K8s)', url: 'k8shttproutes', badge: PFBadges.K8sHTTPRoute },
+  k8sreferencegrant: { name: 'ReferenceGrant (K8s)', url: 'k8sreferencegrants', badge: PFBadges.K8sReferenceGrant },
   meshpolicy: { name: 'MeshPolicy', url: 'meshpolicies', badge: PFBadges.MeshPolicy },
   peerauthentication: {
     name: 'PeerAuthentication',

--- a/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -9,7 +9,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     title: 'Namespace',
     isNumeric: false,
     param: 'ns',
-    compare: (a: IstioConfigItem, b: IstioConfigItem) => {
+    compare: (a: IstioConfigItem, b: IstioConfigItem): number => {
       return a.namespace.localeCompare(b.namespace) || a.name.localeCompare(b.name);
     }
   },
@@ -18,7 +18,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     title: 'Type',
     isNumeric: false,
     param: 'it',
-    compare: (a: IstioConfigItem, b: IstioConfigItem) => {
+    compare: (a: IstioConfigItem, b: IstioConfigItem): number => {
       return a.type.localeCompare(b.type) || a.name.localeCompare(b.name);
     }
   },
@@ -27,7 +27,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     title: 'Istio Name',
     isNumeric: false,
     param: 'in',
-    compare: (a: IstioConfigItem, b: IstioConfigItem) => {
+    compare: (a: IstioConfigItem, b: IstioConfigItem): number => {
       // On same name order is not well defined, we need some fallback methods
       // This happens specially on adapters/templates where Istio 1.0.x calls them "handler"
       // So, we have a lot of objects with same namespace+name
@@ -39,7 +39,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     title: 'Config',
     isNumeric: false,
     param: 'cv',
-    compare: (a: IstioConfigItem, b: IstioConfigItem) => {
+    compare: (a: IstioConfigItem, b: IstioConfigItem): number => {
       let sortValue = -1;
       if (a.validation && !b.validation) {
         sortValue = -1;
@@ -67,7 +67,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     title: 'Cluster',
     isNumeric: false,
     param: 'cl',
-    compare: (a: IstioConfigItem, b: IstioConfigItem) => {
+    compare: (a: IstioConfigItem, b: IstioConfigItem): number => {
       if (a.cluster && b.cluster) {
         let sortValue = a.cluster.localeCompare(b.cluster);
         if (sortValue === 0) {
@@ -119,6 +119,10 @@ export const istioTypeFilter: FilterType = {
     {
       id: 'K8sHTTPRoute',
       title: 'K8sHTTPRoute'
+    },
+    {
+      id: 'K8sReferenceGrant',
+      title: 'K8sReferenceGrant'
     },
     {
       id: 'PeerAuthentication',
@@ -208,6 +212,6 @@ export const sortIstioItems = (
   unsorted: IstioConfigItem[],
   sortField: SortField<IstioConfigItem>,
   isAscending: boolean
-) => {
+): IstioConfigItem[] => {
   return unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
 };

--- a/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -10,6 +10,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     gateways: [],
     k8sGateways: [],
     k8sHTTPRoutes: [],
+    k8sReferenceGrants: [],
     virtualServices: [],
     destinationRules: [],
     serviceEntries: [],
@@ -26,11 +27,11 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     telemetries: []
   };
   names.forEach(name => {
-    testData.authorizationPolicies.push({ metadata: { name: name + '0' }, spec: {} });
-    testData.destinationRules.push({ metadata: { name: name + '1' }, spec: {} });
-    testData.gateways.push({ metadata: { name: name + '2' }, spec: {} });
-    testData.serviceEntries.push({ metadata: { name: name + '3' }, spec: {} });
-    testData.virtualServices.push({ metadata: { name: name + '4' }, spec: {} });
+    testData.authorizationPolicies.push({ metadata: { name: `${name}0` }, spec: {} });
+    testData.destinationRules.push({ metadata: { name: `${name}1` }, spec: {} });
+    testData.gateways.push({ metadata: { name: `${name}2` }, spec: {} });
+    testData.serviceEntries.push({ metadata: { name: `${name}3` }, spec: {} });
+    testData.virtualServices.push({ metadata: { name: `${name}4` }, spec: {} });
   });
   return testData;
 };
@@ -61,6 +62,7 @@ describe('IstioConfigList#filterByName', () => {
     expect(filtered.telemetries.length).toBe(0);
     expect(filtered.k8sGateways.length).toBe(0);
     expect(filtered.k8sHTTPRoutes.length).toBe(0);
+    expect(filtered.k8sReferenceGrants.length).toBe(0);
   });
 });
 

--- a/frontend/src/types/IstioConfigDetails.ts
+++ b/frontend/src/types/IstioConfigDetails.ts
@@ -6,6 +6,7 @@ import {
   Gateway,
   K8sGateway,
   K8sHTTPRoute,
+  K8sReferenceGrant,
   ServiceEntry,
   VirtualService,
   ObjectValidation,
@@ -38,6 +39,7 @@ export interface IstioConfigDetails {
   help?: HelpMessage[];
   k8sGateway: K8sGateway;
   k8sHTTPRoute: K8sHTTPRoute;
+  k8sReferenceGrant: K8sReferenceGrant;
   namespace: Namespace;
   peerAuthentication: PeerAuthentication;
   permissions: ResourcePermissions;

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -124,6 +124,7 @@ export const dicIstioType = {
   gateway: 'Gateway',
   k8sgateway: 'K8sGateway',
   k8shttproute: 'K8sHTTPRoute',
+  k8sreferencegrant: 'K8sReferenceGrant',
   peerauthentication: 'PeerAuthentication',
   requestauthentication: 'RequestAuthentication',
   serviceentry: 'ServiceEntry',

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -6,6 +6,7 @@ import {
   Gateway,
   K8sGateway,
   K8sHTTPRoute,
+  K8sReferenceGrant,
   ObjectValidation,
   PeerAuthentication,
   RequestAuthentication,
@@ -30,6 +31,7 @@ export interface IstioConfigItem {
   gateway?: Gateway;
   k8sGateway?: K8sGateway;
   k8sHTTPRoute?: K8sHTTPRoute;
+  k8sReferenceGrant?: K8sReferenceGrant;
   name: string;
   namespace: string;
   peerAuthentication?: PeerAuthentication;
@@ -53,6 +55,7 @@ export interface IstioConfigList {
   gateways: Gateway[];
   k8sGateways: K8sGateway[];
   k8sHTTPRoutes: K8sHTTPRoute[];
+  k8sReferenceGrants: K8sReferenceGrant[];
   namespace: Namespace;
   peerAuthentications: PeerAuthentication[];
   permissions: { [key: string]: ResourcePermissions };
@@ -87,6 +90,7 @@ export const dicIstioType = {
   Gateway: 'gateways',
   K8sGateway: 'k8sgateways',
   K8sHTTPRoute: 'k8shttproutes',
+  K8sReferenceGrant: 'k8sreferencegrants',
   PeerAuthentication: 'peerauthentications',
   RequestAuthentication: 'requestauthentications',
   ServiceEntry: 'serviceentries',
@@ -103,6 +107,7 @@ export const dicIstioType = {
   gateways: 'Gateway',
   k8sgateways: 'K8sGateway',
   k8shttproutes: 'K8sHTTPRoute',
+  k8sreferencegrants: 'K8sReferenceGrant',
   peerauthentications: 'PeerAuthentication',
   requestauthentications: 'RequestAuthentication',
   serviceentries: 'ServiceEntry',
@@ -157,6 +162,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     gateways: unfiltered.gateways.filter(gw => includeName(gw.metadata.name, names)),
     k8sGateways: unfiltered.k8sGateways.filter(gw => includeName(gw.metadata.name, names)),
     k8sHTTPRoutes: unfiltered.k8sHTTPRoutes.filter(route => includeName(route.metadata.name, names)),
+    k8sReferenceGrants: unfiltered.k8sReferenceGrants.filter(rg => includeName(rg.metadata.name, names)),
     virtualServices: unfiltered.virtualServices.filter(vs => includeName(vs.metadata.name, names)),
     destinationRules: unfiltered.destinationRules.filter(dr => includeName(dr.metadata.name, names)),
     serviceEntries: unfiltered.serviceEntries.filter(se => includeName(se.metadata.name, names)),
@@ -211,7 +217,7 @@ export const filterByConfigValidation = (unfiltered: IstioConfigItem[], configFi
 export const toIstioItems = (istioConfigList: IstioConfigList, cluster?: string): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
 
-  const hasValidations = (type: string, name: string, namespace?: string) =>
+  const hasValidations = (type: string, name: string, namespace?: string): ObjectValidation =>
     istioConfigList.validations[type] && istioConfigList.validations[type][validationKey(name, namespace)];
 
   const nonItems = ['validations', 'permissions', 'namespace', 'cluster'];
@@ -263,7 +269,8 @@ export const vsToIstioItems = (
   cluster?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.virtualservice && validations.virtualservice[vKey];
+  const hasValidations = (vKey: string): ObjectValidation =>
+    validations.virtualservice && validations.virtualservice[vKey];
 
   const typeNameProto = dicIstioType['virtualservices']; // ex. serviceEntries -> ServiceEntry
   const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
@@ -295,7 +302,8 @@ export const drToIstioItems = (
   cluster?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.destinationrule && validations.destinationrule[vKey];
+  const hasValidations = (vKey: string): ObjectValidation =>
+    validations.destinationrule && validations.destinationrule[vKey];
 
   const typeNameProto = dicIstioType['destinationrules']; // ex. serviceEntries -> ServiceEntry
   const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
@@ -328,7 +336,7 @@ export const gwToIstioItems = (
   cluster?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.gateway && validations.gateway[vKey];
+  const hasValidations = (vKey: string): ObjectValidation => validations.gateway && validations.gateway[vKey];
   const vsGateways = new Set();
 
   const typeNameProto = dicIstioType['gateways']; // ex. serviceEntries -> ServiceEntry
@@ -374,7 +382,7 @@ export const k8sGwToIstioItems = (
   cluster?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.k8sgateway && validations.k8sgateway[vKey];
+  const hasValidations = (vKey: string): ObjectValidation => validations.k8sgateway && validations.k8sgateway[vKey];
   const k8sGateways = new Set();
 
   const typeNameProto = dicIstioType['k8sgateways']; // ex. serviceEntries -> ServiceEntry
@@ -415,7 +423,7 @@ export const k8sGwToIstioItems = (
 
 export const seToIstioItems = (see: ServiceEntry[], validations: Validations, cluster?: string): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.serviceentry && validations.serviceentry[vKey];
+  const hasValidations = (vKey: string): ObjectValidation => validations.serviceentry && validations.serviceentry[vKey];
 
   const typeNameProto = dicIstioType['serviceentries']; // ex. serviceEntries -> ServiceEntry
   const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
@@ -447,7 +455,7 @@ export const k8sHTTPRouteToIstioItems = (
   cluster?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
-  const hasValidations = (vKey: string) => validations.k8shttproute && validations.k8shttproute[vKey];
+  const hasValidations = (vKey: string): ObjectValidation => validations.k8shttproute && validations.k8shttproute[vKey];
 
   const typeNameProto = dicIstioType['k8shttproutes']; // ex. serviceEntries -> ServiceEntry
   const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -181,6 +181,10 @@ export type AccessLog = {
   bytes_received: string;
   // BytesSent as part of the request body %BYTES_SENT%
   bytes_sent: string;
+  // DownstreamLocal is the local address of the downstream connection %DOWNSTREAM_LOCAL_ADDRESS%
+  downstream_local: string;
+  // DownstreamRemote is the remote address of the downstream connection %DOWNSTREAM_REMOTE_ADDRESS%
+  downstream_remote: string;
   // Duration of the request %DURATION%
   duration: string;
   // ForwardedFor is the X-Forwarded-For header value %REQ(FORWARDED-FOR)%
@@ -191,32 +195,28 @@ export type AccessLog = {
   protocol: string;
   // RequestId is the envoy generated X-REQUEST-ID header "%REQ(X-REQUEST-ID)%"
   request_id: string;
+  // RequestedServer is the String value set on ssl connection socket for Server Name Indication (SNI) %REQUESTED_SERVER_NAME%
+  requested_server: string;
   // ResponseFlags provide any additional details about the response or connection, if any. %RESPONSE_FLAGS%
   response_flags: string;
+  // RouteName is the name of the VirtualService route which matched this request %ROUTE_NAME%
+  route_name: string;
   // StatusCode is the response status code %RESPONSE_CODE%
   status_code: string;
   // TcpServiceTime is the time the tcp request took
   tcp_service_time: string;
   // Timestamp is the Start Time %START_TIME%
   timestamp: string;
+  // UpstreamCluster is the upstream envoy cluster being reached %UPSTREAM_CLUSTER%
+  upstream_cluster: string;
+  // UpstreamFailureReason is the upstream transport failure reason %UPSTREAM_TRANSPORT_FAILURE_REASON%
+  upstream_failure_reason: string;
+  // UpstreamLocal is the local address of the upstream connection %UPSTREAM_LOCAL_ADDRESS%
+  upstream_local: string;
   // UpstreamService is the upstream host the request is intended for %UPSTREAM_HOST%
   upstream_service: string;
   // UpstreamServiceTime is the time taken to reach target host %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%
   upstream_service_time: string;
-  // UpstreamCluster is the upstream envoy cluster being reached %UPSTREAM_CLUSTER%
-  upstream_cluster: string;
-  // UpstreamLocal is the local address of the upstream connection %UPSTREAM_LOCAL_ADDRESS%
-  upstream_local: string;
-  // DownstreamLocal is the local address of the downstream connection %DOWNSTREAM_LOCAL_ADDRESS%
-  downstream_local: string;
-  // DownstreamRemote is the remote address of the downstream connection %DOWNSTREAM_REMOTE_ADDRESS%
-  downstream_remote: string;
-  // RequestedServer is the String value set on ssl connection socket for Server Name Indication (SNI) %REQUESTED_SERVER_NAME%
-  requested_server: string;
-  // RouteName is the name of the VirtualService route which matched this request %ROUTE_NAME%
-  route_name: string;
-  // UpstreamFailureReason is the upstream transport failure reason %UPSTREAM_TRANSPORT_FAILURE_REASON%
-  upstream_failure_reason: string;
   // UriParam is the params field of the request path
   uri_param: string;
   // UriPath is the base request path
@@ -283,8 +283,8 @@ export interface ClusterSummary {
 }
 
 export interface ListenerSummary {
-  destination: string;
   address: string;
+  destination: string;
   match: string;
   port: number;
 }
@@ -550,8 +550,8 @@ export interface TrafficPolicy {
 
 // 1.6
 export interface Subset {
-  name: string;
   labels?: { [key: string]: string };
+  name: string;
   trafficPolicy?: TrafficPolicy;
 }
 
@@ -776,8 +776,8 @@ export interface Listener {
 }
 
 export interface Address {
-  value: string;
   type: string;
+  value: string;
 }
 
 export interface AllowedRoutes {
@@ -806,6 +806,17 @@ export interface K8sGatewaySpec {
 
 export interface K8sGateway extends IstioObject {
   spec: K8sGatewaySpec;
+}
+
+export interface K8sReferenceGrantSpec {
+  from?: K8sReferenceRule[];
+  to?: K8sReferenceRule[];
+}
+
+export interface K8sReferenceRule {
+  group: string;
+  kind: string;
+  namespace?: string;
 }
 
 export interface K8sHTTPRouteSpec {
@@ -848,8 +859,8 @@ export interface K8sHTTPHeaderFilter {
 export interface K8sHTTPRouteRequestRedirect {
   hostname?: string;
   port?: number;
-  statusCode?: number;
   scheme?: string;
+  statusCode?: number;
 }
 
 export interface K8sHTTPRouteMatch {
@@ -867,6 +878,10 @@ export interface HTTPMatch {
 
 export interface K8sHTTPRoute extends IstioObject {
   spec: K8sHTTPRouteSpec;
+}
+
+export interface K8sReferenceGrant extends IstioObject {
+  spec: K8sReferenceGrantSpec;
 }
 
 // Sidecar resource https://preliminary.istio.io/docs/reference/config/networking/v1alpha3/sidecar
@@ -934,9 +949,9 @@ export interface Server {
 }
 
 export interface ServerForm {
+  hosts: string[];
   name: string;
   number: string;
-  hosts: string[];
   protocol: string;
   tlsCaCertificate: string;
   tlsMode: string;
@@ -1101,8 +1116,8 @@ export interface Operation {
 
 export interface Condition {
   key: string;
-  values?: string[];
   notValues?: string[];
+  values?: string[];
 }
 
 export interface PeerAuthentication extends IstioObject {
@@ -1151,8 +1166,8 @@ export interface WorkloadGroup extends IstioObject {
 
 export interface WorkloadGroupSpec {
   // Note that WorkloadGroup has a metadata section inside Spec
-  probe?: ReadinessProbe;
   metadata?: K8sMetadata;
+  probe?: ReadinessProbe;
   template: WorkloadEntrySpec;
 }
 
@@ -1163,8 +1178,8 @@ export interface ReadinessProbe {
   initialDelaySeconds?: number;
   periodSeconds?: number;
   successThreshold?: number;
-  timeoutSeconds?: number;
   tcpSocket?: TCPHealthCheckConfig;
+  timeoutSeconds?: number;
 }
 
 export interface HTTPHealthCheckConfig {

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -14,7 +14,7 @@ export const mergeJsonPatch = (objectModified: object, object?: object): object 
   if (!object) {
     return objectModified;
   }
-  const customizer = (objValue, srcValue) => {
+  const customizer = (objValue, srcValue): object | null => {
     if (!objValue) {
       return null;
     }
@@ -27,7 +27,7 @@ export const mergeJsonPatch = (objectModified: object, object?: object): object 
   return objectModified;
 };
 
-export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioConfigItem) => {
+export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioConfigItem): IstioObject | undefined => {
   let istioObject: IstioObject | undefined;
   if (istioObjectDetails) {
     if (istioObjectDetails.gateway) {

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -36,6 +36,8 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioCo
       istioObject = istioObjectDetails.k8sGateway;
     } else if (istioObjectDetails.k8sHTTPRoute) {
       istioObject = istioObjectDetails.k8sHTTPRoute;
+    } else if (istioObjectDetails.k8sReferenceGrant) {
+      istioObject = istioObjectDetails.k8sReferenceGrant;
     } else if (istioObjectDetails.virtualService) {
       istioObject = istioObjectDetails.virtualService;
     } else if (istioObjectDetails.destinationRule) {

--- a/kiali_internal_api.md
+++ b/kiali_internal_api.md
@@ -8894,6 +8894,7 @@ This type is used for returning a response of IstioConfigList
 | Gateways | [][Gateway](#gateway)| `[]*Gateway` |  | |  |  |
 | K8sGateways | [][Gateway](#gateway)| `[]*Gateway` |  | |  |  |
 | K8sHTTPRoutes | [][HTTPRoute](#http-route)| `[]*HTTPRoute` |  | |  |  |
+| K8sReferenceGrants | [][ReferenceGrant](#reference-grant)| `[]*ReferenceGrant` |  | |  |  |
 | PeerAuthentications | [][PeerAuthentication](#peer-authentication)| `[]*PeerAuthentication` |  | |  |  |
 | RequestAuthentications | [][RequestAuthentication](#request-authentication)| `[]*RequestAuthentication` |  | |  |  |
 | ServiceEntries | [][ServiceEntry](#service-entry)| `[]*ServiceEntry` |  | |  |  |
@@ -10945,6 +10946,7 @@ Invalid values include:
 | DestinationRules | [][DestinationRule](#destination-rule)| `[]*DestinationRule` |  | |  |  |
 | IstioSidecar | boolean| `bool` |  | |  |  |
 | K8sHTTPRoutes | [][HTTPRoute](#http-route)| `[]*HTTPRoute` |  | |  |  |
+| K8sReferenceGrants | [][ReferenceGrant](#reference-grant)| `[]*ReferenceGrant` |  | |  |  |
 | ServiceEntries | [][ServiceEntry](#service-entry)| `[]*ServiceEntry` |  | |  |  |
 | SubServices | [][ServiceOverview](#service-overview)| `[]*ServiceOverview` |  | | Services with same app labels (different versions or a single version) |  |
 | VirtualServices | [][VirtualService](#virtual-service)| `[]*VirtualService` |  | |  |  |

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -239,7 +239,7 @@ func checkGatewayAPIs(in *K8SClient, version string, types map[string]string) bo
 	}
 	if found > 0 && found < len(types) {
 		keys := make([]string, 0, len(types))
-		for key, _ := range types {
+		for key := range types {
 			keys = append(keys, key)
 		}
 		log.Warningf("Not all required K8s Gateway API CRDs are installed for version: %s, expected: %s", version, strings.Join(keys, ", "))

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -73,6 +73,11 @@ const (
 	K8sActualHTTPRouteType = "HTTPRoute"
 	K8sActualHTTPRoutes    = "httproutes"
 
+	K8sReferenceGrants          = "k8sreferencegrants"
+	K8sReferenceGrantType       = "K8sReferenceGrant"
+	K8sActualReferenceGrantType = "ReferenceGrant"
+	K8sActualReferenceGrants    = "referencegrants"
+
 	// Authorization PeerAuthentications
 	AuthorizationPolicies     = "authorizationpolicies"
 	AuthorizationPoliciesType = "AuthorizationPolicy"
@@ -92,6 +97,12 @@ var (
 		Version: "v1alpha3",
 	}
 	ApiNetworkingVersionV1Alpha3 = NetworkingGroupVersionV1Alpha3.Group + "/" + NetworkingGroupVersionV1Alpha3.Version
+
+	K8sNetworkingGroupVersionV1Beta1 = schema.GroupVersion{
+		Group:   "gateway.networking.k8s.io",
+		Version: "v1beta1",
+	}
+	K8sApiNetworkingVersionV1Beta1 = K8sNetworkingGroupVersionV1Beta1.Group + "/" + K8sNetworkingGroupVersionV1Beta1.Version
 
 	K8sNetworkingGroupVersionV1 = schema.GroupVersion{
 		Group:   "gateway.networking.k8s.io",
@@ -137,8 +148,9 @@ var (
 		Telemetries:      TelemetryType,
 
 		// K8s Networking Gateways
-		K8sGateways:   K8sGatewayType,
-		K8sHTTPRoutes: K8sHTTPRouteType,
+		K8sGateways:        K8sGatewayType,
+		K8sHTTPRoutes:      K8sHTTPRouteType,
+		K8sReferenceGrants: K8sReferenceGrantType,
 
 		// Security
 		AuthorizationPolicies:  AuthorizationPoliciesType,
@@ -158,8 +170,9 @@ var (
 		WasmPlugins:      ExtensionGroupVersionV1Alpha1.Group,
 		Telemetries:      TelemetryGroupV1Alpha1.Group,
 
-		K8sGateways:   K8sNetworkingGroupVersionV1.Group,
-		K8sHTTPRoutes: K8sNetworkingGroupVersionV1.Group,
+		K8sGateways:        K8sNetworkingGroupVersionV1.Group,
+		K8sHTTPRoutes:      K8sNetworkingGroupVersionV1.Group,
+		K8sReferenceGrants: K8sNetworkingGroupVersionV1.Group,
 
 		AuthorizationPolicies:  SecurityGroupVersion.Group,
 		PeerAuthentications:    SecurityGroupVersion.Group,

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -7,6 +7,7 @@ import (
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // IstioConfigList istioConfigList
@@ -29,8 +30,9 @@ type IstioConfigList struct {
 	WasmPlugins      []*extentions_v1alpha1.WasmPlugin     `json:"wasmPlugins"`
 	Telemetries      []*v1alpha1.Telemetry                 `json:"telemetries"`
 
-	K8sGateways   []*k8s_networking_v1.Gateway   `json:"k8sGateways"`
-	K8sHTTPRoutes []*k8s_networking_v1.HTTPRoute `json:"k8sHTTPRoutes"`
+	K8sGateways        []*k8s_networking_v1.Gateway             `json:"k8sGateways"`
+	K8sHTTPRoutes      []*k8s_networking_v1.HTTPRoute           `json:"k8sHTTPRoutes"`
+	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant `json:"k8sReferenceGrants"`
 
 	AuthorizationPolicies  []*security_v1beta.AuthorizationPolicy   `json:"authorizationPolicies"`
 	PeerAuthentications    []*security_v1beta.PeerAuthentication    `json:"peerAuthentications"`
@@ -59,8 +61,9 @@ type IstioConfigDetails struct {
 	WasmPlugin            *extentions_v1alpha1.WasmPlugin        `json:"wasmPlugin"`
 	Telemetry             *v1alpha1.Telemetry                    `json:"telemetry"`
 
-	K8sGateway   *k8s_networking_v1.Gateway   `json:"k8sGateway"`
-	K8sHTTPRoute *k8s_networking_v1.HTTPRoute `json:"k8sHTTPRoute"`
+	K8sGateway        *k8s_networking_v1.Gateway             `json:"k8sGateway"`
+	K8sHTTPRoute      *k8s_networking_v1.HTTPRoute           `json:"k8sHTTPRoute"`
+	K8sReferenceGrant *k8s_networking_v1beta1.ReferenceGrant `json:"k8sReferenceGrant"`
 
 	Permissions           ResourcePermissions `json:"permissions"`
 	IstioValidation       *IstioValidation    `json:"validation"`
@@ -171,6 +174,11 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 	"k8shttproutes": { // TODO
 		{ObjectField: "", Message: "Kubernetes Gateway API Configuration Object. HTTPRoute is for multiplexing HTTP or terminated HTTPS connections."},
 	},
+	"k8sreferencegrants": {
+		{ObjectField: "", Message: "Kubernetes Gateway API Configuration Object. ReferenceGrant is for enabling cross namespace references within Gateway API."},
+		{ObjectField: "spec.from", Message: "Define the group, kind, and namespace of resources that may reference items described in the to list."},
+		{ObjectField: "spec.to", Message: "Define the group and kind of resources that may be referenced by items described in the from list."},
+	},
 	"internal": {
 		{ObjectField: "", Message: "Internal resources are not editable"},
 	},
@@ -207,6 +215,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			filtered[ns].Gateways = []*networking_v1beta1.Gateway{}
 			filtered[ns].K8sGateways = []*k8s_networking_v1.Gateway{}
 			filtered[ns].K8sHTTPRoutes = []*k8s_networking_v1.HTTPRoute{}
+			filtered[ns].K8sReferenceGrants = []*k8s_networking_v1beta1.ReferenceGrant{}
 			filtered[ns].VirtualServices = []*networking_v1beta1.VirtualService{}
 			filtered[ns].ServiceEntries = []*networking_v1beta1.ServiceEntry{}
 			filtered[ns].Sidecars = []*networking_v1beta1.Sidecar{}
@@ -245,6 +254,12 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 		for _, route := range configList.K8sHTTPRoutes {
 			if route.Namespace == ns {
 				filtered[ns].K8sHTTPRoutes = append(filtered[ns].K8sHTTPRoutes, route)
+			}
+		}
+
+		for _, rg := range configList.K8sReferenceGrants {
+			if rg.Namespace == ns {
+				filtered[ns].K8sReferenceGrants = append(filtered[ns].K8sReferenceGrants, rg)
 			}
 		}
 
@@ -324,6 +339,7 @@ func (configList IstioConfigList) MergeConfigs(ns IstioConfigList) IstioConfigLi
 	configList.AuthorizationPolicies = append(configList.AuthorizationPolicies, ns.AuthorizationPolicies...)
 	configList.K8sGateways = append(configList.K8sGateways, ns.K8sGateways...)
 	configList.K8sHTTPRoutes = append(configList.K8sHTTPRoutes, ns.K8sHTTPRoutes...)
+	configList.K8sReferenceGrants = append(configList.K8sReferenceGrants, ns.K8sReferenceGrants...)
 	configList.PeerAuthentications = append(configList.PeerAuthentications, ns.PeerAuthentications...)
 	configList.RequestAuthentications = append(configList.RequestAuthentications, ns.RequestAuthentications...)
 	configList.ServiceEntries = append(configList.ServiceEntries, ns.ServiceEntries...)

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -166,8 +166,8 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{},
 	},
 	"k8sgateways": {
-		{ObjectField: "", Message: "Kubernetes Gateway API Configuration Object. A Gateway describes how traffic can be translated to Services within the cluster."},
-		{ObjectField: "spec.GatewayClassName", Message: "Defines the name of a GatewayClass object used by this Gateway."},
+		{ObjectField: "spec", Message: "Kubernetes Gateway API Configuration Object. A Gateway describes how traffic can be translated to Services within the cluster."},
+		{ObjectField: "spec.gatewayClassName", Message: "Defines the name of a GatewayClass object used by this Gateway."},
 		{ObjectField: "spec.listeners", Message: "Define the hostnames, ports, protocol, termination, TLS settings and which routes can be attached to a listener."},
 		{ObjectField: "spec.addresses", Message: "Define the network addresses requested for this gateway."},
 	},
@@ -175,7 +175,7 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "", Message: "Kubernetes Gateway API Configuration Object. HTTPRoute is for multiplexing HTTP or terminated HTTPS connections."},
 	},
 	"k8sreferencegrants": {
-		{ObjectField: "", Message: "Kubernetes Gateway API Configuration Object. ReferenceGrant is for enabling cross namespace references within Gateway API."},
+		{ObjectField: "spec", Message: "Kubernetes Gateway API Configuration Object. ReferenceGrant is for enabling cross namespace references within Gateway API."},
 		{ObjectField: "spec.from", Message: "Define the group, kind, and namespace of resources that may reference items described in the to list."},
 		{ObjectField: "spec.to", Message: "Define the group and kind of resources that may be referenced by items described in the from list."},
 	},

--- a/tests/integration/assets/bookinfo-k8sgateways.yaml
+++ b/tests/integration/assets/bookinfo-k8sgateways.yaml
@@ -37,3 +37,17 @@ spec:
       backendRefs:
         - name: httpbin
           port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: referencegrant
+  namespace: bookinfo
+spec:
+  from:
+    - group: "gateway.networking.k8s.io"
+      kind: HTTPRoute
+      namespace: bookinfo
+  to:
+    - group: ""
+      kind: Service

--- a/tests/integration/tests/istio_config_test.go
+++ b/tests/integration/tests/istio_config_test.go
@@ -86,6 +86,11 @@ func assertConfigs(configList kiali.IstioConfigListJson, require *require.Assert
 		require.True(gw.Namespace == configList.Namespace.Name)
 		require.NotNil(gw.Name)
 	}
+	require.NotNil(configList.K8sReferenceGrants)
+	for _, rg := range configList.K8sReferenceGrants {
+		require.True(rg.Namespace == configList.Namespace.Name)
+		require.NotNil(rg.Name)
+	}
 	require.NotNil(configList.RequestAuthentications)
 	for _, ra := range configList.RequestAuthentications {
 		require.True(ra.Namespace == configList.Namespace.Name)


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6918

Added support to list and show YAML details of K8s Gateway API "ReferenceGrant" object.

```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: ReferenceGrant
metadata:
  name: referencegrant
  namespace: bookinfo
spec:
  from:
  - group: "gateway.networking.k8s.io"
    kind: HTTPRoute
    namespace: bookinfo
  to:
  - group: ""
    kind: Service
```

![Screenshot from 2023-12-15 16-02-51](https://github.com/kiali/kiali/assets/604313/43c4b62d-cc56-4912-82de-04e3acf870c5)
![Screenshot from 2023-12-15 16-02-40](https://github.com/kiali/kiali/assets/604313/e11f7af3-661a-414d-ba74-b6908fe7ea39)
