### PR TITLE
remove verbose_mode that has been deprecated

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -132,27 +132,12 @@ func resolveLogLevelFromEnv() zerolog.Level {
 		return zerolog.InfoLevel
 	}
 
-	switch logLevel {
-	case "0":
-		return zerolog.FatalLevel
-	case "1":
-		return zerolog.ErrorLevel
-	case "2":
-		return zerolog.WarnLevel
-	case "3":
+	logLevelFromString, err := zerolog.ParseLevel(strings.ToLower(logLevel))
+	if err != nil {
+		log.Warn().Msgf("Provided LOG_LEVEL [%s] is invalid. Falling back to 'info'.", os.Getenv("LOG_LEVEL"))
 		return zerolog.InfoLevel
-	case "4":
-		return zerolog.DebugLevel
-	case "5":
-		return zerolog.TraceLevel
-	default:
-		logLevelFromString, err := zerolog.ParseLevel(strings.ToLower(logLevel))
-		if err != nil {
-			log.Warn().Msgf("Provided LOG_LEVEL %s is invalid. Fallback to info.", os.Getenv("LOG_LEVEL"))
-			return zerolog.InfoLevel
-		}
-		return logLevelFromString
 	}
+	return logLevelFromString
 }
 
 // Resolves and validates the log format. FallbackLogFormat is used as a default.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -54,30 +54,6 @@ func TestEnvVarLogLevel(t *testing.T) {
 			level:       zerolog.TraceLevel,
 		},
 		{
-			stringLevel: "0",
-			level:       zerolog.FatalLevel,
-		},
-		{
-			stringLevel: "1",
-			level:       zerolog.ErrorLevel,
-		},
-		{
-			stringLevel: "2",
-			level:       zerolog.WarnLevel,
-		},
-		{
-			stringLevel: "3",
-			level:       zerolog.InfoLevel,
-		},
-		{
-			stringLevel: "4",
-			level:       zerolog.DebugLevel,
-		},
-		{
-			stringLevel: "5",
-			level:       zerolog.TraceLevel,
-		},
-		{
 			stringLevel: "invalid",
 			level:       zerolog.InfoLevel,
 		},


### PR DESCRIPTION
It has been deprecated/superceded since v1.26 (4 years ago)

fixes: https://github.com/kiali/kiali/issues/7208
