### PR TITLE
[v1.73] Add make ossmconsole-create option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ CYPRESS_TESTS_QUAY_TAG ?= ${CYPRESS_TESTS_QUAY_NAME}:${CYPRESS_TESTS_CONTAINER_V
 
 # Where the control plane is
 ISTIO_NAMESPACE ?= istio-system
-# Declares the namespace/project where the objects are to be deployed.
+# Declares the namespace/project where the Kiali objects are to be deployed.
 NAMESPACE ?= ${ISTIO_NAMESPACE}
+# Declares the namespace/project where the OSSM Console objects are to be deployed.
+OSSMCONSOLE_NAMESPACE ?= ossmconsole
 
 # Local arch details needed when downloading tools
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -132,6 +134,7 @@ OPERATOR_WATCH_NAMESPACE ?= \"\"
 OPERATOR_INSTALL_KIALI ?= false
 OPERATOR_ALLOW_AD_HOC_KIALI_NAMESPACE ?= true
 OPERATOR_ALLOW_AD_HOC_KIALI_IMAGE ?= true
+OPERATOR_ALLOW_AD_HOC_OSSMCONSOLE_IMAGE ?= true
 ifeq ($(OPERATOR_WATCH_NAMESPACE),\"\")
 OPERATOR_INSTALL_KIALI_CR_NAMESPACE ?= ${OPERATOR_NAMESPACE}
 else
@@ -153,20 +156,12 @@ endif
 SERVICE_TYPE ?= ClusterIP
 KIALI_CR_SPEC_VERSION ?= default
 
-# Determine if Maistra/ServiceMesh is deployed. If not, assume we are working with upstream Istio.
-ifeq ($(OC_READY),true)
-IS_MAISTRA ?= $(shell if ${OC} get namespace ${NAMESPACE} -o jsonpath='{.metadata.labels}' 2>/dev/null | grep -q maistra ; then echo "true" ; else echo "false" ; fi)
-else
-IS_MAISTRA ?= false
-endif
-
-# Path to Kiali CR file which is different based on what Istio implementation is deployed (upstream or Maistra)
-# This is used when deploying Kiali via make
-ifeq ($(IS_MAISTRA),true)
-KIALI_CR_FILE ?= ${ROOTDIR}/operator/deploy/kiali/kiali_cr_dev_servicemesh.yaml
-else
+# Path to Kiali CR file. This is used when deploying Kiali via make
 KIALI_CR_FILE ?= ${ROOTDIR}/operator/deploy/kiali/kiali_cr_dev.yaml
-endif
+
+# When creating a OSSMConsole CR, these can customize it
+OSSMCONSOLE_CR_FILE ?= ${ROOTDIR}/operator/deploy/ossmconsole/ossmconsole_cr_dev.yaml
+OSSMCONSOLE_CR_SPEC_VERSION ?= default
 
 # When ensuring the helm chart repo exists, by default the make infrastructure will pull the latest code from git.
 # If you do not want this to happen (i.e. if you want to retain the local copies of your helm charts), set this to false.
@@ -218,11 +213,6 @@ help: Makefile
 	@echo "Misc targets"
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
 	@echo
-
-## git-init: Set the hooks under ./git/hooks
-git-init:
-	@echo Setting Git Hooks
-	cp hack/hooks/* .git/hooks
 
 .ensure-oc-exists:
 	@if [ ! -x "${OC}" ]; then \

--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -7,8 +7,8 @@ OLM_IMAGE_ORG ?= ${IMAGE_ORG}
 OLM_BUNDLE_NAME ?= ${OLM_IMAGE_ORG}/kiali-operator-bundle
 OLM_INDEX_NAME ?= ${OLM_IMAGE_ORG}/kiali-operator-index
 
-# set this package name to kiali-ossm if you want to test with the OSSM metadata
-OLM_BUNDLE_PACKAGE ?= kiali
+# set this package name to kiali if you want to test with the community (if OC=oc) or upstream (if OC=kubectl) metadata
+OLM_BUNDLE_PACKAGE ?= kiali-ossm
 
 OLM_INDEX_BASE_IMAGE ?= quay.io/openshift/origin-operator-registry:4.11
 OPM_VERSION ?= 1.28.0
@@ -113,7 +113,9 @@ build-olm-index: .ensure-opm-exists cluster-push-olm-bundle
 	@rm -rf ${OUTDIR}/index
 	@mkdir -p ${OUTDIR}/index/kiali-index
 	${OPM} init ${OLM_BUNDLE_PACKAGE} --default-channel=stable --output yaml > ${OUTDIR}/index/kiali-index/index.yaml
-	${OPM} render $$(if [[ "${OC}" = *"oc" ]]; then echo '--skip-tls-verify'; else echo '--use-http'; fi) ${CLUSTER_OLM_BUNDLE_NAME}:${BUNDLE_VERSION} --output yaml >> ${OUTDIR}/index/kiali-index/index.yaml
+	@if [ "${DORP}" == "podman" -a -n "$${XDG_RUNTIME_DIR}" -a -f "$${XDG_RUNTIME_DIR}/containers/auth.json" ]; then cp "$${XDG_RUNTIME_DIR}/containers/auth.json" "${OUTDIR}/index/kiali-index/config.json"; fi
+	@if [ -f "${OUTDIR}/index/kiali-index/config.json" ]; then export DOCKER_CONFIG="${OUTDIR}/index/kiali-index"; fi ; ${OPM} render $$(if [[ "${OC}" = *"oc" ]]; then echo '--skip-tls-verify'; else echo '--use-http'; fi) ${CLUSTER_OLM_BUNDLE_NAME}:${BUNDLE_VERSION} --output yaml >> ${OUTDIR}/index/kiali-index/index.yaml
+	@rm -f ${OUTDIR}/index/kiali-index/config.json
 	@# We need OLM to pull the index from the internal registry - change the index to only use the internal registry name
 	sed -i 's|${CLUSTER_REPO}|${CLUSTER_REPO_INTERNAL}|g' ${OUTDIR}/index/kiali-index/index.yaml
 	@echo "---"                                               >> ${OUTDIR}/index/kiali-index/index.yaml
@@ -203,6 +205,8 @@ catalog-source-delete: .generate-catalog-source .remove-operator-pull-secret
 	@echo '      value: "true"'                       >> ${OUTDIR}/kiali-subscription.yaml
 	@echo "    - name: ALLOW_AD_HOC_KIALI_IMAGE"      >> ${OUTDIR}/kiali-subscription.yaml
 	@echo '      value: "true"'                       >> ${OUTDIR}/kiali-subscription.yaml
+	@echo "    - name: ALLOW_AD_HOC_OSSMCONSOLE_IMAGE" >> ${OUTDIR}/kiali-subscription.yaml
+	@echo '      value: "true"'                       >> ${OUTDIR}/kiali-subscription.yaml
 
 ## subscription-create: Creates the OLM Subscription on the remote cluster which installs the operator
 subscription-create: .ensure-oc-login .generate-subscription
@@ -213,11 +217,11 @@ subscription-delete: .ensure-oc-login .generate-subscription
 	${OC} delete --ignore-not-found=true -f ${OUTDIR}/kiali-subscription.yaml
 
 ## olm-operator-create: Installs everything needed to get the Kiali operator installed via OLM.
-olm-operator-create: catalog-source-create subscription-create .wait-for-kiali-crd
+olm-operator-create: catalog-source-create subscription-create .wait-for-kiali-crd .wait-for-ossmconsole-crd
 	@echo "You can now create a Kiali CR to install Kiali."
 
 ## olm-operator-delete: Deletes the Kiali CR, undeploys the OLM subscription and catalog source and purges the operator
-olm-operator-delete: kiali-delete subscription-delete catalog-source-delete crd-delete
+olm-operator-delete: kiali-delete ossmconsole-delete subscription-delete catalog-source-delete crd-delete
 	@echo "Deleting OLM CSVs to fully uninstall Kiali operator and its related resources"
 	@for csv in $$(${OC} get csv --all-namespaces --no-headers -o custom-columns=NS:.metadata.namespace,N:.metadata.name | sed 's/  */:/g' | grep kiali-operator) ;\
 	do \

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -2,6 +2,10 @@
 # Targets to deploy the operator and Kiali in a remote cluster.
 #
 
+# These must match the OSSM Console build.
+PLUGIN_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
+PLUGIN_CONTAINER_NAME ?= "kiali/ossmconsole"
+
 .ensure-operator-ns-does-not-exist: .ensure-oc-exists
 	@_cmd="${OC} get namespace ${OPERATOR_NAMESPACE}"; \
 	$$_cmd > /dev/null 2>&1 ; \
@@ -35,6 +39,34 @@ endif
 .remove-operator-pull-secret: .prepare-operator-pull-secret
 	@if [ -n "${OPERATOR_IMAGE_PULL_SECRET_NAME}" ]; then ${OC} delete --ignore-not-found=true secret ${OPERATOR_IMAGE_PULL_SECRET_NAME} --namespace=${OPERATOR_NAMESPACE} ; fi
 
+.prepare-plugin-pull-secret: .prepare-cluster
+ifeq ($(CLUSTER_TYPE),openshift)
+	@# base64 encode a pull secret (using the logged in user token) that can be used to pull the plugin image from the internal image registry
+	@$(eval PLUGIN_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} --to=/tmp/json2 &>/dev/null && cat /tmp/json2 | base64 -w0))
+	@$(eval PLUGIN_IMAGE_PULL_SECRET_NAME ?= ossmconsole-plugin-pull-secret)
+	@rm /tmp/json2
+else
+	@$(eval PLUGIN_IMAGE_PULL_SECRET_JSON = )
+	@$(eval PLUGIN_IMAGE_PULL_SECRET_NAME = )
+endif
+
+.create-plugin-pull-secret: .prepare-plugin-pull-secret .create-ossmconsole-namespace
+	@if [ -n "${PLUGIN_IMAGE_PULL_SECRET_JSON}" ] && ! (${OC} get secret ${PLUGIN_IMAGE_PULL_SECRET_NAME} --namespace ${OSSMCONSOLE_NAMESPACE} &> /dev/null); then \
+		echo "${PLUGIN_IMAGE_PULL_SECRET_JSON}" | base64 -d > /tmp/ossmconsole-plugin-pull-secret.json ;\
+		${OC} create secret generic ${PLUGIN_IMAGE_PULL_SECRET_NAME} --from-file=.dockerconfigjson=/tmp/ossmconsole-plugin-pull-secret.json --type=kubernetes.io/dockerconfigjson --namespace=${OSSMCONSOLE_NAMESPACE} ;\
+		${OC} label secret ${PLUGIN_IMAGE_PULL_SECRET_NAME} --namespace ${OSSMCONSOLE_NAMESPACE} app.kubernetes.io/name=ossmconsole ;\
+		rm /tmp/ossmconsole-plugin-pull-secret.json ;\
+	fi
+
+.remove-plugin-pull-secret: .prepare-plugin-pull-secret
+	@if [ -n "${PLUGIN_IMAGE_PULL_SECRET_NAME}" ]; then ${OC} delete --ignore-not-found=true secret ${PLUGIN_IMAGE_PULL_SECRET_NAME} --namespace=${OSSMCONSOLE_NAMESPACE}; fi
+
+.create-ossmconsole-namespace: .ensure-oc-login
+	${OC} get namespace ${OSSMCONSOLE_NAMESPACE} &> /dev/null || ${OC} create namespace ${OSSMCONSOLE_NAMESPACE}
+
+.delete-ossmconsole-namespace: .ensure-oc-login
+	${OC} delete --ignore-not-found=true namespace ${OSSMCONSOLE_NAMESPACE}
+
 ## operator-create: Deploy the Kiali operator to the cluster using the install script.
 # By default, this target will not deploy Kiali - it will only deploy the operator.
 # You can tell it to also install Kiali by setting OPERATOR_INSTALL_KIALI=true.
@@ -49,6 +81,7 @@ operator-create: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists
     --helm-set                      "debug.enableProfiler=${OPERATOR_PROFILER_ENABLED}" \
     --helm-set                      "allowAdHocKialiNamespace=${OPERATOR_ALLOW_AD_HOC_KIALI_NAMESPACE}" \
     --helm-set                      "allowAdHocKialiImage=${OPERATOR_ALLOW_AD_HOC_KIALI_IMAGE}" \
+    --helm-set                      "allowAdHocOSSMConsoleImage=${OPERATOR_ALLOW_AD_HOC_OSSMCONSOLE_IMAGE}" \
     --helm-set                      "image.pullSecrets={${OPERATOR_IMAGE_PULL_SECRET_NAME}}" \
     --operator-cluster-role-creator "true" \
     --operator-image-name           "${CLUSTER_OPERATOR_INTERNAL_NAME}" \
@@ -67,12 +100,10 @@ operator-create: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists
     --version                       "${KIALI_CR_SPEC_VERSION}"
 
 ## operator-delete: Remove the Kiali operator resources from the cluster along with Kiali itself
-operator-delete: .ensure-oc-exists kiali-delete kiali-purge .remove-operator-pull-secret
+operator-delete: .ensure-oc-exists kiali-delete kiali-purge ossmconsole-delete ossmconsole-purge crd-delete .remove-operator-pull-secret .delete-ossmconsole-namespace
 	@echo Remove Operator
 	${OC} delete --ignore-not-found=true all,sa,deployments,secrets --selector="app.kubernetes.io/name=kiali-operator" -n "${OPERATOR_NAMESPACE}"
 	${OC} delete --ignore-not-found=true clusterroles,clusterrolebindings --selector="app.kubernetes.io/name=kiali-operator"
-	${OC} delete --ignore-not-found=true customresourcedefinitions kialis.kiali.io
-	${OC} delete --ignore-not-found=true customresourcedefinitions monitoringdashboards.monitoring.kiali.io
 	${OC} delete --ignore-not-found=true namespace "${OPERATOR_NAMESPACE}"
 
 ## operator-reload-image: Restarts the Kiali Operator pod by deleting it which forces a redeployment
@@ -82,6 +113,8 @@ operator-reload-image: .ensure-oc-exists
 
 ## kiali-create: Create a Kiali CR to the cluster, informing the Kiali operator to install Kiali.
 kiali-create: .ensure-operator-repo-exists .prepare-cluster
+	@# Make sure the namespace exists
+	${OC} get namespace ${OPERATOR_INSTALL_KIALI_CR_NAMESPACE} &> /dev/null || ${OC} create namespace ${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}
 	@echo Deploy Kiali using the settings found in ${KIALI_CR_FILE}
 	cat ${KIALI_CR_FILE} | \
 ACCESSIBLE_NAMESPACES="${ACCESSIBLE_NAMESPACES}" \
@@ -96,22 +129,23 @@ ROUTER_HOSTNAME="$(shell ${OC} get $(shell (${OC} get routes -n ${NAMESPACE} -o 
 SERVICE_TYPE="${SERVICE_TYPE}" \
 KIALI_CR_SPEC_VERSION="${KIALI_CR_SPEC_VERSION}" \
 envsubst | ${OC} apply -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" -f -
-ifeq ($(IS_MAISTRA),true)
-	@echo "Deploying within a Maistra environment - create network policy to enable access to the Kiali UI"
-	@echo '{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"labels":{"app.kubernetes.io/name":"kiali"},"name":"kiali-network-policy-from-make"},"spec":{"ingress":[{}],"podSelector":{"matchLabels":{"app":"kiali"}},"policyTypes":["Ingress"]}}' | ${OC} apply -n ${NAMESPACE} -f -
-endif
 
 ## kiali-delete: Remove a Kiali CR from the cluster, informing the Kiali operator to uninstall Kiali.
 kiali-delete: .ensure-oc-exists
 	@echo Remove Kiali
 	${OC} delete --ignore-not-found=true kiali kiali -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" ; true
-	@echo "Remove NetworkPolicy if it exists (was only created within Maistra environment)"
-	${OC} delete --ignore-not-found=true networkpolicies.networking.k8s.io -n ${NAMESPACE} kiali-network-policy-from-make
 
 ## kiali-purge: Purges all Kiali resources directly without going through the operator or ansible.
 kiali-purge: .ensure-oc-exists
 	@echo Purge Kiali resources
-	${OC} patch kiali kiali -n "${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}" -p '{"metadata":{"finalizers": []}}' --type=merge ; true
+	@for k in $(shell ${OC} get kiali --ignore-not-found=true --all-namespaces -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | sed 's/  */:/g') ;\
+	  do \
+	    cr_namespace="$$(echo $${k} | cut -d: -f1)" ;\
+	    cr_name="$$(echo $${k} | cut -d: -f2)" ;\
+	    echo "Deleting Kiali CR [$${cr_name}] in namespace [$${cr_namespace}]" ;\
+	    ${OC} patch  kiali $${cr_name} -n $${cr_namespace} -p '{"metadata":{"finalizers": []}}' --type=merge ;\
+	    ${OC} delete kiali $${cr_name} -n $${cr_namespace} ;\
+	  done
 	${OC} delete --ignore-not-found=true all,secrets,sa,configmaps,deployments,roles,rolebindings,ingresses,horizontalpodautoscalers --selector="app.kubernetes.io/name=kiali" -n "${NAMESPACE}"
 	${OC} delete --ignore-not-found=true clusterroles,clusterrolebindings --selector="app.kubernetes.io/name=kiali"
 	${OC} delete --ignore-not-found=true networkpolicies.networking.k8s.io -n ${NAMESPACE} kiali-network-policy-from-make
@@ -120,23 +154,84 @@ ifeq ($(CLUSTER_TYPE),openshift)
 	${OC} delete --ignore-not-found=true consolelinks.console.openshift.io,oauthclients.oauth.openshift.io --selector="app.kubernetes.io/name=kiali" ; true
 endif
 
+## ossmconsole-create: Create a OSSMConsole CR to the cluster, informing the Kiali operator to install OSSMC.
+ossmconsole-create: .ensure-operator-repo-exists .prepare-cluster .create-plugin-pull-secret
+ifeq ($(CLUSTER_TYPE),openshift)
+	@while ! (${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running); do echo "Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start..."; sleep 2; done
+	@echo Deploy OSSM Console using the settings found in ${OSSMCONSOLE_CR_FILE}
+	cat ${OSSMCONSOLE_CR_FILE} | \
+DEPLOYMENT_IMAGE_NAME="${CLUSTER_PLUGIN_INTERNAL_NAME}" \
+DEPLOYMENT_IMAGE_VERSION="${PLUGIN_CONTAINER_VERSION}" \
+PULL_SECRET_NAME="${PLUGIN_IMAGE_PULL_SECRET_NAME}" \
+OSSMCONSOLE_CR_SPEC_VERSION="${OSSMCONSOLE_CR_SPEC_VERSION}" \
+envsubst | ${OC} apply -n "${OSSMCONSOLE_NAMESPACE}" -f -
+else
+	@echo "Will not create OSSMConsole CR on non-OpenShift environments."
+endif
+
+## ossmconsole-delete: Remove a OSSMConsole CR from the cluster, informing the Kiali operator to uninstall OSSMC.
+ossmconsole-delete: .ensure-oc-exists .remove-plugin-pull-secret
+ifeq ($(CLUSTER_TYPE),openshift)
+	@echo Remove OSSMConsole
+	${OC} delete --ignore-not-found=true ossmconsole ossmconsole -n "${OSSMCONSOLE_NAMESPACE}" ; true
+else
+	@echo "No OSSMConsole CR to delete on non-OpenShift environments."
+endif
+
+## ossmconsole-purge: Purges all OSSM Console resources directly without going through the operator or ansible.
+ossmconsole-purge: .ensure-oc-exists .remove-plugin-pull-secret
+ifeq ($(CLUSTER_TYPE),openshift)
+	@echo Purge OSSM Console resources
+	@for cr in $(shell ${OC} get ossmconsole --ignore-not-found=true --all-namespaces -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | sed 's/  */:/g') ;\
+	  do \
+	    cr_namespace="$$(echo $${cr} | cut -d: -f1)" ;\
+	    cr_name="$$(echo $${cr} | cut -d: -f2)" ;\
+	    echo "Deleting OSSMConsole CR [$${cr_name}] in namespace [$${cr_namespace}]" ;\
+	    ${OC} patch  ossmconsole $${cr_name} -n $${cr_namespace} -p '{"metadata":{"finalizers": []}}' --type=merge ;\
+	    ${OC} delete ossmconsole $${cr_name} -n $${cr_namespace} ;\
+	  done
+	${OC} delete --ignore-not-found=true all,configmaps,deployments,consoleplugins --selector="app.kubernetes.io/name=ossmconsole" -n "${NAMESPACE}"
+	index="$$(${OC} get consoles.operator.openshift.io cluster -o json | jq '.spec.plugins | index("ossmconsole")')" && [ "$${index}" != "null" ] && ${OC} patch consoles.operator.openshift.io cluster --type=json -p '[{"op":"remove","path":"/spec/plugins/'$${index}'"}]' || true
+else
+	@echo "No OSSMConsole resources to delete on non-OpenShift environments."
+endif
+
 ## kiali-reload-image: Refreshing the Kiali pod by deleting it which forces a redeployment
 kiali-reload-image: .ensure-oc-exists
 	@echo Refreshing Kiali pod within namespace ${NAMESPACE}
 	${OC} delete pod --selector=app.kubernetes.io/name=kiali -n ${NAMESPACE}
 
-## run-operator-playbook: Run the operator dev playbook to run the operator ansible script locally.
-run-operator-playbook: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists
+.prepare-operator-playbook-kiali:
+	@$(eval OPERATOR_PLAYBOOK_KIND ?= kiali)
+
+.prepare-operator-playbook-ossmconsole:
+	@$(eval OPERATOR_PLAYBOOK_KIND ?= ossmconsole)
+
+.run-operator-playbook: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists
 ifeq ($(OPERATOR_PROFILER_ENABLED),true)
 	@$(eval ANSIBLE_CALLBACK_WHITELIST_ARG ?= ANSIBLE_CALLBACK_WHITELIST=profile_tasks)
 endif
 	@$(eval ANSIBLE_PYTHON_INTERPRETER ?= $(shell if (which python 2>/dev/null 1>&2 && python --version 2>&1 | grep -q " 2\.*"); then echo "-e ansible_python_interpreter=python3"; else echo ""; fi))
 	@if [ ! -z "${ANSIBLE_PYTHON_INTERPRETER}" ]; then echo "ANSIBLE_PYTHON_INTERPRETER is [${ANSIBLE_PYTHON_INTERPRETER}]. Make sure that refers to a Python3 installation. If you do not have Python3 in that location, you must ensure you have Python3 and ANSIBLE_PYTHON_INTERPRETER is set to '-e ansible_python_interpreter=<full path to your python3 executable>"; fi
 	@echo "Ensure the CRDs exist"; ${OC} apply -f ${HELM_CHARTS_REPO}/kiali-operator/crds/crds.yaml
-	@echo "Create a dummy Kiali CR"; ${OC} apply -f ${ROOTDIR}/operator/dev-playbook-config/dev-kiali-cr.yaml
+	@echo "Create a dummy [${OPERATOR_PLAYBOOK_KIND}] CR"; ${OC} apply -f ${ROOTDIR}/operator/dev-playbook-config/${OPERATOR_PLAYBOOK_KIND}/dev-cr.yaml
 	ansible-galaxy collection install operator_sdk.util kubernetes.core
-	ALLOW_AD_HOC_KIALI_NAMESPACE=true ALLOW_AD_HOC_KIALI_IMAGE=true ALLOW_ALL_ACCESSIBLE_NAMESPACES=true ANSIBLE_ROLES_PATH=${ROOTDIR}/operator/roles ${ANSIBLE_CALLBACK_WHITELIST_ARG} ansible-playbook -vvv ${ANSIBLE_PYTHON_INTERPRETER} -i ${ROOTDIR}/operator/dev-playbook-config/dev-hosts.yaml ${ROOTDIR}/operator/dev-playbook-config/dev-playbook.yaml
-	@echo "Remove the dummy Kiali CR"; ${OC} delete -f ${ROOTDIR}/operator/dev-playbook-config/dev-kiali-cr.yaml
+	ALLOW_AD_HOC_KIALI_NAMESPACE=true \
+	ALLOW_AD_HOC_KIALI_IMAGE=true \
+	ALLOW_AD_HOC_OSSMCONSOLE_IMAGE=true \
+	ALLOW_ALL_ACCESSIBLE_NAMESPACES=true \
+	ANSIBLE_ROLES_PATH=${ROOTDIR}/operator/roles \
+	${ANSIBLE_CALLBACK_WHITELIST_ARG} \
+	ansible-playbook -vvv ${ANSIBLE_PYTHON_INTERPRETER} \
+	  -i ${ROOTDIR}/operator/dev-playbook-config/${OPERATOR_PLAYBOOK_KIND}/dev-hosts.yaml \
+	  ${ROOTDIR}/operator/dev-playbook-config/${OPERATOR_PLAYBOOK_KIND}/dev-playbook.yaml
+	@echo "Remove the dummy [${OPERATOR_PLAYBOOK_KIND}] CR"; ${OC} delete -f ${ROOTDIR}/operator/dev-playbook-config/${OPERATOR_PLAYBOOK_KIND}/dev-cr.yaml
+
+## run-operator-playbook-kiali: Run the operator dev playbook to run the operator ansible script locally and process a Kiali CR
+run-operator-playbook-kiali: .prepare-operator-playbook-kiali .run-operator-playbook
+
+## run-operator-playbook-ossmconsole: Run the operator dev playbook to run the operator ansible script locally and process a OSSMConsole CR
+run-operator-playbook-ossmconsole: .prepare-operator-playbook-ossmconsole .run-operator-playbook
 
 # Set an operator environment variable to configure features inside the operator.
 # Example values for OPERATOR_ENV_NAME [OPERATOR_ENV_VALUE] are:
@@ -231,13 +326,20 @@ operator-set-config-ansible-profiler-off: .operator-set-env-ansible-profiler-off
 get-ansible-operator: .ensure-ansible-operator-exists .ensure-ansible-runner-exists
 	@echo "Ansible Operator location: ${ANSIBLE_OPERATOR_BIN} (ansible-runner: ${ANSIBLE_RUNNER_BIN})"
 
-## crd-create: Installs the Kiali CRD. Useful if running the operator outside of OLM or Helm.
+## crd-create: Installs the Kiali CRD and OSSMConsole CRD. Useful if running the operator outside of OLM or Helm.
 crd-create: .ensure-oc-login
 	${OC} apply -f "${OPERATOR_DIR}/manifests/kiali-ossm/manifests/kiali.crd.yaml"
+ifeq ($(CLUSTER_TYPE),openshift)
+	${OC} apply -f "${OPERATOR_DIR}/manifests/kiali-ossm/manifests/ossmconsole.crd.yaml"
+endif
 
-## crd-delete: Uninstalls the Kiali CRD and all CRs. Useful if running the operator outside of OLM or Helm.
-crd-delete:
+## crd-delete: Uninstalls the Kiali CRD and OSSMConsole CRD and all CRs. Useful if running the operator outside of OLM or Helm.
+crd-delete: .ensure-oc-login
+	@echo "Deleting CRDs"
 	${OC} delete --ignore-not-found=true crd kialis.kiali.io
+ifeq ($(CLUSTER_TYPE),openshift)
+	${OC} delete --ignore-not-found=true crd ossmconsoles.kiali.io
+endif
 
 .wait-for-kiali-crd:
 	@echo -n "Waiting for the Kiali CRD to be established"
@@ -249,14 +351,38 @@ crd-delete:
 	[ $${i} -lt 60 ] || (echo "The Kiali CRD does not exist. You should install the operator." && exit 1)
 	${OC} wait --for condition=established --timeout=60s crd kialis.kiali.io
 
+.wait-for-ossmconsole-crd:
+ifeq ($(CLUSTER_TYPE),openshift)
+	@echo -n "Waiting for the OSSMConsole CRD to be established"
+	@i=0 ;\
+	until [ $${i} -eq 60 ] || ${OC} get crd ossmconsoles.kiali.io &> /dev/null; do \
+	    echo -n '.' ; sleep 2 ; (( i++ )) ;\
+	done ;\
+	echo ;\
+	[ $${i} -lt 60 ] || (echo "The OSSMConsole CRD does not exist. You should install the operator." && exit 1)
+	${OC} wait --for condition=established --timeout=60s crd ossmconsoles.kiali.io
+else
+	@echo "No OSSMConsole CRD expected on non-OpenShift environments."
+endif
+
 ## run-operator: Runs the Kiali Operator via the ansible-operator locally.
-run-operator: get-ansible-operator crd-create .wait-for-kiali-crd
+run-operator: get-ansible-operator crd-create .wait-for-kiali-crd .wait-for-ossmconsole-crd
+ifeq ($(CLUSTER_TYPE),openshift)
+	@$(eval WATCHES_FILE ?= watches-os.yaml)
+else
+	@$(eval WATCHES_FILE ?= watches-k8s.yaml)
+endif
+	@# Make sure we have the collections we need
+	ansible-galaxy collection install -r ${OPERATOR_DIR}/requirements.yml --force-with-deps
+	@# Run the operator directly
 	cd ${OPERATOR_DIR} && \
 	ANSIBLE_ROLES_PATH="${OPERATOR_DIR}/roles" \
 	ALLOW_AD_HOC_KIALI_NAMESPACE="true" \
 	ALLOW_AD_HOC_KIALI_IMAGE="true" \
+	ALLOW_AD_HOC_OSSMCONSOLE_IMAGE="true" \
 	ALLOW_ALL_ACCESSIBLE_NAMESPACES="true" \
 	ANSIBLE_VERBOSITY_KIALI_KIALI_IO="1" \
+	ANSIBLE_VERBOSITY_OSSMCONSOLE_KIALI_IO="1" \
 	ANSIBLE_DEBUG_LOGS="True" \
 	ANSIBLE_CALLBACK_WHITELIST="profile_tasks" \
 	ANSIBLE_CALLBACKS_ENABLED="profile_tasks" \
@@ -264,4 +390,4 @@ run-operator: get-ansible-operator crd-create .wait-for-kiali-crd
 	POD_NAMESPACE="does-not-exist" \
 	WATCH_NAMESPACE="" \
 	PATH="${PATH}:${OUTDIR}/ansible-operator-install" \
-	ansible-operator run --zap-log-level=debug --leader-election-id=kiali-operator
+	ansible-operator run --zap-log-level=debug --leader-election-id=kiali-operator --watches-file=${WATCHES_FILE}


### PR DESCRIPTION
### Describe the change

Backport of make option `ossmconsole-create` to be able to deploy local OSSMConsole plugin in remote clusters for 1.73 release (OSSM 2.5)

### Steps to test the PR

Run `make clean build build-ui cluster-push operator-create kiali-create ossmconsole-create` in OCP cluster to check that OSSMConsole plugin is installed correctly 
