### PR TITLE
[Perf] Added performance baselines

### DIFF
--- a/frontend/cypress/fixtures/perf/baselines.json
+++ b/frontend/cypress/fixtures/perf/baselines.json
@@ -1,0 +1,17 @@
+{
+  "workloadListAll": "2",
+  "workloadListSelected": "2",
+  "workloadDetails": "1",
+  "serviceListAll": "2",
+  "serviceListSelected": "2",
+  "serviceDetails": "1",
+  "appListAll": "2",
+  "appListSelected": "2",
+  "appDetails": "1",
+  "configListAdd": "2",
+  "configListSelected": "2",
+  "configDetails": "1",
+  "overview10": "2",
+  "overview50": "2",
+  "overview100": "2"
+}

--- a/frontend/cypress/fixtures/perf/baselines.json
+++ b/frontend/cypress/fixtures/perf/baselines.json
@@ -13,5 +13,5 @@
   "configDetails": "1",
   "overview10": "2",
   "overview50": "2",
-  "overview100": "2"
+  "overview300": "2"
 }

--- a/frontend/cypress/perf/appsload.spec.ts
+++ b/frontend/cypress/perf/appsload.spec.ts
@@ -1,4 +1,4 @@
-import { reportFilePath, measureListsLoadTime, visits, measureDetailsLoadTime } from './common';
+import { reportFilePath, measureListsLoadTime, measureDetailsLoadTime, baselines } from './common';
 
 describe('Apps performance tests', () => {
   beforeEach(() => {
@@ -25,10 +25,10 @@ describe('Apps performance tests', () => {
     });
 
     it('Measures All Namespaces Apps load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('All Namespaces Apps', visits, appsUrlAllNamespaces);
+      measureListsLoadTime('All Namespaces Apps', Cypress.env(baselines).appListAll, appsUrlAllNamespaces);
     });
     it('Measures Apps load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('Selected Namespaces Apps', visits, appsUrl);
+      measureListsLoadTime('Selected Namespaces Apps', Cypress.env(baselines).appListSelected, appsUrl);
     });
   });
 
@@ -54,7 +54,7 @@ describe('Apps performance tests', () => {
 
     it('App details load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       appUrls.forEach((url, name) => {
-        measureDetailsLoadTime(name, visits, url);
+        measureDetailsLoadTime(name, Cypress.env(baselines).appDetails, url);
       });
     });
   });

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -65,17 +65,17 @@ export const measureDetailsLoadTime = (name: string, baseline: number, detailsUr
 export const compareToBaseline = (resultMS: number, baseline: number): string => {
   // to seconds
   const result = resultMS / 1000;
-  const resultSeconds = result.toPrecision(5);
-  const difference = baseline - result;
+  const resultOutput = result.toPrecision(5);
 
-  return `${resultSeconds} sec, baseline: ${baseline} sec, difference: ${formatNumberWithSign(difference)} sec\n`;
+  return `${resultOutput} sec, baseline: ${baseline} sec, difference: ${getDifference(result, baseline)} sec\n`;
 };
 
-const formatNumberWithSign = (num: number): string => {
-  if (num > 0) {
-    return `+${num.toPrecision(precision)}`;
-  } else if (num < 0) {
-    return `-${Math.abs(num).toPrecision(precision)}`;
+const getDifference = (result, baseline: number): string => {
+  const difference = result - baseline;
+  if (difference > 0) {
+    return `+${difference.toPrecision(precision)}`;
+  } else if (difference < 0) {
+    return `-${Math.abs(difference).toPrecision(precision)}`;
   } else {
     return '0';
   }

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -1,6 +1,7 @@
 export const reportFilePath = 'cypress/results/performance.txt';
 
 export const visits = 5;
+const precision = 5;
 export const baselines = 'baselines';
 
 before(() => {
@@ -9,8 +10,6 @@ before(() => {
       Cypress.env(baselines, data);
     })
     .as('data');
-
-  cy.writeFile(reportFilePath, '\n[Loaded Baselines]\n', { flag: 'a+' });
 });
 
 const measureLoadTime = (name: string, baseline: number, loadUrl: string, loadElementToCheck: string): void => {
@@ -68,5 +67,16 @@ export const compareToBaseline = (resultMS: number, baseline: number): string =>
   const result = resultMS / 1000;
   const resultSeconds = result.toPrecision(5);
   const difference = baseline - result;
-  return `${resultSeconds} sec, baseline: ${baseline} sec, difference: ${difference.toPrecision(5)} sec\n`;
+
+  return `${resultSeconds} sec, baseline: ${baseline} sec, difference: ${formatNumberWithSign(difference)} sec\n`;
+};
+
+const formatNumberWithSign = (num: number): string => {
+  if (num > 0) {
+    return `+${num.toPrecision(precision)}`;
+  } else if (num < 0) {
+    return `-${Math.abs(num).toPrecision(precision)}`;
+  } else {
+    return '0';
+  }
 };

--- a/frontend/cypress/perf/istioconfigsload.spec.ts
+++ b/frontend/cypress/perf/istioconfigsload.spec.ts
@@ -1,4 +1,4 @@
-import { reportFilePath, measureListsLoadTime, visits, measureDetailsLoadTime } from './common';
+import { reportFilePath, measureListsLoadTime, measureDetailsLoadTime, baselines } from './common';
 
 describe('Istio Configs performance tests', () => {
   beforeEach(() => {
@@ -21,10 +21,14 @@ describe('Istio Configs performance tests', () => {
     });
 
     it('Measures All Namespaces Istio Configs load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('All Namespaces Istio Configs', visits, configsUrlAllNamespaces);
+      measureListsLoadTime(
+        'All Namespaces Istio Configs',
+        Cypress.env(baselines).configListAdd,
+        configsUrlAllNamespaces
+      );
     });
     it('Measures Istio Configs load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('Selected Namespaces Istio Configs', visits, configsUrl);
+      measureListsLoadTime('Selected Namespaces Istio Configs', Cypress.env(baselines).configListSelected, configsUrl);
     });
   });
 
@@ -46,7 +50,7 @@ describe('Istio Configs performance tests', () => {
 
     it('Istio Config details load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       configUrls.forEach((url, name) => {
-        measureDetailsLoadTime(name, visits, url);
+        measureDetailsLoadTime(name, Cypress.env(baselines).configDetails, url);
       });
     });
   });

--- a/frontend/cypress/perf/overviewload.spec.ts
+++ b/frontend/cypress/perf/overviewload.spec.ts
@@ -36,7 +36,7 @@ describe('Overview performance tests', () => {
   // Testing empty namespaces to understand the impact of adding namespaces alone.
   describe('Overview page with empty namespaces', () => {
     before(() => {
-      cy.writeFile(reportFilePath, '\n[Empty Namespaces]\n\n', { flag: 'a+' });
+      cy.writeFile(reportFilePath, '\n[Overview page]\n\n', { flag: 'a+' });
     });
 
     (overviewCases as OverviewCase[]).forEach(testCase => {
@@ -86,7 +86,7 @@ describe('Overview performance tests', () => {
 
               const contents = `Namespaces: ${testCase.namespaces}\nInit page load time: ${compareToBaseline(
                 sum,
-                Cypress.env(baselines).overview
+                Cypress.env(baselines)[`overview${testCase.namespaces}`]
               )}\n`;
               cy.writeFile(reportFilePath, contents, { flag: 'a+' });
             });

--- a/frontend/cypress/perf/overviewload.spec.ts
+++ b/frontend/cypress/perf/overviewload.spec.ts
@@ -1,5 +1,5 @@
 import overviewCases from '../fixtures/perf/overviewPage.json';
-import { baselines, compareToBaseline, reportFilePath } from './common';
+import { baselines, compareToBaseline, reportFilePath, visits } from './common';
 
 const createNamespaces = (count: number): void => {
   cy.log(`Creating ${count} namespaces...`);
@@ -53,9 +53,9 @@ describe('Overview performance tests', () => {
           // Getting an average to smooth out the results.
           let sum = 0;
 
-          const visits = Array.from({ length: 5 });
+          const visitsList = Array.from({ length: visits });
 
-          cy.wrap(visits)
+          cy.wrap(visitsList)
             .each(() => {
               // Disabling refresh so that we can see how long it takes to load the page without additional requests
               // being made due to the refresh.
@@ -82,7 +82,7 @@ describe('Overview performance tests', () => {
                 });
             })
             .then(() => {
-              sum = sum / visits.length;
+              sum = sum / visitsList.length;
 
               const contents = `Namespaces: ${testCase.namespaces}\nInit page load time: ${compareToBaseline(
                 sum,

--- a/frontend/cypress/perf/overviewload.spec.ts
+++ b/frontend/cypress/perf/overviewload.spec.ts
@@ -1,5 +1,5 @@
 import overviewCases from '../fixtures/perf/overviewPage.json';
-import { reportFilePath } from './common';
+import { baselines, compareToBaseline, reportFilePath } from './common';
 
 const createNamespaces = (count: number): void => {
   cy.log(`Creating ${count} namespaces...`);
@@ -84,9 +84,10 @@ describe('Overview performance tests', () => {
             .then(() => {
               sum = sum / visits.length;
 
-              const contents = `Namespaces: ${testCase.namespaces}\nInit page load time: ${(sum / 1000).toPrecision(
-                5
-              )} seconds\n`;
+              const contents = `Namespaces: ${testCase.namespaces}\nInit page load time: ${compareToBaseline(
+                sum,
+                Cypress.env(baselines).overview
+              )}\n`;
               cy.writeFile(reportFilePath, contents, { flag: 'a+' });
             });
         });

--- a/frontend/cypress/perf/servicesload.spec.ts
+++ b/frontend/cypress/perf/servicesload.spec.ts
@@ -1,4 +1,4 @@
-import { reportFilePath, measureListsLoadTime, visits, measureDetailsLoadTime } from './common';
+import { reportFilePath, measureListsLoadTime, measureDetailsLoadTime, baselines } from './common';
 
 describe('Services performance tests', () => {
   beforeEach(() => {
@@ -25,10 +25,10 @@ describe('Services performance tests', () => {
     });
 
     it('Measures All Namespaces Services load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('All Namespaces Services', visits, servicesUrlAllNamespaces);
+      measureListsLoadTime('All Namespaces Services', Cypress.env(baselines).serviceListAll, servicesUrlAllNamespaces);
     });
     it('Measures Services load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('Selected Namespaces Services', visits, servicesUrl);
+      measureListsLoadTime('Selected Namespaces Services', Cypress.env(baselines).serviceListSelected, servicesUrl);
     });
   });
 
@@ -53,7 +53,7 @@ describe('Services performance tests', () => {
 
     it('Service details load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       serviceUrls.forEach((url, name) => {
-        measureDetailsLoadTime(name, visits, url);
+        measureDetailsLoadTime(name, Cypress.env(baselines).serviceDetails, url);
       });
     });
   });

--- a/frontend/cypress/perf/workloadsload.spec.ts
+++ b/frontend/cypress/perf/workloadsload.spec.ts
@@ -1,4 +1,4 @@
-import { reportFilePath, measureListsLoadTime, measureDetailsLoadTime, visits } from './common';
+import { reportFilePath, measureListsLoadTime, measureDetailsLoadTime, baselines } from './common';
 
 describe('Workloads performance tests', () => {
   beforeEach(() => {
@@ -25,10 +25,14 @@ describe('Workloads performance tests', () => {
     });
 
     it('Measures All Namespaces Workloads load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('All Namespaces Workloads', visits, workloadsUrlAllNamespaces);
+      measureListsLoadTime(
+        'All Namespaces Workloads',
+        Cypress.env(baselines).workloadListAll,
+        workloadsUrlAllNamespaces
+      );
     });
     it('Measures Workloads load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('Selected Namespaces Workloads', visits, workloadsUrl);
+      measureListsLoadTime('Selected Namespaces Workloads', Cypress.env(baselines).workloadListSelected, workloadsUrl);
     });
   });
 
@@ -61,7 +65,7 @@ describe('Workloads performance tests', () => {
 
     it('Workload details load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       workloadUrls.forEach((url, name) => {
-        measureDetailsLoadTime(name, visits, url);
+        measureDetailsLoadTime(name, Cypress.env(baselines).workloadDetails, url);
       });
     });
   });


### PR DESCRIPTION
### Describe the change

Added 'baselines.json' file with some test baselines.
Using the baselines to compare load time for each test.
Currently only logging the compared results without failing.

### Steps to test the PR
make perf-tests-run

### Issue reference
https://github.com/kiali/kiali/issues/7174
