### PR TITLE
Fix clusters e2e test for operator deployments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -513,8 +513,8 @@ type Clustering struct {
 	// Clusters is a list of clusters that cannot be autodetected by the Kiali Server.
 	// Remote clusters are specified here if ‘autodetect_secrets.enabled’ is false or
 	// if the Kiali Server does not have access to the remote cluster’s secret.
-	Clusters  []Cluster  `yaml:"clusters,omitempty" json:"clusters,omitempty"`
-	KialiURLs []KialiURL `yaml:"kiali_urls,omitempty" json:"kiali_urls,omitempty"`
+	Clusters  []Cluster  `yaml:"clusters" json:"clusters"`
+	KialiURLs []KialiURL `yaml:"kiali_urls" json:"kiali_urls"`
 }
 
 type FeatureFlagClustering struct {
@@ -570,7 +570,7 @@ type Config struct {
 	AdditionalDisplayDetails []AdditionalDisplayItem             `yaml:"additional_display_details,omitempty"`
 	API                      ApiConfig                           `yaml:"api,omitempty"`
 	Auth                     AuthConfig                          `yaml:"auth,omitempty"`
-	Clustering               Clustering                          `yaml:"clustering,omitempty"`
+	Clustering               Clustering                          `yaml:"clustering"`
 	CustomDashboards         dashboards.MonitoringDashboardsList `yaml:"custom_dashboards,omitempty"`
 	Deployment               DeploymentConfig                    `yaml:"deployment,omitempty"`
 	ExternalServices         ExternalServices                    `yaml:"external_services,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -517,6 +517,13 @@ type Clustering struct {
 	KialiURLs []KialiURL `yaml:"kiali_urls" json:"kiali_urls"`
 }
 
+// IsZero implements: https://pkg.go.dev/gopkg.in/yaml.v2#IsZeroer so that
+// tests can patch the Clustering struct and have it be recognized as non-zero
+// while keeping the omitempty yaml tag.
+func (c Clustering) IsZero() bool {
+	return c.Clusters == nil && c.KialiURLs == nil
+}
+
 type FeatureFlagClustering struct {
 	// TODO: Deprecate this in favor of Clustering.Clusters.
 	Clustering         `yaml:",inline"`
@@ -570,7 +577,7 @@ type Config struct {
 	AdditionalDisplayDetails []AdditionalDisplayItem             `yaml:"additional_display_details,omitempty"`
 	API                      ApiConfig                           `yaml:"api,omitempty"`
 	Auth                     AuthConfig                          `yaml:"auth,omitempty"`
-	Clustering               Clustering                          `yaml:"clustering"`
+	Clustering               Clustering                          `yaml:"clustering,omitempty"`
 	CustomDashboards         dashboards.MonitoringDashboardsList `yaml:"custom_dashboards,omitempty"`
 	Deployment               DeploymentConfig                    `yaml:"deployment,omitempty"`
 	ExternalServices         ExternalServices                    `yaml:"external_services,omitempty"`

--- a/tests/integration/tests/clusters_test.go
+++ b/tests/integration/tests/clusters_test.go
@@ -30,6 +30,11 @@ func TestRemoteKialiShownInClustersResponse(t *testing.T) {
 	conf, err := instance.GetConfig(ctx)
 	require.NoError(err)
 	originalConf := *conf
+	// Set this to something so that the patch isn't omitted for being empty.
+	originalConf.Clustering = config.Clustering{
+		Clusters:  []config.Cluster{},
+		KialiURLs: []config.KialiURL{},
+	}
 
 	conf.Clustering.Clusters = []config.Cluster{{Name: "inaccessible"}}
 	conf.Clustering.KialiURLs = []config.KialiURL{{ClusterName: "inaccessible", URL: "http://inaccessible:20001", InstanceName: "kiali", Namespace: "istio-system"}}

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -1,14 +1,9 @@
 package tests
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 
 	k8s "github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/tests/integration/utils"
@@ -16,43 +11,30 @@ import (
 	"github.com/kiali/kiali/tests/integration/utils/kube"
 )
 
-const kialiNamespace = "istio-system"
-
-func update_istio_api_enabled(ctx context.Context, t *testing.T, value bool, kubeClientSet kubernetes.Interface, dynamicClient dynamic.Interface, kialiCRDExists bool) {
-	require := require.New(t)
-
-	kialiPodName := kube.GetKialiPodName(ctx, kubeClientSet, kialiNamespace, t)
-
-	if kialiCRDExists {
-		registryPatch := []byte(fmt.Sprintf(`{"spec": {"external_services": {"istio": {"istio_api_enabled": %t}}}}`, value))
-		kube.UpdateKialiCR(ctx, dynamicClient, kubeClientSet, kialiNamespace, "istio_api_enabled", registryPatch, t)
-	} else {
-		config, cm := kube.GetKialiConfigMap(ctx, kubeClientSet, kialiNamespace, "kiali", t)
-		config.ExternalServices.Istio.IstioAPIEnabled = value
-		kube.UpdateKialiConfigMap(ctx, kubeClientSet, kialiNamespace, config, cm, t)
-	}
-
-	// Restart Kiali pod to pick up the new config.
-	if !kialiCRDExists {
-		require.NoError(kube.DeleteKialiPod(ctx, kubeClientSet, kialiNamespace, kialiPodName))
-	}
-	require.NoError(kube.DeleteKialiPod(ctx, kubeClientSet, kialiNamespace, kialiPodName))
-	require.NoError(kube.RestartKialiPod(ctx, kubeClientSet, kialiNamespace, kialiPodName))
-}
-
 func TestNoIstiod(t *testing.T) {
+	require := require.New(t)
 	kubeClientSet := kube.NewKubeClient(t)
 	dynamicClient := kube.NewDynamicClient(t)
-	ctx := context.TODO()
 
-	kialiCRDExists := false
-	_, err := kubeClientSet.Discovery().RESTClient().Get().AbsPath("/apis/kiali.io").DoRaw(ctx)
-	if !kubeerrors.IsNotFound(err) {
-		kialiCRDExists = true
-	}
+	ctx := contextWithTestingDeadline(t)
 
-	defer update_istio_api_enabled(ctx, t, true, kubeClientSet, dynamicClient, kialiCRDExists)
-	update_istio_api_enabled(ctx, t, false, kubeClientSet, dynamicClient, kialiCRDExists)
+	instance, err := kiali.NewInstance(ctx, kubeClientSet, dynamicClient)
+	require.NoError(err)
+
+	cfg, err := instance.GetConfig(ctx)
+	require.NoError(err)
+
+	defer func() {
+		cfg.ExternalServices.Istio.IstioAPIEnabled = true
+		require.NoError(instance.UpdateConfig(ctx, cfg))
+		require.NoError(instance.Restart(ctx))
+	}()
+
+	// Disable Istio API
+	cfg.ExternalServices.Istio.IstioAPIEnabled = false
+	require.NoError(instance.UpdateConfig(ctx, cfg))
+	require.NoError(instance.Restart(ctx))
+
 	t.Run("ServicesListNoRegistryServices", servicesListNoRegistryServices)
 	t.Run("NoProxyStatus", noProxyStatus)
 	t.Run("istioStatus", istioStatus)

--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -1,19 +1,13 @@
 package tests
 
 import (
-	"context"
 	"path"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/kiali/kiali/config"
@@ -28,7 +22,6 @@ import (
 var assetsFolder = path.Join(cmd.KialiProjectRoot, kiali.ASSETS)
 
 // Testing a remote istiod by exposing /debug endpoints through a proxy.
-// It assumes you've deployed Kiali through the operator.
 func TestRemoteIstiod(t *testing.T) {
 	require := require.New(t)
 
@@ -38,86 +31,27 @@ func TestRemoteIstiod(t *testing.T) {
 
 	kubeClient := kube.NewKubeClient(t)
 	dynamicClient := kube.NewDynamicClient(t)
-	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
+	ctx := contextWithTestingDeadline(t)
 
-	deadline, _ := t.Deadline()
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
-	// This is used by cleanup so needs to be added to cleanup instead of deferred.
-	t.Cleanup(cancel)
+	instance, err := kiali.NewInstance(ctx, kubeClient, dynamicClient)
+	require.NoError(err)
 
-	var kialiCRDExists bool
-	_, err = kubeClient.Discovery().RESTClient().Get().AbsPath("/apis/kiali.io").DoRaw(ctx)
-	if !kubeerrors.IsNotFound(err) {
-		require.NoError(err)
-		kialiCRDExists = true
-	}
+	originalConf, err := instance.GetConfig(ctx)
+	require.NoError(err)
+	// Set this to something so that the patch isn't omitted for being empty.
+	originalConf.ExternalServices.Istio.Registry = &config.RegistryConfig{}
 
-	if kialiCRDExists {
-		log.Debug("Kiali CRD found. Assuming Kiali is deployed through the operator.")
-	} else {
-		log.Debug("Kiali CRD not found. Assuming Kiali is deployed through helm.")
-	}
-
-	kialiName := "kiali"
-	kialiNamespace := "istio-system"
-	kialiDeploymentNamespace := kialiNamespace
-	ipods, err := kubeClient.AppsV1().Deployments(kialiNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=istiod"})
+	ipods, err := kubeClient.AppsV1().Deployments(originalConf.IstioNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=istiod"})
 	istioDeploymentName := ipods.Items[0].Name
-
-	if kialiCRDExists {
-		// Find the Kiali CR and override some settings if they're set on the CR.
-		kialiCRs, err := dynamicClient.Resource(kialiGVR).List(ctx, metav1.ListOptions{})
-		require.NoError(err)
-
-		kialiCR := kialiCRs.Items[0]
-
-		kialiName = kialiCR.GetName()
-		kialiNamespace = kialiCR.GetNamespace()
-		if spec, ok := kialiCR.Object["spec"].(map[string]interface{}); ok {
-			if deployment, ok := spec["deployment"].(map[string]interface{}); ok {
-				if namespace, ok := deployment["namespace"].(string); ok {
-					kialiDeploymentNamespace = namespace
-				}
-			}
-		}
-	}
 
 	// Register clean up before creating resources in case of failure.
 	t.Cleanup(func() {
 		log.Debug("Cleaning up resources from RemoteIstiod test")
-
-		currentKialiPod := kube.GetKialiPodName(ctx, kubeClient, kialiDeploymentNamespace, t)
-
-		if kialiCRDExists {
-			undoRegistryPatch := []byte(`[{"op": "remove", "path": "/spec/external_services/istio/registry"}]`)
-			_, err2 := dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.JSONPatchType, undoRegistryPatch, metav1.PatchOptions{})
-			require.NoError(err2)
-		} else {
-			// Update the configmap directly by getting the configmap and patching it.
-			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-			require.NoError(err)
-
-			var currentConfig config.Config
-			require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &currentConfig))
-			currentConfig.ExternalServices.Istio.Registry = nil
-
-			newConfig, err := yaml.Marshal(currentConfig)
-			require.NoError(err)
-			cm.Data["config.yaml"] = string(newConfig)
-
-			log.Debugf("Kiali namespace: %s ", kialiNamespace)
-			log.Debugf("Kiali deployment namespace: %s ", kialiDeploymentNamespace)
-
-			_, err = kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Update(ctx, cm, metav1.UpdateOptions{})
-			require.NoError(err)
-
-			require.NoError(kube.DeleteKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod))
-			// Restart Kiali pod to pick up the new config.
-			require.NoError(kube.RestartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod))
-		}
+		require.NoError(instance.UpdateConfig(ctx, originalConf))
+		require.NoError(instance.Restart(ctx))
 
 		// Remove service:
-		err = kubeClient.CoreV1().Services("istio-system").Delete(ctx, "istiod-debug", metav1.DeleteOptions{})
+		err = kubeClient.CoreV1().Services(originalConf.IstioNamespace).Delete(ctx, "istiod-debug", metav1.DeleteOptions{})
 		if kubeerrors.IsNotFound(err) {
 			err = nil
 		}
@@ -125,7 +59,7 @@ func TestRemoteIstiod(t *testing.T) {
 
 		log.Debugf("Remove nginx container from istio deployment %s", istioDeploymentName)
 		// Remove nginx container
-		istiod, err := kubeClient.AppsV1().Deployments("istio-system").Get(ctx, istioDeploymentName, metav1.GetOptions{})
+		istiod, err := kubeClient.AppsV1().Deployments(originalConf.IstioNamespace).Get(ctx, istioDeploymentName, metav1.GetOptions{})
 		require.NoError(err)
 
 		for i, container := range istiod.Spec.Template.Spec.Containers {
@@ -134,66 +68,29 @@ func TestRemoteIstiod(t *testing.T) {
 				break
 			}
 		}
-		_, err = kubeClient.AppsV1().Deployments("istio-system").Update(ctx, istiod, metav1.UpdateOptions{})
+		_, err = kubeClient.AppsV1().Deployments(originalConf.IstioNamespace).Update(ctx, istiod, metav1.UpdateOptions{})
 		require.NoError(err)
-
-		currentKialiPod = kube.GetKialiPodName(ctx, kubeClient, kialiDeploymentNamespace, t)
-
-		// Wait for the configmap to be updated again before exiting.
-		require.NoError(wait.PollUntilContextTimeout(ctx, time.Second*5, time.Minute*2, false, func(ctx context.Context) (bool, error) {
-			cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			return !strings.Contains(cm.Data["config.yaml"], "http://istiod-debug.istio-system:9240"), nil
-		}), "Error waiting for kiali configmap to update")
-
-		if !kialiCRDExists {
-			require.NoError(kube.DeleteKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod))
-		}
-		require.NoError(kube.RestartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod))
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.
 	log.Debugf("Patching istiod %s deployment with proxy", istioDeploymentName)
-	_, err = kubeClient.AppsV1().Deployments("istio-system").Patch(ctx, istioDeploymentName, types.StrategicMergePatchType, proxyPatch, metav1.PatchOptions{})
+	_, err = kubeClient.AppsV1().Deployments(originalConf.IstioNamespace).Patch(ctx, istioDeploymentName, types.StrategicMergePatchType, proxyPatch, metav1.PatchOptions{})
 	require.NoError(err)
 	log.Debug("Successfully patched istiod deployment with proxy")
 
 	// Then create a service for the proxy/debug endpoint.
-	require.True(utils.ApplyFile(assetsFolder+"/remote-istiod/istiod-debug-service.yaml", "istio-system"), "Could not create istiod debug service")
+	require.True(utils.ApplyFile(assetsFolder+"/remote-istiod/istiod-debug-service.yaml", originalConf.IstioNamespace), "Could not create istiod debug service")
 
 	// Now patch kiali to use that remote endpoint.
 	log.Debug("Patching kiali to use remote istiod")
-	var currentKialiPod string
-
-	pods, err := kubeClient.CoreV1().Pods(kialiDeploymentNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-	if err != nil {
-		log.Error("Error getting the pods list %s", err)
-	} else {
-		currentKialiPod = pods.Items[0].Name
+	conf := *originalConf
+	conf.ExternalServices.Istio.Registry = &config.RegistryConfig{
+		IstiodURL: "http://istiod-debug.istio-system:9240",
 	}
+	require.NoError(instance.UpdateConfig(ctx, &conf))
+	require.NoError(instance.Restart(ctx))
 
-	if kialiCRDExists {
-		registryPatch := []byte(`{"spec": {"external_services": {"istio": {"registry": {"istiod_url": "http://istiod-debug.istio-system:9240"}}}}}`)
-		kube.UpdateKialiCR(ctx, dynamicClient, kubeClient, kialiDeploymentNamespace, "http://istiod-debug.istio-system:9240", registryPatch, t)
-	} else {
-		// Update the configmap directly.
-		currentConfig, cm := kube.GetKialiConfigMap(ctx, kubeClient, kialiDeploymentNamespace, kialiName, t)
-
-		currentConfig.ExternalServices.Istio.Registry = &config.RegistryConfig{
-			IstiodURL: "http://istiod-debug.istio-system:9240",
-		}
-
-		kube.UpdateKialiConfigMap(ctx, kubeClient, kialiNamespace, currentConfig, cm, t)
-	}
 	log.Debugf("Successfully patched kiali to use remote istiod")
-
-	// Restart Kiali pod to pick up the new config.
-	if !kialiCRDExists {
-		require.NoError(kube.DeleteKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod))
-	}
-	require.NoError(kube.RestartKialiPod(ctx, kubeClient, kialiDeploymentNamespace, currentKialiPod), "Error waiting for kiali deployment to update")
 
 	configs, err := kiali.IstioConfigs()
 	require.NoError(err)

--- a/tests/integration/utils/kube/kube_client.go
+++ b/tests/integration/utils/kube/kube_client.go
@@ -1,23 +1,11 @@
 package kube
 
 import (
-	"context"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/tools/cmd"
 )
 
@@ -51,117 +39,4 @@ func NewKubeClient(t *testing.T) kubernetes.Interface {
 	}
 
 	return client
-}
-
-func DeleteKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, currentKialiPod string) error {
-	log.Debugf("Deleting Kiali pod %s", currentKialiPod)
-	err := kubeClient.CoreV1().Pods(namespace).Delete(ctx, currentKialiPod, metav1.DeleteOptions{})
-	if err != nil {
-		log.Errorf("Error deleting Kiali pod %s", err)
-		return err
-	}
-	return nil
-}
-
-// Waits for old kiali pod to terminate and for the new one to be ready
-func RestartKialiPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, currentKialiPod string) error {
-	return wait.PollUntilContextTimeout(ctx, time.Second*5, time.Minute*4, true, func(ctx context.Context) (bool, error) {
-		log.Debugf("Waiting for kiali pod %s in %s namespace to be ready", currentKialiPod, namespace)
-		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-		if err != nil {
-			log.Errorf("Error getting the pods list %s", err)
-			return false, err
-		} else {
-			log.Debugf("Found %d pods", len(pods.Items))
-		}
-
-		for _, pod := range pods.Items {
-			if pod.Name == currentKialiPod {
-				log.Debug("Old kiali pod still exists.")
-				return false, nil
-			}
-			for _, condition := range pod.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "False" {
-					log.Debugf("New kiali pod is not ready.")
-					log.Debugf("Condition type %s status %s pod name %s", condition.Type, condition.Status, pod.Name)
-					return false, nil
-				}
-			}
-		}
-		return true, nil
-	})
-}
-
-// Returns the name of the Kiali pod
-// It expects to find just one Kiali pod
-func GetKialiPodName(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, t *testing.T) string {
-	require := require.New(t)
-	pods, err := kubeClient.CoreV1().Pods(kialiNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
-	require.NoError(err)
-	require.Len(pods.Items, 1)
-
-	return pods.Items[0].Name
-}
-
-// Get Kiali config map
-func GetKialiConfigMap(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, kialiName string, t *testing.T) (*config.Config, *v1.ConfigMap) {
-	require := require.New(t)
-
-	// Update the configmap directly by getting the configmap and patching it.
-	cm, err := kubeClient.CoreV1().ConfigMaps(kialiNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-	require.NoError(err)
-
-	currentConfig := config.NewConfig()
-	require.NoError(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), currentConfig))
-
-	return currentConfig, cm
-}
-
-func UpdateKialiCR(ctx context.Context, dynamicClient dynamic.Interface, kubeClient kubernetes.Interface,
-	kialiNamespace string, check string, registryPatch []byte, t *testing.T,
-) {
-	require := require.New(t)
-	kialiGVR := schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
-	// Find the Kiali CR and override some settings if they're set on the CR.
-	kialiCRs, err := dynamicClient.Resource(kialiGVR).List(ctx, metav1.ListOptions{})
-	require.NoError(err)
-
-	kialiCR := kialiCRs.Items[0]
-
-	kialiName := kialiCR.GetName()
-	kialiDeploymentNamespace := kialiNamespace
-	kialiNamespace = kialiCR.GetNamespace()
-	if spec, ok := kialiCR.Object["spec"].(map[string]interface{}); ok {
-		if deployment, ok := spec["deployment"].(map[string]interface{}); ok {
-			if namespace, ok := deployment["namespace"].(string); ok {
-				kialiDeploymentNamespace = namespace
-			}
-		}
-	}
-
-	_, err = dynamicClient.Resource(kialiGVR).Namespace(kialiNamespace).Patch(ctx, kialiName, types.MergePatchType, registryPatch, metav1.PatchOptions{})
-	require.NoError(err)
-
-	// Need to know when the kiali operator has seen the CR change and finished updating
-	// the configmap. There's no ObservedGeneration on the Kiali CR so just checking the configmap itself.
-	require.NoError(wait.PollUntilContextTimeout(ctx, time.Second*5, time.Minute*2, true, func(ctx context.Context) (bool, error) {
-		log.Debug("Waiting for kiali configmap to update")
-		cm, err := kubeClient.CoreV1().ConfigMaps(kialiDeploymentNamespace).Get(ctx, kialiName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		return strings.Contains(cm.Data["config.yaml"], check), nil
-	}), "Error waiting for kiali configmap to update")
-}
-
-// Update Kiali config map
-func UpdateKialiConfigMap(ctx context.Context, kubeClient kubernetes.Interface, kialiNamespace string, currentConfig *config.Config, cm *v1.ConfigMap, t *testing.T) {
-	require := require.New(t)
-
-	newConfig, err := yaml.Marshal(currentConfig)
-	require.NoError(err)
-	cm.Data["config.yaml"] = string(newConfig)
-
-	_, err = kubeClient.CoreV1().ConfigMaps(kialiNamespace).Update(ctx, cm, metav1.UpdateOptions{})
-	require.NoError(err)
 }


### PR DESCRIPTION
** Describe the change **

Fix clusters test for operator deployments and cleanup e2e tests by using `kiali.Instance` to manage config.