### PR TITLE
Pass cluster name when deleting istio obj from graph

### DIFF
--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -129,6 +129,7 @@ When(
           // element will get unmounted and disappear when
           // the context changes but the graph-side-panel does not.
           cy.get('#graph-side-panel').contains(service);
+          cy.wrap(serviceNode).as('contextNode');
         });
       });
   }
@@ -148,23 +149,19 @@ Then('{string} cluster badge for the graph side panel should be visible', (clust
 
 When('user chooses to delete the routing', () => {
   cy.get('@contextNode').then(node => {
-    // const cluster = node.data('cluster');
+    const cluster = node.data('cluster');
     const service = node.data('service');
     const namespace = node.data('namespace');
     cy.log(`Deleting traffic routing for ${service} service in namespace ${namespace}, data: ${node.data()}`);
     cy.intercept({
       pathname: `**/api/namespaces/${namespace}/istio/virtualservices/${service}`,
-      method: 'DELETE'
-      // TODO: This should include cluster name.
-      // include when https://github.com/kiali/kiali/issues/7024 is fixed.
-      // query: { clusterName: cluster }
+      method: 'DELETE',
+      query: { clusterName: cluster }
     }).as('delete-vs');
     cy.intercept({
       pathname: `**/api/namespaces/${namespace}/istio/destinationrules/${service}`,
-      method: 'DELETE'
-      // TODO: This should include cluster name.
-      // include when https://github.com/kiali/kiali/issues/7024 is fixed.
-      // query: { clusterName: cluster }
+      method: 'DELETE',
+      query: { clusterName: cluster }
     }).as('delete-dr');
 
     cy.getBySel('confirm-delete').click();

--- a/frontend/cypress/integration/featureFiles/graph_side_panel.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel.feature
@@ -43,12 +43,11 @@ Feature: Kiali Graph page - Side panel menu actions
     And the side panel links should contain a "clusterName=west" parameter
     And "west" cluster badge for the graph side panel should be visible
     And user opens the kebab menu of the graph side panel
-    # TODO: Uncomment when https://github.com/kiali/kiali/issues/7024 is fixed
-    #And user clicks the "delete_traffic_routing" item of the kebab menu of the graph side panel
-    #Then user should see the confirmation dialog to delete all traffic routing
-    #When user chooses to delete the routing
-    #And user is at the "istio" list page
-    #Then user does not see traffic routing objects for the "reviews" service in the "bookinfo" namespace in the "west" cluster
+    And user clicks the "delete_traffic_routing" item of the kebab menu of the graph side panel
+    Then user should see the confirmation dialog to delete all traffic routing
+    When user chooses to delete the routing
+    And user is at the "istio" list page
+    Then user does not see traffic routing objects for the "reviews" service in the "bookinfo" namespace in the "west" cluster
 
   @multi-cluster
   Scenario Outline: Ability to launch <action> wizard from graph side panel

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -45,7 +45,12 @@ import { IstioMetricsMap, MetricsStatsResult } from '../types/Metrics';
 import { Namespace } from '../types/Namespace';
 import { KialiCrippledFeatures, ServerConfig } from '../types/ServerConfig';
 import { StatusState } from '../types/StatusState';
-import { ServiceDetailsInfo, ServiceDetailsQuery, ServiceUpdateQuery } from '../types/ServiceInfo';
+import {
+  ServiceDetailsInfo,
+  ServiceDetailsQuery,
+  ServiceUpdateQuery,
+  isServiceDetailsInfo
+} from '../types/ServiceInfo';
 import { ServiceList, ServiceListQuery } from '../types/ServiceList';
 import { Span, TracingQuery } from 'types/Tracing';
 import { TLSStatus } from '../types/TLSStatus';
@@ -1110,6 +1115,12 @@ export function deleteServiceTrafficRouting(
   let drList: DestinationRuleC[];
   let routeList: K8sHTTPRoute[];
   const deletePromises: Promise<ApiResponse<string>>[] = [];
+
+  if (isServiceDetailsInfo(vsOrSvc)) {
+    if (!cluster) {
+      cluster = vsOrSvc.cluster;
+    }
+  }
 
   if ('virtualServices' in vsOrSvc) {
     vsList = vsOrSvc.virtualServices;

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -82,6 +82,16 @@ export interface ServiceDetailsInfo {
   workloads?: WorkloadOverview[];
 }
 
+// Type guard to distinguish between ServiceDetailsInfo and VirtualService[].
+// Only use it for that otherwise you'll likely to get false positives.
+export function isServiceDetailsInfo(obj: any): obj is ServiceDetailsInfo {
+  if (Array.isArray(obj)) {
+    return false;
+  }
+
+  return true;
+}
+
 export interface ServiceDetailsQuery {
   rateInterval?: string;
   validate?: boolean;


### PR DESCRIPTION
### Describe the change

Passes cluster name to API call when deleting istio object from the graph's context menu.

### Steps to test the PR

1. Deploy kiali in a multi-primary env: `./hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`
2. Remove traffic routing in the "west" cluster from the graph's context menu.
3. Should see success.

### Automation testing

Covered by added cypress test.

### Issue reference

Fixes #7024 
