### PR TITLE
Added new check KIA1601 for ReferenceGrant

### DIFF
--- a/business/checkers/k8sreferencegrants/namespace_checker.go
+++ b/business/checkers/k8sreferencegrants/namespace_checker.go
@@ -2,6 +2,7 @@ package k8sreferencegrants
 
 import (
 	"fmt"
+
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/models"

--- a/business/checkers/k8sreferencegrants/namespace_checker.go
+++ b/business/checkers/k8sreferencegrants/namespace_checker.go
@@ -9,8 +9,8 @@ import (
 )
 
 type NamespaceChecker struct {
-	ReferenceGrant k8s_networking_v1beta1.ReferenceGrant
 	Namespaces     models.Namespaces
+	ReferenceGrant k8s_networking_v1beta1.ReferenceGrant
 }
 
 func (in NamespaceChecker) Check() ([]*models.IstioCheck, bool) {

--- a/business/checkers/k8sreferencegrants/namespace_checker.go
+++ b/business/checkers/k8sreferencegrants/namespace_checker.go
@@ -1,0 +1,29 @@
+package k8sreferencegrants
+
+import (
+	"fmt"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kiali/kiali/models"
+)
+
+type NamespaceChecker struct {
+	ReferenceGrant k8s_networking_v1beta1.ReferenceGrant
+	Namespaces     models.Namespaces
+}
+
+func (in NamespaceChecker) Check() ([]*models.IstioCheck, bool) {
+	validations := make([]*models.IstioCheck, 0)
+
+	if len(in.ReferenceGrant.Spec.From) > 0 {
+		for nsIndex, from := range in.ReferenceGrant.Spec.From {
+			if !in.Namespaces.Includes(string(from.Namespace)) {
+				validation := models.Build("k8sreferencegrants.from.namespacenotfound",
+					fmt.Sprintf("spec/from[%d]/namespace", nsIndex))
+				validations = append(validations, &validation)
+			}
+		}
+	}
+
+	return validations, len(validations) == 0
+}

--- a/business/checkers/k8sreferencegrants/namespace_checker_test.go
+++ b/business/checkers/k8sreferencegrants/namespace_checker_test.go
@@ -1,13 +1,13 @@
 package k8sreferencegrants
 
 import (
-	"github.com/kiali/kiali/tests/data"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
 )
 

--- a/business/checkers/k8sreferencegrants/namespace_checker_test.go
+++ b/business/checkers/k8sreferencegrants/namespace_checker_test.go
@@ -1,0 +1,50 @@
+package k8sreferencegrants
+
+import (
+	"github.com/kiali/kiali/tests/data"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestFromNamespaceExists(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	vals, valid := NamespaceChecker{
+		ReferenceGrant: *data.CreateReferenceGrant("test", "bookinfo", "default"),
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "bookinfo2"},
+			models.Namespace{Name: "default"},
+		},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestFromNamespaceNotFound(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	vals, valid := NamespaceChecker{
+		ReferenceGrant: *data.CreateReferenceGrant("test", "bookinfo", "bookinfo3"),
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "bookinfo2"},
+			models.Namespace{Name: "default"},
+		},
+	}.Check()
+
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sreferencegrants.from.namespacenotfound", vals[0]))
+}

--- a/business/checkers/k8sreferencegrants_checker.go
+++ b/business/checkers/k8sreferencegrants_checker.go
@@ -1,0 +1,55 @@
+package checkers
+
+import (
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kiali/kiali/business/checkers/k8sreferencegrants"
+	"github.com/kiali/kiali/models"
+)
+
+const K8sReferenceGrantCheckerType = "k8sreferencegrant"
+
+type K8sReferenceGrantChecker struct {
+	Cluster            string
+	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant
+	Namespaces         models.Namespaces
+}
+
+// Check runs checks for the all namespaces actions as well as for the single namespace validations
+func (in K8sReferenceGrantChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	validations = validations.MergeValidations(in.runIndividualChecks())
+
+	return validations
+}
+
+// Runs individual checks for each Reference Grant
+func (in K8sReferenceGrantChecker) runIndividualChecks() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	for _, rt := range in.K8sReferenceGrants {
+		validations.MergeValidations(in.runChecks(rt))
+	}
+
+	return validations
+}
+
+func (in K8sReferenceGrantChecker) runChecks(rg *k8s_networking_v1beta1.ReferenceGrant) models.IstioValidations {
+	key, validations := EmptyValidValidation(rg.Name, rg.Namespace, K8sReferenceGrantCheckerType, in.Cluster)
+
+	enabledCheckers := []Checker{
+		k8sreferencegrants.NamespaceChecker{
+			Namespaces:     in.Namespaces,
+			ReferenceGrant: *rg,
+		},
+	}
+
+	for _, checker := range enabledCheckers {
+		checks, validChecker := checker.Check()
+		validations.Checks = append(validations.Checks, checks...)
+		validations.Valid = validations.Valid && validChecker
+	}
+
+	return models.IstioValidations{key: validations}
+}

--- a/business/checkers/k8sreferencegrants_checker_test.go
+++ b/business/checkers/k8sreferencegrants_checker_test.go
@@ -1,0 +1,49 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestNoCrashOnEmptyGrant(t *testing.T) {
+	assert := assert.New(t)
+
+	typeValidations := K8sReferenceGrantChecker{
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{},
+		Namespaces:         models.Namespaces{},
+	}.Check()
+
+	assert.Empty(typeValidations)
+}
+
+func TestMissingFromNamespace(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	vals := K8sReferenceGrantChecker{
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{
+			data.CreateReferenceGrant("grant1", "bookinfo", "bookinfo3"),
+			data.CreateReferenceGrant("grant2", "bookinfo3", "default")},
+		Namespaces: models.Namespaces{
+			models.Namespace{Name: "bookinfo"},
+			models.Namespace{Name: "bookinfo2"},
+		},
+	}.Check()
+
+	assert.NotEmpty(vals)
+
+	grant1 := vals[models.IstioValidationKey{ObjectType: "k8sreferencegrant", Namespace: "bookinfo", Name: "grant1"}]
+	assert.False(grant1.Valid)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sreferencegrants.from.namespacenotfound", grant1.Checks[0]))
+	grant2 := vals[models.IstioValidationKey{ObjectType: "k8sreferencegrant", Namespace: "bookinfo3", Name: "grant2"}]
+	assert.False(grant2.Valid)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sreferencegrants.from.namespacenotfound", grant2.Checks[0]))
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -142,9 +142,10 @@ func (in *IstioValidationsService) getAllObjectCheckers(istioConfigList models.I
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadsPerNamespace: workloadsPerNamespace, Cluster: cluster},
 		checkers.WorkloadChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, WorkloadsPerNamespace: workloadsPerNamespace, Cluster: cluster},
 		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses()},
+		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
+		checkers.K8sReferenceGrantChecker{K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Cluster: cluster},
 		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
 		checkers.TelemetryChecker{Telemetries: istioConfigList.Telemetries, Namespaces: namespaces},
-		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
 	}
 }
 
@@ -265,7 +266,9 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		objectCheckers = []ObjectChecker{noServiceChecker, httpRouteChecker}
 		referenceChecker = references.K8sHTTPRouteReferences{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: namespaces, K8sReferenceGrants: istioConfigList.K8sReferenceGrants}
 	case kubernetes.K8sReferenceGrants:
-		// TODO
+		objectCheckers = []ObjectChecker{
+			checkers.K8sReferenceGrantChecker{K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces},
+		}
 	default:
 		err = fmt.Errorf("object type not found: %v", objectType)
 	}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -221,6 +221,31 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "No matching workload found for the selector in this namespace",
 		Severity: WarningSeverity,
 	},
+	"k8sgateways.gatewayclassnotfound": {
+		Code:     "KIA1504",
+		Message:  "Gateway API Class not found in Kiali configuration",
+		Severity: ErrorSeverity,
+	},
+	"k8sgateways.multimatch.listener": {
+		Code:     "KIA1501",
+		Message:  "More than one K8s Gateway for the same host port combination",
+		Severity: WarningSeverity,
+	},
+	"k8sgateways.multimatch.ip": {
+		Code:     "KIA1502",
+		Message:  "More than one K8s Gateway for the same address and type combination",
+		Severity: WarningSeverity,
+	},
+	"k8sgateways.unique.listener": {
+		Code:     "KIA1503",
+		Message:  "Each listener must have a unique combination of Hostname, Port, and Protocol",
+		Severity: ErrorSeverity,
+	},
+	"k8sreferencegrants.from.namespacenotfound": {
+		Code:     "KIA1601",
+		Message:  "Namespace is not found or is not accessible",
+		Severity: ErrorSeverity,
+	},
 	"k8shttproutes.nohost.namenotfound": {
 		Code:     "KIA1402",
 		Message:  "BackendRef on rule doesn't have a valid service (Service name not found)",
@@ -325,26 +350,6 @@ var checkDescriptors = map[string]IstioCheck{
 		Code:     "KIA1301",
 		Message:  "This workload is not covered by any authorization policy",
 		Severity: WarningSeverity,
-	},
-	"k8sgateways.gatewayclassnotfound": {
-		Code:     "KIA1504",
-		Message:  "Gateway API Class not found in Kiali configuration",
-		Severity: ErrorSeverity,
-	},
-	"k8sgateways.multimatch.listener": {
-		Code:     "KIA1501",
-		Message:  "More than one K8s Gateway for the same host port combination",
-		Severity: WarningSeverity,
-	},
-	"k8sgateways.multimatch.ip": {
-		Code:     "KIA1502",
-		Message:  "More than one K8s Gateway for the same address and type combination",
-		Severity: WarningSeverity,
-	},
-	"k8sgateways.unique.listener": {
-		Code:     "KIA1503",
-		Message:  "Each listener must have a unique combination of Hostname, Port, and Protocol",
-		Severity: ErrorSeverity,
 	},
 }
 

--- a/tests/integration/assets/bookinfo-k8sreferencegrants-from-namespaces.yaml
+++ b/tests/integration/assets/bookinfo-k8sreferencegrants-from-namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: referencegrantfromns
+  namespace: bookinfo
+spec:
+  from:
+    - group: "gateway.networking.k8s.io"
+      kind: HTTPRoute
+      namespace: wrong
+  to:
+    - group: ""
+      kind: Secret


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6918

An Error severity message is added for "Spec.From.Namespace" field of "K8sReferenceGrant" object checking if namespace exists: "KIA1601 Namespace is not found or is not accessible"

![Screenshot from 2024-01-08 11-12-03](https://github.com/kiali/kiali/assets/604313/20cc488e-e586-497f-91a6-3521ec408201)
