### PR TITLE
Hide application link for waypoint in graph

### DIFF
--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -60,6 +60,24 @@ const infoStyle = kialiStyle({
   marginLeft: '0.5rem'
 });
 
+export const renderWaypoint = (bgsize?: string): React.ReactNode => {
+  const badgeSize = bgsize === 'global' || bgsize === 'sm' ? bgsize : 'global';
+  return [
+    <>
+      <div key="waypoint-workloads-title">
+        <PFBadge badge={PFBadges.Waypoint} position={TooltipPosition.top} size={badgeSize} />
+        Waypoint proxy
+        <Tooltip
+          position={TooltipPosition.right}
+          content="This workload is identified as a waypoint proxy, as part of Istio Ambient"
+        >
+          <KialiIcon.Info className={infoStyle} />
+        </Tooltip>
+      </div>
+    </>
+  ];
+};
+
 const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
   const renderAppItem = (namespace: string, appName: string): React.ReactNode => {
     let href = `/namespaces/${namespace}/applications/${appName}`;
@@ -364,23 +382,6 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
           {serviceList}
         </ul>
       </div>
-    ];
-  };
-
-  const renderWaypoint = (): React.ReactNode => {
-    return [
-      <>
-        <div key="waypoint-workloads-title">
-          <PFBadge badge={PFBadges.Waypoint} position={TooltipPosition.top} />
-          Waypoint proxy
-          <Tooltip
-            position={TooltipPosition.right}
-            content="This workload is identified as a waypoint proxy, as part of Istio Ambient"
-          >
-            <KialiIcon.Info className={infoStyle} />
-          </Tooltip>
-        </div>
-      </>
     ];
   };
 

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -67,7 +67,7 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
   Template: { badge: 'T', tt: 'Template' } as PFBadgeType,
   Unknown: { badge: 'U', tt: 'Unknown' } as PFBadgeType,
   VirtualService: { badge: 'VS', tt: 'Virtual Service' } as PFBadgeType,
-  Waypoint: { badge: 'W', tt: 'Waypoint proxy' } as PFBadgeType,
+  Waypoint: { badge: 'WP', tt: 'Waypoint proxy' } as PFBadgeType,
   Workload: { badge: 'W', tt: 'Workload', style: { backgroundColor: PFColors.Blue500 } } as PFBadgeType,
   WorkloadEntry: { badge: 'WE', tt: 'Workload Entry' } as PFBadgeType,
   WorkloadGroup: { badge: 'WG', tt: 'Workload Group' } as PFBadgeType

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -48,8 +48,6 @@ const defaultState: SummaryPanelNodeState = {
   isActionOpen: false
 };
 
-const waypointPrefix = 'istio-waypoint';
-
 type ReduxProps = {
   kiosk: string;
   rankResult: RankResult;
@@ -226,7 +224,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
               )}
 
               {secondBadge}
-              {!this.isWaypoint(nodeData) && (
+              {!nodeData.isWaypoint && (
                 <div className={nodeInfoStyle}>
                   {renderBadgedLink(nodeData)}
                   {renderHealth(nodeData.health)}
@@ -249,10 +247,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       </div>
     );
   }
-
-  private isWaypoint = (nodeData: DecoratedGraphNodeData): boolean => {
-    return nodeData.app?.endsWith(waypointPrefix) ? true : false;
-  };
 
   private renderWorkloadSection = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     if (!nodeData.hasWorkloadEntry) {

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -129,7 +129,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     const shouldRenderDestsList = destsList && destsList.length > 0;
     const shouldRenderSvcList = servicesList && servicesList.length > 0;
     const shouldRenderService = service && ![NodeType.SERVICE, NodeType.UNKNOWN].includes(nodeType);
-    const shouldRenderApp = app && ![NodeType.APP, NodeType.UNKNOWN].includes(nodeType);
+    const shouldRenderApp = app && ![NodeType.APP, NodeType.UNKNOWN].includes(nodeType) && !nodeData.isWaypoint;
     const shouldRenderWorkload = workload && ![NodeType.WORKLOAD, NodeType.UNKNOWN].includes(nodeType);
     const shouldRenderTraces =
       !isServiceEntry &&

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -48,6 +48,8 @@ const defaultState: SummaryPanelNodeState = {
   isActionOpen: false
 };
 
+const waypointPrefix = 'istio-waypoint';
+
 type ReduxProps = {
   kiosk: string;
   rankResult: RankResult;
@@ -224,11 +226,12 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
               )}
 
               {secondBadge}
-
-              <div className={nodeInfoStyle}>
-                {renderBadgedLink(nodeData)}
-                {renderHealth(nodeData.health)}
-              </div>
+              {!this.isWaypoint(nodeData) && (
+                <div className={nodeInfoStyle}>
+                  {renderBadgedLink(nodeData)}
+                  {renderHealth(nodeData.health)}
+                </div>
+              )}
             </span>
           </div>
 
@@ -246,6 +249,10 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       </div>
     );
   }
+
+  private isWaypoint = (nodeData: DecoratedGraphNodeData): boolean => {
+    return nodeData.app?.endsWith(waypointPrefix) ? true : false;
+  };
 
   private renderWorkloadSection = (nodeData: DecoratedGraphNodeData): React.ReactNode => {
     if (!nodeData.hasWorkloadEntry) {

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -39,6 +39,7 @@ import { useKialiSelector } from '../../hooks/redux';
 import { groupMenuStyle, kebabToggleStyle } from 'styles/DropdownStyles';
 import { isMultiCluster, serverConfig } from '../../config';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from './SummaryPanelStyle';
+import { renderWaypoint } from '../../components/DetailDescription/DetailDescription';
 
 type SummaryPanelNodeState = {
   isActionOpen: boolean;
@@ -235,6 +236,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
 
           <div>
             {this.renderBadgeSummary(nodeData)}
+            {nodeData.isWaypoint && renderWaypoint('sm')}
             {shouldRenderDestsList && <div>{destsList}</div>}
             {shouldRenderSvcList && <div>{servicesList}</div>}
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -399,7 +399,6 @@ export interface GraphNodeData {
   isOutside?: boolean;
   isRoot?: boolean;
   isServiceEntry?: SEInfo;
-  // true if is an Ambient Istio waypoint
   isWaypoint?: boolean;
   labels?: { [key: string]: string };
   namespace: string;

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -474,6 +474,8 @@ export interface DecoratedGraphNodeData extends GraphNodeData {
   httpOut: number;
   // true if has istio namespace
   isIstio?: boolean;
+  // true if is an Ambient Istio waypoint
+  isWaypoint?: boolean;
   // assigned when node ranking is enabled. relative importance from most to least important [1..100]. Multiple nodes can have same rank.
   rank?: number;
   tcpIn: number;

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -399,6 +399,8 @@ export interface GraphNodeData {
   isOutside?: boolean;
   isRoot?: boolean;
   isServiceEntry?: SEInfo;
+  // true if is an Ambient Istio waypoint
+  isWaypoint?: boolean;
   labels?: { [key: string]: string };
   namespace: string;
   nodeType: NodeType;
@@ -474,8 +476,6 @@ export interface DecoratedGraphNodeData extends GraphNodeData {
   httpOut: number;
   // true if has istio namespace
   isIstio?: boolean;
-  // true if is an Ambient Istio waypoint
-  isWaypoint?: boolean;
   // assigned when node ranking is enabled. relative importance from most to least important [1..100]. Multiple nodes can have same rank.
   rank?: number;
   tcpIn: number;
@@ -590,6 +590,7 @@ export const NodeAttr = {
   isOutside: 'isOutside',
   isRoot: 'isRoot',
   isServiceEntry: 'isServiceEntry',
+  isWaypoint: 'isWaypoint',
   namespace: 'namespace',
   nodeType: 'nodeType',
   rank: 'rank',

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -121,6 +121,7 @@ type NodeData struct {
 	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
 	IsRoot                bool                `json:"isRoot,omitempty"`                // true | false
 	IsServiceEntry        *graph.SEInfo       `json:"isServiceEntry,omitempty"`        // set static service entry information
+	IsWaypoint            bool                `json:"isWaypoint,omitempty"`            // true | false
 }
 
 type EdgeData struct {
@@ -350,6 +351,11 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// check if node is on another namespace
 		if val, ok := n.Metadata[graph.IsOutside]; ok {
 			nd.IsOutside = val.(bool)
+		}
+
+		// check if node is a waypoint proxy
+		if val, ok := n.Metadata[graph.IsWaypoint]; ok {
+			nd.IsWaypoint = val.(bool)
 		}
 
 		if val, ok := n.Metadata[graph.HasMirroring]; ok {

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -43,6 +43,7 @@ const (
 	IsOutside             MetadataKey = "isOutside"
 	IsRoot                MetadataKey = "isRoot"
 	IsServiceEntry        MetadataKey = "isServiceEntry"
+	IsWaypoint            MetadataKey = "isWaypoint"
 	Labels                MetadataKey = "labels"
 	ProtocolKey           MetadataKey = "protocol"
 	ResponseTime          MetadataKey = "responseTime"

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -64,6 +64,7 @@ func (a AmbientAppender) isWaypoint(trafficMap graph.TrafficMap, globalInfo *gra
 						break
 					} else {
 						n.Metadata[graph.IsWaypoint] = true
+						n.Metadata[graph.IsOutOfMesh] = false
 						break
 					}
 				}

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -33,10 +33,10 @@ func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *gr
 
 	log.Trace("Running ambient appender")
 
-	a.isWaypoint(trafficMap, globalInfo, !a.Waypoints)
+	a.handleWaypoints(trafficMap, globalInfo, !a.Waypoints)
 }
 
-func (a AmbientAppender) isWaypoint(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, remove bool) {
+func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, remove bool) {
 
 	for name, n := range trafficMap {
 

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -33,11 +33,7 @@ func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *gr
 
 	log.Trace("Running ambient appender")
 
-	if !a.Waypoints {
-		a.isWaypoint(trafficMap, globalInfo, true)
-	} else {
-		a.isWaypoint(trafficMap, globalInfo, false)
-	}
+	a.isWaypoint(trafficMap, globalInfo, !a.Waypoints)
 }
 
 func (a AmbientAppender) isWaypoint(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, remove bool) {

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -34,11 +34,13 @@ func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *gr
 	log.Trace("Running ambient appender")
 
 	if !a.Waypoints {
-		a.removeWaypointEntries(trafficMap, globalInfo, namespaceInfo)
+		a.isWaypoint(trafficMap, globalInfo, true)
+	} else {
+		a.isWaypoint(trafficMap, globalInfo, false)
 	}
 }
 
-func (a AmbientAppender) removeWaypointEntries(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a AmbientAppender) isWaypoint(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, remove bool) {
 
 	for name, n := range trafficMap {
 
@@ -57,8 +59,13 @@ func (a AmbientAppender) removeWaypointEntries(trafficMap graph.TrafficMap, glob
 			}
 			for k, l := range workload.Labels {
 				if k == config.WaypointLabel && l == config.WaypointLabelValue {
-					delete(trafficMap, n.ID)
-					break
+					if remove {
+						delete(trafficMap, n.ID)
+						break
+					} else {
+						n.Metadata[graph.IsWaypoint] = true
+						break
+					}
 				}
 			}
 		}

--- a/graph/telemetry/istio/appender/mesh_check.go
+++ b/graph/telemetry/istio/appender/mesh_check.go
@@ -88,7 +88,7 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 			continue
 		}
 
-		if !hasIstioSidecar && !hasIstioAmbient {
+		if !hasIstioSidecar && !hasIstioAmbient && n.Metadata[graph.IsWaypoint] == false {
 			n.Metadata[graph.IsOutOfMesh] = true
 		}
 

--- a/graph/telemetry/istio/appender/mesh_check.go
+++ b/graph/telemetry/istio/appender/mesh_check.go
@@ -88,7 +88,7 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 			continue
 		}
 
-		if !hasIstioSidecar && !hasIstioAmbient && n.Metadata[graph.IsWaypoint] == false {
+		if !hasIstioSidecar && !hasIstioAmbient && n.Metadata[graph.IsWaypoint] != true {
 			n.Metadata[graph.IsOutOfMesh] = true
 		}
 


### PR DESCRIPTION
**Describe the change**

It looks like the graph generation is not looking at the labels of the workload, it is looking at the [source_canonical_service](https://github.com/kiali/kiali/blob/master/graph/telemetry/istio/istio.go#L280) to fill the fill the app field. 

That's the reason to include the waypoint check in the frontend code. 

**Issue reference**

Ref. https://github.com/kiali/kiali/issues/7022
