### PR TITLE
feat: Add AWS EKS ARN support for remote cluster name

### DIFF
--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -245,6 +245,12 @@ create_kiali_remote_cluster_secret() {
     local cert_auth_yaml="certificate-authority-data: ${remote_cluster_ca_bytes}"
   fi
 
+  # Check if the REMOTE_CLUSTER_NAME matches the AWS EKS ARN regex pattern.
+  # If it does, extract the cluster name from the ARN and assign it back to REMOTE_CLUSTER_NAME.
+  AWS_REGION_REGEX='(us|eu|ap|sa|ca|me)-(north|south|east|west|central)-\d'
+  AWS_EKS_ARN_REGEX="^arn:aws:eks:${AWS_REGION_REGEX}:\d{12}:cluster\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
+  if echo "${REMOTE_CLUSTER_NAME}" | grep -Eq "${AWS_EKS_ARN_REGEX}"; then
+      REMOTE_CLUSTER_NAME=$(echo "${REMOTE_CLUSTER_NAME}" | sed 's/^.*:cluster\/\(.*\)$/\1/')
   # a Secret stringData key must conform to Kubernetes naming rules. Othewise, this kind of error will result:
   #    a valid config key must consist of alphanumeric characters, '-', '_' or '.'
   #    (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -250,7 +250,6 @@ create_kiali_remote_cluster_secret() {
   AWS_REGION_REGEX='(us|eu|ap|sa|ca|me|af|il|us-gov)-(north|south|east|west|central|southeast|northeast)-[0-9]'
   AWS_EKS_ARN_REGEX="arn:aws:eks:${AWS_REGION_REGEX}:[0-9]{12}:cluster/([0-9A-Za-z][_A-Za-z0-9\-]{0,99})$"
   if echo "${REMOTE_CLUSTER_NAME}" | grep -Eq "${AWS_EKS_ARN_REGEX}"; then
-      echo "The remote cluster name [${REMOTE_CLUSTER_NAME}] matches the AWS EKS ARN regex pattern."
       REMOTE_CLUSTER_NAME=$(echo "${REMOTE_CLUSTER_NAME}" | sed 's/^.*:cluster\/\(.*\)$/\1/')
   fi
   # a Secret stringData key must conform to Kubernetes naming rules. Othewise, this kind of error will result:

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -247,9 +247,10 @@ create_kiali_remote_cluster_secret() {
 
   # Check if the REMOTE_CLUSTER_NAME matches the AWS EKS ARN regex pattern.
   # If it does, extract the cluster name from the ARN and assign it back to REMOTE_CLUSTER_NAME.
-  AWS_REGION_REGEX='(us|eu|ap|sa|ca|me)-(north|south|east|west|central)-[0-9]'
-  AWS_EKS_ARN_REGEX="^arn:aws:eks:${AWS_REGION_REGEX}:[0-9]{12}:cluster/([A-Za-z0-9\-]+)$"
+  AWS_REGION_REGEX='(us|eu|ap|sa|ca|me|af|il|us-gov)-(north|south|east|west|central|southeast|northeast)-[0-9]'
+  AWS_EKS_ARN_REGEX="arn:aws:eks:${AWS_REGION_REGEX}:[0-9]{12}:cluster/([0-9A-Za-z][_A-Za-z0-9\-]{0,99})$"
   if echo "${REMOTE_CLUSTER_NAME}" | grep -Eq "${AWS_EKS_ARN_REGEX}"; then
+      echo "The remote cluster name [${REMOTE_CLUSTER_NAME}] matches the AWS EKS ARN regex pattern."
       REMOTE_CLUSTER_NAME=$(echo "${REMOTE_CLUSTER_NAME}" | sed 's/^.*:cluster\/\(.*\)$/\1/')
   fi
   # a Secret stringData key must conform to Kubernetes naming rules. Othewise, this kind of error will result:

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -247,8 +247,8 @@ create_kiali_remote_cluster_secret() {
 
   # Check if the REMOTE_CLUSTER_NAME matches the AWS EKS ARN regex pattern.
   # If it does, extract the cluster name from the ARN and assign it back to REMOTE_CLUSTER_NAME.
-  AWS_REGION_REGEX='(us|eu|ap|sa|ca|me)-(north|south|east|west|central)-\d'
-  AWS_EKS_ARN_REGEX="^arn:aws:eks:${AWS_REGION_REGEX}:\d{12}:cluster\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
+  AWS_REGION_REGEX='(us|eu|ap|sa|ca|me)-(north|south|east|west|central)-[0-9]'
+  AWS_EKS_ARN_REGEX="^arn:aws:eks:${AWS_REGION_REGEX}:[0-9]{12}:cluster/([A-Za-z0-9\-]+)$"
   if echo "${REMOTE_CLUSTER_NAME}" | grep -Eq "${AWS_EKS_ARN_REGEX}"; then
       REMOTE_CLUSTER_NAME=$(echo "${REMOTE_CLUSTER_NAME}" | sed 's/^.*:cluster\/\(.*\)$/\1/')
   fi

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -251,6 +251,7 @@ create_kiali_remote_cluster_secret() {
   AWS_EKS_ARN_REGEX="^arn:aws:eks:${AWS_REGION_REGEX}:\d{12}:cluster\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
   if echo "${REMOTE_CLUSTER_NAME}" | grep -Eq "${AWS_EKS_ARN_REGEX}"; then
       REMOTE_CLUSTER_NAME=$(echo "${REMOTE_CLUSTER_NAME}" | sed 's/^.*:cluster\/\(.*\)$/\1/')
+  fi
   # a Secret stringData key must conform to Kubernetes naming rules. Othewise, this kind of error will result:
   #    a valid config key must consist of alphanumeric characters, '-', '_' or '.'
   #    (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')


### PR DESCRIPTION
- Extend validation to allow AWS EKS ARN format for REMOTE_CLUSTER_NAME
- Extract cluster name from ARN if REMOTE_CLUSTER_NAME is in ARN format
- Update error messages to reflect new validation rules

### Describe the change

Adds AWS EKS ARN support for remote cluster names and updates error messages.

### Steps to test the PR

Set REMOTE_CLUSTER_NAME to a valid Kubernetes name and verify no errors.
Set REMOTE_CLUSTER_NAME to a valid AWS EKS ARN and verify extraction of the cluster name.
Set REMOTE_CLUSTER_NAME to an invalid value and verify the appropriate error message.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

fixes: https://github.com/kiali/kiali/issues/7160
