### PR TITLE
Fix the dataplane namespaces box

### DIFF
--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -248,7 +248,6 @@ const TopologyContent: React.FC<{
 
       function addNode(data: NodeData): NodeModel {
         data.onHover = onHover;
-        console.log(`infraType=${data.infraType}`);
         const size = data.infraType === MeshInfraType.NAMESPACE ? NAMESPACE_NODE_SIZE : DEFAULT_NODE_SIZE;
         const node: NodeModel = {
           data: data,

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -37,7 +37,7 @@ import { TourStop } from 'components/Tour/TourStop';
 import { getFocusSelector, unsetFocusSelector } from 'utils/SearchParamUtils';
 import { meshComponentFactory } from './components/meshComponentFactory';
 import { MeshData } from './MeshPage';
-import { MeshNodeData, MeshTarget } from 'types/Mesh';
+import { MeshInfraType, MeshTarget } from 'types/Mesh';
 import { MeshHighlighter } from './MeshHighlighter';
 import {
   EdgeData,
@@ -55,7 +55,8 @@ import { MeshTourStops } from './MeshHelpTour';
 let initialLayout = false;
 let requestFit = false;
 
-const DEFAULT_NODE_SIZE = 40;
+const DEFAULT_NODE_SIZE = 150;
+const NAMESPACE_NODE_SIZE = 70;
 const ZOOM_IN = 4 / 3;
 const ZOOM_OUT = 3 / 4;
 
@@ -139,7 +140,7 @@ const TopologyContent: React.FC<{
         }
         case ModelKind.node: {
           highlighter.setSelectedId(selectedIds[0]);
-          const isBox = (elem.getData() as MeshNodeData).isBox;
+          const isBox = (elem.getData() as NodeData).isBox;
           setTarget({ type: isBox ? 'box' : 'node', elem: elem } as MeshTarget);
           return;
         }
@@ -226,7 +227,7 @@ const TopologyContent: React.FC<{
       };
 
       function addGroup(data: NodeData): NodeModel {
-        const collapsed = data.isBox === BoxByType.OTHER; // always collapse non-infra to start
+        const collapsed = data.isBox === BoxByType.DATAPLANES; // always collapse data-planes to start
         data.collapsible = collapsed;
         data.onHover = onHover;
         const group: NodeModel = {
@@ -247,15 +248,17 @@ const TopologyContent: React.FC<{
 
       function addNode(data: NodeData): NodeModel {
         data.onHover = onHover;
+        console.log(`infraType=${data.infraType}`);
+        const size = data.infraType === MeshInfraType.NAMESPACE ? NAMESPACE_NODE_SIZE : DEFAULT_NODE_SIZE;
         const node: NodeModel = {
           data: data,
-          height: DEFAULT_NODE_SIZE,
+          height: size,
           id: data.id,
           shape: getNodeShape(data),
           status: getNodeStatus(data),
           style: { padding: 50 },
           type: 'node',
-          width: DEFAULT_NODE_SIZE
+          width: size
         };
         setNodeLabel(node, nodeMap);
         nodeMap.set(data.id, node);

--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -97,7 +97,7 @@ export const getNodeStatus = (data: NodeData): NodeStatus => {
 export const getNodeShape = (data: NodeData): NodeShape => {
   switch (data.infraType) {
     case MeshInfraType.NAMESPACE:
-      return NodeShape.trapezoid;
+      return NodeShape.rect;
     default:
       return NodeShape.hexagon;
   }

--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -95,9 +95,11 @@ export const getNodeStatus = (data: NodeData): NodeStatus => {
 };
 
 export const getNodeShape = (data: NodeData): NodeShape => {
-  switch (data.nodeType) {
+  switch (data.infraType) {
+    case MeshInfraType.NAMESPACE:
+      return NodeShape.trapezoid;
     default:
-      return NodeShape.circle;
+      return NodeShape.hexagon;
   }
 };
 
@@ -130,7 +132,7 @@ export const setNodeLabel = (node: NodeModel, _nodeMap: NodeMap): void => {
         pfBadge = PFBadges.Cluster;
         break;
       case BoxByType.NAMESPACE:
-      case BoxByType.OTHER:
+      case BoxByType.DATAPLANES:
         content.push(data.namespace);
         pfBadge = PFBadges.Namespace;
         break;

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -156,7 +156,6 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
     // the toolbar can render and ensure all redux props are updated with URL
     // settings. That in turn ensures the initial fetchParams are correct.
     const isInitialLoad = !this.state.meshData.timestamp;
-    console.log(`mesh isInitialLoad=${isInitialLoad}`);
 
     if (curr.target?.type === 'mesh') {
       this.controller = curr.target.elem as Controller;
@@ -168,9 +167,6 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
       (prev.hideValue !== curr.hideValue && curr.hideValue.includes('label:')) ||
       prev.lastRefreshAt !== curr.lastRefreshAt
     ) {
-      console.log(
-        `componentDidUpdate: ${isInitialLoad} ${this.state.meshData.timestamp} ${prev.lastRefreshAt} ${curr.lastRefreshAt}`
-      );
       this.loadMeshFromBackend();
     }
 

--- a/frontend/src/pages/Mesh/layouts/layoutFactory.ts
+++ b/frontend/src/pages/Mesh/layouts/layoutFactory.ts
@@ -17,7 +17,6 @@ export const LAYOUT_DEFAULTS: LayoutOptions = {
 */
 
 export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
-  console.log(`type=${type}`);
   switch (type) {
     case LayoutName.Dagre:
       return new DagreLayout(graph, {

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -175,11 +175,6 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     nextState: Readonly<TargetPanelNamespaceState>,
     _nextContext: any
   ): boolean {
-    if (nextState.loading) {
-      console.log(`Loading...: ${JSON.stringify(this.state.nsInfo)}`);
-    } else {
-      console.log(`Done Loading: ${JSON.stringify(this.state.nsInfo)}`);
-    }
     return nextState.loading === false;
   }
 
@@ -795,7 +790,6 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   private fetchHealthStatus(): Promise<void> {
     return API.getNamespaceAppHealth(this.namespace, duration, this.cluster)
       .then(rs => {
-        console.log('In HealthStatus');
         const nsStatus: NamespaceStatus = {
           inNotReady: [],
           inError: [],
@@ -804,10 +798,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
           notAvailable: []
         };
 
-        console.log(`rs=${JSON.stringify(rs)}`);
-
         Object.keys(rs).forEach(item => {
-          console.log(`In Key ${item}`);
           const health: Health = rs[item];
           const status = health.getGlobalStatus();
 
@@ -822,11 +813,8 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
           } else {
             nsStatus.notAvailable.push(item);
           }
-          console.log(`Out Key ${item}`);
         });
-        console.log('In SetState');
         this.setState({ status: nsStatus });
-        console.log('Out HealthStatus');
       })
       .catch(err => this.handleApiError('Could not fetch namespace health', err));
   }

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -182,8 +182,8 @@ export enum GraphType {
 export enum BoxByType {
   APP = 'app',
   CLUSTER = 'cluster',
-  NAMESPACE = 'namespace',
-  OTHER = 'other'
+  DATAPLANES = 'dataplanes',
+  NAMESPACE = 'namespace'
 }
 
 export enum NodeType {

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -95,6 +95,8 @@ trustDomain: cluster.local
 
 	objects := []api_runtime.Object{
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-1"}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-2"}},
 		&istiodDeployment,
 		&istioConfigMap,
 		&sidecarConfigMap,

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -45,6 +45,43 @@
       },
       {
         "data": {
+          "id": "454b7f21d8606d21091fd1c20ac21249",
+          "parent": "a020e49831af01e1d51016dec6171dfd",
+          "cluster": "East",
+          "infraName": "",
+          "infraType": "",
+          "namespace": "Data Plane Namespaces",
+          "nodeType": "box",
+          "healthData": null,
+          "isBox": "dataplanes"
+        }
+      },
+      {
+        "data": {
+          "id": "6f5f68dba350e8facdca4582344ee74c",
+          "parent": "454b7f21d8606d21091fd1c20ac21249",
+          "cluster": "East",
+          "infraName": "data-plane-1",
+          "infraType": "namespace",
+          "namespace": "data-plane-1",
+          "nodeType": "infra",
+          "healthData": null
+        }
+      },
+      {
+        "data": {
+          "id": "e351c7bbefbd8305a74e5916b3bc570b",
+          "parent": "454b7f21d8606d21091fd1c20ac21249",
+          "cluster": "East",
+          "infraName": "data-plane-2",
+          "infraType": "namespace",
+          "namespace": "data-plane-2",
+          "nodeType": "infra",
+          "healthData": null
+        }
+      },
+      {
+        "data": {
           "id": "1c965c180910c6bfaddf3412b0fa1340",
           "parent": "a7784c32ca8454299b1c0d174df2034d",
           "cluster": "East",

--- a/mesh/options.go
+++ b/mesh/options.go
@@ -24,9 +24,9 @@ const (
 )
 
 const (
-	BoxByCluster   string = "cluster"
-	BoxByNamespace string = "namespace"
-	BoxByOther     string = "other" // generic boxing option
+	BoxByCluster    string = "cluster"
+	BoxByDataPlanes string = "dataplanes"
+	BoxByNamespace  string = "namespace"
 )
 
 // CommonOptions are those supplied to Vendors


### PR DESCRIPTION
The namespace box was not properly attached to its parent cluster box.
- change "non-infra" terminology to "data planes"
- simplify boxing strategy
- change node shapes to be more distinct from the traffic graph
- increase node sizes for easier visibility and more distinction from the traffic graph
- add dataplane namespaces to test mesh

Closes https://github.com/kiali/kiali/issues/7118