### PR TITLE
e2e tests - Wait for deployment replicas to fully match spec

### DIFF
--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -233,6 +233,16 @@ func waitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface,
 			return false, nil
 		}
 
+		if deployment.Status.Replicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be fully rolled out (%d/%d replicas)", deployment.Status.Replicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		if deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be updated (%d/%d replicas)", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
 		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
 			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
 			return false, nil


### PR DESCRIPTION
** Describe the change **

Waits for old kiali pod to be deleted before continuing with the test.