### PR TITLE
Retrieve log level from correct source

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -121,7 +121,7 @@ func Fatalf(format string, args ...interface{}) {
 // Return log level
 // Used to get debug info
 func GetLogLevel() string {
-	return log.Logger.GetLevel().String()
+	return zerolog.GlobalLevel().String()
 }
 
 // Resolves the environment settings for the log level. Considers the verbose_mode from server version <=1.25.


### PR DESCRIPTION
**Describe the change**

Correct log level information can be found in zerolog.GlobalLevel(), not from log.Logger.GetLevel()

** Issue reference **

Fixes #6964 