### PR TITLE
Fix Workload Logs scrollbar issue

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -158,7 +158,6 @@ const logsDiv = kialiStyle({
 const logsDisplay = kialiStyle({
   fontFamily: 'monospace',
   margin: 0,
-  overflow: 'auto',
   padding: 0,
   resize: 'none',
   whiteSpace: 'pre',

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -184,8 +184,7 @@ const checkboxStyle = kialiStyle({
 });
 
 const logListStyle = kialiStyle({
-  overflowX: 'auto',
-  overflowY: 'auto',
+  overflow: 'auto !important',
   paddingTop: '0.375rem',
   paddingBottom: '0.75rem'
 });


### PR DESCRIPTION
**Describe the change**

Fix of two scrollbar issues in workload logs:
- Horizontal scrollbar does not appear in Firefox:
 
  React Virtualized List component has different overflow style depending on browser:
  - Chrome: `overflow: auto`
  - Firefox: `overflow: hidden auto`

  Setting the oveflow style to `auto !important` makes the trick.

- Double scrollbar in Chrome when user zooms in:

  Extra `overflow` style present in the List component. 





**Issue reference**

Fixes #6982 