### PR TITLE
Move `AmbientEnabled` to the `KialiCache`

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -842,6 +842,9 @@ func fakeDaemonSetWithStatus(name string, labels map[string]string, status apps_
 		},
 		Status: status,
 		Spec: apps_v1.DaemonSetSpec{
+			Selector: &meta_v1.LabelSelector{
+				MatchLabels: labels,
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:   "",

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -141,7 +141,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(istioConfigList models.I
 		checkers.SidecarChecker{Sidecars: istioConfigList.Sidecars, Namespaces: namespaces, WorkloadsPerNamespace: workloadsPerNamespace, ServiceEntries: istioConfigList.ServiceEntries, RegistryServices: registryServices, Cluster: cluster},
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadsPerNamespace: workloadsPerNamespace, Cluster: cluster},
 		checkers.WorkloadChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, WorkloadsPerNamespace: workloadsPerNamespace, Cluster: cluster},
-		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses()},
+		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses(cluster)},
 		checkers.K8sHTTPRouteChecker{K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
 		checkers.K8sReferenceGrantChecker{K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Cluster: cluster},
 		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
@@ -258,7 +258,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 	case kubernetes.K8sGateways:
 		// Validations on K8sGateways
 		objectCheckers = []ObjectChecker{
-			checkers.K8sGatewayChecker{Cluster: cluster, K8sGateways: istioConfigList.K8sGateways, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses()},
+			checkers.K8sGatewayChecker{Cluster: cluster, K8sGateways: istioConfigList.K8sGateways, GatewayClasses: in.businessLayer.IstioConfig.GatewayAPIClasses(cluster)},
 		}
 		referenceChecker = references.K8sGatewayReferences{K8sGateways: istioConfigList.K8sGateways, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes}
 	case kubernetes.K8sGRPCRoutes:
@@ -531,7 +531,7 @@ func (in *IstioValidationsService) filterSEExportToNamespaces(allNamespaces mode
 
 func (in *IstioValidationsService) isExportedObjectIncluded(exportTo []string, allNamespaces models.Namespaces, objectNamespace, exportedNamespace string, cluster string) bool {
 	// Ambient mode namespace does not support ExportTo, so export only to own namespace
-	if in.businessLayer.IstioConfig.IsAmbientEnabled() && allNamespaces.IsNamespaceAmbient(objectNamespace, cluster) {
+	if in.businessLayer.IstioConfig.IsAmbientEnabled(cluster) && allNamespaces.IsNamespaceAmbient(objectNamespace, cluster) {
 		return objectNamespace == exportedNamespace
 	} else {
 		if len(exportTo) > 0 {

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -195,9 +195,6 @@ func TestFilterExportToNamespacesVS(t *testing.T) {
 }
 
 func TestAmbientFilterExportToNamespacesVS(t *testing.T) {
-	// skip as businessLayer.IstioConfigService state is not reset from test to test
-	// this test pass when running alone
-	t.SkipNow()
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -274,9 +271,6 @@ func TestFilterExportToNamespacesDR(t *testing.T) {
 }
 
 func TestAmbientFilterExportToNamespacesDR(t *testing.T) {
-	// skip as businessLayer.IstioConfigService state is not reset from test to test
-	// this test pass when running alone
-	t.SkipNow()
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -353,9 +347,6 @@ func TestFilterExportToNamespacesSE(t *testing.T) {
 }
 
 func TestAmbientFilterExportToNamespacesSE(t *testing.T) {
-	// skip as businessLayer.IstioConfigService state is not reset from test to test
-	// this test pass when running alone
-	t.SkipNow()
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/testing.go
+++ b/business/testing.go
@@ -74,8 +74,3 @@ func FindOrFail[T any](t *testing.T, s []T, f func(T) bool) T {
 	}
 	return s[idx]
 }
-
-// asPtr returns a pointer to the argument.
-func asPtr[T any](t T) *T {
-	return &t
-}

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/util"
 )
 
 func TestMeshStatusEnabled(t *testing.T) {
@@ -47,7 +48,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(false)
+	tlsService.enabledAutoMtls = util.AsPtr(false)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{"test"}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -79,7 +80,7 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(true)
+	tlsService.enabledAutoMtls = util.AsPtr(true)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{"test"}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -114,7 +115,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(false)
+	tlsService.enabledAutoMtls = util.AsPtr(false)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{"test"}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -145,7 +146,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(false)
+	tlsService.enabledAutoMtls = util.AsPtr(false)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{ns.Name}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -179,7 +180,7 @@ func TestMeshStatusDisabled(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(false)
+	tlsService.enabledAutoMtls = util.AsPtr(false)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{"test"}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -200,7 +201,7 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(true)
+	tlsService.enabledAutoMtls = util.AsPtr(true)
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), []string{ns.Name}, conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -329,7 +330,7 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	tlsService := NewWithBackends(k8sclients, k8sclients, nil, nil).TLS
-	tlsService.enabledAutoMtls = asPtr(false)
+	tlsService.enabledAutoMtls = util.AsPtr(false)
 	status, err := tlsService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -116,8 +116,8 @@ func Config(w http.ResponseWriter, r *http.Request) {
 
 		// @TODO hardcoded home cluster
 		publicConfig.GatewayAPIEnabled = layer.IstioConfig.IsGatewayAPI(conf.KubernetesConfig.ClusterName)
-		publicConfig.AmbientEnabled = layer.IstioConfig.IsAmbientEnabled()
-		publicConfig.GatewayAPIClasses = layer.IstioConfig.GatewayAPIClasses()
+		publicConfig.AmbientEnabled = layer.IstioConfig.IsAmbientEnabled(conf.KubernetesConfig.ClusterName)
+		publicConfig.GatewayAPIClasses = layer.IstioConfig.GatewayAPIClasses(conf.KubernetesConfig.ClusterName)
 
 		// Fetch the list of all clusters in the mesh
 		// One usage of this data is to cross-link Kiali instances, when possible.

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -113,7 +113,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 	// This can result on an error when IstioAPI is disabled, so filter here
 	// Even if all namespaces are not accessible, but the IstioAPI is enabled, still use the Istio Registry by AllNamespaces=true
 	// In Ambient mode ExportTo is ignored, so proceed per namespace
-	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() && !config.Get().ExternalServices.Istio.IstioAPIEnabled || (business.IstioConfig.IsAmbientEnabled() && len(nss) > 0) {
+	if criteria.AllNamespaces && !config.Get().AllNamespacesAccessible() && !config.Get().ExternalServices.Istio.IstioAPIEnabled || (business.IstioConfig.IsAmbientEnabled(cluster) && len(nss) > 0) {
 		criteria.AllNamespaces = false
 		for _, ns := range nss {
 			criteria.Namespace = ns

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -1,4 +1,4 @@
-package cache
+package cache_test
 
 import (
 	"sync"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -23,7 +24,12 @@ func TestNoHomeClusterReturnsError(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(client)
 	clientFactory.SetClients(map[string]kubernetes.ClientInterface{"nothomecluster": client})
 
-	_, err := NewKialiCache(clientFactory, *conf)
+	cache, err := cache.NewKialiCache(clientFactory, *conf)
+	defer func() {
+		if cache != nil {
+			cache.Stop()
+		}
+	}()
 	require.Error(err, "no home cluster should return an error")
 }
 
@@ -43,14 +49,12 @@ func TestKubeCacheCreatedPerClient(t *testing.T) {
 		"cluster2":                        client2,
 	})
 
-	kialiCache, err := NewKialiCache(clientFactory, *conf)
-	require.NoError(err)
-	defer kialiCache.Stop()
+	kialiCache := cache.NewTestingCacheWithFactory(t, clientFactory, *conf)
 
 	caches := kialiCache.GetKubeCaches()
 	require.Equal(2, len(caches))
 
-	_, err = caches[conf.KubernetesConfig.ClusterName].GetDeployment("test", "deployment1")
+	_, err := caches[conf.KubernetesConfig.ClusterName].GetDeployment("test", "deployment1")
 	require.NoError(err)
 
 	_, err = caches["cluster2"].GetDeployment("test", "deployment2")
@@ -66,18 +70,61 @@ func TestKubeCacheCreatedPerClient(t *testing.T) {
 	require.Error(err)
 }
 
+func ztunnelDaemonSet() *apps_v1.DaemonSet {
+	return &apps_v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ztunnel",
+			Namespace: "istio-system",
+		},
+		Spec: apps_v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "ztunnel"},
+			},
+		},
+	}
+}
+
 func TestIsAmbientEnabled(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
 	client := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
-		&apps_v1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel", Namespace: "istio-system"}},
+		ztunnelDaemonSet(),
 	)
-	cache := NewTestingCache(t, client, *conf)
+	cache := cache.NewTestingCache(t, client, *conf)
 
 	require.True(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
 	// Call multiple times to ensure results are consistent.
 	require.True(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
+}
+
+func TestIsAmbientEnabledOutsideIstioSystem(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	ztunnel := ztunnelDaemonSet()
+	ztunnel.Namespace = "alternate-istio-namespace"
+	client := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "alternate-istio-namespace"}},
+		ztunnel,
+	)
+	cache := cache.NewTestingCache(t, client, *conf)
+
+	require.True(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
+	// Call multiple times to ensure results are consistent.
+	require.True(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
+}
+
+func TestIsAmbientDisabled(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	client := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+	)
+	cache := cache.NewTestingCache(t, client, *conf)
+
+	require.False(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
+	// Call multiple times to ensure results are consistent.
+	require.False(cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName))
 }
 
 func TestIsAmbientMultiCluster(t *testing.T) {
@@ -86,7 +133,7 @@ func TestIsAmbientMultiCluster(t *testing.T) {
 	conf.KubernetesConfig.ClusterName = "east"
 	east := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
-		&apps_v1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel", Namespace: "istio-system"}},
+		ztunnelDaemonSet(),
 	)
 	west := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
@@ -96,7 +143,7 @@ func TestIsAmbientMultiCluster(t *testing.T) {
 		"east": east,
 		"west": west,
 	})
-	cache := NewTestingCacheWithFactory(t, clientFactory, *conf)
+	cache := cache.NewTestingCacheWithFactory(t, clientFactory, *conf)
 
 	require.True(cache.IsAmbientEnabled("east"))
 	require.False(cache.IsAmbientEnabled("west"))
@@ -107,9 +154,9 @@ func TestIsAmbientIsThreadSafe(t *testing.T) {
 	conf := config.NewConfig()
 	client := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
-		&apps_v1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel", Namespace: "istio-system"}},
+		ztunnelDaemonSet(),
 	)
-	cache := NewTestingCache(t, client, *conf)
+	cache := cache.NewTestingCache(t, client, *conf)
 
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {

--- a/kubernetes/cache/proxy_status.go
+++ b/kubernetes/cache/proxy_status.go
@@ -36,8 +36,8 @@ func (c *kialiCacheImpl) SetPodProxyStatus(proxyStatus []*kubernetes.ProxyStatus
 
 func (c *kialiCacheImpl) GetPodProxyStatus(cluster, namespace, pod string) *kubernetes.ProxyStatus {
 	key := proxyStatusKey(cluster, namespace, pod)
-	proxyStatus, err := c.proxyStatusStore.Get(key)
-	if err != nil {
+	proxyStatus, found := c.proxyStatusStore.Get(key)
+	if !found {
 		return nil
 	}
 	return proxyStatus

--- a/kubernetes/cache/registry_status.go
+++ b/kubernetes/cache/registry_status.go
@@ -13,11 +13,11 @@ type (
 )
 
 func (c *kialiCacheImpl) GetRegistryStatus(cluster string) *kubernetes.RegistryStatus {
-	status, err := c.registryStatusStore.Get(cluster)
-	if err != nil {
+	status, found := c.registryStatusStore.Get(cluster)
+	if !found {
 		// Ignoring any errors here because registry services are optional. Most likely any errors
 		// here are due to cache misses since populating the cache is handled asynchronously.
-		log.Tracef("Unable to get registry status for cluster [%s]. Err: %v", cluster, err)
+		log.Tracef("Unable to get registry status for cluster [%s]. Registry status not found in cache.", cluster)
 		return nil
 	}
 

--- a/store/expiration_store.go
+++ b/store/expiration_store.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/util"
+)
+
+const (
+	defaultKeyExpirationCheckInterval = 10 * time.Second
+	defaultKeyTTL                     = 10 * time.Second
+)
+
+// TODO: A better implementation would probably use a priority queue
+// to more efficiently expire keys but this is simpler and good enough for now.
+
+// ExpirationStore is a generic key value store that expires keys after a certain time.
+// It keeps track of which keys are expired separately from the main store.
+type ExpirationStore[T any] struct {
+	Store[T]
+	Stopped <-chan struct{}
+
+	keyExpirationCheckInterval time.Duration
+	keyTTLs                    Store[time.Time]
+	ttl                        time.Duration
+}
+
+// NewExpirationStore returns a new ExpirationStore with the given store and expiration time.
+// TODO: Provide functional options if the arguments list continues to grow.
+func NewExpirationStore[T any](ctx context.Context, store Store[T], keyTTL *time.Duration, keyExpirationCheckInterval *time.Duration) *ExpirationStore[T] {
+	if keyExpirationCheckInterval == nil {
+		keyExpirationCheckInterval = util.AsPtr(defaultKeyExpirationCheckInterval)
+	}
+
+	if keyTTL == nil {
+		keyTTL = util.AsPtr(defaultKeyTTL)
+	}
+
+	s := &ExpirationStore[T]{
+		Store:                      store,
+		keyExpirationCheckInterval: *keyExpirationCheckInterval,
+		keyTTLs:                    New[time.Time](),
+		ttl:                        *keyTTL,
+	}
+	s.Stopped = s.checkAndRemoveExpiredKeys(ctx)
+	return s
+}
+
+// Set associates the given value with the given key and sets the expiration time.
+func (s *ExpirationStore[T]) Set(key string, value T) {
+	s.Store.Set(key, value)
+	s.keyTTLs.Set(key, time.Now().Add(s.ttl))
+}
+
+// Remove removes the given key from the store. If the key does not exist, it does nothing.
+// Removes the expiration key as well.
+func (s *ExpirationStore[T]) Remove(key string) {
+	s.Store.Remove(key)
+	s.keyTTLs.Remove(key)
+}
+
+// Replace replaces the contents of the store with the given map and renews key timers.
+func (s *ExpirationStore[T]) Replace(items map[string]T) {
+	now := time.Now()
+	s.Store.Replace(items)
+	if items == nil {
+		s.keyTTLs.Replace(nil)
+		return
+	}
+
+	for key := range items {
+		s.keyTTLs.Set(key, now.Add(s.ttl))
+	}
+}
+
+func (s *ExpirationStore[T]) checkAndRemoveExpiredKeys(ctx context.Context) <-chan struct{} {
+	stopped := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-time.After(s.keyExpirationCheckInterval):
+				// Check for expired keys and remove them from the store.
+				// If a key is expired, send a signal on the channel.
+				for _, key := range s.Keys() {
+					expiration, found := s.keyTTLs.Get(key)
+					if !found {
+						continue
+					}
+
+					if time.Now().After(expiration) {
+						log.Tracef("Key %s expired. Removing from store", key)
+						s.Remove(key)
+					}
+				}
+
+			case <-ctx.Done():
+				s.Replace(nil)
+				// Don't block on sending stopped.
+				select {
+				case stopped <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}()
+	return stopped
+}

--- a/store/expiration_store_test.go
+++ b/store/expiration_store_test.go
@@ -1,0 +1,94 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/store"
+)
+
+func testingContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestSetAndGet(t *testing.T) {
+	require := require.New(t)
+	ctx := testingContext(t)
+
+	store := store.NewExpirationStore(ctx, store.New[string](), nil, nil)
+
+	key := "testKey"
+	value := "testValue"
+	store.Set(key, value)
+	_, found := store.Get(key)
+	require.True(found)
+}
+
+func TestKeyExpiration(t *testing.T) {
+	require := require.New(t)
+	ctx := testingContext(t)
+
+	ms := 1 * time.Millisecond
+	store := store.NewExpirationStore(ctx, store.New[string](), &ms, &ms)
+
+	key := "testKey"
+	value := "testValue"
+	store.Set(key, value)
+	time.Sleep(time.Millisecond * 30)
+	_, found := store.Get(key)
+	require.False(found)
+}
+
+func TestRemoveKey(t *testing.T) {
+	require := require.New(t)
+	ctx := testingContext(t)
+
+	store := store.NewExpirationStore(ctx, store.New[string](), nil, nil)
+
+	key := "testKey"
+	value := "testValue"
+	store.Set(key, value)
+	store.Remove(key)
+	_, found := store.Get(key)
+	require.False(found)
+}
+
+func TestReplace(t *testing.T) {
+	require := require.New(t)
+	ctx := testingContext(t)
+
+	store := store.NewExpirationStore(ctx, store.New[string](), nil, nil)
+
+	initialData := map[string]string{"key1": "value1"}
+	newData := map[string]string{"key2": "value2"}
+
+	store.Replace(initialData)
+	store.Replace(newData)
+
+	_, found := store.Get("key1")
+	require.False(found)
+
+	val, found := store.Get("key2")
+	require.True(found)
+	require.Equal("value2", val)
+}
+
+func TestStoppedReceivesWhenContextCancelled(t *testing.T) {
+	require := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := store.NewExpirationStore(ctx, store.New[string](), nil, nil)
+
+	cancel()
+	select {
+	case <-store.Stopped:
+	case <-time.After(time.Second):
+		require.Fail("Expected store to send a stop message on Stopped when context cancelled but received none")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -1,24 +1,15 @@
 package store
 
-import (
-	"fmt"
-)
-
-// NotFoundError is returned when a key is not found in the store.
-type NotFoundError struct {
-	Key string
-}
-
-func (e *NotFoundError) Error() string {
-	return fmt.Sprintf("key \"%s\" not found in store", e.Key)
-}
-
 // Store is a generic key value store. Implementations should be safe for concurrent use.
 // It is basically just a map with a lock. Does not yet implement Set so we don't have to
 // worry about this thing growing without bound.
 type Store[T any] interface {
-	// Get returns the value associated with the given key or an error.
-	Get(key string) (T, error)
+	// Get returns the value associated with the given key. Returns false if key was not found.
+	Get(key string) (T, bool)
+	// Keys returns all the keys in the store.
+	Keys() []string
+	// Remove removes the given key from the store. If the key does not exist, it does nothing.
+	Remove(key string)
 	// Replace replaces the contents of the store with the given map.
 	Replace(map[string]T)
 	// Set associates the given value with the given key. It will overwrite any existing value
@@ -30,6 +21,3 @@ type Store[T any] interface {
 func New[T any]() Store[T] {
 	return &threadSafeStore[T]{data: make(map[string]T)}
 }
-
-// Interface guard to ensure NotFoundError implements the error interface.
-var _ error = &NotFoundError{}

--- a/store/store.go
+++ b/store/store.go
@@ -21,6 +21,9 @@ type Store[T any] interface {
 	Get(key string) (T, error)
 	// Replace replaces the contents of the store with the given map.
 	Replace(map[string]T)
+	// Set associates the given value with the given key. It will overwrite any existing value
+	// or create a new entry if the key does not exist.
+	Set(key string, value T)
 }
 
 // New returns a new store safe for concurrent use.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -66,3 +66,33 @@ func TestReplaceWithEmptyKey(t *testing.T) {
 	require.NoError(err)
 	require.Equal(1, val)
 }
+
+func TestSetNewKey(t *testing.T) {
+	require := require.New(t)
+
+	testStore := store.New[int]()
+	_, err := testStore.Get("key1")
+	require.Error(err)
+
+	testStore.Set("key1", 42)
+	val, err := testStore.Get("key1")
+	require.NoError(err)
+	require.Equal(42, val)
+}
+
+func TestSetExistingKey(t *testing.T) {
+	require := require.New(t)
+
+	testStore := store.New[int]()
+	_, err := testStore.Get("key1")
+	require.Error(err)
+
+	testStore.Set("key1", 42)
+	_, err = testStore.Get("key1")
+	require.NoError(err)
+
+	testStore.Set("key1", 43)
+	val, err := testStore.Get("key1")
+	require.NoError(err)
+	require.Equal(43, val)
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -13,9 +13,9 @@ func TestGetKeyExists(t *testing.T) {
 
 	testStore := store.New[int]()
 	testStore.Replace(map[string]int{"key1": 42})
-	value, err := testStore.Get("key1")
+	value, found := testStore.Get("key1")
 
-	require.NoError(err)
+	require.True(found)
 	require.Equal(42, value)
 }
 
@@ -23,9 +23,8 @@ func TestGetNonExistantKeyFails(t *testing.T) {
 	require := require.New(t)
 
 	testStore := store.New[int]()
-	_, err := testStore.Get("nonexistent")
-	require.Error(err)
-	require.IsType(&store.NotFoundError{}, err)
+	_, found := testStore.Get("nonexistent")
+	require.False(found)
 }
 
 func TestReplaceStoreContents(t *testing.T) {
@@ -37,23 +36,16 @@ func TestReplaceStoreContents(t *testing.T) {
 	newData := map[string]int{"key2": 99, "key3": 100}
 	testStore.Replace(newData)
 
-	_, err := testStore.Get("key1")
-	require.Error(err)
+	_, found := testStore.Get("key1")
+	require.False(found)
 
-	value, err := testStore.Get("key2")
-	require.NoError(err)
+	value, found := testStore.Get("key2")
+	require.True(found)
 	require.Equal(99, value)
 
-	value, err = testStore.Get("key3")
-	require.NoError(err)
+	value, found = testStore.Get("key3")
+	require.True(found)
 	require.Equal(100, value)
-}
-
-func TestNotFoundImplementsStringer(t *testing.T) {
-	require := require.New(t)
-
-	err := &store.NotFoundError{Key: "key1"}
-	require.NotEmpty(err.Error())
 }
 
 func TestReplaceWithEmptyKey(t *testing.T) {
@@ -62,8 +54,8 @@ func TestReplaceWithEmptyKey(t *testing.T) {
 	testStore := store.New[int]()
 	testStore.Replace(map[string]int{"": 1})
 
-	val, err := testStore.Get("")
-	require.NoError(err)
+	val, found := testStore.Get("")
+	require.True(found)
 	require.Equal(1, val)
 }
 
@@ -71,12 +63,12 @@ func TestSetNewKey(t *testing.T) {
 	require := require.New(t)
 
 	testStore := store.New[int]()
-	_, err := testStore.Get("key1")
-	require.Error(err)
+	_, found := testStore.Get("key1")
+	require.False(found)
 
 	testStore.Set("key1", 42)
-	val, err := testStore.Get("key1")
-	require.NoError(err)
+	val, found := testStore.Get("key1")
+	require.True(found)
 	require.Equal(42, val)
 }
 
@@ -84,15 +76,41 @@ func TestSetExistingKey(t *testing.T) {
 	require := require.New(t)
 
 	testStore := store.New[int]()
-	_, err := testStore.Get("key1")
-	require.Error(err)
+	_, found := testStore.Get("key1")
+	require.False(found)
 
 	testStore.Set("key1", 42)
-	_, err = testStore.Get("key1")
-	require.NoError(err)
+	_, found = testStore.Get("key1")
+	require.True(found)
 
 	testStore.Set("key1", 43)
-	val, err := testStore.Get("key1")
-	require.NoError(err)
+	val, found := testStore.Get("key1")
+	require.True(found)
 	require.Equal(43, val)
+}
+
+func TestKeys(t *testing.T) {
+	require := require.New(t)
+
+	testStore := store.New[int]()
+
+	testStore.Set("key1", 42)
+	testStore.Set("key2", 43)
+
+	keys := testStore.Keys()
+	require.Len(keys, 2)
+	require.Contains(keys, "key1")
+	require.Contains(keys, "key2")
+}
+
+func TestRemove(t *testing.T) {
+	require := require.New(t)
+
+	testStore := store.New[int]()
+
+	testStore.Set("key1", 42)
+	testStore.Remove("key1")
+	v, found := testStore.Get("key1")
+	require.False(found)
+	require.Zero(v)
 }

--- a/store/threadsafe_store.go
+++ b/store/threadsafe_store.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"sync"
+
+	"golang.org/x/exp/maps"
 )
 
 // threadSafeStore implements the Store interface and is safe for concurrent use.
@@ -11,7 +13,7 @@ type threadSafeStore[T any] struct {
 }
 
 // Get returns the value associated with the given key or an error.
-func (s *threadSafeStore[T]) Get(key string) (T, error) {
+func (s *threadSafeStore[T]) Get(key string) (T, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	var (
@@ -19,16 +21,17 @@ func (s *threadSafeStore[T]) Get(key string) (T, error) {
 		found bool
 	)
 	v, found = s.data[key]
-	if !found {
-		return v, &NotFoundError{key}
-	}
-	return v, nil
+	return v, found
 }
 
 // Replace replaces the contents of the store with the given map.
 func (s *threadSafeStore[T]) Replace(items map[string]T) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	// In case this gets re-used, we don't want items to be nil for other methods.
+	if items == nil {
+		items = make(map[string]T)
+	}
 	s.data = items
 }
 
@@ -38,6 +41,19 @@ func (s *threadSafeStore[T]) Set(key string, value T) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.data[key] = value
+}
+
+func (s *threadSafeStore[T]) Remove(key string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.data, key)
+}
+
+// Keys returns all the keys in the store.
+func (s *threadSafeStore[T]) Keys() []string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return maps.Keys(s.data)
 }
 
 // Interface guard to ensure threadSafeStore implements the Store.

--- a/store/threadsafe_store.go
+++ b/store/threadsafe_store.go
@@ -32,5 +32,13 @@ func (s *threadSafeStore[T]) Replace(items map[string]T) {
 	s.data = items
 }
 
+// Set associates the given value with the given key. It will overwrite any existing value
+// or create a new entry if the key does not exist.
+func (s *threadSafeStore[T]) Set(key string, value T) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data[key] = value
+}
+
 // Interface guard to ensure threadSafeStore implements the Store.
 var _ Store[any] = &threadSafeStore[any]{}

--- a/util/pointer.go
+++ b/util/pointer.go
@@ -1,0 +1,6 @@
+package util
+
+// AsPtr returns a pointer to the argument.
+func AsPtr[T any](t T) *T {
+	return &t
+}


### PR DESCRIPTION
### Describe the change

Moves `AmbientEnabled` check to the `KialiCache` and make the check cluster specific. This gets rid of the global variables that were breaking the unit tests.

Split out from #7136 