### PR TITLE
[e2e] - Implement the rest of the multi-cluster details pages 

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -4,7 +4,7 @@
   pages since these are all similar.
 */
 
-import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Step, Then, When, Given } from '@badeball/cypress-cucumber-preprocessor';
 import {
   checkHealthIndicatorInTable,
   checkHealthStatusInTable,
@@ -185,3 +185,90 @@ Then('user should see no duplicate namespaces', () => {
 
   cy.get('[data-test="namespace-dropdown"]').siblings().contains('bookinfo').should('be.visible').and('have.length', 1);
 });
+
+// And user clicks on the "reviews" <type> from the "west" cluster visible in the graph
+Given(
+  'the {string} {string} from the {string} cluster is visible in the minigraph',
+  (name: string, type: string, cluster: string) => {
+    Step(this, 'user sees a minigraph');
+    cy.waitForReact();
+    cy.getReact('CytoscapeGraph')
+      .should('have.length', '1')
+      .then($graph => {
+        cy.wrap($graph)
+          .getProps()
+          .then(props => {
+            const graphType = props.graphData.fetchParams.graphType;
+            const { nodeType, isBox } = nodeInfo(type, graphType);
+            cy.wrap($graph)
+              .getCurrentState()
+              .then(state => {
+                cy.wrap(
+                  state.cy
+                    .nodes()
+                    .some(
+                      node =>
+                        node.data('nodeType') === nodeType &&
+                        node.data('namespace') === 'bookinfo' &&
+                        node.data(type) === name &&
+                        node.data('cluster') === cluster &&
+                        node.data('isBox') === isBox
+                    )
+                ).should('be.true');
+              });
+          });
+      });
+  }
+);
+
+// node type and box type varies based on the graph so this is a helper function to get the right values.
+const nodeInfo = (nodeType: string, graphType: string): { isBox?: string; nodeType: string } => {
+  let isBox: string | undefined;
+  if (nodeType === 'app') {
+    // Apps are boxes in versioned app graph...
+    nodeType = 'box';
+    isBox = 'app';
+  } else if (nodeType === 'workload' && graphType === 'versionedApp') {
+    // Workloads are apps in versioned app graph...
+    nodeType = 'app';
+  }
+
+  return {
+    nodeType,
+    isBox
+  };
+};
+
+When(
+  'user clicks on the {string} {string} from the {string} cluster in the graph',
+  (name: string, type: string, cluster: string) => {
+    cy.waitForReact();
+    cy.getReact('CytoscapeGraph')
+      .should('have.length', '1')
+      .then($graph => {
+        cy.wrap($graph)
+          .getProps()
+          .then(props => {
+            const graphType = props.graphData.fetchParams.graphType;
+            cy.wrap($graph)
+              .getCurrentState()
+              .then(state => {
+                const node = state.cy
+                  .nodes()
+                  .toArray()
+                  .find(node => {
+                    const { nodeType, isBox } = nodeInfo(type, graphType);
+                    return (
+                      node.data('nodeType') === nodeType &&
+                      node.data('namespace') === 'bookinfo' &&
+                      node.data(type) === name &&
+                      node.data('cluster') === cluster &&
+                      node.data('isBox') === isBox
+                    );
+                  });
+                node.emit('tap');
+              });
+          });
+      });
+  }
+);

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -37,32 +37,49 @@ Given(
     const namespaceAndName = namespacedNamed.split('/');
     const namespace = namespaceAndName[0];
     const name = namespaceAndName[1];
+    const pageDetail = getPageDetail(detail);
 
-    let pageDetail: string;
-
-    switch (detail) {
-      case detailType.App:
-        pageDetail = 'applications';
-        break;
-      case detailType.Service:
-        pageDetail = 'services';
-
-        cy.intercept({
-          pathname: '**/api/namespaces/bookinfo/services/productpage',
-          query: {
-            objects: ''
-          }
-        }).as('waitForCall');
-
-        break;
-      case detailType.Workload:
-        pageDetail = 'workloads';
-        break;
+    if (pageDetail === 'services') {
+      cy.intercept({
+        pathname: '**/api/namespaces/bookinfo/services/productpage',
+        query: {
+          objects: ''
+        }
+      }).as('waitForCall');
     }
 
     cy.visit(`${Cypress.config('baseUrl')}/console/namespaces/${namespace}/${pageDetail}/${name}?refresh=0${cluster}`);
-
     ensureKialiFinishedLoading();
+  }
+);
+
+const getPageDetail = (detail: detailType): string => {
+  let pageDetail: string;
+  switch (detail) {
+    case detailType.App:
+      pageDetail = 'applications';
+      break;
+    case detailType.Service:
+      pageDetail = 'services';
+      break;
+    case detailType.Workload:
+      pageDetail = 'workloads';
+      break;
+  }
+  return pageDetail;
+};
+
+// Then the browser is at the details page for the "<type>" "bookinfo/<name>" located in the "west" cluster
+Given(
+  'the browser is at the details page for the {string} {string} located in the {string} cluster',
+  (detail: detailType, namespacedName: string, cluster: string) => {
+    const namespaceAndName = namespacedName.split('/');
+    const namespace = namespaceAndName[0];
+    const name = namespaceAndName[1];
+    const pageDetail = getPageDetail(detail);
+
+    cy.url().should('include', `/namespaces/${namespace}/${pageDetail}/${name}`);
+    cy.url().should('include', `clusterName=${cluster}`);
   }
 );
 

--- a/frontend/cypress/integration/featureFiles/app_details_multicluster_graph.feature
+++ b/frontend/cypress/integration/featureFiles/app_details_multicluster_graph.feature
@@ -1,7 +1,6 @@
 @app-details-multi-cluster
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 @multi-cluster
-@skip
 Feature: Kiali App Details page minigraph in multicluster setup
 
   Some App Details minigraph tests, which required a different setup. 
@@ -16,19 +15,21 @@ Feature: Kiali App Details page minigraph in multicluster setup
     Then user does not see a minigraph
 
   Scenario Outline: User should be able to navigate through the graph to remotely located apps, services and workloads
-    When user is at the details page for the "app" "bookinfo/productpage" located in the "east" cluster
-    And user clicks on the "reviews" <type> from the "west" cluster visible in the graph
-    Then user is at the details page for the <type> <url> located in the "west" cluster
+    Given user is at the details page for the "app" "bookinfo/productpage" located in the "east" cluster
+    And the "<name>" "<type>" from the "west" cluster is visible in the minigraph
+    When user clicks on the "<name>" "<type>" from the "west" cluster in the graph
+    Then the browser is at the details page for the "<type>" "bookinfo/<name>" located in the "west" cluster
 
     Examples:
-      | <type>   | <url>               |
-      | app      | bookinfo/reviews    |
-      | service  | bookinfo/reviews    |
-      | workload | bookinfo/reviews-v3 |
+      | type     | name       |
+      | app      | reviews    |
+      | service  | reviews    |
+      | workload | reviews-v3 |
 
   #this is a regression to this bug (https://github.com/kiali/kiali/issues/6185)
   #I used the sleep namespace in the Gherkin, because I feel like we might need a new demoapp for this scenario,
   #if we don't want to change access to bookinfo namespace in the middle of the test run.
+  @skip
   Scenario: Remote nodes should be restricted if user does not have access rights to a remote namespace
     When user "is" given access rights to a "sleep" namespace located in the "east" cluster  
     And user "is not" given access rights to a "sleep" namespace located in the "west" cluster  

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster_graph.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster_graph.feature
@@ -2,7 +2,6 @@
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 @multi-cluster
-@skip
 Feature: Kiali Workloads Details minigraph in multicluster setup
 
   Scenario: Minigraph should not be visible for a service, which is not deployed in specific cluster.
@@ -10,18 +9,21 @@ Feature: Kiali Workloads Details minigraph in multicluster setup
     Then user does not see a minigraph
 
   Scenario Outline: User should be able to navigate through the graph to remote workloads and services.
-    When user is at the details page for the "app" "bookinfo/productpage" located in the "east" cluster
-    And user clicks on the "reviews" <type> from the "west" cluster visible in the graph
-    Then user is at the details page for the <type> <url> located in the "west" cluster
+    Given user is at the details page for the "workload" "bookinfo/productpage-v1" located in the "east" cluster
+    And the "<name>" "<type>" from the "west" cluster is visible in the minigraph
+    When user clicks on the "<name>" "<type>" from the "west" cluster in the graph
+    Then the browser is at the details page for the "<type>" "bookinfo/<name>" located in the "west" cluster
 
     Examples:
-      | <type>   | <url>               |
-      | service  | bookinfo/reviews    |
-      | workload | bookinfo/reviews-v3 |
+      | type     | name       |
+      | service  | reviews    |
+      | workload | reviews-v3 |
 
   #this is a regression to this bug (https://github.com/kiali/kiali/issues/6185)
   #I used the sleep namespace in the Gherkin, because I feel like we might need a new demoapp for this scenario,
   #if we don't want to change access to bookinfo namespace in the middle of the test run.
+  #TODO: Implement
+  @skip
   Scenario: Remote nodes should be restricted if user does not have access rights to a remote namespace
     When user "is" given access rights to a "sleep" namespace located in the "east" cluster  
     And user "is not" given access rights to a "sleep" namespace located in the "west" cluster  


### PR DESCRIPTION
** Describe the change **

Implements the rest of the multi-cluster detail page definitions for multi-cluster. There's one scenario that is skipped since that will require much more work outside cypress to get working properly. Created this issue is a followup for that one: https://github.com/kiali/kiali/issues/7021.

** Issue reference **

Fixes #6475 