### PR TITLE
Skip forbidden namespaces in multi-cluster mode

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -161,7 +161,7 @@ func (in *IstioConfigService) GetIstioConfigListForNamespace(ctx context.Context
 	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		// Check if the namespace exists on the cluster in multi-cluster mode.
 		// TODO: Remove this once other business methods stop looping over all clusters.
-		if api_errors.IsNotFound(err) && len(in.userClients) > 1 {
+		if (api_errors.IsNotFound(err) || api_errors.IsForbidden(err)) && len(in.userClients) > 1 {
 			return &models.IstioConfigList{}, nil
 		}
 		return nil, err

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -632,9 +632,14 @@ func (in *NamespaceService) UpdateNamespace(ctx context.Context, namespace strin
 		return nil, err
 	}
 	kubeCache.Refresh(namespace)
+	// Clear all namespaces for this cluster.
 	in.kialiCache.RefreshTokenNamespaces(cluster)
 
-	// Call GetNamespace to update the caching
+	// Call GetClusterNamespaces to update the cache for this cluster.
+	if _, err := in.GetClusterNamespaces(ctx, cluster); err != nil {
+		return nil, err
+	}
+
 	return in.GetClusterNamespace(ctx, namespace, cluster)
 }
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -598,7 +598,10 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 	}
 
 	// Refresh namespace in cache since we've just fetched it from the API.
-	in.GetClusterNamespaces(ctx, cluster)
+	if _, err := in.GetClusterNamespaces(ctx, cluster); err != nil {
+		log.Errorf("Unable to refresh cache for cluster [%s]: %s", cluster, err)
+	}
+
 	return &result, nil
 }
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -598,7 +598,7 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 	}
 
 	// Refresh namespace in cache since we've just fetched it from the API.
-	in.kialiCache.SetNamespace(client.GetToken(), result)
+	in.GetClusterNamespaces(ctx, cluster)
 	return &result, nil
 }
 
@@ -632,7 +632,6 @@ func (in *NamespaceService) UpdateNamespace(ctx context.Context, namespace strin
 		return nil, err
 	}
 	kubeCache.Refresh(namespace)
-	// Clear all namespaces for this cluster.
 	in.kialiCache.RefreshTokenNamespaces(cluster)
 
 	// Call GetClusterNamespaces to update the cache for this cluster.

--- a/business/services.go
+++ b/business/services.go
@@ -668,7 +668,6 @@ func (in *SvcService) UpdateService(ctx context.Context, cluster, namespace, ser
 		return nil, err
 	}
 	kubeCache.Refresh(namespace)
-	in.kialiCache.RefreshTokenNamespaces(cluster)
 
 	// After the update we fetch the whole workload
 	return in.GetServiceDetails(ctx, cluster, namespace, service, interval, queryTime)


### PR DESCRIPTION
### Describe the change

1. Ignores `IsForbidden` errors in `business.IstioConfig` when in multi-cluster mode. 
2. In the apps handler, only checks namespaces filtered by `GetClusterNamespaces`

Test with:

1. Setup
```
hack/istio/multicluster/install-multi-primary.sh -mm true -kudi true -md kvm2
hack/istio/multicluster/deploy-kiali.sh --single-kiali true --cluster1-context east --cluster2-context west --kiali-auth-strategy openid
```
2. Login to kiali with kiali user
3. Verify no errors on the apps/graph pages
