### PR TITLE
Start moving component info from About Box to Mesh Page

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -991,16 +991,21 @@ func Set(conf *Config) {
 	configuration = *conf
 }
 
-// String marshals the given Config into a YAML string
-// WARNING: do NOT use the result of this function to retrieve any configuration: some fields are obfuscated for security reasons.
-func (conf Config) String() (str string) {
-	obf := conf
+func (conf Config) Obfuscate() (obf Config) {
+	obf = conf
 	obf.ExternalServices.Grafana.Auth.Obfuscate()
 	obf.ExternalServices.Prometheus.Auth.Obfuscate()
 	obf.ExternalServices.Tracing.Auth.Obfuscate()
 	obf.Identity.Obfuscate()
 	obf.LoginToken.Obfuscate()
 	obf.Auth.OpenId.ClientSecret = "xxx"
+	return
+}
+
+// String marshals the given Config into a YAML string
+// WARNING: do NOT use the result of this function to retrieve any configuration: some fields are obfuscated for security reasons.
+func (conf Config) String() (str string) {
+	obf := conf.Obfuscate()
 	str, err := Marshal(&obf)
 	if err != nil {
 		str = fmt.Sprintf("Failed to marshal config to string. err=%v", err)

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -11,16 +11,13 @@ import {
   Alert
 } from '@patternfly/react-core';
 import kialiIconAbout from '../../assets/img/icon-aboutbkg.svg';
-import { ExternalServiceInfo, Status, StatusKey } from '../../types/StatusState';
+import { Status, StatusKey } from '../../types/StatusState';
 import { config, kialiLogoDark } from '../../config';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from 'config/KialiIcon';
-import { TEMPO } from '../../types/Tracing';
-
-import { GetTracingUrlProvider } from '../../utils/tracing/UrlProviders';
+import { IstioLogo } from 'pages/Mesh/MeshLegendData';
 
 type AboutUIModalProps = {
-  externalServices: ExternalServiceInfo[];
   isOpen: boolean;
   onClose: () => void;
   status: Status;
@@ -37,10 +34,6 @@ const iconStyle = kialiStyle({
   marginRight: '0.5rem'
 });
 
-const websiteStyle = kialiStyle({
-  marginRight: '2rem'
-});
-
 const textContentStyle = kialiStyle({
   $nest: {
     '& dt, & dd': {
@@ -49,8 +42,13 @@ const textContentStyle = kialiStyle({
   }
 });
 
+const websiteStyle = kialiStyle({
+  marginRight: '2rem'
+});
+
 export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalProps) => {
-  const additionalComponentInfoContent = (externalService: ExternalServiceInfo): string | JSX.Element => {
+  /*
+  const additionalComponentInfoContent = (externalService: ExternalServiceInfo) => {
     if (!externalService.version && !externalService.url) {
       return 'N/A';
     }
@@ -70,8 +68,10 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
       </>
     );
   };
+  */
 
-  const renderTempo = (externalServices: ExternalServiceInfo[]): JSX.Element => {
+  /*
+  const renderTempo = (externalServices: ExternalServiceInfo[]) => {
     const tempoService = externalServices.find(service => service.name === TEMPO);
 
     if (tempoService) {
@@ -81,8 +81,10 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
       return <></>;
     }
   };
+  */
 
-  const renderComponent = (externalService: ExternalServiceInfo): JSX.Element => {
+  /*
+  const renderComponent = (externalService: ExternalServiceInfo) => {
     const name = externalService.version ? externalService.name : `${externalService.name} URL`;
     const additionalInfo = additionalComponentInfoContent(externalService);
     return (
@@ -91,6 +93,33 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
         <TextListItem component="dd">{additionalInfo}</TextListItem>
       </React.Fragment>
     );
+  };
+  */
+
+  const renderMeshLink = () => {
+    if (config?.about?.mesh) {
+      return (
+        <Button component="a" href={config.about.mesh.url} variant={ButtonVariant.link} isInline>
+          <IstioLogo className={iconStyle} />
+          {config.about.mesh.linkText}
+        </Button>
+      );
+    }
+
+    return null;
+  };
+
+  const renderProjectLink = () => {
+    if (config?.about?.project) {
+      return (
+        <Button component="a" href={config.about.project.url} variant={ButtonVariant.link} target="_blank" isInline>
+          <KialiIcon.Repository className={iconStyle} />
+          {config.about.project.linkText}
+        </Button>
+      );
+    }
+
+    return null;
   };
 
   const renderWebsiteLink = (): JSX.Element | null => {
@@ -113,19 +142,6 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
     return null;
   };
 
-  const renderProjectLink = (): JSX.Element | null => {
-    if (config?.about?.project) {
-      return (
-        <Button component="a" href={config.about.project.url} variant={ButtonVariant.link} target="_blank" isInline>
-          <KialiIcon.Repository className={iconStyle} />
-          {config.about.project.linkText}
-        </Button>
-      );
-    }
-
-    return null;
-  };
-
   const coreVersion =
     props.status[StatusKey.KIALI_CORE_COMMIT_HASH] === '' ||
     props.status[StatusKey.KIALI_CORE_COMMIT_HASH] === 'unknown'
@@ -138,9 +154,9 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
     ? `${props.status[StatusKey.MESH_NAME]} ${props.status[StatusKey.MESH_VERSION] ?? ''}`
     : 'Unknown';
 
-  const filteredServices = props.externalServices.filter(element => element.name !== TEMPO);
-  const componentList = filteredServices.map(externalService => renderComponent(externalService));
-  const tempoComponent = renderTempo(props.externalServices);
+  //const filteredServices = props.externalServices.filter(element => element.name !== TEMPO);
+  //const componentList = filteredServices.map(externalService => renderComponent(externalService));
+  //const tempoComponent = renderTempo(props.externalServices);
 
   return (
     <AboutModal
@@ -166,12 +182,16 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
           <TextListItem key="kiali-container-version" component="dd">
             {containerVersion!}
           </TextListItem>
-          <TextListItem key="service-mesh-name" component="dt">
-            Service Mesh
-          </TextListItem>
-          <TextListItem key="service-mesh-version" component="dd">
-            {meshVersion!}
-          </TextListItem>
+          {false && (
+            <>
+              <TextListItem key="service-mesh-name" component="dt">
+                Service Mesh
+              </TextListItem>
+              <TextListItem key="service-mesh-version" component="dd">
+                {meshVersion!}
+              </TextListItem>
+            </>
+          )}
         </TextList>
       </TextContent>
 
@@ -180,15 +200,14 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
       )}
 
       <TextContent className={textContentStyle}>
-        <Title headingLevel="h3" size={TitleSizes.xl} style={{ padding: '1.25rem 0 1.25rem' }}>
+        <Title headingLevel="h3" size={TitleSizes.xl} style={{ padding: '2.5rem 0 0 0', marginBottom: '0' }}>
           Components
         </Title>
+        {renderMeshLink()}
 
-        <TextList component="dl">
-          {componentList}
-          {tempoComponent}
-        </TextList>
-
+        <Title headingLevel="h3" size={TitleSizes.xl} style={{ padding: '1.0rem 0 0 0', marginBottom: '0' }}>
+          External Links
+        </Title>
         {renderWebsiteLink()}
         {renderProjectLink()}
       </TextContent>

--- a/frontend/src/components/MTls/MTLSStatus.tsx
+++ b/frontend/src/components/MTls/MTLSStatus.tsx
@@ -27,12 +27,15 @@ export const MTLSStatus: React.FC<MTLSStatusProps> = (props: MTLSStatusProps) =>
 
   if (statusDescriptor.showStatus) {
     return (
-      <MTLSIcon
-        icon={statusDescriptor.icon}
-        iconClassName={props.className ?? ''}
-        tooltipText={statusDescriptor.message}
-        tooltipPosition={props.overlayPosition ?? TooltipPosition.left}
-      />
+      <span>
+        <MTLSIcon
+          icon={statusDescriptor.icon}
+          iconClassName={props.className ?? ''}
+          tooltipText={statusDescriptor.message}
+          tooltipPosition={props.overlayPosition ?? TooltipPosition.left}
+        />
+        {`  ${statusDescriptor.message}`}
+      </span>
     );
   }
 

--- a/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
+++ b/frontend/src/components/Nav/Masthead/HelpDropdown.tsx
@@ -5,17 +5,18 @@ import { DebugInformation } from '../../../components/DebugInformation/DebugInfo
 import { QuestionCircleIcon } from '@patternfly/react-icons/';
 import { connect } from 'react-redux';
 import { isUpstream } from '../../UpstreamDetector/UpstreamDetector';
-import { Status, ExternalServiceInfo, StatusKey } from '../../../types/StatusState';
+import { Status, StatusKey } from '../../../types/StatusState';
 import { config, serverConfig } from '../../../config';
 import { IstioCertsInfo } from 'components/IstioCertsInfo/IstioCertsInfo';
 import { kialiStyle } from 'styles/StyleUtils';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 
-type HelpDropdownProps = {
-  externalServices: ExternalServiceInfo[];
+type HelpDropdownReduxProps = {
   status: Status;
   warningMessages: string[];
 };
+
+type HelpDropdownProps = HelpDropdownReduxProps & {};
 
 const menuToggleStyle = kialiStyle({
   marginTop: '0.25rem',
@@ -77,7 +78,6 @@ const HelpDropdownComponent: React.FC<HelpDropdownProps> = (props: HelpDropdownP
     <>
       <AboutUIModal
         status={props.status}
-        externalServices={props.externalServices}
         warningMessages={props.warningMessages}
         isOpen={isAboutModalOpen}
         onClose={() => setIsAboutModalOpen(false)}
@@ -116,7 +116,6 @@ const HelpDropdownComponent: React.FC<HelpDropdownProps> = (props: HelpDropdownP
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.statusState.status,
-  externalServices: state.statusState.externalServices,
   warningMessages: state.statusState.warningMessages
 });
 

--- a/frontend/src/components/Nav/Masthead/Masthead.tsx
+++ b/frontend/src/components/Nav/Masthead/Masthead.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Label, Flex, FlexItem, Tooltip, Toolbar, ToolbarItem } from '@patternfly/react-core';
 
 import { homeCluster, serverConfig } from '../../../config';
-import { MeshMTLSStatus } from '../../../components/MTls/MeshMTLSStatus';
 import { IstioStatus } from '../../IstioStatus/IstioStatus';
 import { PfSpinner } from '../../PfSpinner';
 import { UserDropdown } from './UserDropdown';
@@ -41,9 +40,6 @@ export const MastheadItems: React.FC = () => {
             </FlexItem>
             <FlexItem>
               <IstioStatus cluster={homeCluster?.name} />
-            </FlexItem>
-            <FlexItem>
-              <MeshMTLSStatus />
             </FlexItem>
             <FlexItem style={{ marginRight: 0 }}>
               <MessageCenterTrigger />

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -67,15 +67,20 @@ const conf = {
   },
   /** About dialog configuration */
   about: {
+    mesh: {
+      url: '/mesh',
+      icon: 'IstioIcon',
+      linkText: 'Visit the Mesh page'
+    },
     project: {
       url: 'https://github.com/kiali',
       icon: 'RepositoryIcon',
-      linkText: 'Find us on GitHub'
+      linkText: 'Kiali on GitHub'
     },
     website: {
       url: 'https://www.kiali.io', // Without www, we get an SSL error
       icon: 'HomeIcon',
-      linkText: 'Visit our web page'
+      linkText: 'kiali.io'
     }
   },
   /** */

--- a/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
@@ -8,7 +8,8 @@ import {
   TargetPanelCommonProps,
   shouldRefreshData,
   targetPanel,
-  targetPanelHR,
+  targetPanelBody,
+  targetPanelBorder,
   targetPanelHeading,
   targetPanelWidth
 } from './TargetPanelCommon';
@@ -21,6 +22,7 @@ import * as FilterHelper from '../../../components/FilterList/FilterHelper';
 import { ApiError } from 'types/Api';
 import { KialiIcon } from 'config/KialiIcon';
 import { Tooltip } from '@patternfly/react-core';
+import { classes } from 'typestyle';
 
 type TargetPanelClusterState = {
   clusterNode?: Node<NodeModel, any>;
@@ -85,9 +87,29 @@ export class TargetPanelCluster extends React.Component<TargetPanelCommonProps, 
   }
 
   render() {
+    const cluster = this.meshCluster;
     return (
-      <div className={targetPanel} style={TargetPanelCluster.panelStyle}>
-        <div className={targetPanelHeading}>{this.renderCluster(this.meshCluster)}</div>
+      <div id="target-panel-cluster" className={classes(targetPanelBorder, targetPanel)}>
+        <div id="target-panel-cluster-heading" className={targetPanelHeading}>
+          {cluster.isKialiHome && (
+            <Tooltip content="Kiali home cluster">
+              <KialiIcon.Star />
+            </Tooltip>
+          )}
+          <PFBadge badge={PFBadges.Cluster} size="sm" style={{ marginLeft: '0.225rem', marginBottom: '0.125rem' }} />
+          {cluster.name}
+        </div>
+        <div className={targetPanelBody}>
+          {this.renderKialiLinks(cluster.kialiInstances)}
+          {`Network: `}
+          {cluster.network ? cluster.network : 'n/a'}
+          <br />
+          {`API Endpoint: `}
+          {cluster.apiEndpoint ? cluster.apiEndpoint : 'n/a'}
+          <br />
+          {`Secret Name: `}
+          {cluster.secretName ? cluster.secretName : 'n/a'}
+        </div>
       </div>
     );
   }
@@ -116,32 +138,6 @@ export class TargetPanelCluster extends React.Component<TargetPanelCommonProps, 
   private handleApiError(message: string, error: ApiError): void {
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
-
-  private renderCluster = (meshCluster: MeshCluster): React.ReactNode => {
-    return (
-      <React.Fragment key={meshCluster.name}>
-        <span>
-          {meshCluster.isKialiHome && (
-            <Tooltip content="Kiali home cluster">
-              <KialiIcon.Star />
-            </Tooltip>
-          )}
-          <PFBadge badge={PFBadges.Cluster} size="sm" style={{ marginLeft: '0.225rem', marginBottom: '0.125rem' }} />
-          {meshCluster.name}
-        </span>
-        {targetPanelHR()}
-        {this.renderKialiLinks(meshCluster.kialiInstances)}
-        {`Network: `}
-        {meshCluster.network ? meshCluster.network : 'n/a'}
-        <br />
-        {`API Endpoint: `}
-        {meshCluster.apiEndpoint ? meshCluster.apiEndpoint : 'n/a'}
-        <br />
-        {`Secret Name: `}
-        {meshCluster.secretName ? meshCluster.secretName : 'n/a'}
-      </React.Fragment>
-    );
-  };
 
   private renderKialiLinks = (kialiInstances: KialiInstance[]): React.ReactNode => {
     const kialiIcon = getKialiTheme() === Theme.DARK ? kialiIconDark : kialiIconLight;

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -26,7 +26,7 @@ export const targetPanel = kialiStyle({
   width: targetPanelWidth
 });
 
-export const targetPanelBodyStyle = kialiStyle({
+export const targetPanelBody = kialiStyle({
   padding: '15px',
   $nest: {
     '&:after, &:before': {

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -4,9 +4,12 @@ import {
   TargetPanelCommonProps,
   getTitle,
   targetPanel,
-  targetPanelHeading,
-  targetPanelWidth
+  targetPanelBody,
+  targetPanelBorder,
+  targetPanelHeading
 } from './TargetPanelCommon';
+import { MeshMTLSStatus } from 'components/MTls/MeshMTLSStatus';
+import { classes } from 'typestyle';
 
 type TargetPanelMeshState = {
   loading: boolean;
@@ -19,14 +22,6 @@ const defaultState: TargetPanelMeshState = {
 };
 
 export class TargetPanelMesh extends React.Component<TargetPanelCommonProps, TargetPanelMeshState> {
-  static readonly panelStyle = {
-    height: '100%',
-    margin: 0,
-    minWidth: targetPanelWidth,
-    overflowY: 'auto' as 'auto',
-    width: targetPanelWidth
-  };
-
   constructor(props: TargetPanelCommonProps) {
     super(props);
 
@@ -53,9 +48,12 @@ export class TargetPanelMesh extends React.Component<TargetPanelCommonProps, Tar
     }
 
     return (
-      <div id="target-panel-mesh" className={targetPanel} style={TargetPanelMesh.panelStyle}>
-        <div id="summary-panel-graph-heading" className={targetPanelHeading}>
-          {getTitle('Current Mesh')}
+      <div id="target-panel-mesh" className={classes(targetPanelBorder, targetPanel)}>
+        <div id="target-panel-mesh-heading" className={targetPanelHeading}>
+          {getTitle('Istio Mesh')}
+        </div>
+        <div className={targetPanelBody}>
+          <MeshMTLSStatus />
         </div>
       </div>
     );

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -5,7 +5,7 @@ import {
   TargetPanelCommonProps,
   shouldRefreshData,
   targetPanel,
-  targetPanelBodyStyle as targetPanelBody,
+  targetPanelBody,
   targetPanelBorder,
   targetPanelHR,
   targetPanelWidth
@@ -88,29 +88,11 @@ const defaultState: TargetPanelNamespaceState = {
 const healthType: OverviewType = 'app';
 const direction: DirectionType = 'outbound';
 
-/*
-const namespaceStyle = kialiStyle({
-  alignItems: 'center',
-  display: 'flex'
-});
-*/
-
 const cardGridStyle = kialiStyle({
   textAlign: 'center',
   marginTop: 0,
   marginBottom: '0.5rem'
-  // width: 'auto'
 });
-
-/*
-const namespaceHeaderStyle = kialiStyle({
-  $nest: {
-    '& .pf-v5-c-card__header-main': {
-      width: '85%'
-    }
-  }
-});
-*/
 
 const namespaceNameStyle = kialiStyle({
   display: 'block',

--- a/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { Node, NodeModel } from '@patternfly/react-topology';
 import { kialiStyle } from 'styles/StyleUtils';
-import { TargetPanelCommonProps, targetPanel, targetPanelHeading, targetPanelWidth } from './TargetPanelCommon';
+import {
+  TargetPanelCommonProps,
+  targetPanel,
+  targetPanelBody,
+  targetPanelHeading,
+  targetPanelWidth
+} from './TargetPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { MeshInfraType, MeshNodeData } from 'types/Mesh';
 import { classes } from 'typestyle';
@@ -55,12 +61,15 @@ export class TargetPanelNode extends React.Component<TargetPanelCommonProps, Tar
 
     return (
       <div className={classes(panelStyle, targetPanel)}>
-        <div className={targetPanelHeading}>{this.renderNode(data)}</div>
+        <div className={targetPanelHeading}>{this.renderNodeHeader(data)}</div>
+        <div className={targetPanelBody}>
+          <pre>{JSON.stringify(data.infraData, null, 2)}</pre>
+        </div>
       </div>
     );
   }
 
-  private renderNode = (data: MeshNodeData): React.ReactNode => {
+  private renderNodeHeader = (data: MeshNodeData): React.ReactNode => {
     let pfBadge;
 
     switch (data.infraType) {

--- a/graph/telemetry/istio/appender/mesh_check.go
+++ b/graph/telemetry/istio/appender/mesh_check.go
@@ -44,7 +44,7 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 		}
 
 		// skip if the node is not in an accessible namespace, we can't do the checking
-		if !a.nodeOK(n, namespaceInfo) {
+		if !a.nodeOK(n) {
 			continue
 		}
 
@@ -96,7 +96,7 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 }
 
 // nodeOK returns true if we have access to its workload info
-func (a *MeshCheckAppender) nodeOK(node *graph.Node, namespaceInfo *graph.AppenderNamespaceInfo) bool {
+func (a *MeshCheckAppender) nodeOK(node *graph.Node) bool {
 	key := graph.GetClusterSensitiveKey(node.Cluster, node.Namespace)
 	_, ok := a.AccessibleNamespaces[key]
 	return ok

--- a/mesh/config/cytoscape/cytoscape.go
+++ b/mesh/config/cytoscape/cytoscape.go
@@ -272,7 +272,7 @@ func boxByNamespace(nodes *[]*NodeWrapper) {
 	}
 }
 
-// boxByNamespace boxes nodes in the same namespace, within a cluster
+// boxByCluster boxes nodes in the same namespace, within a cluster
 func boxByCluster(nodes *[]*NodeWrapper) {
 	for _, box := range *nodes {
 		if box.Data.InfraType != mesh.InfraTypeCluster {
@@ -280,7 +280,10 @@ func boxByCluster(nodes *[]*NodeWrapper) {
 		}
 		box.Data.IsBox = mesh.BoxByCluster
 		for _, member := range *nodes {
-			if member.Data.Parent != "" || (member.Data.InfraType != mesh.InfraTypeNamespace && member.Data.IsBox != mesh.BoxByDataPlanes) {
+			if member.Data.Parent != "" || member.Data.InfraType == mesh.InfraTypeCluster {
+				continue
+			}
+			if !(member.Data.InfraType == mesh.InfraTypeNamespace || member.Data.IsBox == mesh.BoxByDataPlanes || member.Data.Cluster == mesh.Unknown) {
 				continue
 			}
 			if member.Data.Cluster == box.Data.Cluster {

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -24,26 +24,17 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 	_, finalizers := appender.ParseAppenders(o)
 	meshMap := mesh.NewMeshMap()
 
-	// start by creating infra nodes for each accessible namespace
-	// note - namespace infra nodes will be converted, as needed, by namespace boxes at the config-gen stage (e.g. in Cytoscape.go)
-	clusterMap := make(map[string]bool)
-	for _, ns := range o.AccessibleNamespaces {
-		clusterMap[ns.Cluster] = true
-
-		var err error
-		_, _, err = addInfra(meshMap, mesh.InfraTypeNamespace, ns.Cluster, ns.Name, ns.Name, nil)
-		mesh.CheckError(err)
-	}
-
+	// start by adding istio control planes and the mesh clusters
 	meshDef, err := gi.Business.Mesh.GetMesh(ctx)
 	graph.CheckError(err)
 
+	clusterMap := make(map[string]bool)
 	for _, cp := range meshDef.ControlPlanes {
-		// add any cluster that is configured but somehow has no accessible namespace
 		if _, ok := clusterMap[cp.Cluster.Name]; !ok {
 			_, _, err := addInfra(meshMap, mesh.InfraTypeCluster, cp.Cluster.Name, mesh.Unknown, cp.Cluster.Name, cp.Cluster)
 			mesh.CheckError(err)
 		}
+
 		for _, mc := range cp.ManagedClusters {
 			if _, ok := clusterMap[mc.Name]; ok {
 				_, _, err := addInfra(meshMap, mesh.InfraTypeCluster, mc.Name, mesh.Unknown, mc.Name, mc)
@@ -54,41 +45,52 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 		}
 
 		// add the control plane istiod
-		_, _, err := addInfra(meshMap, mesh.InfraTypeIstiod, cp.Cluster.Name, cp.IstiodNamespace, cp.IstiodName, nil)
+		_, _, err := addInfra(meshMap, mesh.InfraTypeIstiod, cp.Cluster.Name, cp.IstiodNamespace, cp.IstiodName, cp.Config)
 		mesh.CheckError(err)
 
-		// add any Kiali instances (note, this will not include the home Kiali)
-		for _, kiali := range cp.Cluster.KialiInstances {
-			_, _, err = addInfra(meshMap, mesh.InfraTypeKiali, cp.Cluster.Name, kiali.Namespace, kiali.ServiceName, nil)
+		// add any Kiali instances
+		for _, ki := range cp.Cluster.KialiInstances {
+			kiali, _, err := addInfra(meshMap, mesh.InfraTypeKiali, cp.Cluster.Name, ki.Namespace, ki.ServiceName, nil)
 			mesh.CheckError(err)
-		}
 
-		// add the home Kiali
-		var kiali *mesh.Node
-		conf := config.Get()
-		kiali, _, err = addInfra(meshMap, mesh.InfraTypeKiali, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, conf.Deployment.InstanceName, nil)
-		mesh.CheckError(err)
+			// TODO HOW DO WE PLACE THE EXTERNAL RESOURCES AND ESTABLISH PROPER LINKS?  FOR NOW JUST ASSUME LOCAL...
+			conf := config.Get().Obfuscate()
+			es := conf.ExternalServices
 
-		// add the Kiali external services...  How to do this?
-		var node *mesh.Node
-		node, _, err = addInfra(meshMap, mesh.InfraTypeMetricStore, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, "Prometheus", nil)
-		mesh.CheckError(err)
+			// add the home Kiali
+			// var kiali *mesh.Node
+			// kiali, _, err = addInfra(meshMap, mesh.InfraTypeKiali, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, conf.Deployment.InstanceName, nil)
+			// mesh.CheckError(err)
 
-		kiali.AddEdge(node)
-
-		if conf.ExternalServices.Tracing.Enabled {
-			node, _, err = addInfra(meshMap, mesh.InfraTypeTraceStore, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, string(conf.ExternalServices.Tracing.Provider), nil)
+			// add the Kiali external services...
+			var node *mesh.Node
+			node, _, err = addInfra(meshMap, mesh.InfraTypeMetricStore, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, "Prometheus", es.Prometheus)
 			mesh.CheckError(err)
 
 			kiali.AddEdge(node)
-		}
 
-		if conf.ExternalServices.Grafana.Enabled {
-			node, _, err = addInfra(meshMap, mesh.InfraTypeGrafana, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, "Grafana", nil)
-			mesh.CheckError(err)
+			if conf.ExternalServices.Tracing.Enabled {
+				node, _, err = addInfra(meshMap, mesh.InfraTypeTraceStore, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, string(es.Tracing.Provider), es.Tracing)
+				mesh.CheckError(err)
 
-			kiali.AddEdge(node)
+				kiali.AddEdge(node)
+			}
+
+			if conf.ExternalServices.Grafana.Enabled {
+				node, _, err = addInfra(meshMap, mesh.InfraTypeGrafana, conf.KubernetesConfig.ClusterName, conf.Deployment.Namespace, "Grafana", nil)
+				mesh.CheckError(err)
+
+				kiali.AddEdge(node)
+			}
 		}
+	}
+
+	// start by creating infra nodes for each accessible namespace
+	// note - namespace infra nodes will be converted, as needed, by namespace boxes at the config-gen stage (e.g. in Cytoscape.go)
+	for _, ns := range o.AccessibleNamespaces {
+		var err error
+		_, _, err = addInfra(meshMap, mesh.InfraTypeNamespace, ns.Cluster, ns.Name, ns.Name, nil)
+		mesh.CheckError(err)
 	}
 
 	// The finalizers can perform final manipulations on the complete graph


### PR DESCRIPTION
- replace components in About with link to mesh page
- move Mesh TLS Status from masthead to mesh page side panel
- add more proper external service handling/url auto-discovery in mesh generation
- move Kiali instance info to Cluster side panel
- fix headers for some side panels
- add formatted config json as side panel body for nodes
    
Closes #6431
