### PR TITLE
[v1.73] OSSMC - Make overview background fulfill whole window

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -81,7 +81,8 @@ import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 const gridStyleCompact = kialiStyle({
   backgroundColor: PFColors.BackgroundColor200,
   paddingBottom: '20px',
-  marginTop: '0px'
+  marginTop: '0px',
+  flex: '1'
 });
 
 const gridStyleList = kialiStyle({
@@ -89,7 +90,8 @@ const gridStyleList = kialiStyle({
   // The VirtualTable component has a different style than cards
   // We need to adjust the grid style if we are on compact vs list view
   padding: '0 !important',
-  marginTop: '0px'
+  marginTop: '0px',
+  flex: '1'
 });
 
 const cardGridStyle = kialiStyle({


### PR DESCRIPTION
**Describe the change**

Modify overview background style to cover whole window (only affects OSSMC)

**Steps to test PR**
This PR does not affect Kiali, only OSSMC.
1. (Optional) Check that Kiali overview page looks fine
2. Copy `OverviewPage.tsx file` into local OSSMC repository (folder `plugin/src/kiali/pages/Overview/OverviewPage.tsx`)
3. Run OSSMC plugin locally and check that PR fixes the issue.

![image](https://github.com/kiali/kiali/assets/122779323/e41b73ad-ba07-46c5-b475-6c59bf028d12)

**Issue reference**

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/237