### PR TITLE
add profiler to kiali server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,7 @@ type Server struct {
 	GzipEnabled                bool          `yaml:"gzip_enabled,omitempty"`
 	Observability              Observability `yaml:"observability,omitempty"`
 	Port                       int           `yaml:",omitempty"`
+	Profiler                   Profiler      `yaml:"profiler,omitempty"`
 	StaticContentRootDirectory string        `yaml:"static_content_root_directory,omitempty"`
 	WebFQDN                    string        `yaml:"web_fqdn,omitempty"`
 	WebPort                    string        `yaml:"web_port,omitempty"`
@@ -570,6 +571,11 @@ type Rate struct {
 // HealthConfig rates
 type HealthConfig struct {
 	Rate []Rate `yaml:"rate,omitempty" json:"rate,omitempty"`
+}
+
+// Profiler provides settings about the profiler that can be used to debug the Kiali server internals.
+type Profiler struct {
+	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 // Config defines full YAML configuration.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -101,7 +101,7 @@ func TestProfilerRoute(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		assert.Equal(t, 200, resp.StatusCode, "Response should be ok for profile [%v]: %v", p.Name(), string(body))
 	}
-	// note we can't test "profile" endpoint - puts the system into a deadlock
+	// note we do not test "profile" endpoint - it takes too long and besides that the test framework eventually times out
 	for _, p := range []string{"symbol", "trace"} {
 		resp, err = http.Get(ts.URL + "/debug/pprof/" + p)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -79,12 +79,18 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 		NextProtos: []string{"h2", "http/1.1"},
 	}
 
+	// The /debug/pprof/profiler needs a longer write timeout. We only increate the timeout this if the profiler is enabled.
+	writeTimeout := 30 * time.Second
+	if conf.Server.Profiler.Enabled {
+		writeTimeout = 5 * time.Minute
+	}
+
 	// create the server definition that will handle both console and api server traffic
 	httpServer := &http.Server{
 		Addr:         fmt.Sprintf("%v:%v", conf.Server.Address, conf.Server.Port),
 		TLSConfig:    tlsConfig,
 		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: writeTimeout,
 	}
 
 	// return our new Server

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -207,6 +207,7 @@ func TestSecureComm(t *testing.T) {
 	conf.Server.StaticContentRootDirectory = tmpDir
 	conf.Server.Observability.Metrics.Enabled = true
 	conf.Server.Observability.Metrics.Port = testMetricsPort
+	conf.Server.Profiler.Enabled = true
 	conf.Auth.Strategy = "anonymous"
 	util.Clock = util.RealClock{}
 
@@ -214,7 +215,7 @@ func TestSecureComm(t *testing.T) {
 	apiURLWithAuthentication := serverURL + "/api/authenticate"
 	apiURL := serverURL + "/api"
 	metricsURL := fmt.Sprintf("http://%v:%v/", testHostname, testMetricsPort)
-
+	profilerURL := serverURL + "/debug/pprof/"
 	assert.True(t, conf.IsServerHTTPS())
 
 	config.Set(conf)
@@ -269,6 +270,10 @@ func TestSecureComm(t *testing.T) {
 		if !strings.Contains(s, "HELP go_") || !strings.Contains(s, "TYPE go_") {
 			t.Fatalf("Failed: Metrics URL returned bad results - there are no kial metrics:\n%s", s)
 		}
+	}
+
+	if _, err = getRequestResults(t, httpClient, profilerURL, noCredentials); err != nil {
+		t.Fatalf("Failed: Profiler URL shouldn't have failed with no credentials: %v", err)
 	}
 
 	// Make sure the server rejects anything trying to use TLS 1.1 or under


### PR DESCRIPTION
To test, set Kiali CR `spec.server.profiler.enabled` to `true`. The server logs should then have a line like this at startup:

```
2024-02-07T18:09:40Z INF Profiler is enabled
```

Go to the Kiali URL, specifically the `<root context>/debug/pprof/` endpoint and you get the html index page of the profiler. Click all the links to see the data.

For example, if you port-forward to the Kiali server that is running on minikube (say, via `hack/kiali-port-forward.sh`), you should be able to see it at http://localhost:20001/kiali/debug/pprof/

Then use the "go tool pprof" utility to view it in a web browser. For example:

```
go tool pprof -http :8080 http://localhost:20001/kiali/debug/pprof/heap?debug=1
```

will bring up a browser tab pointing to the heap profiler. You can access the other profiles by just changing `heap` in the above URL to another profile name (such as `goroutine`, `allocs`, `profile` (which takes a while to load), et. al.).

fixes: https://github.com/kiali/kiali/issues/4597