### PR TITLE
Remove duration labeling for Overview control plan charts

### DIFF
--- a/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardControlPlaneNamespace.tsx
@@ -4,8 +4,6 @@ import { SparklineChart } from 'components/Charts/SparklineChart';
 import { VCLine, RichDataPoint } from 'types/VictoryChartInfo';
 import { PFColors } from 'components/Pf/PfColors';
 import { toVCLine } from 'utils/VictoryChartsUtils';
-import { DurationInSeconds } from 'types/Common';
-import { getName } from 'utils/RateIntervals';
 import { Card, CardBody, Flex, FlexItem, Grid, GridItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -18,7 +16,6 @@ export const infoStyle = kialiStyle({
 const controlPlaneAnnotation = 'topology.istio.io/controlPlaneClusters';
 
 type ControlPlaneProps = {
-  duration: DurationInSeconds;
   istiodContainerMemory?: Metric[];
   istiodContainerCpu?: Metric[];
   istiodProcessMemory?: Metric[];
@@ -141,15 +138,11 @@ export const OverviewCardControlPlaneNamespace: React.FC<ControlPlaneProps> = (p
                   >
                     <FlexItem>
                       <b>Memory</b>
-                    </FlexItem>
-
-                    <FlexItem>
-                      {getName(props.duration).toLowerCase()}
                       <Tooltip
                         position={TooltipPosition.right}
                         content={
                           <div style={{ textAlign: 'left' }}>
-                            This values represents the memory of the istiod {memoryMetricSource}
+                            This chart shows memory consumption for the istiod {memoryMetricSource}
                           </div>
                         }
                       >
@@ -190,15 +183,11 @@ export const OverviewCardControlPlaneNamespace: React.FC<ControlPlaneProps> = (p
                   >
                     <FlexItem>
                       <b>CPU</b>
-                    </FlexItem>
-
-                    <FlexItem>
-                      {getName(props.duration).toLowerCase()}
                       <Tooltip
                         position={TooltipPosition.right}
                         content={
                           <div style={{ textAlign: 'left' }}>
-                            This values represents cpu of the istiod {cpuMetricSource}
+                            This chart shows cpu consumption for the istiod {cpuMetricSource}
                           </div>
                         }
                       >

--- a/frontend/src/pages/Overview/OverviewCardSparklineCharts.tsx
+++ b/frontend/src/pages/Overview/OverviewCardSparklineCharts.tsx
@@ -43,7 +43,6 @@ const OverviewCardSparklineChartsComponent: React.FC<Props> = (props: Props) => 
           istiodContainerCpu={props.controlPlaneMetrics?.istiod_container_cpu}
           istiodProcessMemory={props.controlPlaneMetrics?.istiod_process_mem}
           istiodProcessCpu={props.controlPlaneMetrics?.istiod_process_cpu}
-          duration={props.duration}
           istiodResourceThresholds={props.istiodResourceThresholds}
         />
       )}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/7147

Remove duration labeling for Overview control plan charts
- move info icon up when space allows
- improve info icon tooltip text

Now looks like:

![image](https://github.com/kiali/kiali/assets/2104052/c4c6b4fa-a13f-4316-a2b2-680d29aaf69d)


