### PR TITLE
Ignore ExportTo for Ambient mesh

### DIFF
--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -33,8 +33,10 @@ func (s ServiceEntryChecker) runSingleChecks(se *networking_v1beta1.ServiceEntry
 	key, validations := EmptyValidValidation(se.Name, se.Namespace, ServiceEntryCheckerType, s.Cluster)
 
 	enabledCheckers := []Checker{
-		common.ExportToNamespaceChecker{ExportTo: se.Spec.ExportTo, Namespaces: s.Namespaces},
 		serviceentries.HasMatchingWorkloadEntryAddress{ServiceEntry: se, WorkloadEntries: workloadEntriesMap},
+	}
+	if !s.Namespaces.IsNamespaceAmbient(se.Namespace, s.Cluster) {
+		enabledCheckers = append(enabledCheckers, common.ExportToNamespaceChecker{ExportTo: se.Spec.ExportTo, Namespaces: s.Namespaces})
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -64,7 +64,9 @@ func (in VirtualServiceChecker) runChecks(virtualService *networking_v1beta1.Vir
 	enabledCheckers := []Checker{
 		virtualservices.RouteChecker{VirtualService: virtualService, Namespaces: in.Namespaces.GetNames()},
 		virtualservices.SubsetPresenceChecker{Namespaces: in.Namespaces.GetNames(), VirtualService: virtualService, DestinationRules: in.DestinationRules},
-		common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces},
+	}
+	if !in.Namespaces.IsNamespaceAmbient(virtualService.Namespace, in.Cluster) {
+		enabledCheckers = append(enabledCheckers, common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: in.Namespaces})
 	}
 
 	for _, checker := range enabledCheckers {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -112,7 +112,8 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 
 	// This can result on an error when IstioAPI is disabled, so filter here
 	// Even if all namespaces are not accessible, but the IstioAPI is enabled, still use the Istio Registry by AllNamespaces=true
-	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() && !config.Get().ExternalServices.Istio.IstioAPIEnabled {
+	// In Ambient mode ExportTo is ignored, so proceed per namespace
+	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() && !config.Get().ExternalServices.Istio.IstioAPIEnabled || (business.IstioConfig.IsAmbientEnabled() && len(nss) > 0) {
 		criteria.AllNamespaces = false
 		for _, ns := range nss {
 			criteria.Namespace = ns
@@ -212,7 +213,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectType: models.ObjectTypeSingular[objectType], Namespace: namespace, Name: object}]; found {
+		if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectType: models.ObjectTypeSingular[objectType], Namespace: namespace, Name: object, Cluster: cluster}]; found {
 			istioConfigDetails.IstioValidation = validation
 		}
 		if references, found := istioConfigReferences[models.IstioReferenceKey{ObjectType: models.ObjectTypeSingular[objectType], Namespace: namespace, Name: object}]; found {

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -104,6 +104,15 @@ func (nss Namespaces) Includes(namespace string) bool {
 	return false
 }
 
+func (nss Namespaces) IsNamespaceAmbient(namespace, cluster string) bool {
+	for _, ns := range nss {
+		if ns.Name == namespace && ns.Cluster == cluster {
+			return ns.IsAmbient
+		}
+	}
+	return false
+}
+
 func (nss Namespaces) GetNames() []string {
 	names := make([]string, len(nss))
 	for _, ns := range nss {

--- a/tests/data/validations/exportto/cns/dr_bookinfo1_to_2_3.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo1_to_2_3.yaml
@@ -1,0 +1,10 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: "dr_bookinfo1_to_2_3"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  exportTo:
+    - bookinfo2
+    - bookinfo3

--- a/tests/data/validations/exportto/cns/dr_bookinfo1_to_this.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo1_to_this.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: "dr_bookinfo1_to_this"
+  namespace: "bookinfo"
+spec:
+  host: "*.local"
+  exportTo:
+    - .

--- a/tests/data/validations/exportto/cns/dr_bookinfo2_to_1.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo2_to_1.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo2_to_1
+  namespace: bookinfo2
+spec:
+  host: "*.local"
+  exportTo:
+    - bookinfo

--- a/tests/data/validations/exportto/cns/dr_bookinfo2_to_this.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo2_to_this.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo2_to_this
+  namespace: bookinfo2
+spec:
+  host: "*.local"
+  exportTo:
+    - .

--- a/tests/data/validations/exportto/cns/dr_bookinfo3.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo3.yaml
@@ -1,0 +1,7 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo3
+  namespace: bookinfo3
+spec:
+  host: "*.local"

--- a/tests/data/validations/exportto/cns/dr_bookinfo3_to_2.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo3_to_2.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo3_to_2
+  namespace: bookinfo3
+spec:
+  host: "*.local"
+  exportTo:
+    - bookinfo2

--- a/tests/data/validations/exportto/cns/dr_bookinfo3_to_all.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo3_to_all.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo3_to_all
+  namespace: bookinfo3
+spec:
+  host: "*.local"
+  exportTo:
+    - '*'

--- a/tests/data/validations/exportto/cns/dr_bookinfo3_to_wrong.yaml
+++ b/tests/data/validations/exportto/cns/dr_bookinfo3_to_wrong.yaml
@@ -1,0 +1,9 @@
+apiVersion: "networking.istio.io/v1beta1"
+kind: "DestinationRule"
+metadata:
+  name: dr_bookinfo3_to_wrong
+  namespace: bookinfo3
+spec:
+  host: "*.local"
+  exportTo:
+    - 'wrong'

--- a/tests/data/validations/exportto/cns/se_bookinfo1_to_2_3.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo1_to_2_3.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo1_to_2_3
+  namespace: bookinfo
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - bookinfo2
+    - bookinfo3

--- a/tests/data/validations/exportto/cns/se_bookinfo1_to_this.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo1_to_this.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo1_to_this
+  namespace: bookinfo
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - .

--- a/tests/data/validations/exportto/cns/se_bookinfo2_to_1.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo2_to_1.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo2_to_1
+  namespace: bookinfo2
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - bookinfo

--- a/tests/data/validations/exportto/cns/se_bookinfo2_to_this.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo2_to_this.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo2_to_this
+  namespace: bookinfo2
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - .

--- a/tests/data/validations/exportto/cns/se_bookinfo3_to_2.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo3_to_2.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo3_to_2
+  namespace: bookinfo3
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - bookinfo2

--- a/tests/data/validations/exportto/cns/se_bookinfo3_to_all.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo3_to_all.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo3_to_all
+  namespace: bookinfo3
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - '*'

--- a/tests/data/validations/exportto/cns/se_bookinfo3_to_wrong.yaml
+++ b/tests/data/validations/exportto/cns/se_bookinfo3_to_wrong.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se_bookinfo3_to_wrong
+  namespace: bookinfo3
+spec:
+  hosts:
+    - www.googleapis.com
+  exportTo:
+    - 'wrong'


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6879

In a case of Ambient mesh, the `ExportTo` field of several Istio config objects are ignored, and the Object is validated only in own namespace scope. Affected configs: VirtualService, DestinationRule, ServiceEntry.

Added tests, but in fact made tests disabled because the `layer.IstioConfig` is not reset from test to test.