### PR TITLE
Services list per cluster

### DIFF
--- a/frontend/cypress/integration/common/namespace.ts
+++ b/frontend/cypress/integration/common/namespace.ts
@@ -8,3 +8,16 @@ When('user selects the {string} namespace', (namespace: string) => {
 
   ensureKialiFinishedLoading();
 });
+
+When('user selects the {string} namespace and waits for services', (namespace: string) => {
+  cy.intercept(`${Cypress.config('baseUrl')}/api/clusters/services`).as('fetchServices');
+
+  cy.getBySel('namespace-dropdown').click();
+  cy.get(`input[type="checkbox"][value="${namespace}"]`).check();
+  cy.getBySel('namespace-dropdown').click();
+
+  cy.wait('@fetchServices');
+  cy.waitForReact(1000, '#root');
+
+  ensureKialiFinishedLoading();
+});

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -335,6 +335,9 @@ Then('the list is sorted by column {string} in {string} order', (column: string,
     });
 });
 
-Then("the {string} {string} for {string} cluster {string} namespace should not exist in the table",(name:string,object:string,cluster:string,ns:string) =>{
-  cy.get(`[data-test="VirtualItem_Cluster${cluster}_Ns${ns}_${object.toLowerCase()}_${name}"]`).should('not.exist');
-});
+Then(
+  'the {string} {string} for {string} cluster {string} namespace should not exist in the table',
+  (name: string, object: string, cluster: string, ns: string) => {
+    cy.get(`[data-test="VirtualItem_Cluster${cluster}_Ns${ns}_${object.toLowerCase()}_${name}"]`).should('not.exist');
+  }
+);

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -121,6 +121,7 @@ const conf = {
       clusters: 'api/clusters',
       clustersHealth: () => `api/clusters/health`,
       clustersMetrics: () => `api/clusters/metrics`,
+      clustersServices: () => `api/clusters/services`,
       clustersTls: () => `api/clusters/tls`,
       configValidations: () => `api/istio/validations`,
       crippledFeatures: 'api/crippled',

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -23,7 +23,7 @@ import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 import { validationKey } from '../../types/IstioConfigList';
 import { ServiceHealth } from '../../types/Health';
 import { RefreshNotifier } from '../../components/Refresh/RefreshNotifier';
-import { isMultiCluster } from 'config';
+import { isMultiCluster, serverConfig } from 'config';
 
 type ServiceListPageState = FilterComponent.State<ServiceListItem>;
 
@@ -96,10 +96,15 @@ class ServiceListPageComponent extends FilterComponent.Component<
 
     const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const activeToggles: ActiveTogglesInfo = Toggles.getToggles();
-    const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
 
-    if (namespacesSelected.length !== 0) {
-      this.fetchServices(namespacesSelected, activeFilters, activeToggles, this.props.duration);
+    const uniqueClusters = new Set<string>();
+
+    Object.keys(serverConfig.clusters).forEach(cluster => {
+      uniqueClusters.add(cluster);
+    });
+
+    if (this.props.activeNamespaces.length !== 0) {
+      this.fetchServices(Array.from(uniqueClusters), activeFilters, activeToggles, this.props.duration);
     } else {
       this.setState({ listItems: [] });
     }
@@ -111,14 +116,14 @@ class ServiceListPageComponent extends FilterComponent.Component<
         name: service.name,
         istioSidecar: service.istioSidecar,
         istioAmbient: service.istioAmbient,
-        namespace: data.namespace.name,
+        namespace: service.namespace,
         cluster: service.cluster,
-        health: ServiceHealth.fromJson(data.namespace.name, service.name, service.health, {
+        health: ServiceHealth.fromJson(service.namespace, service.name, service.health, {
           rateInterval: rateInterval,
           hasSidecar: service.istioSidecar,
           hasAmbient: service.istioAmbient
         }),
-        validation: this.getServiceValidation(service.name, data.namespace.name, data.validations),
+        validation: this.getServiceValidation(service.name, service.namespace, data.validations),
         additionalDetailSample: service.additionalDetailSample,
         labels: service.labels ?? {},
         ports: service.ports ?? {},
@@ -132,7 +137,7 @@ class ServiceListPageComponent extends FilterComponent.Component<
   }
 
   fetchServices(
-    namespaces: string[],
+    clusters: string[],
     filters: ActiveFiltersInfo,
     toggles: ActiveTogglesInfo,
     rateInterval: number
@@ -141,13 +146,17 @@ class ServiceListPageComponent extends FilterComponent.Component<
     const istioResources = toggles.get('istioResources') ? 'true' : 'false';
     const onlyDefinitions = toggles.get('configuration') ? 'false' : 'true'; // !configuration => onlyDefinitions
 
-    const servicesPromises = namespaces.map(ns =>
-      API.getServices(ns, {
-        health: health,
-        istioResources: istioResources,
-        rateInterval: `${String(rateInterval)}s`,
-        onlyDefinitions: onlyDefinitions
-      })
+    const servicesPromises = clusters.map(cluster =>
+      API.getClustersServices(
+        this.props.activeNamespaces.map(ns => ns.name).join(','),
+        {
+          health: health,
+          istioResources: istioResources,
+          rateInterval: `${String(rateInterval)}s`,
+          onlyDefinitions: onlyDefinitions
+        },
+        cluster
+      )
     );
 
     this.promises

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -453,6 +453,22 @@ export const getServices = (namespace: string, params?: ServiceListQuery): Promi
   return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), params, {});
 };
 
+export const getClustersServices = (
+  namespaces: string,
+  params: ServiceListQuery,
+  cluster?: string
+): Promise<ApiResponse<ServiceList>> => {
+  const queryParams: QueryParams<ServiceListQuery & Namespaces> = {
+    ...params,
+    namespaces: namespaces
+  };
+
+  if (cluster) {
+    queryParams.clusterName = cluster;
+  }
+  return newRequest<ServiceList>(HTTP_VERBS.GET, urls.clustersServices(), queryParams, {});
+};
+
 export const getServiceMetrics = (
   namespace: string,
   service: string,

--- a/frontend/src/types/ServiceList.ts
+++ b/frontend/src/types/ServiceList.ts
@@ -19,6 +19,7 @@ export interface ServiceOverview {
   kialiWizard: string;
   labels: { [key: string]: string };
   name: string;
+  namespace: string;
   ports: { [key: string]: number };
   serviceRegistry: string;
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -354,6 +354,26 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 			handlers.IstioConfigCreate,
 			true,
 		},
+		// swagger:route GET /clusters/services services clustersServices
+		// ---
+		// Endpoint to get the list of services from given cluster
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      500: internalError
+		//      200: clustersServicesResponse
+		//
+		{
+			"ClustersServices",
+			"GET",
+			"/api/clusters/services",
+			handlers.ClustersServices,
+			true,
+		},
 		// swagger:route GET /namespaces/{namespace}/services services serviceList
 		// ---
 		// Endpoint to get the details of a given service

--- a/tests/integration/tests/services_test.go
+++ b/tests/integration/tests/services_test.go
@@ -37,6 +37,30 @@ func TestServicesList(t *testing.T) {
 	require.Equal(kiali.BOOKINFO, serviceList.Namespace.Name)
 }
 
+func TestClusterServicesList(t *testing.T) {
+	require := require.New(t)
+	serviceList, err := kiali.ClusterServicesList(kiali.BOOKINFO)
+
+	require.NoError(err)
+	require.NotEmpty(serviceList)
+	require.True(len(serviceList.Services) >= 4)
+	for _, service := range serviceList.Services {
+		require.NotEmpty(service.Name)
+		if service.Name == "productpage" {
+			require.True(service.IstioSidecar)
+			require.True(service.AppLabel)
+			require.NotNil(service.Namespace)
+			require.Equal(kiali.BOOKINFO, service.Namespace)
+			require.NotNil(service.Cluster)
+			require.NotNil(service.Health)
+			require.NotNil(service.Health.Requests)
+			require.NotNil(service.Health.Requests.Outbound)
+			require.NotNil(service.Health.Requests.Inbound)
+		}
+	}
+	require.NotNil(serviceList.Validations)
+}
+
 func TestServiceDetails(t *testing.T) {
 	name := "productpage"
 	require := require.New(t)

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -311,6 +311,14 @@ func ServicesList(namespace string) (*ServiceListJson, error) {
 	}
 }
 
+func ClusterServicesList(namespace string) (*ServiceListJson, error) {
+	serviceList := new(ServiceListJson)
+	if err := getRequestAndUnmarshalInto(client.kialiURL+"/api/clusters/services?namespaces="+namespace, serviceList); err != nil {
+		return nil, err
+	}
+	return serviceList, nil
+}
+
 func ServiceDetails(name, namespace string) (*ServiceDetailsJson, int, error) {
 	body, code, _, err := httpGETWithRetry(client.kialiURL+"/api/namespaces/"+namespace+"/services/"+name+"?validate=true&health=true", client.GetAuth(), TIMEOUT, nil, client.kialiCookies)
 	if err == nil {


### PR DESCRIPTION
### Describe the change

In Service list page, there was sending a REST API request to retrieve services per namespace, which was causing to filter per cluster which contains the provided namespace.
Now Optimized to send Service list request to REST API per cluster with providing selected namespaces list.

### Steps to test the PR

Create a set of namespaces:
`for i in {1..200}; do kubectl create ns test-$i; done`
Open the Service list page and select all services.
Compare the loading time between before and now.
Check if Health and Configuration fields are loading correctly: There was a bug here which was mirroring one cluster's Configuration to another one when two Services with same name/namespace.

### Automation testing

Added unit tests. Added integration tests.

### Issue reference
https://github.com/kiali/kiali/issues/4832