### PR TITLE
Remove accessible field and rename inaccessible_clusters

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -307,10 +307,13 @@ func (in *MeshService) GetClusters() ([]kubernetes.Cluster, error) {
 	}
 
 	// Add clusters from config.
-	for _, cluster := range in.conf.Clustering.InaccessibleClusters {
+	for _, cluster := range in.conf.Clustering.Clusters {
 		if _, found := clustersByName[cluster.Name]; !found {
 			clustersByName[cluster.Name] = kubernetes.Cluster{
 				Name: cluster.Name,
+				// Clusters without a SecretName are not accessible
+				// because we don't have a kubeconfig for them.
+				Accessible: cluster.SecretName != "",
 			}
 		}
 	}

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -1120,7 +1120,7 @@ func TestGetClustersShowsConfiguredKialiInstances(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	conf := config.NewConfig()
-	conf.Clustering.InaccessibleClusters = []config.Cluster{{
+	conf.Clustering.Clusters = []config.Cluster{{
 		Name: "west",
 	}}
 	conf.Clustering.KialiURLs = []config.KialiURL{{

--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,7 @@ type Cluster struct {
 	Name string `yaml:"name,omitempty"`
 
 	// SecretName is the name of the secret that contains the credentials necessary to connect to the remote cluster.
-	// This secret must exist in the Kiali deployment namespace. If not secret name is provided, then it's
+	// This secret must exist in the Kiali deployment namespace. If no secret name is provided, then it's
 	// assumed that this cluster is inaccessible.
 	SecretName string `yaml:"secret_name,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,11 @@ var overrideSecretsDir = "/kiali-override-secrets"
 type Cluster struct {
 	// Name of the cluster. Must be unique and match what is in telemetry.
 	Name string `yaml:"name,omitempty"`
+
+	// SecretName is the name of the secret that contains the credentials necessary to connect to the remote cluster.
+	// This secret must exist in the Kiali deployment namespace. If not secret name is provided, then it's
+	// assumed that this cluster is inaccessible.
+	SecretName string `yaml:"secret_name,omitempty"`
 }
 
 // Metrics provides metrics configuration for the Kiali server.
@@ -507,9 +512,11 @@ type CertificatesInformationIndicators struct {
 
 // Clustering defines configuration around multi-cluster functionality.
 type Clustering struct {
-	// InaccessibleClusters represents clusters that are part of the mesh but that Kiali may not have access to.
-	InaccessibleClusters []Cluster  `yaml:"inaccessible_clusters,omitempty" json:"inaccessible_clusters,omitempty"`
-	KialiURLs            []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
+	// Clusters is a list of clusters that cannot be autodetected by the Kiali Server.
+	// Remote clusters are specified here if ‘autodetect_secrets.enabled’ is false or
+	// if the Kiali Server does not have access to the remote cluster’s secret.
+	Clusters  []Cluster  `yaml:"clusters,omitempty" json:"clusters,omitempty"`
+	KialiURLs []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
 }
 
 type FeatureFlagClustering struct {
@@ -1040,8 +1047,8 @@ func Unmarshal(yamlString string) (conf *Config, err error) {
 
 	// Copy over feature flags that have been upgraded to the new format.
 	// TODO: Remove when we no longer support the old format.
-	if conf.Clustering.InaccessibleClusters == nil && conf.KialiFeatureFlags.Clustering.InaccessibleClusters != nil {
-		conf.Clustering.InaccessibleClusters = conf.KialiFeatureFlags.Clustering.InaccessibleClusters
+	if conf.Clustering.Clusters == nil && conf.KialiFeatureFlags.Clustering.Clusters != nil {
+		conf.Clustering.Clusters = conf.KialiFeatureFlags.Clustering.Clusters
 	}
 
 	if conf.Clustering.KialiURLs == nil && conf.KialiFeatureFlags.Clustering.KialiURLs != nil {

--- a/tests/integration/tests/clusters_test.go
+++ b/tests/integration/tests/clusters_test.go
@@ -31,7 +31,7 @@ func TestRemoteKialiShownInClustersResponse(t *testing.T) {
 	require.NoError(err)
 	originalConf := *conf
 
-	conf.Clustering.InaccessibleClusters = []config.Cluster{{Name: "inaccessible"}}
+	conf.Clustering.Clusters = []config.Cluster{{Name: "inaccessible"}}
 	conf.Clustering.KialiURLs = []config.KialiURL{{ClusterName: "inaccessible", URL: "http://inaccessible:20001", InstanceName: "kiali", Namespace: "istio-system"}}
 
 	t.Cleanup(func() {


### PR DESCRIPTION
** Describe the change **

Removes the `inaccessible_clusters` field in favor of the existing `clusters` field. `clusters` is already used by the operator and there's no need to have both `clusters` and `inaccessible_clusters`. Also removes the `accessible` field from the `cluster` object. Instead specifying a cluster without a secret name will automatically mark the cluster as inaccessible.

To test:

1. Create two clusters. You can use: `hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`.
2. Deploy kiali on both clusters including the "west" cluster. `./hack/istio/multicluster/deploy-kiali.sh --single-kiali false --cluster1-context kind-east --cluster2-context kind-west --kiali-auth-strategy anonymous --manage-kind true --kiali-use-dev-image true`
3. Add the "east" cluster to the "west" kiali config by editing the "west" kiali configmap (`kubectl --context kind-west edit cm kiali -n istio-system`):
    ```
    clustering:
      clusters:
        - name: east
      kiali_urls:
        - cluster_name: east
          url: http://<kiali_url>/kiali
          instance_name: kiali
          namespace: istio-system
    ```
4. Restart the west kiali: `kubectl --context kind-west delete pod -n istio-system -l app=kiali`
5. Navigate to the west kiali's "mesh" page (you can port-forward to it via `hack/kiali-port-forward.sh -kc kind-west`).
  You should see two kiali instances on the mesh page and a link to the "east" kiali:
![Screenshot from 2023-12-20 13-31-19](https://github.com/kiali/kiali/assets/6226732/e3dc7efe-667e-4700-8ace-a056e69100e0)
  You should _not_ see a cluster column on any of the app/service/istio/workload pages for the "west" kiali.

** Issue reference **

Relates to #6243