### PR TITLE
change detection method for Istio Ambient

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1020,10 +1020,8 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 	}
 	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > (10*time.Minute) {
 		ambientEnabled = new(bool)
-		selector := map[string]string{
-			"app": "ztunnel",
-		}
-		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, selector)
+
+		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, "app=ztunnel")
 		if err != nil {
 			log.Debugf("No ztunnel daemonset found in Kiali accessible namespaces: %s ", err.Error())
 		} else {

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1020,9 +1020,9 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 	}
 	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > time.Minute {
 		ambientEnabled = new(bool)
-		daemonset, err := in.kialiCache.GetDaemonSet(in.config.IstioNamespace, "ztunnel")
+		daemonset, err := in.kialiCache.GetDaemonSet(in.config.ExternalServices.Istio.IstioAmbientNamespace, "ztunnel")
 		if err != nil {
-			log.Debugf("No ztunnel found in istio namespace: %s ", err.Error())
+			log.Debugf("No ztunnel found in Istio Ambient namespace (%s): %s ", in.config.ExternalServices.Istio.IstioAmbientNamespace, err.Error())
 		} else {
 			if daemonset != nil {
 				*ambientEnabled = true

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1018,7 +1018,7 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 		lastUpdateTime = new(time.Time)
 		lastUpdateTime = &currentTime
 	}
-	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > time.Minute {
+	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > (10*time.Minute) {
 		ambientEnabled = new(bool)
 		selector := map[string]string{
 			"app": "ztunnel",

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1011,7 +1011,7 @@ func (in *IstioConfigService) GatewayAPIClasses() []config.GatewayAPIClass {
 }
 
 // Check if istio Ambient profile was enabled
-// ATM it is defined in the istio-cni-config configmap
+// ATM it will look for app=ztunnel selector from a configmap
 func (in *IstioConfigService) IsAmbientEnabled() bool {
 	currentTime := time.Now()
 	if lastUpdateTime == nil {
@@ -1020,11 +1020,14 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 	}
 	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > time.Minute {
 		ambientEnabled = new(bool)
-		daemonset, err := in.kialiCache.GetDaemonSet(in.config.ExternalServices.Istio.IstioAmbientNamespace, "ztunnel")
+		selector := map[string]string{
+			"app": "ztunnel",
+		}
+		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, selector)
 		if err != nil {
 			log.Debugf("No ztunnel found in Istio Ambient namespace (%s): %s ", in.config.ExternalServices.Istio.IstioAmbientNamespace, err.Error())
 		} else {
-			if daemonset != nil {
+			if len(daemonset) > 0 {
 				*ambientEnabled = true
 				return true
 			} else {

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1020,8 +1020,10 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 	}
 	if ambientEnabled == nil || currentTime.Sub(*lastUpdateTime) > (10*time.Minute) {
 		ambientEnabled = new(bool)
-
-		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, "app=ztunnel")
+		selector := map[string]string{
+			"app": "ztunnel",
+		}
+		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, selector)
 		if err != nil {
 			log.Debugf("No ztunnel daemonset found in Kiali accessible namespaces: %s ", err.Error())
 		} else {

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1025,7 +1025,7 @@ func (in *IstioConfigService) IsAmbientEnabled() bool {
 		}
 		daemonset, err := in.kialiCache.GetDaemonSetsWithSelector(meta_v1.NamespaceAll, selector)
 		if err != nil {
-			log.Debugf("No ztunnel found in Istio Ambient namespace (%s): %s ", in.config.ExternalServices.Istio.IstioAmbientNamespace, err.Error())
+			log.Debugf("No ztunnel daemonset found in Kiali accessible namespaces: %s ", err.Error())
 		} else {
 			if len(daemonset) > 0 {
 				*ambientEnabled = true

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -44,6 +44,27 @@ func setupNamespaceServiceWithNs() kubernetes.ClientInterface {
 	return k8s
 }
 
+// Namespace service setup
+func setupAmbientNamespaceServiceWithNs() kubernetes.ClientInterface {
+	c := config.NewConfig()
+	labels := map[string]string{
+		c.IstioLabels.AmbientNamespaceLabel: c.IstioLabels.AmbientNamespaceLabelValue,
+	}
+	// config needs to be set by other services since those rely on the global.
+	objects := []runtime.Object{
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo", Labels: labels}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "alpha"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "beta"}},
+	}
+	for _, obj := range fakeNamespaces() {
+		o := obj
+		objects = append(objects, &o)
+	}
+	k8s := kubetest.NewFakeK8sClient(objects...)
+	k8s.OpenShift = false
+	return k8s
+}
+
 // Get namespaces
 func TestGetNamespaces(t *testing.T) {
 	conf := config.NewConfig()
@@ -97,6 +118,31 @@ func TestGetNamespaceWithError(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Nil(t, ns2)
+}
+
+// Get Ambient namespace
+func TestAmbientNamespace(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := setupAmbientNamespaceServiceWithNs()
+
+	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
+	SetWithBackends(mockClientFactory, nil)
+
+	nsservice := setupNamespaceService(t, k8s, conf)
+
+	ns, _ := nsservice.GetClusterNamespace(context.TODO(), "bookinfo", config.Get().KubernetesConfig.ClusterName)
+
+	assert.NotNil(t, ns)
+	assert.Equal(t, ns.Name, "bookinfo")
+	assert.True(t, ns.IsAmbient)
+
+	ns2, _ := nsservice.GetClusterNamespace(context.TODO(), "alpha", config.Get().KubernetesConfig.ClusterName)
+
+	assert.NotNil(t, ns2)
+	assert.Equal(t, ns2.Name, "alpha")
+	assert.False(t, ns2.IsAmbient)
 }
 
 // Update namespaces

--- a/config/config.go
+++ b/config/config.go
@@ -270,7 +270,6 @@ type IstioConfig struct {
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
-	IstioAmbientNamespace             string              `yaml:"istio_ambient_namespace"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
@@ -703,7 +702,6 @@ func NewConfig() (c *Config) {
 				},
 				ConfigMapName:                     "istio",
 				EnvoyAdminLocalPort:               15000,
-				IstioAmbientNamespace:             "istio-system", // Should be kube-system in OpenShift
 				IstioAPIEnabled:                   true,
 				IstioIdentityDomain:               "svc.cluster.local",
 				IstioInjectionAnnotation:          "sidecar.istio.io/inject",

--- a/config/config.go
+++ b/config/config.go
@@ -270,6 +270,7 @@ type IstioConfig struct {
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
+	IstioAmbientNamespace             string              `yaml:"istio_ambient_namespace"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
@@ -702,6 +703,7 @@ func NewConfig() (c *Config) {
 				},
 				ConfigMapName:                     "istio",
 				EnvoyAdminLocalPort:               15000,
+				IstioAmbientNamespace:             "istio-system", // Should be kube-system in OpenShift
 				IstioAPIEnabled:                   true,
 				IstioIdentityDomain:               "svc.cluster.local",
 				IstioInjectionAnnotation:          "sidecar.istio.io/inject",

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -563,9 +563,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 					return nil, err2
 				}
 				for _, ds := range dsNS {
-					d := ds.DeepCopy()
-					d.Kind = kubernetes.DaemonSetType
-					daemonSets = append(daemonSets, *d)
+					daemonSets = append(daemonSets, *ds)
 				}
 
 			}
@@ -576,9 +574,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 			return nil, errDs
 		}
 		for _, ds := range dsNS {
-			d := ds.DeepCopy()
-			d.Kind = kubernetes.DaemonSetType
-			daemonSets = append(daemonSets, *d)
+			daemonSets = append(daemonSets, *ds)
 		}
 	}
 

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -563,7 +563,9 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 					return nil, err2
 				}
 				for _, ds := range dsNS {
-					daemonSets = append(daemonSets, *ds)
+					d := ds.DeepCopy()
+					d.Kind = kubernetes.DaemonSetType
+					daemonSets = append(daemonSets, *d)
 				}
 
 			}
@@ -574,7 +576,9 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 			return nil, errDs
 		}
 		for _, ds := range dsNS {
-			daemonSets = append(daemonSets, *ds)
+			d := ds.DeepCopy()
+			d.Kind = kubernetes.DaemonSetType
+			daemonSets = append(daemonSets, *d)
 		}
 	}
 

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -69,7 +69,7 @@ type KubeCache interface {
 	GetConfigMap(namespace, name string) (*core_v1.ConfigMap, error)
 	GetDaemonSets(namespace string) ([]apps_v1.DaemonSet, error)
 	GetDaemonSet(namespace, name string) (*apps_v1.DaemonSet, error)
-	GetDaemonSetsWithSelector(namespace string, labelSelector string) ([]apps_v1.DaemonSet, error)
+	GetDaemonSetsWithSelector(namespace string, labelSelector map[string]string) ([]apps_v1.DaemonSet, error)
 	GetDeployments(namespace string) ([]apps_v1.Deployment, error)
 	GetDeploymentsWithSelector(namespace string, labelSelector string) ([]apps_v1.Deployment, error)
 	GetDeployment(namespace, name string) (*apps_v1.Deployment, error)
@@ -538,17 +538,13 @@ func (c *kubeCache) GetDaemonSet(namespace, name string) (*apps_v1.DaemonSet, er
 	return retDS, nil
 }
 
-func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels string) ([]apps_v1.DaemonSet, error) {
+func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels map[string]string) ([]apps_v1.DaemonSet, error) {
 	defer c.cacheLock.RUnlock()
 	c.cacheLock.RLock()
 
 	var daemonSets []apps_v1.DaemonSet
 	var err error
-
-	selector, err := labels.ConvertSelectorToLabelsMap(selectorLabels)
-	if err != nil {
-		return nil, err
-	}
+	selector := labels.Set(selectorLabels)
 
 	if namespace == metav1.NamespaceAll {
 		if c.clusterScoped {
@@ -558,7 +554,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 			}
 		} else {
 			for _, nsCacheLister := range c.nsCacheLister {
-				dsNS, err2 := nsCacheLister.daemonSetLister.List(selector.AsSelector())
+				dsNS, err2 := nsCacheLister.daemonSetLister.List(labels.Everything())
 				if err2 != nil {
 					return nil, err2
 				}
@@ -569,7 +565,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 			}
 		}
 	} else {
-		dsNS, errDs := c.getCacheLister(namespace).daemonSetLister.DaemonSets(namespace).List(selector.AsSelector())
+		dsNS, errDs := c.getCacheLister(namespace).daemonSetLister.DaemonSets(namespace).List(labels.Everything())
 		if errDs != nil {
 			return nil, errDs
 		}
@@ -578,7 +574,26 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels s
 		}
 	}
 
-	return daemonSets, nil
+	// Now, filter by selector
+	retDS := []apps_v1.DaemonSet{}
+	for _, ds := range daemonSets {
+
+		labelMap, err := metav1.LabelSelectorAsMap(ds.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		labelSet := labels.Set(labelMap)
+
+		svcSelector := labelSet.AsSelector()
+		// selector match is done after listing all daemonSets, similar to registry reading
+		if selector.AsSelector().Empty() || (!svcSelector.Empty() && svcSelector.Matches(selector)) {
+			// Do not modify what is returned by the lister since that is shared and will cause data races.
+			svc := ds.DeepCopy()
+			svc.Kind = kubernetes.DaemonSetType
+			retDS = append(retDS, *svc)
+		}
+	}
+	return retDS, nil
 }
 
 func (c *kubeCache) GetDeployments(namespace string) ([]apps_v1.Deployment, error) {

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -559,8 +559,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels m
 		labelSet := labels.Set(labelMap)
 
 		svcSelector := labelSet.AsSelector()
-		// selector match is done after listing all services, similar to registry reading
-		// empty selector is loading all services, or match the service selector
+		// selector match is done after listing all daemonSets, similar to registry reading
 		if selector.AsSelector().Empty() || (!svcSelector.Empty() && svcSelector.Matches(selector)) {
 			// Do not modify what is returned by the lister since that is shared and will cause data races.
 			svc := ds.DeepCopy()

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -85,13 +85,16 @@ func CastProjectCollection(ps []osproject_v1.Project, cluster string) []Namespac
 }
 
 func CastProject(p osproject_v1.Project, cluster string) Namespace {
+	istioLabels := config.Get().IstioLabels
 	namespace := Namespace{}
 	namespace.Name = p.Name
 	namespace.Cluster = cluster
 	namespace.CreationTimestamp = p.CreationTimestamp.Time
 	namespace.Labels = p.Labels
 	namespace.Annotations = p.Annotations
-
+	if p.Labels[istioLabels.AmbientNamespaceLabel] == istioLabels.AmbientNamespaceLabelValue {
+		namespace.IsAmbient = true
+	}
 	return namespace
 }
 


### PR DESCRIPTION
### Describe the change

Add istioAmbientNamespace as a config parameter and add Ambient Namespace logic to projects (For OpenShift). 

Kiali running in OpenShift and Istio 1.22.alpha: 

![image](https://github.com/kiali/kiali/assets/49480155/e60302bf-a132-485d-b3ca-d0ea3f21e1e4)

![image](https://github.com/kiali/kiali/assets/49480155/aa80d8c9-644c-4190-aa6a-2cb5bdfc27ff)

![image](https://github.com/kiali/kiali/assets/49480155/c349c291-f105-44dc-8d8e-b9ee1a096fde)

![image](https://github.com/kiali/kiali/assets/49480155/547be438-7d76-44cb-a5af-cb854d4acb49)


### Steps to test the PR

(Note: I was not able to run it from the hack script because I was received `Error: generate config: failed to read profile openshift-ambient from : open profiles/openshift-ambient.yaml: file does not exist`, tested with: `istio/install-istio-via-istioctl.sh -cp openshift-ambient -ih gcr.io/istio-testing -it 1.22-alpha.f1898ff2fc1406b7899dcf2409876f94b0e76dca -ic ~/Downloads/istio-1.21.0-rc.0/bin/istioctl`

`wget -O - https://storage.googleapis.com/istio-build/dev/1.22-alpha.f1898ff2fc1406b7899dcf2409876f94b0e76dca/istioctl-1.22-alpha.f1898ff2fc1406b7899dcf2409876f94b0e76dca-linux-amd64.tar.gz | tar zxvf -`

./istioctl install --set hub=gcr.io/istio-testing --set tag=1.22-alpha.f1898ff2fc1406b7899dcf2409876f94b0e76dca --set values.meshConfig.enableAutoMtls=true --set values.pilot.env.ENABLE_NATIVE_SIDECARS=false   --set values.gateways.istio-egressgateway.enabled=true --set values.gateways.istio-ingressgateway.enabled=true --set values.meshConfig.defaultConfig.tracing.sampling=100.00 --set values.meshConfig.accessLogFile=/dev/stdout --set components.cni.enabled=true --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName=istio-cni.conf --set values.sidecarInjectorWebhook.injectedAnnotations.k8s\.v1\.cni\.cncf\.io/networks=istio-cni --set profile=openshift-ambient

Deploy Kiali in the cluster. As the operator PR is not done, in order to test this, I just updated this line: https://github.com/kiali/kiali/compare/master...josunect:kiali:issue7159?expand=1#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R706 with `kube_system` value. 

Install bookinfo: 

`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg`


### Automation testing

Added unit testing coverage

### Issue reference

Fixes #7159 
