### PR TITLE
use built-in SA token refresh functionality within client-go

### DIFF
--- a/business/authentication/header_auth_controller.go
+++ b/business/authentication/header_auth_controller.go
@@ -72,7 +72,7 @@ func (c headerAuthController) Authenticate(r *http.Request, w http.ResponseWrite
 		}
 	}
 
-	kialiToken, err := kubernetes.GetKialiTokenForHomeCluster()
+	kialiToken, _, err := kubernetes.GetKialiTokenForHomeCluster()
 	if err != nil {
 		return nil, err
 	}

--- a/business/authentication/openid_auth_controller.go
+++ b/business/authentication/openid_auth_controller.go
@@ -247,7 +247,7 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 		// If RBAC is off, it's assumed that the kubernetes cluster will reject the OpenId token.
 		// Instead, we use the Kiali token and this has the side effect that all users will share the
 		// same privileges.
-		token, err = kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err = kubernetes.GetKialiTokenForHomeCluster()
 		if err != nil {
 			return nil, fmt.Errorf("error reading the Kiali ServiceAccount token: %w", err)
 		}

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/dashboards"
 	"github.com/kiali/kiali/log"
@@ -129,7 +127,7 @@ func (in *DashboardsService) resolveReferences(dashboard *dashboards.MonitoringD
 }
 
 // GetDashboard returns a dashboard filled-in with target data
-func (in *DashboardsService) GetDashboard(authInfo *api.AuthInfo, params models.DashboardQuery, template string) (*models.MonitoringDashboard, error) {
+func (in *DashboardsService) GetDashboard(params models.DashboardQuery, template string) (*models.MonitoringDashboard, error) {
 	promClient, err := in.prom()
 	if err != nil {
 		return nil, err

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/dashboards"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	pmock "github.com/kiali/kiali/prometheus/prometheustest"
@@ -57,7 +57,7 @@ func TestGetDashboard(t *testing.T) {
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	SetWithBackends(mockClientFactory, nil)
 
-	dashboard, err := service.GetDashboard(&api.AuthInfo{Token: ""}, query, "dashboard1")
+	dashboard, err := service.GetDashboard(query, "dashboard1")
 
 	assert.Nil(err)
 	assert.Equal("Dashboard 1", dashboard.Title)
@@ -76,6 +76,9 @@ func TestGetDashboard(t *testing.T) {
 func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	assert := assert.New(t)
 
+	// allows GetDashboard to get the SA client under the covers
+	kubernetes.NewTestingClientFactory(t)
+
 	// Setup mocks
 	service, prom := setupService("my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
 
@@ -93,7 +96,7 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	prom.MockMetric("my_metric_1_1", expectedLabels, &query.RangeQuery, 10)
 	prom.MockHistogram("my_metric_1_2", expectedLabels, &query.RangeQuery, 11, 12)
 
-	dashboard, err := service.GetDashboard(&api.AuthInfo{Token: ""}, query, "dashboard1")
+	dashboard, err := service.GetDashboard(query, "dashboard1")
 
 	assert.Nil(err)
 	assert.Equal("Dashboard 1", dashboard.Title)

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -270,7 +270,7 @@ func getAddonStatus(name string, enabled bool, isCore bool, auth *config.Auth, u
 	}
 
 	if auth.UseKialiToken {
-		token, err := kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err := kubernetes.GetKialiTokenForHomeCluster()
 		if err != nil {
 			log.Errorf("Could not read the Kiali Service Account token: %v", err)
 		}

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -35,7 +35,7 @@ type sessionInfo struct {
 
 func NewAuthenticationHandler() (AuthenticationHandler, error) {
 	// Read token from the filesystem
-	saToken, err := kubernetes.GetKialiTokenForHomeCluster()
+	saToken, _, err := kubernetes.GetKialiTokenForHomeCluster()
 	if err != nil {
 		return AuthenticationHandler{}, err
 	}
@@ -62,7 +62,7 @@ func (aHandler AuthenticationHandler) Handle(next http.Handler) http.Handler {
 			}
 		case config.AuthStrategyAnonymous:
 			log.Tracef("Access to the server endpoint is not secured with credentials - letting request come in. Url: [%s]", r.URL.String())
-			token, err := kubernetes.GetKialiTokenForHomeCluster()
+			token, _, err := kubernetes.GetKialiTokenForHomeCluster()
 			if err != nil {
 				token = ""
 			}
@@ -133,7 +133,7 @@ func AuthenticationInfo(w http.ResponseWriter, r *http.Request) {
 
 	switch conf.Auth.Strategy {
 	case config.AuthStrategyOpenshift:
-		token, err := kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err := kubernetes.GetKialiTokenForHomeCluster()
 		if err != nil {
 			RespondWithDetailedError(w, http.StatusInternalServerError, "Error obtaining Kiali SA token", err.Error())
 			return

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -252,6 +252,7 @@ func (r *rejectClient) GetProjects(labelSelector string) ([]osproject_v1.Project
 
 func mockK8s(t *testing.T, reject bool) {
 	kubernetes.KialiTokenForHomeCluster = "notrealtoken"
+	kubernetes.KialiTokenFileForHomeCluster = "notrealtokenpath"
 	k8s := kubetest.NewFakeK8sClient(&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}})
 	k8s.OpenShift = true
 	var kubeClient kubernetes.ClientInterface = k8s

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -20,12 +20,6 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 	namespace := pathParams["namespace"]
 	dashboardName := pathParams["dashboard"]
 
-	authInfo, err := getAuthInfo(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
 	layer, err := getBusiness(r)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -65,7 +59,7 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dashboard, err := svc.GetDashboard(authInfo, params, dashboardName)
+	dashboard, err := svc.GetDashboard(params, dashboardName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			RespondWithError(w, http.StatusNotFound, err.Error())

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -1,9 +1,7 @@
 package cache
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -14,57 +12,6 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
-
-// Need to lock the client when we go to check the value of the token
-// but only the tests need this functionality so we can use a fake
-// that has access to the kubeCache's lock and has a getClient() method
-// that returns the client after locking. Without this, the tests will
-// fail with the race detector enabled.
-type fakeKubeCache struct {
-	*kubeCache
-}
-
-func (f *fakeKubeCache) getClient() kubernetes.ClientInterface {
-	f.kubeCache.cacheLock.RLock()
-	defer f.kubeCache.cacheLock.RUnlock()
-	return f.kubeCache.client
-}
-
-func TestClientUpdatedWhenSAClientChanges(t *testing.T) {
-	require := require.New(t)
-	conf := config.NewConfig()
-	config.Set(conf)
-
-	client := kubetest.NewFakeK8sClient()
-	client.Token = "current-token"
-	clientFactory := kubetest.NewK8SClientFactoryMock(client)
-	k8sCache, err := NewKubeCache(client, *conf)
-	require.NoError(err)
-
-	kubeCache := &fakeKubeCache{kubeCache: k8sCache}
-	kialiCache := &kialiCacheImpl{
-		clientRefreshPollingPeriod: time.Millisecond,
-		clientFactory:              clientFactory,
-		KubeCache:                  kubeCache,
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	kialiCache.watchForClientChanges(ctx, client.Token)
-
-	// Update the client. This should trigger a cache refresh.
-	newClient := kubetest.NewFakeK8sClient()
-	newClient.Token = "new-token"
-	clientFactory.SetClients(map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: newClient})
-
-	require.Eventually(
-		func() bool { return kubeCache.getClient() != client },
-		500*time.Millisecond,
-		5*time.Millisecond,
-		"client and cache should have been updated",
-	)
-}
 
 func TestNoHomeClusterReturnsError(t *testing.T) {
 	require := require.New(t)

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -62,11 +62,6 @@ type KubeCache interface {
 	// using the Kiali Service Account client.
 	Client() kubernetes.ClientInterface
 
-	// UpdateClient will update the client used by the cache.
-	// Useful for when the token is refreshed for the client.
-	// This causes a full refresh of the cache.
-	UpdateClient(client kubernetes.ClientInterface) error
-
 	GetConfigMap(namespace, name string) (*core_v1.ConfigMap, error)
 	GetDaemonSets(namespace string) ([]apps_v1.DaemonSet, error)
 	GetDaemonSet(namespace, name string) (*apps_v1.DaemonSet, error)

--- a/kubernetes/cluster_secret.go
+++ b/kubernetes/cluster_secret.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -137,40 +136,6 @@ func getClusterName(config *api.Config) string {
 		break
 	}
 	return clusterName
-}
-
-// reloadRemoteClusterInfoFromFile will re-read the remote cluster secret from the file system and if the data is different
-// than the given RemoteClusterInfo, a new one is returned. Otherwise, nil is returned to indicate nothing has changed and
-// the given RemoteClusterInfo is already up to date.
-func reloadRemoteClusterInfoFromFile(rci RemoteClusterInfo) (*RemoteClusterInfo, error) {
-	newRci, err := newRemoteClusterInfo(rci.SecretName, rci.SecretFile)
-	if err != nil {
-		kubeConfig, cfgErr := rci.Config.RawConfig()
-		if cfgErr == nil {
-			return nil, fmt.Errorf("Failed to process data for remote cluster [%s] secret file [%s]", getClusterName(&kubeConfig), rci.SecretFile)
-		}
-		return nil, fmt.Errorf("failed to process data for remote cluster secret file [%s]", rci.SecretFile)
-	}
-
-	// Compare the byte representation of the two
-	o, _ := rci.Config.RawConfig()
-	old, err := clientcmd.Write(o)
-	if err != nil {
-		return nil, fmt.Errorf("unable to marshal old config. Err: %s", err)
-	}
-
-	n, _ := newRci.Config.RawConfig()
-	new, err := clientcmd.Write(n)
-	if err != nil {
-		return nil, fmt.Errorf("unable to marshal old config. Err: %s", err)
-	}
-
-	if !bytes.Equal(old, new) {
-		return &newRci, nil
-	}
-
-	// the information did not change - return nil to indicate the original one passed to this funcation is already up to date
-	return nil, nil
 }
 
 // TODO: These types probably belong in the business package but since the biz package imports

--- a/kubernetes/cluster_secret_test.go
+++ b/kubernetes/cluster_secret_test.go
@@ -4,20 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kiali/kiali/config"
 )
 
 func TestReloadRemoteClusterSecret(t *testing.T) {
 	check := assert.New(t)
-	require := require.New(t)
 	conf := config.NewConfig()
 
 	const testClusterName = "TestRemoteCluster"
 
-	remoteSecretFilename := createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
+	createTestRemoteClusterSecret(t, testClusterName, remoteClusterYAML)
 
 	clientFactory := NewTestingClientFactory(t)
 
@@ -29,26 +26,18 @@ func TestReloadRemoteClusterSecret(t *testing.T) {
 	check.Contains(clusterNames, conf.KubernetesConfig.ClusterName)
 	check.Contains(clusterNames, testClusterName)
 
-	testRCI := clientFactory.remoteClusterInfos[testClusterName]
-	reloadedObj, err := reloadRemoteClusterInfoFromFile(testRCI)
-	require.Nil(err)
-	require.Nil(reloadedObj, "Nothing changed with the secret - the reload func should have returned nil")
+	rcis, err := GetRemoteClusterInfos()
+	check.Nil(err)
 
-	// change the token and ensure the reload method knows it changed - this is the trigger that will cause clients to be refreshed
-	// Load then change the token and then marshal it back to string and then write it back to the file
-	kubeConfig, err := clientcmd.Load([]byte(remoteClusterYAML))
-	require.NoError(err)
+	// test the home cluster config
+	restConfig := clientFactory.GetSAClient(conf.KubernetesConfig.ClusterName).ClusterInfo().ClientConfig
+	check.Equal(KialiTokenFileForHomeCluster, restConfig.BearerTokenFile, "BearerTokenFile should always be set to the home cluster SA token file")
+	check.Equal(KialiTokenForHomeCluster, restConfig.BearerToken, "BearerToken should be set for home cluster")
 
-	kubeConfig.AuthInfos["remoteuser1"].Token = "CHANGED TOKEN"
-	err = clientcmd.WriteToFile(*kubeConfig, remoteSecretFilename)
-	require.NoError(err)
-
-	reloadedObj, err = reloadRemoteClusterInfoFromFile(testRCI)
-	require.Nil(err)
-	require.NotNil(reloadedObj, "The token changed - the reload func should have returned a new object")
-
-	updatedKubeConfig, err := reloadedObj.Config.RawConfig()
-	require.NoError(err)
-	check.Equal(updatedKubeConfig.AuthInfos["remoteuser1"].Token, "CHANGED TOKEN")
-	check.Equal("CHANGED TOKEN", clientFactory.GetSAClient(testClusterName).GetToken())
+	// test the remote cluster config
+	testRCI := rcis[testClusterName]
+	restConfig, err = clientFactory.getConfig(&testRCI)
+	check.Nil(err)
+	check.Equal("", restConfig.BearerTokenFile, "BearerTokenFile is never set")
+	check.Equal("token", restConfig.BearerToken, "BearerToken should be set to the value in the remote cluster yaml")
 }

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -95,7 +95,7 @@ func NewK8SClientMock() *K8SClientMock {
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("IsGatewayAPI").Return(false)
 	k8s.On("IsIstioAPI").Return(true)
-	k8s.On("GetKialiTokenForHomeCluster").Return("")
+	k8s.On("GetKialiTokenForHomeCluster").Return("", "")
 	return k8s
 }
 

--- a/kubernetes/testdata/sa-token.yaml
+++ b/kubernetes/testdata/sa-token.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:1234
+  name: SATestToken
+contexts: 
+- context:
+    cluster: SATestToken
+    user: sa
+  name: SATestToken
+current-context: "SATestToken"
+kind: Config
+preferences: {}
+users:
+- name: sa
+  user:
+    token: test-token

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -27,7 +27,7 @@ func TestIsTokenExpired(t *testing.T) {
 	DefaultServiceAccountPath = tmpFileTokenExpired
 
 	setupFile(t, "thisisarandomtoken", tmpFileTokenExpired)
-	token, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster()
 	require.NoError(err)
 
 	assert.True(token != "")
@@ -47,7 +47,7 @@ func TestGetKialiToken(t *testing.T) {
 
 	setupFile(t, data, tmpFileGetToken)
 
-	token, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster()
 	require.NoError(err)
 
 	assert.Equal(data, token)
@@ -61,7 +61,7 @@ func TestGetKialiTokenRemoteCluster(t *testing.T) {
 	SetConfig(t, *config)
 	tokenRead = time.Time{}
 
-	token, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster()
 	require.NoError(err)
 
 	require.Equal("token2", token)

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -82,7 +82,7 @@ func NewClientForConfig(cfg config.PrometheusConfig) (*Client, error) {
 		// Note: if we are using the 'bearer' authentication method then we want to use the Kiali
 		// service account token and not the user's token. This is because Kiali does filtering based
 		// on the user's token and prevents people who shouldn't have access to particular metrics.
-		token, err := kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err := kubernetes.GetKialiTokenForHomeCluster()
 		if err != nil {
 			log.Errorf("Could not read the Kiali Service Account token: %v", err)
 			return nil, err

--- a/status/discover.go
+++ b/status/discover.go
@@ -4,8 +4,6 @@ import (
 	"net/url"
 	"strings"
 
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/kiali/kiali/appstate"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -15,11 +13,6 @@ import (
 var clientFactory kubernetes.ClientFactory
 
 func getClient() (kubernetes.ClientInterface, error) {
-	saToken, err := kubernetes.GetKialiTokenForHomeCluster()
-	if err != nil {
-		return nil, err
-	}
-
 	if clientFactory == nil {
 		userClientFactory, err := kubernetes.GetClientFactory()
 		if err != nil {
@@ -28,11 +21,7 @@ func getClient() (kubernetes.ClientInterface, error) {
 		clientFactory = userClientFactory
 	}
 
-	client, err := clientFactory.GetClient(&api.AuthInfo{Token: saToken})
-	if err != nil {
-		return nil, err
-	}
-
+	client := clientFactory.GetSAHomeClusterClient()
 	return client, nil
 }
 

--- a/status/versions.go
+++ b/status/versions.go
@@ -222,7 +222,7 @@ func prometheusVersion() (*ExternalServiceInfo, error) {
 	// Be sure to copy config.Auth and not modify the existing
 	auth := cfg.Auth
 	if auth.UseKialiToken {
-		token, err := kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err := kubernetes.GetKialiTokenForHomeCluster()
 		if err != nil {
 			log.Errorf("Could not read the Kiali Service Account token: %v", err)
 			return nil, err


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6924
