### PR TITLE
Update health_check_url for tracing, better error handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,7 @@ type GrafanaVariablesConfig struct {
 type TracingConfig struct {
 	Auth                 Auth              `yaml:"auth"`
 	Enabled              bool              `yaml:"enabled"` // Enable Tracing in Kiali
+	HealthCheckUrl       string            `yaml:"health_check_url,omitempty"`
 	GrpcPort             int               `yaml:"grpc_port,omitempty"`
 	InClusterURL         string            `yaml:"in_cluster_url"`
 	IsCore               bool              `yaml:"is_core,omitempty"`

--- a/tracing/client_test.go
+++ b/tracing/client_test.go
@@ -22,7 +22,7 @@ func TestCreateJaegerClient(t *testing.T) {
 	assert.NotNil(t, tracingClient)
 }
 
-func TestCreateTempogRPCClient(t *testing.T) {
+func TestCreateTempogGRPCClient(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Tracing.Enabled = true
 	conf.ExternalServices.Tracing.Provider = "tempo"

--- a/tracing/otel/model/types.go
+++ b/tracing/otel/model/types.go
@@ -48,3 +48,8 @@ type Traces struct {
 	Traces  []Trace  `json:"traces"`
 	Metrics struct{} `json:"metrics"`
 }
+
+type TracesError struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}

--- a/tracing/tempo/http_client_test.go
+++ b/tracing/tempo/http_client_test.go
@@ -125,7 +125,7 @@ func TestErrorResponse(t *testing.T) {
 		Cluster:     "",
 	}
 	response, err := tempoClient.GetAppTracesHTTP(httpClient, baseUrl, serviceName, q)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.NotNil(t, response)
 	assert.Nil(t, response.Data)
 	assert.Equal(t, response.TracingServiceName, serviceName)


### PR DESCRIPTION
### Describe the change

- Use a healh_check_url for tracing
- Better error handling in case of http errors to the API 

### Steps to test the PR

I've a Grafana cloud endpoint for testing, please ping me for details if needed. 

The datasource provides the health check at https://tempo-prod-10-prod-eu-west-2.grafana.net 
Kiali really doesn't validates the response, so I guess the URL could be just the search api url, but, the difference is that the check url is not authenticated. 

With this endpoint configuration: 

```
  tracing:
    enabled: true
    provider: "tempo"
    in_cluster_url: https://tempo-prod-10-prod-eu-west-2.grafana.net/tempo
    url: https://tempo-prod-10-prod-eu-west-2.grafana.net/tempo
    use_grpc: false
    query_timeout: 40
    whitelist_istio_system:
    - jaeger-query
    - istio-ingressgateway
    namespace: istio-system
    port: 443
    service: tracing
    health_check_url: "https://tempo-prod-10-prod-eu-west-2.grafana.net"
    auth:
      insecure_skip_verify: true
      password: TOKEN
      type: basic
      use_kiali_token: false
      username: 825501
```

When the health_check_url is not specified, we will see: 

![image](https://github.com/kiali/kiali/assets/49480155/2b471e26-e399-4fd0-9129-5f662e94084f)

With the health_check_url parameter: 

![image](https://github.com/kiali/kiali/assets/49480155/c54610cb-482b-4f21-8c5a-f2b8eaeb4b42)

Regarding the error handleling, when an incorrect user is specified: 

We will be able to see the specific error in the messages: 

![image](https://github.com/kiali/kiali/assets/49480155/c7a3ff45-f995-440f-88db-4beb0f75fdc0)


### Automation testing

N/A There are already existing e2e testing

### Issue reference

Fixes https://github.com/kiali/kiali/issues/7176

Ref Operator PR: https://github.com/kiali/kiali-operator/pull/747