### PR TITLE
[OSSM-5564][hack] Fix install testing demo script to support OSSM 2.5

### DIFF
--- a/hack/istio/functions.sh
+++ b/hack/istio/functions.sh
@@ -8,6 +8,7 @@
 # 1. Create a SMM (this is skipped for the cluster wide mode)
 # 2. Label the member namespace (only for the cluster wide mode)
 # 3. Annotate all of the namespace's Deployments with the sidecar injection annotation if enabled
+#! Be sure, that ISTIO_NAMESPACE and (ENABLE_INJECTION or AUTO_INJECTION) are properly set in the script where the function is called!
 prepare_maistra() {
   local ns="${1}"
   if $(is_cluster_wide);
@@ -30,7 +31,7 @@ EOM
     ${CLIENT_EXE} wait --for condition=Ready -n ${ISTIO_NAMESPACE} smmr/default --timeout 300s
   fi
 
-  if [ "${ENABLE_INJECTION}" == "true" ]; then
+  if [ "${ENABLE_INJECTION}" == "true" ] || [ "${AUTO_INJECTION}" == "true" ]; then
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"

--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -19,6 +19,8 @@ SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 ISTIO_DIR=
 CLIENT_EXE="oc"
 DELETE_SLEEP="false"
+: ${ISTIO_NAMESPACE:=istio-system}
+: ${ENABLE_INJECTION:=true}
 
 # process command line args
 while [[ $# -gt 0 ]]; do
@@ -33,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -id|--istio-dir)
       ISTIO_DIR="$2"
+      shift;shift
+      ;;
+    -in|--istio-namespace)
+      ISTIO_NAMESPACE="$2"
       shift;shift
       ;;
     -c|--client-exe)

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -112,7 +112,7 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
     echo "Deploying error rates demo ..."
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH}
     echo "Deploying sleep demo ..."
-    "${SCRIPT_DIR}/install-sleep-demo.sh" 
+    "${SCRIPT_DIR}/install-sleep-demo.sh" -in ${ISTIO_NAMESPACE}
 
   else
     gateway_yaml=""
@@ -169,7 +169,7 @@ EOF
     "${SCRIPT_DIR}/install-error-rates-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH}
 
     echo "Deploying sleep demo ..."
-    "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl
+    "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE}
   fi
 
   if [ -v "${GATEWAY_HOST}" ]; then
@@ -179,7 +179,7 @@ EOF
     ${CLIENT_EXE} patch VirtualService bookinfo -n bookinfo --type json -p "[{\"op\": \"replace\", \"path\": \"/spec/hosts/0\", \"value\": \"${ISTIO_INGRESS_HOST}\"}]"
   fi
 
-  for namespace in bookinfo alpha beta
+  for namespace in bookinfo alpha beta gamma
   do
     wait_for_workloads "${namespace}"
   done


### PR DESCRIPTION
**Describe the change**
Fix autoinjection for `bookinfo` and `sleep` demo projects when using with OSSM

Due to this change https://github.com/kiali/kiali/commit/997f5440113462d0d6fc41e1fbde66e72ad75b31 , the bookinfo script doesn't use `ENABLE_INJECTION` anymore, however, it is needed in `prepare_maistra` function.

Also, `ISTIO_NAMESPACE` env is needed in `prepare_mainstra` function so it was added to `install-sleep-demo.sh` script. (in version 1.65, the sleep installation was a part of `install-testing-demos.sh` where the ENV was available) 

**Issue reference**
https://issues.redhat.com/browse/OSSM-5564