### PR TITLE
put /debug/pprof behind auth

### DIFF
--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -81,7 +81,6 @@ func TestSimpleRoute(t *testing.T) {
 
 func TestProfilerRoute(t *testing.T) {
 	conf := new(config.Config)
-	conf.Auth.Strategy = "anonymous"
 	conf.Server.Profiler.Enabled = true
 
 	router := NewRouter(conf, nil, nil, nil, nil, nil)
@@ -92,15 +91,14 @@ func TestProfilerRoute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 200, resp.StatusCode, "Response to index pprof page should be ok")
+	assert.Equal(t, 400, resp.StatusCode, "pprof index should exist but needed credentials")
 
 	for _, p := range rpprof.Profiles() {
 		resp, err = http.Get(ts.URL + "/debug/pprof/" + p.Name())
 		if err != nil {
 			t.Fatalf("Failed to get profile [%v]: %v", p, err)
 		}
-		body, _ := io.ReadAll(resp.Body)
-		assert.Equal(t, 200, resp.StatusCode, "Response should be ok for profile [%v]: %v", p.Name(), string(body))
+		assert.Equal(t, 400, resp.StatusCode, "pprof profile [%v] should exist but needed credentials", p.Name())
 	}
 	// note we do not test "profile" endpoint - it takes too long and besides that the test framework eventually times out
 	for _, p := range []string{"symbol", "trace"} {
@@ -108,14 +106,12 @@ func TestProfilerRoute(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get profile [%v]: %v", p, err)
 		}
-		body, _ := io.ReadAll(resp.Body)
-		assert.Equal(t, 200, resp.StatusCode, "Response should be ok for profiler endpoint [%v]: %v", p, string(body))
+		assert.Equal(t, 400, resp.StatusCode, "pprof endpoint [%v] should exist but needed credentials", p)
 	}
 }
 
 func TestDisabledProfilerRoute(t *testing.T) {
 	conf := new(config.Config)
-	conf.Auth.Strategy = "anonymous"
 	conf.Server.Profiler.Enabled = false
 
 	router := NewRouter(conf, nil, nil, nil, nil, nil)

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -81,6 +81,7 @@ func TestSimpleRoute(t *testing.T) {
 
 func TestProfilerRoute(t *testing.T) {
 	conf := new(config.Config)
+	conf.Auth.Strategy = "anonymous"
 	conf.Server.Profiler.Enabled = true
 
 	router := NewRouter(conf, nil, nil, nil, nil, nil)
@@ -114,6 +115,7 @@ func TestProfilerRoute(t *testing.T) {
 
 func TestDisabledProfilerRoute(t *testing.T) {
 	conf := new(config.Config)
+	conf.Auth.Strategy = "anonymous"
 	conf.Server.Profiler.Enabled = false
 
 	router := NewRouter(conf, nil, nil, nil, nil, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -79,10 +79,13 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 		NextProtos: []string{"h2", "http/1.1"},
 	}
 
-	// The /debug/pprof/profiler needs a longer write timeout. We only increate the timeout this if the profiler is enabled.
+	// The /debug/pprof/profiler by default needs a write timeout larger than 30s. But also, you can pass in &seconds=XY on the pprof URL
+	// and ask for any profile to extend to those number of seconds you specify, which could be larger than 30s.
+	// To limit the damage this may cause with large write timeouts, we only increase the timeout to 1 minute.
+	// TODO: We could make this configurable in the future. See: https://github.com/kiali/kiali/pull/7108#issuecomment-1932982697
 	writeTimeout := 30 * time.Second
 	if conf.Server.Profiler.Enabled {
-		writeTimeout = 5 * time.Minute
+		writeTimeout = 1 * time.Minute
 	}
 
 	// create the server definition that will handle both console and api server traffic

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	rpprof "runtime/pprof"
 	"strings"
 	"testing"
 	"time"
@@ -272,8 +273,22 @@ func TestSecureComm(t *testing.T) {
 		}
 	}
 
+	// check profiler endpoints
+
 	if _, err = getRequestResults(t, httpClient, profilerURL, noCredentials); err != nil {
 		t.Fatalf("Failed: Profiler URL shouldn't have failed with no credentials: %v", err)
+	}
+
+	for _, p := range rpprof.Profiles() {
+		if _, err = getRequestResults(t, httpClient, profilerURL+p.Name(), noCredentials); err != nil {
+			t.Fatalf("Failed to get profile [%v]: %v", p, err)
+		}
+	}
+	// note we do not test "profile" endpoint - it takes too long and besides that the test framework eventually times out
+	for _, p := range []string{"symbol", "trace"} {
+		if _, err = getRequestResults(t, httpClient, profilerURL+p, noCredentials); err != nil {
+			t.Fatalf("Failed to get profile [%v]: %v", p, err)
+		}
 	}
 
 	// Make sure the server rejects anything trying to use TLS 1.1 or under


### PR DESCRIPTION
To assuage those with security paranoia, this PR puts the pprom endpoint behind the Kiali auth. If Kiali is in anonymous mode, you can still get to pprom without credentials, but if Kiali has a non-anonymous auth-strategy set, then pprom will require credentials just as the Kiali console does.