### PR TITLE
Optimize fetching validations on graph page

### DIFF
--- a/business/checkers/checker.go
+++ b/business/checkers/checker.go
@@ -19,7 +19,9 @@ func EmptyValidValidations(name, namespace, objectType, cluster string) models.I
 func EmptyValidValidation(name, namespace, objectType, cluster string) (models.IstioValidationKey, *models.IstioValidation) {
 	key := models.IstioValidationKey{Name: name, Namespace: namespace, ObjectType: objectType, Cluster: cluster}
 	emptyValidation := &models.IstioValidation{
+		Cluster:    key.Cluster,
 		Name:       key.Name,
+		Namespace:  key.Namespace,
 		ObjectType: key.ObjectType,
 		Valid:      true,
 		Checks:     []*models.IstioCheck{},

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -170,7 +170,7 @@ export const tls: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
 };
 
 export const istioConfig: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
-  let validations: ValidationStatus = { objectCount: 0, errors: 0, warnings: 0 };
+  let validations: ValidationStatus = { namespace: ns.name, objectCount: 0, errors: 0, warnings: 0 };
 
   if (!!ns.validations) {
     validations = ns.validations;

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -534,7 +534,10 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
   }
 
   async fetchValidationResultForCluster(namespaces: NamespaceInfo[], cluster: string): Promise<void> {
-    return Promise.all([API.getConfigValidations(cluster), API.getAllIstioConfigs([], [], false, '', '', cluster)])
+    return Promise.all([
+      API.getConfigValidations(namespaces.map(ns => ns.name).join(','), cluster),
+      API.getAllIstioConfigs([], [], false, '', '', cluster)
+    ])
       .then(results => {
         const validations = results[0].data;
         const istioConfig = results[1].data;

--- a/frontend/src/pages/Overview/__tests__/OverviewSort.test.ts
+++ b/frontend/src/pages/Overview/__tests__/OverviewSort.test.ts
@@ -5,6 +5,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'alpha',
     validations: {
+      namespace: 'alpha',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -13,6 +14,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'beta',
     validations: {
+      namespace: 'beta',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -21,6 +23,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'default',
     validations: {
+      namespace: 'default',
       objectCount: 2,
       errors: 0,
       warnings: 0
@@ -29,6 +32,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'electronic-shop',
     validations: {
+      namespace: 'electronic-shop',
       objectCount: 2,
       errors: 0,
       warnings: 0
@@ -37,6 +41,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'fraud-detection',
     validations: {
+      namespace: 'fraud-detection',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -45,6 +50,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'istio-system',
     validations: {
+      namespace: 'istio-system',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -53,6 +59,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'travel-agency',
     validations: {
+      namespace: 'travel-agency',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -61,6 +68,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'travel-control',
     validations: {
+      namespace: 'travel-control',
       objectCount: 0,
       errors: 0,
       warnings: 0
@@ -69,6 +77,7 @@ const allNamespaces: NamespaceInfo[] = [
   {
     name: 'travel-portal',
     validations: {
+      namespace: 'travel-portal',
       objectCount: 0,
       errors: 0,
       warnings: 0

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -73,6 +73,10 @@ type LoginRequest = BasicAuth & {
   token: Password;
 };
 
+interface Namespaces {
+  namespaces: string;
+}
+
 type QueryParams<T> = T & ClusterParam;
 
 /**
@@ -401,14 +405,20 @@ export const createIstioConfigDetail = (
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), queryParams, json);
 };
 
-export const getConfigValidations = (cluster?: string): Promise<ApiResponse<ValidationStatus>> => {
-  const queryParams: ClusterParam = {};
+// comma separated list of namespaces
+export const getConfigValidations = (
+  namespaces: string,
+  cluster?: string
+): Promise<ApiResponse<[ValidationStatus]>> => {
+  const queryParams: QueryParams<Namespaces> = {
+    namespaces: namespaces
+  };
 
   if (cluster) {
     queryParams.clusterName = cluster;
   }
 
-  return newRequest<ValidationStatus>(HTTP_VERBS.GET, urls.configValidations(), queryParams, {});
+  return newRequest<[ValidationStatus]>(HTTP_VERBS.GET, urls.configValidations(), queryParams, {});
 };
 
 export const getServices = (namespace: string, params?: ServiceListQuery): Promise<ApiResponse<ServiceList>> => {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -130,7 +130,9 @@ export interface ServiceReference {
 }
 
 export interface ValidationStatus {
+  cluster?: string;
   errors: number;
+  namespace: string;
   objectCount?: number;
   warnings: number;
 }

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -67,7 +67,7 @@ func NamespaceValidationSummary(w http.ResponseWriter, r *http.Request) {
 		log.Error(errValidations)
 		RespondWithError(w, http.StatusInternalServerError, errValidations.Error())
 	} else {
-		validationSummary = *istioConfigValidationResults.SummarizeValidation(namespace)
+		validationSummary = *istioConfigValidationResults.SummarizeValidation(namespace, cluster)
 	}
 
 	RespondWithJSON(w, http.StatusOK, validationSummary)
@@ -98,15 +98,16 @@ func ConfigValidationSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	validationSummaries := models.ValidationSummaries{cluster: {}}
 	istioConfigValidationResults, errValidations := business.Validations.GetValidations(r.Context(), cluster, "", "", "")
 	if errValidations != nil {
 		log.Error(errValidations)
 		RespondWithError(w, http.StatusInternalServerError, errValidations.Error())
-	} else {
-		for _, ns := range nss {
-			validationSummaries[cluster][ns] = istioConfigValidationResults.SummarizeValidation(ns)
-		}
+		return
+	}
+
+	validationSummaries := []models.IstioValidationSummary{}
+	for _, ns := range nss {
+		validationSummaries = append(validationSummaries, *istioConfigValidationResults.SummarizeValidation(ns, cluster))
 	}
 
 	RespondWithJSON(w, http.StatusOK, validationSummaries)

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -32,6 +32,14 @@ type IstioValidationSummary struct {
 	// required: true
 	// example: 4
 	Warnings int `json:"warnings"`
+	// Namespace of the Istio Objects.
+	// required: true
+	// example: bookinfo
+	Namespace string `json:"namespace"`
+	// Cluster of the Istio Objects.
+	// required: true
+	// example: east
+	Cluster string `json:"cluster"`
 }
 
 // ValidationSummaries holds a map of IstioValidationSummary per cluster and namespace
@@ -47,6 +55,16 @@ type IstioValidation struct {
 	// required: true
 	// example: reviews
 	Name string `json:"name"`
+
+	// Namespace of the object
+	// required: true
+	// example: bookinfo
+	Namespace string `json:"namespace"`
+
+	// Cluster of the object
+	// required: true
+	// example: east
+	Cluster string `json:"cluster"`
 
 	// Type of the object
 	// required: true
@@ -467,10 +485,13 @@ func (iv IstioValidations) MergeReferences(validations IstioValidations) IstioVa
 	return iv
 }
 
-func (iv IstioValidations) SummarizeValidation(ns string) *IstioValidationSummary {
-	ivs := IstioValidationSummary{}
+func (iv IstioValidations) SummarizeValidation(ns string, cluster string) *IstioValidationSummary {
+	ivs := IstioValidationSummary{
+		Namespace: ns,
+		Cluster:   cluster,
+	}
 	for k, v := range iv {
-		if k.Namespace == ns && k.ObjectType != "workload" {
+		if k.Namespace == ns && k.Cluster == cluster && k.ObjectType != "workload" {
 			ivs.mergeSummaries(v.Checks)
 		}
 	}

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -26,7 +26,7 @@ func TestIstioValidationsMarshal(t *testing.T) {
 	}
 	b, err := json.Marshal(validations)
 	assert.NoError(err)
-	assert.Equal(string(b), `{"virtualservice":{"bar.test2":{"name":"bar","objectType":"virtualservice","valid":false,"checks":null,"references":null},"foo.test":{"name":"foo","objectType":"virtualservice","valid":true,"checks":null,"references":null}}}`)
+	assert.Equal(string(b), `{"virtualservice":{"bar.test2":{"name":"bar","namespace":"","cluster":"","objectType":"virtualservice","valid":false,"checks":null,"references":null},"foo.test":{"name":"foo","namespace":"","cluster":"","objectType":"virtualservice","valid":true,"checks":null,"references":null}}}`)
 }
 
 func TestIstioValidationKeyMarshal(t *testing.T) {
@@ -44,8 +44,8 @@ func TestIstioValidationKeyMarshal(t *testing.T) {
 func TestSummarizeValidations(t *testing.T) {
 	assert := assert.New(t)
 
-	key1 := IstioValidationKey{ObjectType: "virtualservice", Name: "foo", Namespace: "bookinfo"}
-	key2 := IstioValidationKey{ObjectType: "virtualservice", Name: "bar", Namespace: "bookinfo"}
+	key1 := IstioValidationKey{ObjectType: "virtualservice", Name: "foo", Namespace: "bookinfo", Cluster: "east"}
+	key2 := IstioValidationKey{ObjectType: "virtualservice", Name: "bar", Namespace: "bookinfo", Cluster: "east"}
 
 	validations := IstioValidations{
 		key1: &IstioValidation{
@@ -68,7 +68,7 @@ func TestSummarizeValidations(t *testing.T) {
 		},
 	}
 
-	summary := validations.SummarizeValidation("bookinfo")
+	summary := validations.SummarizeValidation("bookinfo", "east")
 
 	assert.Equal(2, summary.Warnings)
 	assert.Equal(2, summary.Errors)
@@ -80,7 +80,7 @@ func TestSummarizeValidations(t *testing.T) {
 	validations.StripIgnoredChecks()
 	assert.Equal(1, len(validations[key1].Checks))
 	assert.Equal(1, len(validations[key2].Checks))
-	summary = validations.SummarizeValidation("bookinfo")
+	summary = validations.SummarizeValidation("bookinfo", "east")
 	assert.Equal(1, summary.Warnings)
 	assert.Equal(1, summary.Errors)
 }


### PR DESCRIPTION
** Describe the change **

Fetches validations once per cluster instead of once per namespace.

** Issue reference **

ref: #7076 

Test with:
1. Creating ~200 namespaces with something like:
```bash
for i in {1..200}; do kubectl create ns test-$i; done
```
2. Visit the graph page.
3. Compare previous time it takes to load all the requests and the page with this PR.

Cleanup with:
```bash
for i in {1..200}; do kubectl delete ns test-$i --wait=false --ignore-not-found=true; done
```

In my environment with 208 namespaces selected:
Before:
211 requests ~10.2s

After:
4 requests ~1.8s