### PR TITLE
Don't show istio status for remote clusters

### DIFF
--- a/frontend/src/pages/Overview/ControlPlaneBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneBadge.tsx
@@ -12,6 +12,8 @@ type Props = {
 };
 
 export const ControlPlaneBadge: React.FC<Props> = (props: Props) => {
+  // Remote clusters do not have istio status because istio is not running there
+  // so don't display istio status badge for those.
   return (
     <>
       <Label style={{ marginLeft: '0.5rem' }} color="green" isCompact>
@@ -24,7 +26,7 @@ export const ControlPlaneBadge: React.FC<Props> = (props: Props) => {
         <AmbientBadge tooltip="Istio Ambient ztunnel detected in the Control plane"></AmbientBadge>
       )}
 
-      <IstioStatusInline cluster={props.cluster} />
+      {!isRemoteCluster(props.annotations) && <IstioStatusInline cluster={props.cluster} />}
     </>
   );
 };

--- a/frontend/src/pages/Overview/__tests__/ControlPlaneBadge.test.tsx
+++ b/frontend/src/pages/Overview/__tests__/ControlPlaneBadge.test.tsx
@@ -1,0 +1,12 @@
+import { shallow } from 'enzyme';
+import { ControlPlaneBadge } from '../ControlPlaneBadge';
+
+describe('ControlPlaneBadge', () => {
+  const controlPlaneAnnotation = 'topology.istio.io/controlPlaneClusters';
+  it('does not show istio status for remote clusters', () => {
+    const wrapper = shallow(
+      <ControlPlaneBadge annotations={{ [controlPlaneAnnotation]: 'primary' }} cluster="remote" />
+    );
+    expect(wrapper.find('IstioStatusInline').exists()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
** Describe the change **

Does not attempt to show istio status for remote clusters on the control plane badge.

** Issue reference **

fixes #7053 