### PR TITLE
Remove Jaeger Exporter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -812,8 +812,9 @@ func NewConfig() (c *Config) {
 					Port:    9090,
 				},
 				Tracing: Tracing{
-					CollectorURL: "jaeger-collector.istio-system:4318",
-					Enabled:      false,
+					CollectorType: OTELCollectorType,
+					CollectorURL:  "jaeger-collector.istio-system:4318",
+					Enabled:       false,
 					Otel: OtelCollector{
 						CAName:     "",
 						Protocol:   "http",
@@ -1164,7 +1165,7 @@ func Validate(cfg Config) error {
 	// Check the observability section
 	observTracing := cfg.Server.Observability.Tracing
 	// If collector is not defined it would be the default "otel"
-	if observTracing.Enabled && observTracing.CollectorType != OTELCollectorType && observTracing.CollectorType != "" {
+	if observTracing.Enabled && observTracing.CollectorType != OTELCollectorType {
 		return fmt.Errorf("error in configuration options getting the observability exporter. Invalid collector type [%s]", observTracing.CollectorType)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,7 @@ type Metrics struct {
 // OpenTelemetry collector configuration for tracing
 type TLSConfig struct {
 	CAName     string `yaml:"ca_name,omitempty"`
+	Enabled    bool   `yaml:"enabled,omitempty"`
 	SkipVerify bool   `yaml:"skip_verify,omitempty"`
 }
 
@@ -121,7 +122,6 @@ type Tracing struct {
 	Protocol     string `yaml:"protocol,omitempty"` // http or https or grpc
 	// Sampling rate for Kiali server traces. >= 1.0 always samples and <= 0 never samples.
 	SamplingRate float64   `yaml:"sampling_rate,omitempty"`
-	TLSEnabled   bool      `yaml:"tls_enabled,omitempty"`
 	TLSConfig    TLSConfig `yaml:"tls_config,omitempty"`
 }
 
@@ -808,9 +808,9 @@ func NewConfig() (c *Config) {
 					Protocol:     "http",
 					// Sample half of traces.
 					SamplingRate: 0.5,
-					TLSEnabled:   false,
 					TLSConfig: TLSConfig{
 						CAName:     "",
+						Enabled:    false,
 						SkipVerify: true,
 					},
 				},

--- a/observability/tracing.go
+++ b/observability/tracing.go
@@ -184,7 +184,7 @@ func getExporter(collectorURL string) (sdktrace.SpanExporter, error) {
 
 			opts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(collectorURL), otlptracegrpc.WithDialOption(grpc.WithBlock())}
 
-			if tracingOpt.TLSEnabled {
+			if tracingOpt.TLSConfig.Enabled {
 				if tracingOpt.TLSConfig.SkipVerify {
 					log.Trace("OpenTelemetry collector will not verify the remote certificate")
 					tlsConfig := &tls.Config{

--- a/observability/tracing_test.go
+++ b/observability/tracing_test.go
@@ -13,30 +13,30 @@ import (
 func TestInitTracer(t *testing.T) {
 	assert := assert.New(t)
 	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = "jaeger"
+	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
 	config.Set(cfg)
 
 	defer func() {
 		err := recover()
 		assert.Nil(err)
 	}()
-	tp := observability.InitTracer("jaegerURL")
+	tp := observability.InitTracer("otelURL")
 	assert.NotNil(tp)
 }
 
 func TestStop(t *testing.T) {
 	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = "jaeger"
+	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
 	config.Set(cfg)
 
-	tp := observability.InitTracer("jaegerURL")
+	tp := observability.InitTracer("otelURL")
 	observability.StopTracer(tp)
 }
 
 func TestStopWithNil(t *testing.T) {
 	assert := assert.New(t)
 	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = "jaeger"
+	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
 	config.Set(cfg)
 
 	defer func() {
@@ -83,7 +83,7 @@ func TestStartSpan(t *testing.T) {
 	assert := assert.New(t)
 	cfg := config.Get()
 	cfg.Server.Observability.Tracing.Enabled = true
-	cfg.Server.Observability.Tracing.CollectorType = "jaeger"
+	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
 	config.Set(cfg)
 
 	ctx := context.Background()

--- a/observability/tracing_test.go
+++ b/observability/tracing_test.go
@@ -12,9 +12,6 @@ import (
 
 func TestInitTracer(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
-	config.Set(cfg)
 
 	defer func() {
 		err := recover()
@@ -25,19 +22,12 @@ func TestInitTracer(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
-	config.Set(cfg)
-
 	tp := observability.InitTracer("otelURL")
 	observability.StopTracer(tp)
 }
 
 func TestStopWithNil(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.Get()
-	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
-	config.Set(cfg)
 
 	defer func() {
 		err := recover()
@@ -83,7 +73,6 @@ func TestStartSpan(t *testing.T) {
 	assert := assert.New(t)
 	cfg := config.Get()
 	cfg.Server.Observability.Tracing.Enabled = true
-	cfg.Server.Observability.Tracing.CollectorType = config.OTELCollectorType
 	config.Set(cfg)
 
 	ctx := context.Background()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -307,6 +307,7 @@ func TestTracingConfigured(t *testing.T) {
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir
 	conf.Server.Observability.Tracing.Enabled = true
+	conf.Server.Observability.Tracing.CollectorType = "otel"
 	conf.Auth.Strategy = "anonymous"
 
 	// Set the global client factory.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -307,7 +307,6 @@ func TestTracingConfigured(t *testing.T) {
 	conf.Server.Port = testPort
 	conf.Server.StaticContentRootDirectory = tmpDir
 	conf.Server.Observability.Tracing.Enabled = true
-	conf.Server.Observability.Tracing.CollectorType = "jaeger"
 	conf.Auth.Strategy = "anonymous"
 
 	// Set the global client factory.


### PR DESCRIPTION
**Describe the change**

Remove Jaeger exporter.
Example to test: 
```
server:
  observability: 
   tracing: 
    collector_url: "localhost:4318"
    enabled: true
    protocol: "http"
    tls_enabled: false
    tls_config: 
     skip_verify: true
     ca_name: "/tmp/tls.crt"
```

I've included some changes in the observability section from the configuration. As there is just one collector type, the option `collector_type` was removed. Because of this, the `otel` configuration section was renamed to `tls_config`, and the `protocol` and `tls_enabled` was moved to the `tracing` section. 
I have in mind to minimize this CR changes, but, I think this reorganization makes more sense and probably the new settings (With the collector_type) were not used a lot yet. 

**Issue reference**

Fixes #6908 