### PR TITLE
Fix Mesh "fit" issues

### DIFF
--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -48,6 +48,7 @@ export type NodeData = DecoratedMeshNodeData & {
   labelIconPadding?: number;
   labelPosition?: LabelPosition;
   marginX?: number;
+  onCollapseChange?: (group: Node, collapsed: boolean) => void;
   onHover?: (element: GraphElement, isMouseIn: boolean) => void;
   row?: number;
   secondaryLabel?: string;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/7122

Fix Mesh "fit" issues via graph reset and/or layout in response to:
- group box collapse/expand
- graph canvas resize

### Steps to test the PR

Check to see if the graph resets/relayouts reasonably(*) when you:
- Collapse/Expand the data-plane box.
- Collapse/Expand the side panel.
- Resize the browser

(*) By "reasonably" I mean it doesn't have to be perfect.  There are still unusual layout issues, especially with the collapsed "dataplane" box, and sometimes labels may not always be completely visible.
