### PR TITLE
Reference Grant form: GRPC/TCP/TLS Routes

### DIFF
--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -19,7 +19,7 @@ type ActionItem = {
   name: string;
 };
 
-export const IstioActionsNamespaceDropdown: React.FC = (): void => {
+export const IstioActionsNamespaceDropdown: React.FC = () => {
   const [dropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
 
   const onSelect = (): void => {

--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -3,6 +3,7 @@ import { history } from '../../app/History';
 import { serverConfig } from '../../config';
 import { NEW_ISTIO_RESOURCE } from '../../pages/IstioConfigNew/IstioConfigNewPage';
 import { K8SGATEWAY } from '../../pages/IstioConfigNew/K8sGatewayForm';
+import { K8S_REFERENCE_GRANT } from '../../pages/IstioConfigNew/K8sReferenceGrantForm';
 import { groupMenuStyle } from 'styles/DropdownStyles';
 import {
   Dropdown,
@@ -18,19 +19,19 @@ type ActionItem = {
   name: string;
 };
 
-export const IstioActionsNamespaceDropdown: React.FC = () => {
+export const IstioActionsNamespaceDropdown: React.FC = (): void => {
   const [dropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
 
-  const onSelect = () => {
+  const onSelect = (): void => {
     setDropdownOpen(!dropdownOpen);
   };
 
-  const onToggle = (dropdownState: boolean) => {
+  const onToggle = (dropdownState: boolean): void => {
     setDropdownOpen(dropdownState);
   };
 
-  const onClickCreate = (type: string) => {
-    history.push('/istio/new/' + type);
+  const onClickCreate = (type: string): void => {
+    history.push(`/istio/new/${type}`);
   };
 
   const dropdownItemsRaw = NEW_ISTIO_RESOURCE.map(
@@ -38,10 +39,12 @@ export const IstioActionsNamespaceDropdown: React.FC = () => {
       name: r.value,
       action: (
         <DropdownItem
-          key={'createIstioConfig_' + r.value}
-          isDisabled={r.value === K8SGATEWAY ? !serverConfig.gatewayAPIEnabled : r.disabled}
+          key={`createIstioConfig_${r.value}`}
+          isDisabled={
+            r.value === K8SGATEWAY || r.value === K8S_REFERENCE_GRANT ? !serverConfig.gatewayAPIEnabled : r.disabled
+          }
           onClick={() => onClickCreate(r.value)}
-          data-test={'create_' + r.label}
+          data-test={`create_${r.label}`}
         >
           {r.label}
         </DropdownItem>

--- a/frontend/src/pages/IstioConfigNew/K8sReferenceGrantForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sReferenceGrantForm.tsx
@@ -13,7 +13,10 @@ export const K8S_REFERENCE_GRANTS = 'k8sreferencegrants';
 
 export const FROM_KINDS = {
   HTTPRoute: 'gateway.networking.k8s.io',
-  Gateway: 'gateway.networking.k8s.io'
+  Gateway: 'gateway.networking.k8s.io',
+  GRPCRoute: 'gateway.networking.k8s.io',
+  TCPRoute: 'gateway.networking.k8s.io',
+  TLSRoute: 'gateway.networking.k8s.io'
 };
 
 export const TO_KINDS = {


### PR DESCRIPTION
Second PR from https://github.com/kiali/kiali/issues/7025 (second subtask)

Having this small feature separately from the main PR https://github.com/kiali/kiali/pull/7033

![Screenshot from 2024-01-17 14-27-41](https://github.com/kiali/kiali/assets/604313/a21f0daa-0152-499b-98f6-4d4923fa8b2f)

Plus a small fix, K8sReferenceGrant action is disabled when K8s Gateway API is not enabled:
![Screenshot from 2024-01-17 16-12-19](https://github.com/kiali/kiali/assets/604313/5ac7e4fc-bc77-45ab-b9f8-a3aad0a0dbd2)

