### PR TITLE
Output failure info in CI to a file instead of stdout/err

### DIFF
--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -54,14 +54,18 @@ jobs:
       - name: Run backend integration tests
         run: hack/run-integration-tests.sh --test-suite backend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
 
+      - name: Testing failure TODO remove
+        run: exit 1
+
       - name: Get debug info when integration tests fail
         if: failure()
         run: |
-          kubectl logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system
-          kubectl describe nodes
-          kubectl get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
-          kubectl describe pods -n metallb-system
-          kubectl logs -p deployments/controller -n metallb-system
-          kubectl logs -p ds/speaker -n metallb-system
-          kubectl logs deployments/controller -n metallb-system
-          kubectl logs ds/speaker -n metallb-system
+          mkdir debug-output
+          hack/get-debug-info.sh --output-directory debug-output --kubectl-context kind-east
+
+      - name: Upload debug info artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-info
+          path: debug-output

--- a/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
@@ -66,14 +66,15 @@ jobs:
       - name: Get debug info when integration tests fail
         if: failure()
         run: |
-          kubectl --context kind-east logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system
-          kubectl --context kind-east describe nodes
-          kubectl --context kind-east get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
-          kubectl --context kind-east describe pods -n metallb-system
-          kubectl --context kind-east logs -p deployments/controller -n metallb-system
-          kubectl --context kind-east logs -p ds/speaker -n metallb-system
-          kubectl --context kind-east logs deployments/controller -n metallb-system
-          kubectl --context kind-east logs ds/speaker -n metallb-system
+          mkdir debug-output
+          hack/get-debug-info.sh --output-directory debug-output --kubectl-context kind-east
+
+      - name: Upload debug info artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-info
+          path: debug-output
 
       - name: Upload cypress screenshots when tests fail
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
@@ -66,14 +66,15 @@ jobs:
       - name: Get debug info when integration tests fail
         if: failure()
         run: |
-          kubectl --context kind-east logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system
-          kubectl --context kind-east describe nodes
-          kubectl --context kind-east get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
-          kubectl --context kind-east describe pods -n metallb-system
-          kubectl --context kind-east logs -p deployments/controller -n metallb-system
-          kubectl --context kind-east logs -p ds/speaker -n metallb-system
-          kubectl --context kind-east logs deployments/controller -n metallb-system
-          kubectl --context kind-east logs ds/speaker -n metallb-system
+          mkdir debug-output
+          hack/get-debug-info.sh --output-directory debug-output --kubectl-context kind-east
+
+      - name: Upload debug info artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-info
+          path: debug-output
 
       - name: Upload cypress screenshots when tests fail
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-tests-frontend-tempo.yml
+++ b/.github/workflows/integration-tests-frontend-tempo.yml
@@ -68,14 +68,15 @@ jobs:
       - name: Get debug info when integration tests fail
         if: failure()
         run: |
-          kubectl logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system
-          kubectl describe nodes
-          kubectl get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
-          kubectl describe pods -n metallb-system
-          kubectl logs -p deployments/controller -n metallb-system
-          kubectl logs -p ds/speaker -n metallb-system
-          kubectl logs deployments/controller -n metallb-system
-          kubectl logs ds/speaker -n metallb-system
+          mkdir debug-output
+          hack/get-debug-info.sh --output-directory debug-output --kubectl-context kind-east
+
+      - name: Upload debug info artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-info
+          path: debug-output
 
       - name: Upload cypress screenshots when tests fail
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -68,14 +68,15 @@ jobs:
       - name: Get debug info when integration tests fail
         if: failure()
         run: |
-          kubectl logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system
-          kubectl describe nodes
-          kubectl get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml
-          kubectl describe pods -n metallb-system
-          kubectl logs -p deployments/controller -n metallb-system
-          kubectl logs -p ds/speaker -n metallb-system
-          kubectl logs deployments/controller -n metallb-system
-          kubectl logs ds/speaker -n metallb-system
+          mkdir debug-output
+          hack/get-debug-info.sh --output-directory debug-output --kubectl-context kind-east
+
+      - name: Upload debug info artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-info
+          path: debug-output
 
       - name: Upload cypress screenshots when tests fail
         uses: actions/upload-artifact@v3

--- a/hack/ci-get-debug-info.sh
+++ b/hack/ci-get-debug-info.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#
+# This script is used to get debug info from the CI environment.
+#
+
+OUTPUT_DIRECTORY=""
+KUBECTL_CONTEXT="kind-east"
+
+# Process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -o|--output-directory)
+      OUTPUT_DIRECTORY="${2}"
+      shift; shift
+      ;;
+    -c|--kubectl-context)
+      KUBECTL_CONTEXT="${2}"
+      shift; shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -o|--output-directory <directory_path>
+    Specify the output directory where the files will be written.
+    If not provided, a temporary directory will be created.
+  -c|--kubectl-context <context_name>
+    Specify the kubectl context to use.
+  -h|--help:
+    Display this help message
+HELPMSG
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# If OUTPUT_DIRECTORY is not provided, create a temporary directory
+if [ -z "$OUTPUT_DIRECTORY" ]; then
+  OUTPUT_DIRECTORY=$(mktemp -d)
+  echo "INFO: Output directory not provided. Using temporary directory: $OUTPUT_DIRECTORY"
+fi
+
+# Get debug info and write to a separate file.
+kubectl --context "${KUBECTL_CONTEXT}" logs -l app.kubernetes.io/name=kiali --tail=-1 --all-containers -n istio-system > "${OUTPUT_DIRECTORY}/kiali_logs.txt" || rm "${OUTPUT_DIRECTORY}/kiali_logs.txt"
+kubectl --context "${KUBECTL_CONTEXT}" describe nodes > "${OUTPUT_DIRECTORY}/describe_nodes.txt" || rm "${OUTPUT_DIRECTORY}/describe_nodes.txt"
+kubectl --context "${KUBECTL_CONTEXT}" get pods -l app.kubernetes.io/name=kiali -n istio-system -o yaml > "${OUTPUT_DIRECTORY}/kiali_pods.yaml" || rm "${OUTPUT_DIRECTORY}/kiali_pods.yaml"
+kubectl --context "${KUBECTL_CONTEXT}" describe pods -n metallb-system > "${OUTPUT_DIRECTORY}/describe_metallb_pods.txt" || rm "${OUTPUT_DIRECTORY}/describe_metallb_pods.txt"
+kubectl --context "${KUBECTL_CONTEXT}" logs -p deployments/controller -n metallb-system > "${OUTPUT_DIRECTORY}/metallb_controller_logs.txt" || rm "${OUTPUT_DIRECTORY}/metallb_controller_logs.txt"
+kubectl --context "${KUBECTL_CONTEXT}" logs -p ds/speaker -n metallb-system > "${OUTPUT_DIRECTORY}/metallb_speaker_logs.txt" || rm "${OUTPUT_DIRECTORY}/metallb_speaker_logs.txt"
+kubectl --context "${KUBECTL_CONTEXT}" logs deployments/controller -n metallb-system > "${OUTPUT_DIRECTORY}/metallb_controller_current_logs.txt" || rm "${OUTPUT_DIRECTORY}/metallb_controller_current_logs.txt"
+kubectl --context "${KUBECTL_CONTEXT}" logs ds/speaker -n metallb-system > "${OUTPUT_DIRECTORY}/metallb_speaker_current_logs.txt" || rm "${OUTPUT_DIRECTORY}/metallb_speaker_current_logs.txt"


### PR DESCRIPTION
** Describe the change **

The output of the `Get debug info when integration tests fail` step in CI is really large and usually when there's a failure you just want to see the test output which is different than this info. This change will write that info to a file that can be downloaded rather than to stdout/err.

