### PR TITLE
[make] ossmconsole-create target should wait for kiali to start

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -157,7 +157,7 @@ endif
 ## ossmconsole-create: Create a OSSMConsole CR to the cluster, informing the Kiali operator to install OSSMC.
 ossmconsole-create: .ensure-operator-repo-exists .prepare-cluster .create-plugin-pull-secret
 ifeq ($(CLUSTER_TYPE),openshift)
-	@if ! (${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running); then echo "Kiali needs to be installed and running before you can install OSSMC."; exit 1; fi
+	@while ! (${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running); do echo "Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start..."; sleep 2; done
 	@echo Deploy OSSM Console using the settings found in ${OSSMCONSOLE_CR_FILE}
 	cat ${OSSMCONSOLE_CR_FILE} | \
 DEPLOYMENT_IMAGE_NAME="${CLUSTER_PLUGIN_INTERNAL_NAME}" \


### PR DESCRIPTION
Rather than abort if kiali isn't installed, wait for kiali to start. This is because usually you use the ossmconsole-create target together with kiali-create. If you do, ossmconsole-create should wait for that Kiali CR to be reconciled by the operator and for Kiali to start.

Assuming you have the operator installed on OpenShift (run `make build build-ui cluster-push operator-create`), you can run this and see that it is successful and both Kiali and OSSMC are installed:

`make kiali-create ossmconsole-create`

You should see the make target wait for some time until the kiali pod starts:

```
$ make kiali-create ossmconsole-create 
...
Deploy Kiali using the settings found in /home/jmazzite/source/kiali/kiali/operator/deploy/kiali/kiali_cr_dev.yaml
...
kiali.kiali.io/kiali created
...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start...
Deploy OSSM Console using the settings found in /home/jmazzite/source/kiali/kiali/operator/deploy/ossmconsole/ossmconsole_cr_dev.yaml
...
ossmconsole.kiali.io/ossmconsole created
```