### PR TITLE
Skip Gateway workload pods proxy status check.

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1161,7 +1161,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
-			if pod.HasIstioSidecar() && config.Get().ExternalServices.Istio.IstioAPIEnabled {
+			if pod.HasIstioSidecar() && !w.IsGateway() && config.Get().ExternalServices.Istio.IstioAPIEnabled {
 				pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name)
 			}
 		}
@@ -1733,10 +1733,8 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
-			if pod.HasIstioSidecar() {
-				if config.Get().ExternalServices.Istio.IstioAPIEnabled {
-					pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(criteria.Cluster, criteria.Namespace, pod.Name)
-				}
+			if pod.HasIstioSidecar() && !w.IsGateway() && config.Get().ExternalServices.Istio.IstioAPIEnabled {
+				pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(criteria.Cluster, criteria.Namespace, pod.Name)
 			}
 			// If Ambient is enabled for pod, check if has any Waypoint proxy
 			if pod.AmbientEnabled() {

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -19,20 +19,21 @@ import { history, URLParam } from '../../app/History';
 import { MiniGraphCard } from '../../components/CytoscapeGraph/MiniGraphCard';
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
 import { MiniGraphCardPF } from 'pages/GraphPF/MiniGraphCardPF';
+import { isGateway } from '../../helpers/LabelFilterHelper';
 
 type WorkloadInfoProps = {
   duration: DurationInSeconds;
-  namespace: string;
-  workload?: Workload;
   health?: WorkloadHealth;
+  namespace: string;
   refreshWorkload: () => void;
+  workload?: Workload;
 };
 
 type WorkloadInfoState = {
-  validations?: Validations;
   currentTab: string;
-  workloadIstioConfig?: IstioConfigList;
   tabHeight?: number;
+  validations?: Validations;
+  workloadIstioConfig?: IstioConfigList;
 };
 
 const fullHeightStyle = kialiStyle({
@@ -61,18 +62,18 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     };
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.fetchBackend();
   }
 
-  componentDidUpdate(prev: WorkloadInfoProps) {
+  componentDidUpdate(prev: WorkloadInfoProps): void {
     // Fetch WorkloadInfo backend on duration changes or WorkloadDetailsPage update
     if (prev.duration !== this.props.duration || this.props.workload !== prev.workload) {
       this.fetchBackend();
     }
   }
 
-  private fetchBackend = () => {
+  private fetchBackend = (): void => {
     if (!this.props.workload) {
       return;
     }
@@ -88,7 +89,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     const labels = this.props.workload.labels;
     const wkLabels: string[] = [];
     Object.keys(labels).forEach(key => {
-      const label = key + (labels[key] ? '=' + labels[key] : '');
+      const label = `${key}${labels[key] ? `=${labels[key]}` : ''}`;
       wkLabels.push(label);
     });
     const workloadSelector = wkLabels.join(',');
@@ -156,7 +157,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
           valid: true,
           checks: []
         };
-        if (!isIstioNamespace(this.props.namespace)) {
+        if (!isIstioNamespace(this.props.namespace) && !isGateway(this.props.workload?.labels || {})) {
           if (!isWaypoint) {
             if (!pod.istioContainers || pod.istioContainers.length === 0) {
               if (
@@ -226,7 +227,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     return validations;
   }
 
-  goToMetrics = (e: GraphEdgeTapEvent) => {
+  goToMetrics = (e: GraphEdgeTapEvent): void => {
     if (e.source !== e.target && this.props.workload) {
       const direction = e.source === this.props.workload.name ? 'outbound' : 'inbound';
       const destination = direction === 'inbound' ? 'source_canonical_service' : 'destination_canonical_service';
@@ -234,13 +235,13 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
       urlParams.set('tab', direction === 'inbound' ? 'in_metrics' : 'out_metrics');
       urlParams.set(
         URLParam.BY_LABELS,
-        destination + '=' + (e.source === this.props.workload.name ? e.target : e.source)
+        `${destination}=${e.source === this.props.workload.name ? e.target : e.source}`
       );
-      history.replace(history.location.pathname + '?' + urlParams.toString());
+      history.replace(`${history.location.pathname}?${urlParams.toString()}`);
     }
   };
 
-  render() {
+  render(): React.ReactNode {
     const workload = this.props.workload;
     const pods = workload?.pods || [];
     const istioConfigItems = this.state.workloadIstioConfig

--- a/models/health.go
+++ b/models/health.go
@@ -184,7 +184,7 @@ func aggregate(sample *model.Sample, requests map[string]map[string]float64) {
 // CastWorkloadStatus returns a WorkloadStatus out of a given Workload
 func (w Workload) CastWorkloadStatus() *WorkloadStatus {
 	syncedProxies := int32(-1)
-	if w.HasIstioSidecar() {
+	if w.HasIstioSidecar() && !w.IsGateway() {
 		syncedProxies = w.Pods.SyncedPodProxiesCount()
 	}
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -439,6 +439,9 @@ func (workload *Workload) IsGateway() bool {
 		if labelValue, ok := workload.Labels["operator.istio.io/component"]; ok && (labelValue == "IngressGateways" || labelValue == "EgressGateways") {
 			return true
 		}
+		if labelValue, ok := workload.Labels["istio"]; ok && (labelValue == "ingressgateway" || labelValue == "egressgateway") {
+			return true
+		}
 	}
 	return false
 }

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -186,6 +186,35 @@ func TestParsePodWithoutLabelsToWorkload(t *testing.T) {
 	assert.Equal(map[string]string{}, w.Labels)
 }
 
+func TestIsGatewayLabelsToWorkload(t *testing.T) {
+	assert := assert.New(t)
+	config.Set(config.NewConfig())
+
+	w := Workload{}
+	w.Type = "Deployment"
+	w.Labels = map[string]string{
+		"istio":   "ingressgateway",
+		"version": "v1",
+	}
+	assert.True(w.IsGateway())
+
+	w = Workload{}
+	w.Type = "Deployment"
+	w.Labels = map[string]string{
+		"operator.istio.io/component": "EgressGateways",
+		"version":                     "v1",
+	}
+	assert.True(w.IsGateway())
+
+	w = Workload{}
+	w.Type = "Deployment"
+	w.Labels = map[string]string{
+		"operator.istio.io/component": "EgressGateway",
+		"istio-system":                "ingressgateway",
+	}
+	assert.False(w.IsGateway())
+}
+
 func fakeDeployment() *apps_v1.Deployment {
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 	replicas := int32(1)

--- a/tests/integration/tests/workloads_test.go
+++ b/tests/integration/tests/workloads_test.go
@@ -47,7 +47,8 @@ func TestWorkloadDetails(t *testing.T) {
 	for _, pod := range wl.Pods {
 		require.NotEmpty(pod.Status)
 		require.NotEmpty(pod.Name)
-		require.NotNil(pod.ProxyStatus)
+		// @TODO fails on CI
+		//require.NotNil(pod.ProxyStatus)
 	}
 	require.NotEmpty(wl.Services)
 	for _, wl := range wl.Services {

--- a/tests/integration/tests/workloads_test.go
+++ b/tests/integration/tests/workloads_test.go
@@ -47,7 +47,7 @@ func TestWorkloadDetails(t *testing.T) {
 	for _, pod := range wl.Pods {
 		require.NotEmpty(pod.Status)
 		require.NotEmpty(pod.Name)
-
+		require.NotNil(pod.ProxyStatus)
 	}
 	require.NotEmpty(wl.Services)
 	for _, wl := range wl.Services {
@@ -62,6 +62,23 @@ func TestWorkloadDetails(t *testing.T) {
 	require.NotNil(wl.Workload.Health.Requests)
 	require.NotNil(wl.Workload.Health.Requests.Outbound)
 	require.NotNil(wl.Workload.Health.Requests.Inbound)
+}
+
+func TestWorkloadIstioIngressEmptyProxyStatus(t *testing.T) {
+	name := "istio-ingressgateway"
+	require := require.New(t)
+	wl, _, err := kiali.WorkloadDetails(name, "istio-system")
+
+	require.NoError(err)
+	require.NotNil(wl)
+	require.Equal(name, wl.Name)
+	require.Equal("Deployment", wl.Type)
+	require.NotNil(wl.Pods)
+	for _, pod := range wl.Pods {
+		require.NotEmpty(pod.Status)
+		require.NotEmpty(pod.Name)
+		require.Nil(pod.ProxyStatus)
+	}
 }
 
 func TestWorkloadDetailsInvalidName(t *testing.T) {


### PR DESCRIPTION
### Describe the change

Skip proxy status checks for Workloads which are Gateways.

### Steps to test the PR

Steps to deploy a Gateway 'istio-ingressgateway' into namespace different than 'istio-system' https://docs.openshift.com/container-platform/4.14/service_mesh/v2x/ossm-traffic-manage.html#ossm-automatic-gateway-injection_traffic-management
Here for this Workload it was showing a Proxy Status warning message, but it fact it should not. For Gateways in 'istio-system' it used to ignore the check.
With this PR it will not show Proxy check warning message on Gateways at all.

Regression test the 'istio-ingressgateway' in 'istio-system' namespace and other Worklaods from 'bookinfo' namespace with sidecars.

### Automation testing

Covered in unit and integration tests.

### Issue reference

Issue https://github.com/kiali/kiali/issues/7127
