### PR TITLE
Initialize tracing client asynchronously

### DIFF
--- a/business/tracing.go
+++ b/business/tracing.go
@@ -40,6 +40,11 @@ func (in *TracingService) client() (tracing.ClientInterface, error) {
 	if !in.conf.ExternalServices.Tracing.Enabled {
 		return nil, fmt.Errorf("Tracing is not enabled")
 	}
+
+	if in.tracing == nil {
+		return nil, fmt.Errorf("Tracing client is not initialized")
+	}
+
 	return in.tracing, nil
 }
 

--- a/status/status.go
+++ b/status/status.go
@@ -103,11 +103,6 @@ func GetStatus(name string) (previous string, hasPrevious bool) {
 	return previous, hasPrevious
 }
 
-// GetStatus returns current status
-func GetStatuses() map[string]string {
-	return info.Status
-}
-
 // AddWarningMessages add warning messages to status
 // CAUTION: Currently, the UI assumes that the only messages passed to this
 // function are the result of Istio version checks (see the istioVersion func of versions.go file)

--- a/tracing/client_test.go
+++ b/tracing/client_test.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestCreateJaegerClient(t *testing.T) {
 	conf.ExternalServices.Tracing.Enabled = true
 	conf.ExternalServices.Tracing.UseGRPC = false
 
-	tracingClient, err := NewClient(conf, token)
+	tracingClient, err := NewClient(context.Background(), conf, token)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, tracingClient)
@@ -27,7 +28,7 @@ func TestCreateTempogRPCClient(t *testing.T) {
 	conf.ExternalServices.Tracing.Provider = "tempo"
 	conf.ExternalServices.Tracing.UseGRPC = true
 
-	tracingClient, err := NewClient(conf, token)
+	tracingClient, err := NewClient(context.Background(), conf, token)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, tracingClient)
@@ -39,7 +40,7 @@ func TestCreateTempoHTTPClient(t *testing.T) {
 	conf.ExternalServices.Tracing.Provider = "tempo"
 	conf.ExternalServices.Tracing.UseGRPC = false
 
-	tracingClient, err := NewClient(conf, token)
+	tracingClient, err := NewClient(context.Background(), conf, token)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, tracingClient)


### PR DESCRIPTION
** Describe the change **

When tracing fails to initialize, the server should still startup because tracing is not an essential component.