### PR TITLE
Use ignorecluster global for tracing

### DIFF
--- a/tracing/client.go
+++ b/tracing/client.go
@@ -99,10 +99,6 @@ func NewClient(token string) (*Client, error) {
 			return nil, errParse
 		}
 
-		if cfg.ExternalServices.Tracing.Provider == JAEGER {
-			httpTracingClient = jaeger.JaegerHTTPClient{}
-		}
-
 		port := u.Port()
 		if port == "" {
 			p, _ := net.LookupPort("tcp", u.Scheme)
@@ -178,6 +174,11 @@ func NewClient(token string) (*Client, error) {
 						return nil, nil
 					}
 					return &Client{httpTracingClient: httpTracingClient, grpcClient: streamClient, httpClient: client, baseURL: u, ctx: ctx}, nil
+				}
+			} else {
+				httpTracingClient, err = jaeger.NewJaegerClient(client, u)
+				if err != nil {
+					return nil, err
 				}
 			}
 			return &Client{httpTracingClient: httpTracingClient, httpClient: client, baseURL: u, ctx: ctx}, nil

--- a/tracing/client.go
+++ b/tracing/client.go
@@ -128,7 +128,10 @@ func NewClient(token string) (*Client, error) {
 			conn, err := grpc.Dial(address, opts...)
 			if err == nil {
 				cc := model.NewQueryServiceClient(conn)
-				client = jaeger.JaegerGRPCClient{JaegergRPCClient: cc}
+				client, err = jaeger.NewGRPCJaegerClient(cc)
+				if err != nil {
+					return nil, err
+				}
 				log.Infof("Create %s GRPC client %s", cfgTracing.Provider, address)
 				return &Client{httpTracingClient: httpTracingClient, grpcClient: client, ctx: ctx}, nil
 			} else {

--- a/tracing/client.go
+++ b/tracing/client.go
@@ -132,9 +132,6 @@ func NewClient(token string) (*Client, error) {
 				if err != nil {
 					return nil, err
 				}
-				if client == nil {
-					return nil, fmt.Errorf("error creating GRPC client")
-				}
 				log.Infof("Create %s GRPC client %s", cfgTracing.Provider, address)
 				return &Client{httpTracingClient: httpTracingClient, grpcClient: client, ctx: ctx}, nil
 			} else {

--- a/tracing/client_test.go
+++ b/tracing/client_test.go
@@ -14,6 +14,7 @@ func TestCreateJaegerClient(t *testing.T) {
 
 	conf := config.NewConfig()
 	conf.ExternalServices.Tracing.Enabled = true
+	conf.ExternalServices.Tracing.UseGRPC = false
 	config.Set(conf)
 
 	tracingClient, err := NewClient(token)

--- a/tracing/jaeger/grpc_client.go
+++ b/tracing/jaeger/grpc_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -23,6 +24,58 @@ import (
 
 type JaegerGRPCClient struct {
 	JaegergRPCClient model.QueryServiceClient
+	IgnoreCluster    bool
+}
+
+func NewGRPCJaegerClient(cc model.QueryServiceClient) (jaegerClient *JaegerGRPCClient, err error) {
+
+	conf := config.Get()
+
+	var jaegerService string
+	var ignoreCluster bool
+
+	if err == nil {
+		services, err := cc.GetServices(context.TODO(), &model.GetServicesRequest{})
+		if err != nil {
+			log.Errorf("Error getting services")
+		} else {
+			for _, service := range services.Services {
+				if !strings.Contains(service, "istio") && !strings.Contains(service, "jaeger") {
+					jaegerService = service
+					break
+				}
+			}
+			end := time.Now()
+			tags := map[string]string{
+				"cluster": conf.KubernetesConfig.ClusterName,
+			}
+			findTracesRQ := &model.FindTracesRequest{
+				Query: &model.TraceQueryParameters{
+					ServiceName:  jaegerService,
+					StartTimeMin: timestamppb.New(end.Add(-10 * time.Minute)),
+					StartTimeMax: timestamppb.New(end),
+					Tags:         tags,
+					DurationMin:  durationpb.New(0),
+					SearchDepth:  int32(10),
+				},
+			}
+			stream, err := cc.FindTraces(context.TODO(), findTracesRQ)
+			if err != nil {
+				err = fmt.Errorf("GetAppTraces, Tracing GRPC client error: %v", err)
+				return nil, err
+			}
+
+			tracesMap, err := readSpansStream(stream)
+			if tracesMap != nil && err == nil && len(tracesMap) == 0 || err != nil {
+				log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
+				ignoreCluster = true
+			} else {
+				ignoreCluster = false
+			}
+			return &JaegerGRPCClient{JaegergRPCClient: cc, IgnoreCluster: ignoreCluster}, nil
+		}
+	}
+	return nil, err
 }
 
 // FindTraces
@@ -32,34 +85,25 @@ func (jc JaegerGRPCClient) FindTraces(ctx context.Context, serviceName string, q
 		Data:               []jsonModel.Trace{},
 		TracingServiceName: jaegerServiceName,
 	}
+
+	var tags = util.CopyStringMap(q.Tags)
+	if jc.IgnoreCluster {
+		delete(tags, "cluster")
+	}
+
 	findTracesRQ := &model.FindTracesRequest{
 		Query: &model.TraceQueryParameters{
 			ServiceName:  jaegerServiceName,
 			StartTimeMin: timestamppb.New(q.Start),
 			StartTimeMax: timestamppb.New(q.End),
-			Tags:         q.Tags,
+			Tags:         tags,
 			DurationMin:  durationpb.New(q.MinDuration),
 			SearchDepth:  int32(q.Limit),
 		},
 	}
 
 	tracesMap, err := jc.queryTraces(ctx, findTracesRQ)
-	if err != nil || len(tracesMap) == 0 {
-		// show warning to user that cannot query by cluster
-		// query second time without cluster filter
-		var tags = util.CopyStringMap(q.Tags)
-		delete(tags, "cluster")
-		findTracesRQ = &model.FindTracesRequest{
-			Query: &model.TraceQueryParameters{
-				ServiceName:  jaegerServiceName,
-				StartTimeMin: timestamppb.New(q.Start),
-				StartTimeMax: timestamppb.New(q.End),
-				Tags:         tags,
-				DurationMin:  durationpb.New(q.MinDuration),
-				SearchDepth:  int32(q.Limit),
-			},
-		}
-		tracesMap, err = jc.queryTraces(ctx, findTracesRQ)
+	if jc.IgnoreCluster {
 		r.FromAllClusters = true
 	}
 

--- a/tracing/jaeger/grpc_client.go
+++ b/tracing/jaeger/grpc_client.go
@@ -30,12 +30,14 @@ type JaegerGRPCClient struct {
 func NewGRPCJaegerClient(cc model.QueryServiceClient) (jaegerClient *JaegerGRPCClient, err error) {
 
 	conf := config.Get()
+	ctx := context.Background()
 
 	var jaegerService string
 	var ignoreCluster bool
 
 	if err == nil {
-		services, err := cc.GetServices(context.TODO(), &model.GetServicesRequest{})
+		var services *model.GetServicesResponse
+		services, err = cc.GetServices(ctx, &model.GetServicesRequest{})
 		if err != nil {
 			log.Errorf("Error getting services")
 		} else {

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -28,8 +28,8 @@ func NewJaegerClient(client http.Client, baseURL *url.URL) (jaegerClient *Jaeger
 	url := *baseURL
 	conf := config.Get()
 	var ignoreCluster bool
-	services := model.Services{}
 	var jaegerService string
+	services := model.Services{}
 
 	url.Path = path.Join(url.Path, "/api/services")
 	resp, code, reqError := makeRequest(client, url.String(), nil)

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tracing/jaeger/model"
@@ -18,6 +19,58 @@ import (
 )
 
 type JaegerHTTPClient struct {
+	IgnoreCluster bool
+}
+
+// New client
+func NewJaegerClient(client http.Client, baseURL *url.URL) (jaegerClient *JaegerHTTPClient, err error) {
+
+	url := *baseURL
+	conf := config.Get()
+	var ignoreCluster bool
+	services := model.Services{}
+	var jaegerService string
+
+	url.Path = path.Join(url.Path, "/api/services")
+	resp, code, reqError := makeRequest(client, url.String(), nil)
+	if code != 200 || reqError != nil {
+		log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
+		ignoreCluster = true
+	}
+	errUnmarshall := json.Unmarshal(resp, &services)
+	if errUnmarshall != nil {
+		log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
+		ignoreCluster = true
+	}
+	for _, service := range services.Data {
+		if !strings.Contains(service, "istio") && !strings.Contains(service, "jaeger") {
+			jaegerService = service
+			break
+		}
+	}
+	urlTraces := *baseURL
+	urlTraces.Path = path.Join(urlTraces.Path, "/api/traces")
+
+	// if cluster exists in tags, use it
+	query := models.TracingQuery{}
+	tags := map[string]string{
+		"cluster": conf.KubernetesConfig.ClusterName,
+	}
+	query.Tags = tags
+	query.End = time.Now()
+	query.Start = query.End.Add(-10 * time.Minute)
+	query.Limit = 100
+	prepareQuery(&urlTraces, jaegerService, query, false)
+	r, err := queryTracesHTTP(client, &urlTraces)
+
+	if r != nil && err == nil && len(r.Data) == 0 || err != nil {
+		log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
+		ignoreCluster = true
+	} else {
+		ignoreCluster = false
+	}
+
+	return &JaegerHTTPClient{IgnoreCluster: ignoreCluster}, nil
 }
 
 func (jc JaegerHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL, serviceName string, q models.TracingQuery) (response *model.TracingResponse, err error) {
@@ -25,19 +78,17 @@ func (jc JaegerHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL
 	url.Path = path.Join(url.Path, "/api/traces")
 
 	// if cluster exists in tags, use it
-	prepareQuery(&url, serviceName, q, false)
+	prepareQuery(&url, serviceName, q, jc.IgnoreCluster)
 	r, err := queryTracesHTTP(client, &url)
-
-	if r != nil && len(r.Data) == 0 && q.Cluster != "" {
-		// query without cluster tag, warn user that tracing is not configured to use cluster tags
-		prepareQuery(&url, serviceName, q, true)
-		r, err = queryTracesHTTP(client, &url)
-		r.FromAllClusters = true
-	}
 
 	if r != nil {
 		r.TracingServiceName = serviceName
+		if jc.IgnoreCluster {
+			r.FromAllClusters = true
+		}
+
 	}
+
 	return r, err
 }
 

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -36,11 +36,13 @@ func NewJaegerClient(client http.Client, baseURL *url.URL) (jaegerClient *Jaeger
 	if code != 200 || reqError != nil {
 		log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
 		ignoreCluster = true
+		return &JaegerHTTPClient{IgnoreCluster: ignoreCluster}, nil
 	}
 	errUnmarshall := json.Unmarshal(resp, &services)
 	if errUnmarshall != nil {
 		log.Debugf("Error getting query for tracing. cluster tags will be disabled.")
 		ignoreCluster = true
+		return &JaegerHTTPClient{IgnoreCluster: ignoreCluster}, nil
 	}
 	for _, service := range services.Data {
 		if !strings.Contains(service, "istio") && !strings.Contains(service, "jaeger") {

--- a/tracing/jaeger/model/types.go
+++ b/tracing/jaeger/model/types.go
@@ -30,3 +30,7 @@ type TracingSpan struct {
 	jaegerModels.Span
 	TraceSize int `json:"traceSize"`
 }
+
+type Services struct {
+	Data []string `json:"data"`
+}


### PR DESCRIPTION
Ref. #6844

https://github.com/kiali/kiali/issues/6844#issuecomment-1854504377

In order to get a sample of the traces from different times and a limited number of results, in some calls (Like the node graph for traces), splits the search query in 10, this is, will perform up to 10 concurrent requests to the tracing platform. 

When there are no cluster tags, each query is repeated, which in a busy environment can be translated in a worst performance. This PR tries to get this information when the tracing client is created and avoid the duplication of calls to the backend. 
