### PR TITLE
Adapt PR template to issue format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+### Describe the change
+
+Explanation of what this PR does
+
+### Where should the reviewer start?
+
+Recommendations for how to test this PR
+
+### Covered unit test cases / E2E test cases
+
+If applicable, explain which unit or E2E tests have been created to test this PR
+
+### Browser checklist (only frontend):
+
+- [ ] Chrome
+- [ ] Firefox
+
+### Issue reference
+
+If this PR is a fix for a github issue, please link it here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Explanation of what this PR does
 
 Recommendations for how to test this PR
 
-### Covered unit test cases / E2E test cases
+### PR checklist
 
-If applicable, explain which unit or E2E tests have been created to test this PR
+- [ ] Include tests (unit or E2E)
 
 ### Browser checklist (only frontend):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,12 @@ Explanation of what this PR does
 
 ### Steps to test the PR
 
-Recommendations for how to test this PR
+Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.
+
+### Automation testing
+
+If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.
 
 ### Issue reference
 
-If this PR is related to a github issue, please link it here (e.g., Closes #100)
+If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,19 +2,10 @@
 
 Explanation of what this PR does
 
-### Where should the reviewer start?
+### Steps to test the PR
 
 Recommendations for how to test this PR
 
-### PR checklist
-
-- [ ] Include tests (unit or E2E)
-
-### Browser checklist (only frontend):
-
-- [ ] Chrome
-- [ ] Firefox
-
 ### Issue reference
 
-If this PR is a fix for a github issue, please link it here
+If this PR is related to a github issue, please link it here (e.g., Closes #100)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-** Describe the change **
-
-_explanation of what it does_
-
-** Issue reference **
-
-* If this is a fix for a GH-issue, please link it here


### PR DESCRIPTION
**Describe the change**

Adapt PR template to recently changed issue template and move it to the same folder (`.github`).

New sections added to complete PR description
