### PR TITLE
Update trace logic for Tempo lo limit the number of results

### DIFF
--- a/business/tracing.go
+++ b/business/tracing.go
@@ -132,7 +132,6 @@ func wkdSpanFilter(ns, workload string) SpanFilter {
 
 func (in *TracingService) GetAppTraces(ns, app string, query models.TracingQuery) (*model.TracingResponse, error) {
 	client, err := in.client()
-	conf := config.Get()
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +139,8 @@ func (in *TracingService) GetAppTraces(ns, app string, query models.TracingQuery
 	if err != nil {
 		return nil, err
 	}
-	// Disable for tempo for performance
-	if len(r.Data) == query.Limit && conf.ExternalServices.Tracing.Provider != config.TempoProvider {
+
+	if len(r.Data) == query.Limit {
 		// Reached the limit, use split & join mode to spread traces over the requested interval
 		log.Trace("Limit of traces was reached, using split & join mode")
 		more, err := in.getAppTracesSlicedInterval(ns, app, query)


### PR DESCRIPTION
For some reason, it looks like Tempo returns more than the limit results. 
It limits the number of results and splits the query when necessary. 
It looks like with increasing the number of results supports the load. 

With this change, with Tempo: 
- No more results than the limit are returned. 
- Traces are distributed between the graph. 

Ref. #6844  