### PR TITLE
Consider ReferenceGrant in HTTPRoute Service validation KIA1402

### DIFF
--- a/business/checkers/k8shttproute_checker.go
+++ b/business/checkers/k8shttproute_checker.go
@@ -2,6 +2,7 @@ package checkers
 
 import (
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/business/checkers/k8shttproutes"
 	"github.com/kiali/kiali/kubernetes"
@@ -11,11 +12,12 @@ import (
 const K8sHTTPRouteCheckerType = "k8shttproute"
 
 type K8sHTTPRouteChecker struct {
-	K8sHTTPRoutes    []*k8s_networking_v1.HTTPRoute
-	K8sGateways      []*k8s_networking_v1.Gateway
-	Namespaces       models.Namespaces
-	RegistryServices []*kubernetes.RegistryService
-	Cluster          string
+	K8sHTTPRoutes      []*k8s_networking_v1.HTTPRoute
+	K8sGateways        []*k8s_networking_v1.Gateway
+	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant
+	Namespaces         models.Namespaces
+	RegistryServices   []*kubernetes.RegistryService
+	Cluster            string
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations
@@ -49,9 +51,10 @@ func (in K8sHTTPRouteChecker) runChecks(rt *k8s_networking_v1.HTTPRoute, gateway
 			GatewayNames: gatewayNames,
 		},
 		k8shttproutes.NoHostChecker{
-			K8sHTTPRoute:     rt,
-			Namespaces:       in.Namespaces,
-			RegistryServices: in.RegistryServices,
+			Namespaces:         in.Namespaces,
+			K8sHTTPRoute:       rt,
+			K8sReferenceGrants: in.K8sReferenceGrants,
+			RegistryServices:   in.RegistryServices,
 		},
 	}
 

--- a/business/checkers/k8shttproute_checker.go
+++ b/business/checkers/k8shttproute_checker.go
@@ -12,12 +12,12 @@ import (
 const K8sHTTPRouteCheckerType = "k8shttproute"
 
 type K8sHTTPRouteChecker struct {
-	K8sHTTPRoutes      []*k8s_networking_v1.HTTPRoute
+	Cluster            string
 	K8sGateways        []*k8s_networking_v1.Gateway
+	K8sHTTPRoutes      []*k8s_networking_v1.HTTPRoute
 	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant
 	Namespaces         models.Namespaces
 	RegistryServices   []*kubernetes.RegistryService
-	Cluster            string
 }
 
 // Check runs checks for the all namespaces actions as well as for the single namespace validations

--- a/business/checkers/k8shttproutes/no_host_checker.go
+++ b/business/checkers/k8shttproutes/no_host_checker.go
@@ -12,9 +12,9 @@ import (
 )
 
 type NoHostChecker struct {
-	Namespaces         models.Namespaces
 	K8sHTTPRoute       *k8s_networking_v1.HTTPRoute
 	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant
+	Namespaces         models.Namespaces
 	RegistryServices   []*kubernetes.RegistryService
 }
 

--- a/business/checkers/k8shttproutes/no_host_checker.go
+++ b/business/checkers/k8shttproutes/no_host_checker.go
@@ -5,15 +5,17 @@ import (
 	"strings"
 
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
 
 type NoHostChecker struct {
-	Namespaces       models.Namespaces
-	K8sHTTPRoute     *k8s_networking_v1.HTTPRoute
-	RegistryServices []*kubernetes.RegistryService
+	Namespaces         models.Namespaces
+	K8sHTTPRoute       *k8s_networking_v1.HTTPRoute
+	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant
+	RegistryServices   []*kubernetes.RegistryService
 }
 
 func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
@@ -31,7 +33,11 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 			}
 			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
 			//service name should not be set in fqdn format
-			if strings.Contains(string(ref.Name), ".") || !n.checkDestination(fqdn.String(), namespace) {
+			// if the http route is referencing to a service from the same namespace, then service should exist there
+			// if the http route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
+			if strings.Contains(string(ref.Name), ".") ||
+				(namespace == n.K8sHTTPRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
+				(namespace != n.K8sHTTPRoute.Namespace && (!n.checkReferenceGrant(n.K8sHTTPRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {
 				path := fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)
 				validation := models.Build("k8shttproutes.nohost.namenotfound", path)
 				validations = append(validations, &validation)
@@ -47,4 +53,9 @@ func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool
 	// Use RegistryService to check destinations that may not be covered with previous check
 	// i.e. Multi-cluster or Federation validations
 	return kubernetes.HasMatchingRegistryService(itemNamespace, sHost, n.RegistryServices)
+}
+
+func (n NoHostChecker) checkReferenceGrant(fromNamespace string, toNamespace string) bool {
+	// Use ReferenceGrant objects to check if cross namespace reference exists
+	return kubernetes.HasMatchingReferenceGrant(fromNamespace, toNamespace, kubernetes.K8sActualHTTPRouteType, kubernetes.ServiceType, n.K8sReferenceGrants)
 }

--- a/business/checkers/k8shttproutes/no_host_checker_test.go
+++ b/business/checkers/k8shttproutes/no_host_checker_test.go
@@ -1,6 +1,7 @@
 package k8shttproutes
 
 import (
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,12 +23,60 @@ func TestValidRefHost(t *testing.T) {
 	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
 	assert.True(valid)
 	assert.Empty(vals)
+}
+
+func TestMissingGrant(t *testing.T) {
+	c := config.Get()
+	c.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	config.Set(c)
+
+	assert := assert.New(t)
+
+	registryService1 := data.CreateFakeRegistryServices("other.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
+	vals, valid := NoHostChecker{
+		RegistryServices: append(registryService1, registryService2...),
+		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", vals[0]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+}
+
+func TestWrongGrant(t *testing.T) {
+	c := config.Get()
+	c.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	config.Set(c)
+
+	assert := assert.New(t)
+
+	registryService1 := data.CreateFakeRegistryServices("other.bookinfo.svc.cluster.local", "bookinfo", "*")
+	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
+
+	vals, valid := NoHostChecker{
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8shttproutes.nohost.namenotfound", vals[0]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
 }
 
 func TestValidRefHostDefaultNs(t *testing.T) {
@@ -41,8 +90,9 @@ func TestValidRefHostDefaultNs(t *testing.T) {
 	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
 	assert.True(valid)
@@ -60,8 +110,9 @@ func TestInvalidRefHostDefaultNs(t *testing.T) {
 	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
 	assert.False(valid)
@@ -83,8 +134,9 @@ func TestNoValidRefHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo2"}))),
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo2"}))),
 	}.Check()
 
 	assert.False(valid)
@@ -110,8 +162,9 @@ func TestInvalidRefHostFQDN(t *testing.T) {
 	registryService2 := data.CreateFakeRegistryServices("reviews.bookinfo.svc.cluster.local", "bookinfo", "*")
 
 	vals, valid := NoHostChecker{
-		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		RegistryServices:   append(registryService1, registryService2...),
+		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
 	assert.False(valid)

--- a/business/checkers/k8shttproutes/no_host_checker_test.go
+++ b/business/checkers/k8shttproutes/no_host_checker_test.go
@@ -1,8 +1,9 @@
 package k8shttproutes
 
 import (
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"testing"
+
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/stretchr/testify/assert"
 
@@ -24,7 +25,7 @@ func TestValidRefHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
@@ -67,7 +68,7 @@ func TestWrongGrant(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
@@ -91,7 +92,7 @@ func TestValidRefHostDefaultNs(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
@@ -111,7 +112,7 @@ func TestInvalidRefHostDefaultNs(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 
@@ -135,7 +136,7 @@ func TestNoValidRefHost(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo2"}))),
 	}.Check()
 
@@ -163,7 +164,7 @@ func TestInvalidRefHostFQDN(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
-		K8sReferenceGrants: []*v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
 		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
 	}.Check()
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -144,7 +144,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(istioConfigList models.I
 		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses()},
 		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
 		checkers.TelemetryChecker{Telemetries: istioConfigList.Telemetries, Namespaces: namespaces},
-		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
+		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
 	}
 }
 
@@ -261,7 +261,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		}
 		referenceChecker = references.K8sGatewayReferences{K8sGateways: istioConfigList.K8sGateways, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes}
 	case kubernetes.K8sHTTPRoutes:
-		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, Namespaces: namespaces, RegistryServices: registryServices}
+		httpRouteChecker := checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []ObjectChecker{noServiceChecker, httpRouteChecker}
 		referenceChecker = references.K8sHTTPRouteReferences{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: namespaces}
 	case kubernetes.K8sReferenceGrants:
@@ -433,6 +433,9 @@ func (in *IstioValidationsService) fetchIstioConfigList(ctx context.Context, rVa
 
 	// All K8sHTTPRoutes
 	rValue.K8sHTTPRoutes = append(rValue.K8sHTTPRoutes, istioConfigList.K8sHTTPRoutes...)
+
+	// All K8sReferenceGrants
+	rValue.K8sReferenceGrants = append(rValue.K8sReferenceGrants, istioConfigList.K8sReferenceGrants...)
 
 	// All Sidecars
 	rValue.Sidecars = append(rValue.Sidecars, istioConfigList.Sidecars...)

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -7,6 +7,7 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/config"
 )
@@ -222,6 +223,20 @@ func HasMatchingRegistryService(namespace string, host string, registryServices 
 		// We assume that on these cases the host.Service is provided in FQDN
 		// i.e. ratings.mesh2-bookinfo.svc.mesh1-imports.local
 		if FilterByRegistryService(namespace, host, rStatus) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMatchingReferenceGrant returns true when the From matches to given fromNamespace and fromKind and To matched given toNamespace and toKind.
+func HasMatchingReferenceGrant(fromNamespace string, toNamespace string, fromKind string, toKind string, referenceGrants []*k8s_networking_v1beta1.ReferenceGrant) bool {
+	for _, rGrant := range referenceGrants {
+		if len(rGrant.Spec.From) > 0 && len(rGrant.Spec.To) > 0 &&
+			string(rGrant.Spec.From[0].Namespace) == fromNamespace &&
+			rGrant.Namespace == toNamespace &&
+			string(rGrant.Spec.From[0].Kind) == fromKind &&
+			string(rGrant.Spec.To[0].Kind) == toKind {
 			return true
 		}
 	}

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -3,6 +3,7 @@ package data
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/kubernetes"
 )
@@ -99,4 +100,13 @@ func UpdateConditionWithError(k8sgw *k8s_networking_v1.Gateway) *k8s_networking_
 	k8sgw.Status.Conditions = append(k8sgw.Status.Conditions, condition)
 
 	return k8sgw
+}
+
+func CreateReferenceGrant(name string, namespace string, fromNamespace string) *k8s_networking_v1beta1.ReferenceGrant {
+	rg := k8s_networking_v1beta1.ReferenceGrant{}
+	rg.Name = name
+	rg.Namespace = namespace
+	rg.Spec.From = append(rg.Spec.From, k8s_networking_v1beta1.ReferenceGrantFrom{Kind: kubernetes.K8sActualHTTPRouteType, Group: k8s_networking_v1beta1.GroupName, Namespace: k8s_networking_v1.Namespace(fromNamespace)})
+	rg.Spec.To = append(rg.Spec.To, k8s_networking_v1beta1.ReferenceGrantTo{Kind: kubernetes.ServiceType})
+	return &rg
 }


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6918

In K8s HTTPRoute Backend reference (https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.BackendObjectReference), when the Namespace where Service is referenced differs from the local namespace, where the HTTPRoute is created, then a ReferenceGrant object is required to reference the Service namespace and local namespace.

Now: KIA1402 validation is modified to consider ReferenceGrant objects when those 2 namespaces are different. 

How to test it:
Apply K8s Gateway API CRD v1.0.0
Create HTTPRoute and ReferenceGrant.
```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: inbookinfo
  namespace: bookinfo
spec:
  rules:
  - matches:
    - path:
        type: Exact
        value: "/bar"
    backendRefs:
      - name: kiali
        namespace: istio-system
        port: 9080
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: ReferenceGrant
metadata:
  name: toistio
  namespace: istio-system
spec:
  from:
  - group: gateway.networking.k8s.io
    kind: HTTPRoute
    namespace: bookinfo
  to:
  - group: ""
    kind: Service
```
Verify that HTTPRoute is referring to a Service from remote namespace, but no error as ReferenceGrant is referencing those namespaces.
![Screenshot from 2023-12-20 19-54-30](https://github.com/kiali/kiali/assets/604313/b3510621-2864-4814-8455-e7473ea4239b)
![Screenshot from 2023-12-20 19-52-32](https://github.com/kiali/kiali/assets/604313/8d79bed1-3b0e-42d2-92cd-ef25b5cbceb6)

When ReferenceGrant does not exist:
![Screenshot from 2023-12-20 19-54-51](https://github.com/kiali/kiali/assets/604313/f3f0645e-ae60-4a90-b86c-fcc007f3d715)
