### PR TITLE
Apps lists page optimized to query per cluster

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -89,6 +89,10 @@ func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteri
 	}
 
 	allApps, err := in.businessLayer.App.fetchNamespaceApps(ctx, namespace, cluster, "")
+	if err != nil {
+		log.Errorf("Error fetching Applications for cluster %s per namespace %s: %s", cluster, namespace, err)
+		return *appList, err
+	}
 
 	icCriteria := IstioConfigCriteria{
 		IncludeAuthorizationPolicies:  true,
@@ -105,7 +109,7 @@ func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteri
 	if criteria.IncludeIstioResources {
 		istioConfigList, err = in.businessLayer.IstioConfig.GetIstioConfigListForNamespace(ctx, cluster, namespace, icCriteria)
 		if err != nil {
-			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
+			log.Errorf("Error fetching Istio Config for Cluster %s per namespace %s: %s", cluster, namespace, err)
 			return *appList, err
 		}
 	}

--- a/business/apps.go
+++ b/business/apps.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -56,6 +57,122 @@ func buildFinalLabels(m map[string][]string) map[string]string {
 		consolidated[k] = strings.Join(list, ",")
 	}
 	return consolidated
+}
+
+// GetClusterAppList is the API handler to fetch the list of applications in a given namespace and cluster
+func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteria) (models.ClusterApps, error) {
+	var end observability.EndFunc
+	ctx, end = observability.StartSpan(ctx, "GetClusterAppList",
+		observability.Attribute("package", "business"),
+		observability.Attribute("namespace", criteria.Namespace),
+		observability.Attribute("cluster", criteria.Cluster),
+		observability.Attribute("includeHealth", criteria.IncludeHealth),
+		observability.Attribute("includeIstioResources", criteria.IncludeIstioResources),
+		observability.Attribute("rateInterval", criteria.RateInterval),
+		observability.Attribute("queryTime", criteria.QueryTime),
+	)
+	defer end()
+
+	appList := &models.ClusterApps{
+		Apps: []models.AppListItem{},
+	}
+
+	namespace := criteria.Namespace
+	cluster := criteria.Cluster
+
+	if _, ok := in.userClients[cluster]; !ok {
+		return *appList, fmt.Errorf("Cluster [%s] is not found or is not accessible for Kiali", cluster)
+	}
+
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
+		return *appList, err
+	}
+
+	allApps, err := in.businessLayer.App.fetchNamespaceApps(ctx, namespace, cluster, "")
+
+	icCriteria := IstioConfigCriteria{
+		IncludeAuthorizationPolicies:  true,
+		IncludeDestinationRules:       true,
+		IncludeEnvoyFilters:           true,
+		IncludeGateways:               true,
+		IncludePeerAuthentications:    true,
+		IncludeRequestAuthentications: true,
+		IncludeSidecars:               true,
+		IncludeVirtualServices:        true,
+	}
+	istioConfigList := &models.IstioConfigList{}
+
+	if criteria.IncludeIstioResources {
+		istioConfigList, err = in.businessLayer.IstioConfig.GetIstioConfigListForNamespace(ctx, cluster, namespace, icCriteria)
+		if err != nil {
+			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
+			return models.AppList{}, err
+		}
+	}
+
+	for keyApp, valueApp := range allApps {
+		appItem := &models.AppListItem{
+			Name:         keyApp,
+			IstioSidecar: true,
+			Health:       models.EmptyAppHealth(),
+		}
+		applabels := make(map[string][]string)
+		svcReferences := make([]*models.IstioValidationKey, 0)
+		for _, srv := range valueApp.Services {
+			joinMap(applabels, srv.Labels)
+			if criteria.IncludeIstioResources {
+				vsFiltered := kubernetes.FilterVirtualServicesByService(istioConfigList.VirtualServices, srv.Namespace, srv.Name)
+				for _, v := range vsFiltered {
+					ref := models.BuildKey(v.Kind, v.Name, v.Namespace)
+					svcReferences = append(svcReferences, &ref)
+				}
+				drFiltered := kubernetes.FilterDestinationRulesByService(istioConfigList.DestinationRules, srv.Namespace, srv.Name)
+				for _, d := range drFiltered {
+					ref := models.BuildKey(d.Kind, d.Name, d.Namespace)
+					svcReferences = append(svcReferences, &ref)
+				}
+				gwFiltered := kubernetes.FilterGatewaysByVirtualServices(istioConfigList.Gateways, istioConfigList.VirtualServices)
+				for _, g := range gwFiltered {
+					ref := models.BuildKey(g.Kind, g.Name, g.Namespace)
+					svcReferences = append(svcReferences, &ref)
+				}
+
+			}
+
+		}
+
+		wkdReferences := make([]*models.IstioValidationKey, 0)
+		for _, wrk := range valueApp.Workloads {
+			joinMap(applabels, wrk.Labels)
+			if criteria.IncludeIstioResources {
+				wSelector := labels.Set(wrk.Labels).AsSelector().String()
+				wkdReferences = append(wkdReferences, FilterWorkloadReferences(wSelector, *istioConfigList)...)
+			}
+		}
+		appItem.Labels = buildFinalLabels(applabels)
+		appItem.IstioReferences = FilterUniqueIstioReferences(append(svcReferences, wkdReferences...))
+
+		for _, w := range valueApp.Workloads {
+			if appItem.IstioSidecar = w.IstioSidecar; !appItem.IstioSidecar {
+				break
+			}
+		}
+		for _, w := range valueApp.Workloads {
+			if appItem.IstioAmbient = w.HasIstioAmbient(); !appItem.IstioAmbient {
+				break
+			}
+		}
+		if criteria.IncludeHealth {
+			appItem.Health, err = in.businessLayer.Health.GetAppHealth(ctx, criteria.Namespace, valueApp.cluster, appItem.Name, criteria.RateInterval, criteria.QueryTime, valueApp)
+			if err != nil {
+				log.Errorf("Error fetching Health in namespace %s for app %s: %s", criteria.Namespace, appItem.Name, err)
+			}
+		}
+		appItem.Namespace = models.Namespace{Cluster: cluster, Name: namespace}
+		appList.Apps = append(appList.Apps, *appItem)
+	}
+
+	return *appList, nil
 }
 
 // GetAppList is the API handler to fetch the list of applications in a given namespace

--- a/business/apps.go
+++ b/business/apps.go
@@ -106,7 +106,7 @@ func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteri
 		istioConfigList, err = in.businessLayer.IstioConfig.GetIstioConfigListForNamespace(ctx, cluster, namespace, icCriteria)
 		if err != nil {
 			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
-			return models.AppList{}, err
+			return *appList, err
 		}
 	}
 
@@ -323,7 +323,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 					log.Errorf("Error fetching Health in namespace %s for app %s: %s", criteria.Namespace, appItem.Name, err)
 				}
 			}
-			appItem.Cluster = valueApp.cluster
+			appItem.Namespace = models.Namespace{Cluster: valueApp.cluster, Name: criteria.Namespace}
 			appList.Apps = append(appList.Apps, *appItem)
 		}
 	}

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -50,14 +50,13 @@ func TestGetAppListFromDeployments(t *testing.T) {
 
 	svc := setupAppService(mockClientFactory.Clients)
 
-	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
-	appList, err := svc.GetAppList(context.TODO(), criteria)
+	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	appList, err := svc.GetClusterAppList(context.TODO(), criteria)
 	require.NoError(err)
-
-	assert.Equal("Namespace", appList.Namespace.Name)
 
 	assert.Equal(1, len(appList.Apps))
 	assert.Equal("httpbin", appList.Apps[0].Name)
+	assert.Equal("Namespace", appList.Apps[0].Namespace.Name)
 }
 
 func TestGetAppFromDeployments(t *testing.T) {
@@ -127,13 +126,12 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 
 	svc := setupAppService(mockClientFactory.Clients)
 
-	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
-	appList, _ := svc.GetAppList(context.TODO(), criteria)
-
-	assert.Equal("Namespace", appList.Namespace.Name)
+	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	appList, _ := svc.GetClusterAppList(context.TODO(), criteria)
 
 	assert.Equal(1, len(appList.Apps))
 	assert.Equal("httpbin", appList.Apps[0].Name)
+	assert.Equal("Namespace", appList.Apps[0].Namespace.Name)
 }
 
 func TestGetAppFromReplicaSets(t *testing.T) {

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -114,10 +114,10 @@ Then('user sees Details information for Apps', () => {
   });
 });
 
-Then('user only sees the apps with the {string} name in the {string} namespace', (name: string, ns: string) => {
+Then('user only sees the apps with the {string} name', (name: string) => {
   let count: number;
 
-  cy.request('GET', `/api/namespaces/${ns}/apps`).should(response => {
+  cy.request('GET', `/api/clusters/apps`).should(response => {
     count = response.body.applications.filter(item => item.name.includes(name)).length;
   });
 

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -65,7 +65,7 @@ Feature: Kiali Apps List page
   Scenario: Filter Applications table by Label
     When the user filters by "Label" for "app=reviews"
     Then user sees "reviews"
-    And user only sees the apps with the "reviews" name in the "bookinfo" namespace
+    And user only sees the apps with the "reviews" name
 
   @bookinfo-app
   Scenario: The healthy status of a logical mesh application is reported in the list of applications
@@ -103,7 +103,7 @@ Feature: Kiali Apps List page
 
   @multi-cluster
   Scenario: The column related to cluster name should be visible
-    Then the "Cluster" column "appears" 
+    Then the "Cluster" column "appears"
     And an entry for "east" cluster should be in the table
     And an entry for "west" cluster should be in the table
 
@@ -118,4 +118,4 @@ Feature: Kiali Apps List page
     Then the list is sorted by column "Cluster" in "ascending" order
     When user sorts the list by column "Cluster" in "descending" order
     Then the list is sorted by column "Cluster" in "descending" order
-    
+

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -11,6 +11,7 @@ import * as React from 'react';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
 import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
+import { getNamespace } from '../../utils/Common';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -29,11 +30,13 @@ export function hasHealth(r: RenderResource): r is SortResource {
 }
 
 export const hasMissingSidecar = (r: SortResource): boolean => {
-  return !isIstioNamespace(r.namespace) && !r.istioSidecar && !isGateway(r.labels) && !isWaypoint(r.labels);
+  return (
+    !isIstioNamespace(getNamespace(r.namespace)) && !r.istioSidecar && !isGateway(r.labels) && !isWaypoint(r.labels)
+  );
 };
 
 export const noAmbientLabels = (r: SortResource): boolean => {
-  return !isIstioNamespace(r.namespace) && !r.istioAmbient;
+  return !isIstioNamespace(getNamespace(r.namespace)) && !r.istioAmbient;
 };
 
 export type ResourceType<R extends RenderResource> = {

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -37,11 +37,15 @@ import { NamespaceStatuses } from 'pages/Overview/NamespaceStatuses';
 import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
 import { KialiIcon } from '../../config/KialiIcon';
 import { Td } from '@patternfly/react-table';
+import { getNamespace } from '../../utils/Common';
 
 // Links
 
 const getLink = (item: TResource, config: Resource, query?: string): string => {
-  let url = config.name === 'istio' ? getIstioLink(item) : `/namespaces/${item.namespace}/${config.name}/${item.name}`;
+  let url =
+    config.name === 'istio'
+      ? getIstioLink(item)
+      : `/namespaces/${getNamespace(item.namespace)}/${config.name}/${item.name}`;
 
   if (item.cluster && isMultiCluster && !url.includes('cluster')) {
     if (url.includes('?')) {
@@ -65,7 +69,7 @@ const getLink = (item: TResource, config: Resource, query?: string): string => {
 const getIstioLink = (item: TResource): string => {
   const type = item['type'];
 
-  return GetIstioObjectUrl(item.name, item.namespace, type, item.cluster);
+  return GetIstioObjectUrl(item.name, getNamespace(item.namespace), type, item.cluster);
 };
 
 // Cells
@@ -94,20 +98,20 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
     <Td
       role="gridcell"
       dataLabel="Details"
-      key={`VirtuaItem_Details_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Details_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle', whiteSpace: 'nowrap' }}
     >
       <ul>
         {hasMissingAP && (
           <li>
-            <MissingAuthPolicy namespace={item.namespace} />
+            <MissingAuthPolicy namespace={getNamespace(item.namespace)} />
           </li>
         )}
 
         {((hasMissingSC && hasMissingA && serverConfig.ambientEnabled) ||
           (!serverConfig.ambientEnabled && hasMissingSC)) && (
           <li>
-            <MissingSidecar namespace={item.namespace} isGateway={isGateway(item.labels)} />
+            <MissingSidecar namespace={getNamespace(item.namespace)} isGateway={isGateway(item.labels)} />
           </li>
         )}
 
@@ -257,7 +261,7 @@ export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Reso
 };
 
 export const item: Renderer<TResource> = (item: TResource, config: Resource, badge: PFBadgeType) => {
-  const key = `link_definition_${config.name}_${item.namespace}_${item.name}`;
+  const key = `link_definition_${config.name}_${getNamespace(item.namespace)}_${item.name}`;
   let serviceBadge = badge;
 
   if (item['serviceRegistry']) {
@@ -275,7 +279,7 @@ export const item: Renderer<TResource> = (item: TResource, config: Resource, bad
     <Td
       role="gridcell"
       dataLabel="Name"
-      key={`VirtuaItem_Item_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Item_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       <PFBadge badge={serviceBadge} position={TooltipPosition.top} />
@@ -306,11 +310,11 @@ export const namespace: Renderer<TResource> = (item: TResource) => {
     <Td
       role="gridcell"
       dataLabel="Namespace"
-      key={`VirtuaItem_Namespace_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Namespace_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       <PFBadge badge={PFBadges.Namespace} position={TooltipPosition.top} />
-      {item.namespace}
+      {getNamespace(item.namespace)}
     </Td>
   );
 };
@@ -355,7 +359,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
     <Td
       role="gridcell"
       dataLabel="Labels"
-      key={`VirtuaItem_Labels_${'namespace' in item && `${item.namespace}_`}${item.name}`}
+      key={`VirtuaItem_Labels_${'namespace' in item && `${getNamespace(item.namespace)}_`}${item.name}`}
       style={{ verticalAlign: 'middle', paddingBottom: '0.25rem' }}
     >
       {item.labels &&
@@ -415,7 +419,7 @@ export const health: Renderer<TResource> = (item: TResource, __: Resource, _: PF
     <Td
       role="gridcell"
       dataLabel="Health"
-      key={`VirtuaItem_Health_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Health_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       {health && <HealthIndicator id={item.name} health={health} />}
@@ -428,7 +432,7 @@ export const workloadType: Renderer<WorkloadListItem> = (item: WorkloadListItem)
     <Td
       role="gridcell"
       dataLabel="Type"
-      key={`VirtuaItem_WorkloadType_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_WorkloadType_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       {item.type}
@@ -444,7 +448,7 @@ export const istioType: Renderer<IstioConfigItem> = (item: IstioConfigItem) => {
     <Td
       role="gridcell"
       dataLabel="Type"
-      key={`VirtuaItem_IstioType_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_IstioType_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       {object.name}
@@ -461,7 +465,7 @@ export const istioConfiguration: Renderer<IstioConfigItem> = (item: IstioConfigI
     <Td
       role="gridcell"
       dataLabel="Configuration"
-      key={`VirtuaItem_Conf_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Conf_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       {validation ? (
@@ -487,7 +491,7 @@ export const serviceConfiguration: Renderer<ServiceListItem> = (item: ServiceLis
     <Td
       role="gridcell"
       dataLabel="Configuration"
-      key={`VirtuaItem_Conf_${item.namespace}_${item.name}`}
+      key={`VirtuaItem_Conf_${getNamespace(item.namespace)}_${item.name}`}
       style={{ verticalAlign: 'middle' }}
     >
       {validation ? (

--- a/frontend/src/components/VirtualList/VirtualItem.tsx
+++ b/frontend/src/components/VirtualList/VirtualItem.tsx
@@ -6,6 +6,7 @@ import { Health } from '../../types/Health';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import { actionRenderer } from './Renderers';
 import { CSSProperties } from 'react';
+import { getNamespace } from '../../utils/Common';
 
 type VirtualItemProps = {
   action?: JSX.Element;
@@ -30,19 +31,19 @@ export class VirtualItem extends React.Component<VirtualItemProps, VirtualItemSt
     this.state = { health: undefined };
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     if (hasHealth(this.props.item)) {
       this.setState({ health: this.props.item.health });
     }
   }
 
-  componentDidUpdate(prevProps: VirtualItemProps) {
+  componentDidUpdate(prevProps: VirtualItemProps): void {
     if (hasHealth(this.props.item) && this.props.item.health !== prevProps.item['health']) {
       this.setState({ health: this.props.item.health });
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.promises.cancelAll();
   }
 
@@ -56,10 +57,10 @@ export class VirtualItem extends React.Component<VirtualItemProps, VirtualItemSt
     return this.props.config.name !== 'istio' ? this.props.config.badge : IstioTypes[this.props.item['type']].badge;
   };
 
-  render() {
+  render(): React.ReactNode {
     const { style, className, item } = this.props;
     const cluster = item.cluster ? `_Cluster${item.cluster}` : '';
-    const namespace = 'namespace' in item ? `_Ns${item.namespace}` : '';
+    const namespace = 'namespace' in item ? `_Ns${getNamespace(item.namespace)}` : '';
     const type = 'type' in item ? `_${item.type}` : '';
     // End result looks like: VirtualItem_Clusterwest_Nsbookinfo_gateway_bookinfo-gateway
 

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -119,6 +119,7 @@ const conf = {
       authInfo: 'api/auth/info',
       canaryUpgradeStatus: () => 'api/mesh/canaries/status',
       clusters: 'api/clusters',
+      clustersApps: () => `api/clusters/apps`,
       clustersHealth: () => `api/clusters/health`,
       clustersMetrics: () => `api/clusters/metrics`,
       clustersTls: () => `api/clusters/tls`,

--- a/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -29,7 +29,9 @@ const emptySvcHealth = new ServiceHealth(
 );
 const appList: AppListItem[] = [
   {
-    namespace: 'bookinfo',
+    namespace: {
+      name: 'bookinfo'
+    },
     health: emptyAppHealth,
     name: 'ratings',
     istioSidecar: false,
@@ -38,7 +40,9 @@ const appList: AppListItem[] = [
     istioReferences: []
   },
   {
-    namespace: 'bookinfo',
+    namespace: {
+      name: 'bookinfo'
+    },
     health: emptyAppHealth,
     name: 'productpage',
     istioSidecar: false,
@@ -47,7 +51,9 @@ const appList: AppListItem[] = [
     istioReferences: []
   },
   {
-    namespace: 'bookinfo',
+    namespace: {
+      name: 'bookinfo'
+    },
     health: emptyAppHealth,
     name: 'details',
     istioSidecar: false,
@@ -56,7 +62,9 @@ const appList: AppListItem[] = [
     istioReferences: []
   },
   {
-    namespace: 'bookinfo',
+    namespace: {
+      name: 'bookinfo'
+    },
     health: emptyAppHealth,
     name: 'reviews',
     istioSidecar: false,
@@ -212,7 +220,9 @@ describe('LabelFilter', () => {
     const result = filterByLabel(appList, ['app', 'service=details'], 'and');
     expect(result).toEqual([
       {
-        namespace: 'bookinfo',
+        namespace: {
+          name: 'bookinfo'
+        },
         health: emptyAppHealth,
         name: 'details',
         istioSidecar: false,
@@ -227,7 +237,9 @@ describe('LabelFilter', () => {
     const result = filterByLabel(appList, ['app', 'version=v2'], 'and');
     expect(result).toEqual([
       {
-        namespace: 'bookinfo',
+        namespace: {
+          name: 'bookinfo'
+        },
         health: emptyAppHealth,
         name: 'reviews',
         istioSidecar: false,

--- a/frontend/src/pages/AppList/AppListClass.tsx
+++ b/frontend/src/pages/AppList/AppListClass.tsx
@@ -5,18 +5,18 @@ import { AppHealth } from '../../types/Health';
 export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {
   if (data.applications) {
     return data.applications.map(app => ({
-      namespace: data.namespace.name,
+      namespace: app.namespace,
       name: app.name,
       istioSidecar: app.istioSidecar,
       istioAmbient: app.istioAmbient,
-      health: AppHealth.fromJson(data.namespace.name, app.name, app.health, {
+      health: AppHealth.fromJson(app.namespace.name, app.name, app.health, {
         rateInterval: rateInterval,
         hasSidecar: app.istioSidecar,
         hasAmbient: app.istioAmbient
       }),
       labels: app.labels,
       istioReferences: sortIstioReferences(app.istioReferences, true),
-      cluster: app.cluster
+      cluster: app.namespace.cluster
     }));
   }
   return [];

--- a/frontend/src/pages/AppList/FiltersAndSorts.ts
+++ b/frontend/src/pages/AppList/FiltersAndSorts.ts
@@ -24,8 +24,8 @@ export const sortFields: SortField<AppListItem>[] = [
     title: 'Namespace',
     isNumeric: false,
     param: 'ns',
-    compare: (a, b) => {
-      let sortValue = a.namespace.localeCompare(b.namespace);
+    compare: (a: AppListItem, b: AppListItem): number => {
+      let sortValue = a.namespace.name.localeCompare(b.namespace.name);
       if (sortValue === 0) {
         sortValue = a.name.localeCompare(b.name);
       }
@@ -37,14 +37,14 @@ export const sortFields: SortField<AppListItem>[] = [
     title: 'App Name',
     isNumeric: false,
     param: 'wn',
-    compare: (a, b) => a.name.localeCompare(b.name)
+    compare: (a: AppListItem, b: AppListItem): number => a.name.localeCompare(b.name)
   },
   {
     id: 'details',
     title: 'Details',
     isNumeric: false,
     param: 'is',
-    compare: (a, b) => {
+    compare: (a: AppListItem, b: AppListItem): number => {
       // First sort by missing sidecar
       const aSC = hasMissingSidecar(a) ? 1 : 0;
       const bSC = hasMissingSidecar(b) ? 1 : 0;
@@ -69,16 +69,16 @@ export const sortFields: SortField<AppListItem>[] = [
     title: 'Health',
     isNumeric: false,
     param: 'he',
-    compare: (a, b) => {
+    compare: (a: AppListItem, b: AppListItem): number => {
       if (hasHealth(a) && hasHealth(b)) {
         const statusForA = a.health.getGlobalStatus();
         const statusForB = b.health.getGlobalStatus();
 
         if (statusForA.priority === statusForB.priority) {
           // If both apps have same health status, use error rate to determine order.
-          const ratioA = calculateErrorRate(a.namespace, a.name, 'app', a.health.requests).errorRatio.global.status
+          const ratioA = calculateErrorRate(a.namespace.name, a.name, 'app', a.health.requests).errorRatio.global.status
             .value;
-          const ratioB = calculateErrorRate(b.namespace, b.name, 'app', b.health.requests).errorRatio.global.status
+          const ratioB = calculateErrorRate(b.namespace.name, b.name, 'app', b.health.requests).errorRatio.global.status
             .value;
           return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
         }
@@ -94,7 +94,7 @@ export const sortFields: SortField<AppListItem>[] = [
     title: 'Cluster',
     isNumeric: false,
     param: 'cl',
-    compare: (a: AppListItem, b: AppListItem) => {
+    compare: (a: AppListItem, b: AppListItem): number => {
       if (a.cluster && b.cluster) {
         let sortValue = a.cluster.localeCompare(b.cluster);
         if (sortValue === 0) {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -512,8 +512,20 @@ export const getApp = (
   return newRequest<App>(HTTP_VERBS.GET, urls.app(namespace, app), queryParams, {});
 };
 
-export const getApps = (namespace: string, params: AppListQuery): Promise<ApiResponse<AppList>> => {
-  return newRequest<AppList>(HTTP_VERBS.GET, urls.apps(namespace), params, {});
+export const getClustersApps = (
+  namespaces: string,
+  params: AppListQuery,
+  cluster?: string
+): Promise<ApiResponse<AppList>> => {
+  const queryParams: QueryParams<AppListQuery & Namespaces> = {
+    ...params,
+    namespaces: namespaces
+  };
+
+  if (cluster) {
+    queryParams.clusterName = cluster;
+  }
+  return newRequest<AppList>(HTTP_VERBS.GET, urls.clustersApps(), queryParams, {});
 };
 
 export const getAppMetrics = (

--- a/frontend/src/types/AppList.ts
+++ b/frontend/src/types/AppList.ts
@@ -3,11 +3,12 @@ import { AppHealth } from './Health';
 import { ObjectReference } from './IstioObjects';
 
 export interface AppList {
-  applications: AppOverview[];
-  namespace: Namespace;
+  applications: AppListItem[];
+  cluster?: string;
 }
 
-export interface AppOverview {
+export interface AppListItem {
+  // @TODO this should be gone as Namespace contains cluster
   cluster?: string;
   health: AppHealth;
   istioAmbient: boolean;
@@ -15,10 +16,7 @@ export interface AppOverview {
   istioSidecar: boolean;
   labels: { [key: string]: string };
   name: string;
-}
-
-export interface AppListItem extends AppOverview {
-  namespace: string;
+  namespace: Namespace;
 }
 
 export interface AppListQuery {

--- a/frontend/src/utils/Common.ts
+++ b/frontend/src/utils/Common.ts
@@ -1,8 +1,8 @@
 import { Namespace } from '../types/Namespace';
 
-export const removeDuplicatesArray = a => [...Array.from(new Set(a))] as string[];
+export const removeDuplicatesArray = (a: string[]): string[] => [...Array.from(new Set(a))] as string[];
 
-export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => boolean) => {
+export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => boolean): boolean => {
   if (a1.length !== a2.length) {
     return false;
   }
@@ -36,4 +36,13 @@ export const isValid = (isValid?: boolean, isWarning?: boolean): validationType 
     return 'success';
   }
   return isWarning ? 'warning' : 'error';
+};
+
+// @TODO this function should be removed once Workloads and Services lists are optimized
+export const getNamespace = (namespace: string | Namespace): string => {
+  if (typeof namespace === 'string') {
+    return namespace;
+  } else {
+    return namespace.name;
+  }
 };

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -185,7 +185,7 @@ ensureKialiTracesReady() {
 ensureMulticlusterApplicationsAreHealthy() {
   local start_time=$(date +%s)
   local timeout=300
-  local url="${KIALI_URL}/api/namespaces/bookinfo/apps?health=true&istioResources=true&rateInterval=60s"
+  local url="${KIALI_URL}/api/clusters/apps?namespaces=bookinfo&clusterName=west&health=true&istioResources=true&rateInterval=60s"
 
   while true; do
     local current_time=$(date +%s)
@@ -197,7 +197,7 @@ ensureMulticlusterApplicationsAreHealthy() {
     fi
 
     response=$(curl -s "$url")
-    has_http_200=$(echo "$response" | jq '[.applications[] | select(.name=="reviews" and .cluster=="west" and .health.requests.inbound.http."200" > 0)] | length > 0')
+    has_http_200=$(echo "$response" | jq '[.applications[] | select(.name=="reviews" and .namespace.cluster=="west" and .health.requests.inbound.http."200" > 0)] | length > 0')
 
     if [ "$has_http_200" = "true" ]; then
       infomsg "'reviews' app in 'west' cluster is healthy enough."

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/models"
 )
 
 // appParams holds the path and query parameters for appList and appDetails
@@ -68,6 +69,11 @@ func ClustersApps(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	clusterAppsList := &models.ClusterApps{
+		Apps:    []models.AppListItem{},
+		Cluster: p.ClusterName,
+	}
+
 	for _, ns := range nss {
 		criteria := business.AppCriteria{Cluster: p.ClusterName, Namespace: ns, IncludeIstioResources: p.IncludeIstioResources,
 			IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime}
@@ -82,15 +88,15 @@ func ClustersApps(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Fetch and build apps
-		appList, err := businessLayer.App.GetAppList(r.Context(), criteria)
+		appList, err := businessLayer.App.GetClusterAppList(r.Context(), criteria)
 		if err != nil {
 			handleErrorResponse(w, err)
 			return
 		}
-
+		clusterAppsList.Apps = append(clusterAppsList.Apps, appList.Apps...)
 	}
 
-	RespondWithJSON(w, http.StatusOK, appList)
+	RespondWithJSON(w, http.StatusOK, clusterAppsList)
 }
 
 // AppDetails is the API handler to fetch all details to be displayed, related to a single app

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -210,10 +210,10 @@ func setupAppListEndpoint(t *testing.T, k8s kubernetes.ClientInterface, conf con
 	business.WithProm(prom)
 
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/apps", http.HandlerFunc(
+	mr.HandleFunc("/api/clusters/apps", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			context := authentication.SetAuthInfoContext(r.Context(), &api.AuthInfo{Token: "test"})
-			AppList(w, r.WithContext(context))
+			ClustersApps(w, r.WithContext(context))
 		}))
 
 	mr.HandleFunc("/api/namespaces/{namespace}/apps/{app}", http.HandlerFunc(
@@ -254,7 +254,7 @@ func TestAppsEndpoint(t *testing.T) {
 	k8s.OpenShift = true
 	ts := setupAppListEndpoint(t, k8s, *cfg)
 
-	url := ts.URL + "/api/namespaces/Namespace/apps"
+	url := ts.URL + "/api/clusters/apps"
 
 	resp, err := http.Get(url)
 	if err != nil {

--- a/models/app.go
+++ b/models/app.go
@@ -4,6 +4,11 @@ type ClusterApps struct {
 	// Applications list for namespaces of a single cluster
 	// required: true
 	Apps []AppListItem `json:"applications"`
+
+	// Cluster where the apps live in
+	// required: true
+	// example: east
+	Cluster string `json:"cluster"`
 }
 
 type AppList struct {

--- a/models/app.go
+++ b/models/app.go
@@ -1,5 +1,11 @@
 package models
 
+type ClusterApps struct {
+	// Applications list for namespaces of a single cluster
+	// required: true
+	Apps []AppListItem `json:"applications"`
+}
+
 type AppList struct {
 	// Namespace where the apps live in
 	// required: true
@@ -23,10 +29,10 @@ type AppListItem struct {
 	// example: reviews
 	Name string `json:"name"`
 
-	// Cluster of the application
+	// Namespace where the apps live in
 	// required: true
-	// example: reviews
-	Cluster string `json:"cluster"`
+	// example: bookinfo
+	Namespace Namespace `json:"namespace"`
 
 	// Define if all Pods related to the Workloads of this app has an IstioSidecar deployed
 	// required: true

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -648,9 +648,9 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 			handlers.WorkloadUpdate,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/apps apps appList
+		// swagger:route GET /clusters/apps apps appList
 		// ---
-		// Endpoint to get the list of apps for a namespace
+		// Endpoint to get the list of apps for a cluster
 		//
 		//     Produces:
 		//     - application/json
@@ -662,10 +662,10 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 		//      200: appListResponse
 		//
 		{
-			"AppList",
+			"ClustersApps",
 			"GET",
-			"/api/namespaces/{namespace}/apps",
-			handlers.AppList,
+			"/api/clusters/apps",
+			handlers.ClustersApps,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/apps/{app} apps appDetails

--- a/tests/integration/tests/applications_test.go
+++ b/tests/integration/tests/applications_test.go
@@ -19,12 +19,12 @@ func TestApplicationsList(t *testing.T) {
 		require.NotEmpty(app.Name)
 		require.NotNil(app.Health)
 		require.NotNil(app.Labels)
+		require.Equal(kiali.BOOKINFO, app.Namespace.Name)
 		if !strings.Contains(app.Name, "traffic-generator") {
 			require.True(app.IstioSidecar)
 			require.NotNil(app.IstioReferences)
 		}
 	}
-	require.Equal(kiali.BOOKINFO, appList.Namespace.Name)
 }
 
 func TestApplicationDetails(t *testing.T) {

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -266,19 +266,14 @@ func NamespaceServiceHealth(namespace string, params map[string]string) (*models
 	}
 }
 
-func ApplicationsList(namespace string) (*models.AppList, error) {
-	body, _, _, err := httpGETWithRetry(client.kialiURL+"/api/namespaces/"+namespace+"/apps", client.GetAuth(), TIMEOUT, nil, client.kialiCookies)
-	if err == nil {
-		appList := new(models.AppList)
-		err = json.Unmarshal(body, &appList)
-		if err == nil {
-			return appList, nil
-		} else {
-			return nil, err
-		}
-	} else {
+func ApplicationsList(namespace string) (*models.ClusterApps, error) {
+	url := fmt.Sprintf("%s/api/clusters/apps?namespaces=%s", client.kialiURL, namespace)
+	appList := new(models.ClusterApps)
+	err := getRequestAndUnmarshalInto(url, appList)
+	if err != nil {
 		return nil, err
 	}
+	return appList, nil
 }
 
 func ApplicationDetails(name, namespace string) (*models.App, int, error) {


### PR DESCRIPTION
### Describe the change

Apps page was querying backend per namespace, now it queries per cluster by providing selected namespaces.
New API endpoing "api/clusters/apps" is added.

### Steps to test the PR

Create a set of namespaces:
for i in {1..200}; do kubectl create ns test-$i; done
Open the Apps list page and select all apps.
Compare the loading time between before and now.
Check if all fields are loaded correctly.

### Automation testing

Modified e2e and unit tests.

### Issue reference
https://github.com/kiali/kiali/issues/4832
