### PR TITLE
[MC] Test coverage for a bug related to double clicking on a graph node + test implementation of a test around Istio Config wizard

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -423,3 +423,21 @@ Then(
     });
   }
 );
+Then('user double-clicks on the {string} {string} from the {string} cluster in the main graph', (name:string,type:string,cluster:string) => {
+  cy.waitForReact();
+
+  cy.getReact('CytoscapeGraph')
+    .should('have.length', '1')
+    .getCurrentState()
+    .then(state => {
+      let node;
+      if (type === 'app'){
+        node = state.cy.nodes(`[app="${name}"][cluster="${cluster}"][isBox="app"]`);
+      } else if (type === 'service'){
+        node = state.cy.nodes(`[nodeType="service"][cluster="${cluster}"][app="${name}"]`);
+      } 
+      // none of the standard cytoscape.js events for double-clicks were not working unfortunately
+      node.emit('tap');
+      node.emit('tap');
+    });
+});

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -269,3 +269,16 @@ Feature: Kiali Graph page - Display menu
     And there are Istio objects in the "bookinfo" namespace for "west" cluster
     When user graphs "bookinfo" namespaces
     Then the Istio objects for the "bookinfo" namespace for both clusters should be grouped together in the panel
+    
+  @multi-cluster
+  Scenario Outline: User double clicks node from specific cluster
+    When user graphs "bookinfo" namespaces
+    And user double-clicks on the "reviews" "<type>" from the "<cluster>" cluster in the main graph
+    Then the browser is at the details page for the "<type>" "bookinfo/reviews" located in the "<cluster>" cluster
+
+    Examples:
+      | type     | cluster |
+      | app      | east    |
+      | app      | west    |
+      | service  | east    |
+      | service  | west    |


### PR DESCRIPTION
Related to #6661.

I had to use 2 tap actions, as none of the default cytoscape.js double-click events worked with the graph. 

I have also removed one skipped test for the Multi-primary, as the gherkins were already implemented. 