### PR TITLE
Adapt Kiali code to make OSSMC compatible with OCP 4.15

### DIFF
--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -13,6 +13,8 @@ import {
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
+import { useKialiSelector } from 'hooks/redux';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type ActionItem = {
   action: JSX.Element;
@@ -20,6 +22,8 @@ type ActionItem = {
 };
 
 export const IstioActionsNamespaceDropdown: React.FC = () => {
+  const kiosk = useKialiSelector(state => state.globalState.kiosk);
+
   const [dropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
 
   const onSelect = (): void => {
@@ -31,7 +35,13 @@ export const IstioActionsNamespaceDropdown: React.FC = () => {
   };
 
   const onClickCreate = (type: string): void => {
-    history.push(`/istio/new/${type}`);
+    const newUrl = `/istio/new/${type}`;
+
+    if (isParentKiosk(kiosk)) {
+      kioskContextMenuAction(newUrl);
+    } else {
+      history.push(newUrl);
+    }
   };
 
   const dropdownItemsRaw = NEW_ISTIO_RESOURCE.map(

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -39,37 +39,42 @@ import { bindActionCreators } from 'redux';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { timeRangeSelector } from '../../store/Selectors';
 import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type MetricsState = {
   cluster?: string;
   dashboard?: DashboardModel;
+  grafanaLinks: ExternalLink[];
   isTimeOptionsOpen: boolean;
   labelsSettings: LabelsSettings;
-  grafanaLinks: ExternalLink[];
+  showSpans: boolean;
   spanOverlay?: Overlay<JaegerLineInfo>;
   tabHeight: number;
-  showSpans: boolean;
 };
 
 type CustomMetricsProps = RouteComponentProps<{}> & {
-  namespace: string;
   app: string;
+  embedded?: boolean;
+  height?: number;
   lastRefreshAt: TimeInMilliseconds;
+  namespace: string;
+  template: string;
   version?: string;
   workload?: string;
   workloadType?: string;
-  template: string;
-  embedded?: boolean;
-  height?: number;
 };
 
-type ReduxProps = {
+type ReduxStateProps = {
+  kiosk: string;
   timeRange: TimeRange;
   tracingIntegration: boolean;
+};
+
+type ReduxDispatchProps = {
   setTimeRange: (range: TimeRange) => void;
 };
 
-type Props = ReduxProps & CustomMetricsProps;
+type Props = ReduxStateProps & ReduxDispatchProps & CustomMetricsProps;
 
 const fullHeightStyle = kialiStyle({
   height: '100%'
@@ -95,6 +100,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     this.toolbarRef = React.createRef<HTMLDivElement>();
     const settings = MetricsHelper.retrieveMetricsSettings();
     this.options = this.initOptions(settings);
+
     // Initialize active filters from URL
     const cluster = HistoryManager.getClusterName();
     this.state = {
@@ -105,11 +111,13 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
       tabHeight: 300,
       showSpans: settings.showSpans
     };
+
     this.spanOverlay = new SpanOverlay(changed => this.setState({ spanOverlay: changed }));
   }
 
-  private initOptions(settings: MetricsSettings): DashboardQuery {
+  private initOptions = (settings: MetricsSettings): DashboardQuery => {
     const filters = `${serverConfig.istioLabels.appLabelName}:${this.props.app}`;
+
     const options: DashboardQuery = this.props.version
       ? {
           labelsFilters: `${filters},${serverConfig.istioLabels.versionLabelName}:${this.props.version}`
@@ -118,15 +126,17 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
           labelsFilters: filters,
           additionalLabels: 'version:Version'
         };
-    MetricsHelper.settingsToOptions(settings, options, []);
-    return options;
-  }
 
-  componentDidMount() {
+    MetricsHelper.settingsToOptions(settings, options, []);
+
+    return options;
+  };
+
+  componentDidMount(): void {
     this.refresh();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props): void {
     if (
       this.props.namespace !== prevProps.namespace ||
       this.props.app !== prevProps.app ||
@@ -143,7 +153,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     }
   }
 
-  private refresh = () => {
+  private refresh = (): void => {
     this.fetchMetrics();
     if (this.props.tracingIntegration) {
       this.spanOverlay.fetch({
@@ -156,15 +166,18 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     }
   };
 
-  private fetchMetrics = () => {
+  private fetchMetrics = (): void => {
     // Time range needs to be reevaluated everytime fetching
     MetricsHelper.timeRangeToOptions(this.props.timeRange, this.options);
+
     // Workload name can be used to find personalized dashboards defined at workload level
     this.options.workload = this.props.workload;
     this.options.workloadType = this.props.workloadType;
+
     API.getCustomDashboard(this.props.namespace, this.props.template, this.options, this.state.cluster)
       .then(response => {
         const labelsSettings = MetricsHelper.extractLabelsSettings(response.data, this.state.labelsSettings);
+
         this.setState({
           dashboard: response.data,
           labelsSettings: labelsSettings,
@@ -176,44 +189,50 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
       });
   };
 
-  private onMetricsSettingsChanged = (settings: MetricsSettings) => {
+  private onMetricsSettingsChanged = (settings: MetricsSettings): void => {
     MetricsHelper.settingsToOptions(settings, this.options, []);
     this.fetchMetrics();
   };
 
-  private onLabelsFiltersChanged = (labelsFilters: LabelsSettings) => {
+  private onLabelsFiltersChanged = (labelsFilters: LabelsSettings): void => {
     this.setState({ labelsSettings: labelsFilters });
   };
 
-  private onRawAggregationChanged = (aggregator: Aggregator) => {
+  private onRawAggregationChanged = (aggregator: Aggregator): void => {
     this.options.rawDataAggregator = aggregator;
     this.fetchMetrics();
   };
 
-  private onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>) => {
+  private onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>): void => {
     if ('start' in datum && 'end' in datum) {
       // Zoom-in bucket
       this.onDomainChange([datum.start as Date, datum.end as Date]);
     } else if ('traceId' in datum) {
       const traceId = datum.traceId;
       const spanId = datum.spanId;
-      history.push(
-        `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.TRACING_TRACE_ID}=${traceId}&${URLParam.TRACING_SPAN_ID}=${spanId}`
-      );
+
+      const traceUrl = `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.TRACING_TRACE_ID}=${traceId}&${URLParam.TRACING_SPAN_ID}=${spanId}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(traceUrl);
+      } else {
+        history.push(traceUrl);
+      }
     }
   };
 
-  private onDomainChange(dates: [Date, Date]) {
+  private onDomainChange = (dates: [Date, Date]): void => {
     if (dates && dates[0] && dates[1]) {
       const range: TimeRange = {
         from: dates[0].getTime(),
         to: dates[1].getTime()
       };
+
       this.props.setTimeRange(range);
     }
-  }
+  };
 
-  renderFetchMetrics = title => {
+  renderFetchMetrics = (title: string): React.ReactNode => {
     return (
       <div className={emptyStyle}>
         <EmptyState variant={EmptyStateVariant.sm}>
@@ -223,9 +242,10 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     );
   };
 
-  render() {
+  render(): React.ReactNode {
     const urlParams = new URLSearchParams(history.location.search);
     const expandedChart = urlParams.get('expand') || undefined;
+
     // 20px (card margin) + 24px (card padding) + 51px (toolbar) + 15px (toolbar padding) + 24px (card padding) + 20px (card margin)
     const toolbarHeight = this.toolbarRef.current ? this.toolbarRef.current.clientHeight : 51;
     const toolbarSpace = 20 + 24 + toolbarHeight + 15 + 24 + 20;
@@ -266,6 +286,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
             </Card>
           </RenderComponentScroll>
         )}
+
         <TimeDurationModal
           customDuration={true}
           isOpen={this.state.isTimeOptionsOpen}
@@ -276,17 +297,20 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     );
   }
 
-  private onSpans = (checked: boolean) => {
+  private onSpans = (checked: boolean): void => {
     const urlParams = new URLSearchParams(history.location.search);
     urlParams.set(URLParam.SHOW_SPANS, String(checked));
-    history.replace(history.location.pathname + '?' + urlParams.toString());
+
+    history.replace(`${history.location.pathname}?${urlParams.toString()}`);
     this.setState({ showSpans: !this.state.showSpans });
   };
 
-  private renderOptionsBar() {
+  private renderOptionsBar = (): React.ReactNode => {
     const hasHistograms =
       this.state.dashboard !== undefined && this.state.dashboard.charts.some(chart => chart.metrics.some(m => m.stat));
+
     const hasLabels = this.state.labelsSettings.size > 0;
+
     return (
       <div ref={this.toolbarRef}>
         <Toolbar style={{ paddingBottom: 15 }}>
@@ -304,9 +328,11 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
                 />
               </ToolbarItem>
             )}
+
             <ToolbarItem>
               <MetricsRawAggregation onChanged={this.onRawAggregationChanged} />
             </ToolbarItem>
+
             <ToolbarItem style={{ alignSelf: 'center' }}>
               <Checkbox
                 id={`spans-show-`}
@@ -316,12 +342,14 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
                 onChange={(_event, checked) => this.onSpans(checked)}
               />
             </ToolbarItem>
+
             <KioskElement>
               <ToolbarItem style={{ marginLeft: 'auto' }}>
                 <TimeDurationIndicator onClick={this.toggleTimeOptionsVisibility} />
               </ToolbarItem>
             </KioskElement>
           </ToolbarGroup>
+
           <ToolbarGroup style={{ marginLeft: 'auto', paddingRight: '20px' }}>
             <GrafanaLinks
               links={this.state.grafanaLinks}
@@ -334,30 +362,33 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
         </Toolbar>
       </div>
     );
-  }
+  };
 
-  private expandHandler = (expandedChart?: string) => {
+  private expandHandler = (expandedChart?: string): void => {
     const urlParams = new URLSearchParams(history.location.search);
     urlParams.delete('expand');
+
     if (expandedChart) {
       urlParams.set('expand', expandedChart);
     }
-    history.push(history.location.pathname + '?' + urlParams.toString());
+
+    history.push(`${history.location.pathname}?${urlParams.toString()}`);
   };
 
-  private toggleTimeOptionsVisibility = () => {
+  private toggleTimeOptionsVisibility = (): void => {
     this.setState(prevState => ({ isTimeOptionsOpen: !prevState.isTimeOptionsOpen }));
   };
 }
 
-const mapStateToProps = (state: KialiAppState) => {
+const mapStateToProps = (state: KialiAppState): ReduxStateProps => {
   return {
+    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state),
     tracingIntegration: state.tracingState.info ? state.tracingState.info.integration : false
   };
 };
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => {
+const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
   return {
     setTimeRange: bindActionCreators(UserSettingsActions.setTimeRange, dispatch)
   };

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -32,6 +32,7 @@ import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { KialiCrippledFeatures } from 'types/ServerConfig';
 import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
 import { ApiResponse } from 'types/Api';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type MetricsState = {
   crippledFeatures?: KialiCrippledFeatures;
@@ -60,6 +61,7 @@ type IstioMetricsProps = ObjectId &
   };
 
 type ReduxStateProps = {
+  kiosk: string;
   refreshInterval: IntervalInMilliseconds;
   timeRange: TimeRange;
   tracingIntegration: boolean;
@@ -264,9 +266,13 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
           ? 'services'
           : 'workloads';
 
-      history.push(
-        `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.TRACING_TRACE_ID}=${traceId}&${URLParam.TRACING_SPAN_ID}=${spanId}`
-      );
+      const traceUrl = `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.TRACING_TRACE_ID}=${traceId}&${URLParam.TRACING_SPAN_ID}=${spanId}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(traceUrl);
+      } else {
+        history.push(traceUrl);
+      }
     }
   };
 
@@ -434,6 +440,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
 
 const mapStateToProps = (state: KialiAppState): ReduxStateProps => {
   return {
+    kiosk: state.globalState.kiosk,
     tracingIntegration: state.tracingState.info ? state.tracingState.info.integration : false,
     timeRange: timeRangeSelector(state),
     refreshInterval: refreshIntervalSelector(state)

--- a/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/frontend/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -38,18 +38,19 @@ export class RenderComponentScroll extends React.Component<Props, State> {
     this.state = { height: 0 };
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.updateWindowDimensions();
     window.addEventListener('resize', this.updateWindowDimensions);
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     window.removeEventListener('resize', this.updateWindowDimensions);
   }
 
-  updateWindowDimensions = () => {
+  updateWindowDimensions = (): void => {
     const isStandalone = !isKiosk(store.getState().globalState.kiosk);
     const topPadding = isStandalone ? TOP_PADDING : EMBEDDED_PADDING;
+
     this.setState(
       {
         height: window.innerHeight - topPadding
@@ -62,12 +63,12 @@ export class RenderComponentScroll extends React.Component<Props, State> {
     );
   };
 
-  render() {
+  render(): React.ReactNode {
     let scrollStyle = {};
 
     // If there is no global scrollbar, height is fixed to force the scrollbar to appear in the component
     if (globalScrollbar === 'false') {
-      scrollStyle = { height: this.state.height, overflowY: 'auto' };
+      scrollStyle = { height: this.state.height, overflowY: 'auto', width: '100%' };
     }
 
     return (

--- a/frontend/src/pages/Graph/GraphLegend.tsx
+++ b/frontend/src/pages/Graph/GraphLegend.tsx
@@ -2,19 +2,19 @@ import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
 import { legendData, GraphLegendItem, GraphLegendItemRow } from './GraphLegendData';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
-import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
 import { PFColors } from 'components/Pf/PfColors';
 import { summaryFont, summaryTitle } from './SummaryPanelCommon';
+import { KialiIcon } from 'config/KialiIcon';
 
 export interface GraphLegendProps {
-  closeLegend: () => void;
   className?: string;
+  closeLegend: () => void;
 }
 
 const width = '190px';
 
 export class GraphLegend extends React.Component<GraphLegendProps> {
-  render() {
+  render(): React.ReactNode {
     const legendBoxStyle = kialiStyle({
       backgroundColor: PFColors.BackgroundColor100,
       border: `1px solid ${PFColors.BorderColor100}`,
@@ -46,7 +46,7 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
           <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
               <Button id="legend_close" variant={ButtonVariant.plain} onClick={this.props.closeLegend}>
-                <CloseIcon />
+                <KialiIcon.Close />
               </Button>
             </Tooltip>
           </span>
@@ -58,7 +58,7 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
     );
   }
 
-  renderGraphLegendList(legendData: GraphLegendItem[]) {
+  renderGraphLegendList = (legendData: GraphLegendItem[]): React.ReactNode => {
     const legendColumnHeadingStyle = kialiStyle({
       fontWeight: 'bold',
       paddingTop: '1.25em'
@@ -77,15 +77,15 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
         ))}
       </div>
     );
-  }
+  };
 
-  renderLegendRowItems(legendData: GraphLegendItemRow[]) {
+  renderLegendRowItems = (legendData: GraphLegendItemRow[]): React.ReactNode => {
     return (
       <>{legendData.map((legendItemRow: GraphLegendItemRow) => GraphLegend.renderLegendIconAndLabel(legendItemRow))}</>
     );
-  }
+  };
 
-  static renderLegendIconAndLabel(legendItemRow: GraphLegendItemRow) {
+  static renderLegendIconAndLabel = (legendItemRow: GraphLegendItemRow): React.ReactNode => {
     const keyWidth = '70px';
 
     const keyStyle = kialiStyle({
@@ -111,5 +111,5 @@ export class GraphLegend extends React.Component<GraphLegendProps> {
         <span className={legendItemLabelStyle}>{legendItemRow.label}</span>
       </div>
     );
-  }
+  };
 }

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -46,11 +46,13 @@ import { INITIAL_USER_SETTINGS_STATE } from 'reducers/UserSettingsState';
 import { GraphReset } from './GraphReset';
 import { GraphFindPF } from './GraphFindPF';
 import { kialiStyle } from 'styles/StyleUtils';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type ReduxStateProps = {
   activeNamespaces: Namespace[];
   edgeLabels: EdgeLabelMode[];
   graphType: GraphType;
+  kiosk: string;
   node?: NodeParamsType;
   rankBy: RankMode[];
   replayActive: boolean;
@@ -272,15 +274,30 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
       !this.props.summaryData ||
       (this.props.summaryData.summaryType !== 'node' && this.props.summaryData.summaryType !== 'box')
     ) {
-      history.push(`/${route}/namespaces`);
+      const returnUrl = `/${route}/namespaces`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(returnUrl);
+      } else {
+        history.push(returnUrl);
+      }
+
       return;
     }
 
     const selector = this.props.isPF
       ? this.props.summaryData!.summaryTarget.getId()
       : `node[id = "${this.props.summaryData!.summaryTarget.data(NodeAttr.id)}"]`;
+
     this.props.setNode(undefined);
-    history.push(`/${route}/namespaces?focusSelector=${encodeURI(selector)}`);
+
+    const returnUrl = `/${route}/namespaces?focusSelector=${encodeURI(selector)}`;
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(returnUrl);
+    } else {
+      history.push(returnUrl);
+    }
   };
 }
 
@@ -288,6 +305,7 @@ const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   activeNamespaces: activeNamespacesSelector(state),
   edgeLabels: edgeLabelsSelector(state),
   graphType: graphTypeSelector(state),
+  kiosk: state.globalState.kiosk,
   node: state.graph.node,
   rankBy: state.graph.toolbarState.rankBy,
   replayActive: replayActiveSelector(state),

--- a/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/frontend/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <CloseIcon />
+          <Close />
         </Button>
       </Tooltip>
     </span>

--- a/frontend/src/pages/GraphPF/GraphLegendPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphLegendPF.tsx
@@ -2,18 +2,18 @@ import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
 import { legendData, GraphLegendItem, GraphLegendItemRow } from './GraphLegendDataPF';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
-import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
 import { PFColors } from 'components/Pf/PfColors';
+import { KialiIcon } from 'config/KialiIcon';
 
 export interface GraphLegendProps {
-  closeLegend: () => void;
   className?: string;
+  closeLegend: () => void;
 }
 
 const width = '190px';
 
 export class GraphLegendPF extends React.Component<GraphLegendProps> {
-  render() {
+  render(): React.ReactNode {
     const legendBoxStyle = kialiStyle({
       backgroundColor: PFColors.BackgroundColor100,
       border: `1px solid ${PFColors.BorderColor100}`,
@@ -42,14 +42,16 @@ export class GraphLegendPF extends React.Component<GraphLegendProps> {
       <div className={legendBoxStyle} data-test="graph-legend">
         <div className={`${headerStyle}`}>
           <span>Legend</span>
+
           <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
               <Button id="legend_close" variant={ButtonVariant.plain} onClick={this.props.closeLegend}>
-                <CloseIcon />
+                <KialiIcon.Close />
               </Button>
             </Tooltip>
           </span>
         </div>
+
         <div className={bodyStyle}>
           <div>{this.renderGraphLegendList(legendData)}</div>
         </div>
@@ -57,11 +59,12 @@ export class GraphLegendPF extends React.Component<GraphLegendProps> {
     );
   }
 
-  renderGraphLegendList(legendData: GraphLegendItem[]) {
+  renderGraphLegendList = (legendData: GraphLegendItem[]): React.ReactNode => {
     const legendColumnHeadingStyle = kialiStyle({
       fontWeight: 'bold',
       paddingTop: '1.25em'
     });
+
     const aStyle = kialiStyle({
       height: '100%'
     });
@@ -71,22 +74,23 @@ export class GraphLegendPF extends React.Component<GraphLegendProps> {
         {legendData.map((legendItem: GraphLegendItem) => (
           <div key={legendItem.title} className={legendColumnHeadingStyle}>
             {legendItem.title}
+
             {this.renderLegendRowItems(legendItem.data)}
           </div>
         ))}
       </div>
     );
-  }
+  };
 
-  renderLegendRowItems(legendData: GraphLegendItemRow[]) {
+  renderLegendRowItems = (legendData: GraphLegendItemRow[]): React.ReactNode => {
     return (
       <>
         {legendData.map((legendItemRow: GraphLegendItemRow) => GraphLegendPF.renderLegendIconAndLabel(legendItemRow))}
       </>
     );
-  }
+  };
 
-  static renderLegendIconAndLabel(legendItemRow: GraphLegendItemRow) {
+  static renderLegendIconAndLabel = (legendItemRow: GraphLegendItemRow): React.ReactNode => {
     const keyWidth = '70px';
 
     const keyStyle = kialiStyle({
@@ -109,8 +113,9 @@ export class GraphLegendPF extends React.Component<GraphLegendProps> {
         <span className={keyStyle}>
           <img alt={legendItemRow.label} src={legendItemRow.icon} />
         </span>
+
         <span className={legendItemLabelStyle}>{legendItemRow.label}</span>
       </div>
     );
-  }
+  };
 }

--- a/frontend/src/pages/GraphPF/styles/styleEdge.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleEdge.tsx
@@ -1,5 +1,5 @@
 import { DefaultEdge, Edge, observer, ScaleDetailsLevel, WithSelectionProps } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -32,11 +32,11 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
 
   let cssClasses: string[] = [];
 
-  const onMouseEnter = () => {
+  const onMouseEnter = (): void => {
     data.onHover(element, true);
   };
 
-  const onMouseLeave = () => {
+  const onMouseLeave = (): void => {
     data.onHover(element, false);
   };
 
@@ -133,11 +133,13 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
     if (detailsLevel !== ScaleDetailsLevel.high) {
       newData.showTag = false;
     }
+
     Object.keys(newData).forEach(key => {
       if (newData[key] === undefined) {
         delete newData[key];
       }
     });
+
     return newData;
   }, [data, detailsLevel]);
 

--- a/frontend/src/pages/GraphPF/styles/styleGroup.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleGroup.tsx
@@ -7,7 +7,7 @@ import {
   ShapeProps,
   WithSelectionProps
 } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import React from 'react';
 

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -8,7 +8,7 @@ import {
   useHover,
   WithSelectionProps
 } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import * as React from 'react';
 import { KeyIcon, TopologyIcon } from '@patternfly/react-icons';
 import { PFColors } from 'components/Pf/PfColors';

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -48,7 +48,7 @@ import { RenderHeader } from '../../components/Nav/Page/RenderHeader';
 import { ErrorMsg } from '../../types/ErrorMsg';
 import { ErrorSection } from '../../components/ErrorSection/ErrorSection';
 import { RefreshNotifier } from '../../components/Refresh/RefreshNotifier';
-import { isParentKiosk } from '../../components/Kiosk/KioskActions';
+import { isParentKiosk, kioskContextMenuAction } from '../../components/Kiosk/KioskActions';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { basicTabStyle } from 'styles/TabStyles';
@@ -253,7 +253,13 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
 
   backToList = (): void => {
     // Back to list page
-    history.push(`/${Paths.ISTIO}?namespaces=${this.props.istioConfigId.namespace}`);
+    const backUrl = `/${Paths.ISTIO}?namespaces=${this.props.istioConfigId.namespace}`;
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(backUrl);
+    } else {
+      history.push(backUrl);
+    }
   };
 
   canDelete = (): boolean => {

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -93,10 +93,12 @@ import { ClusterDropdown } from './ClusterDropdown';
 import { NamespaceDropdown } from '../../components/NamespaceDropdown';
 import { Labels } from '../../components/Label/Labels';
 import { WizardLabels } from '../../components/IstioWizards/WizardLabels';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type ReduxProps = {
   activeClusters: MeshCluster[];
   activeNamespaces: Namespace[];
+  kiosk: string;
   namespacesPerCluster?: Map<string, string[]>;
 };
 
@@ -479,7 +481,13 @@ class IstioConfigNewPageComponent extends React.Component<Props, State> {
   backToList = (): void => {
     this.setState(initState(), () => {
       // Back to list page
-      history.push(`/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.map(n => n.name).join(',')}`);
+      const backUrl = `/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.map(n => n.name).join(',')}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(backUrl);
+      } else {
+        history.push(backUrl);
+      }
     });
   };
 
@@ -761,6 +769,7 @@ const mapStateToProps = (state: KialiAppState): ReduxProps => {
   return {
     activeClusters: activeClustersSelector(state),
     activeNamespaces: activeNamespacesSelector(state),
+    kiosk: state.globalState.kiosk,
     namespacesPerCluster: namespacesPerClusterSelector(state)
   };
 };

--- a/frontend/src/pages/Mesh/MeshHighlighter.ts
+++ b/frontend/src/pages/Mesh/MeshHighlighter.ts
@@ -21,7 +21,7 @@
 //
 
 import { Edge, Node } from '@patternfly/react-topology';
-import { Controller, GraphElement } from '@patternfly/react-topology/dist/esm/types';
+import { Controller, GraphElement } from '@patternfly/react-topology';
 import { NodeData, ancestors, predecessors, successors } from './MeshElems';
 
 export class MeshHighlighter {
@@ -33,7 +33,7 @@ export class MeshHighlighter {
     this.controller = controller;
   }
 
-  setSelectedId(selectedId?: string) {
+  setSelectedId = (selectedId?: string): void => {
     // ignore clicks on the currently selected element
     if (this.selectedId === selectedId) {
       return;
@@ -42,15 +42,15 @@ export class MeshHighlighter {
     this.selectedId = selectedId;
     this.clearHover();
     this.clearHighlighting();
-  }
+  };
 
-  clearHover = () => {
+  clearHover = (): void => {
     if (this.hovered) {
       this.hovered = undefined;
     }
   };
 
-  onMouseIn = (element: GraphElement) => {
+  onMouseIn = (element: GraphElement): void => {
     // only set Hovered when nothing is currently selected, otherwise just leave the selected element as-is
     if (!this.selectedId) {
       this.hovered = element;
@@ -58,23 +58,24 @@ export class MeshHighlighter {
     }
   };
 
-  onMouseOut = (element: GraphElement) => {
+  onMouseOut = (element: GraphElement): void => {
     if (this.hovered === element) {
       this.clearHover();
       this.clearHighlighting();
     }
   };
 
-  clearHighlighting = () => {
+  clearHighlighting = (): void => {
     this.controller.getElements().forEach(e => {
       const data = e.getData() as NodeData;
+
       if (data.isHighlighted || data.isUnhighlighted) {
         e.setData({ ...data, isHighlighted: false, isUnhighlighted: false });
       }
     });
   };
 
-  refresh = () => {
+  refresh = (): void => {
     const highlighted = this.getHighlighted();
     if (!highlighted.toHighlight) {
       return;
@@ -96,9 +97,10 @@ export class MeshHighlighter {
 
   // Returns the nodes to highlight. Highlighting for a hovered or selected element
   // is the same, it extends to full inbound and outbound paths.
-  getHighlighted(): { toHighlight: GraphElement[]; unhighlightOthers: boolean } {
+  getHighlighted = (): { toHighlight: GraphElement[]; unhighlightOthers: boolean } => {
     const isHover = !this.selectedId;
     const element = isHover ? this.hovered : this.controller.getElementById(this.selectedId!);
+
     if (element) {
       switch (element.getKind()) {
         case 'node':
@@ -114,36 +116,41 @@ export class MeshHighlighter {
       }
     }
     return { toHighlight: [], unhighlightOthers: false };
-  }
+  };
 
-  includeAncestorNodes(nodes: GraphElement[]) {
+  includeAncestorNodes = (nodes: GraphElement[]): GraphElement[] => {
     return nodes.reduce((all: GraphElement[], current) => {
       all.push(current);
+
       if (current.getKind() === 'node' && (current as Node).hasParent()) {
         all = Array.from(
           new Set<GraphElement>([...all, ...ancestors(current as Node)])
         );
       }
+
       return all;
     }, []);
-  }
+  };
 
-  getNodeHighlight(node: Node) {
+  getNodeHighlight = (node: Node): GraphElement[] => {
     const elems = predecessors(node).concat(successors(node));
     elems.push(node);
-    return this.includeAncestorNodes(elems);
-  }
 
-  getEdgeHighlight(edge: Edge) {
+    return this.includeAncestorNodes(elems);
+  };
+
+  getEdgeHighlight = (edge: Edge): GraphElement[] => {
     const source = edge.getSource();
     const target = edge.getTarget();
+
     let elems = [edge, source, target, ...predecessors(source), ...successors(target)];
     elems = this.includeAncestorNodes(elems);
-    return elems;
-  }
 
-  getBoxHighlight(box: Node): { toHighlight: GraphElement[]; unhighlightOthers: boolean } {
+    return elems;
+  };
+
+  getBoxHighlight = (box: Node): { toHighlight: GraphElement[]; unhighlightOthers: boolean } => {
     // Namespace and Cluster boxes highlight themselves and their anscestors.
     return { toHighlight: this.includeAncestorNodes([box]), unhighlightOthers: false };
-  }
+  };
 }

--- a/frontend/src/pages/Mesh/MeshLegend.tsx
+++ b/frontend/src/pages/Mesh/MeshLegend.tsx
@@ -2,18 +2,18 @@ import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
 import { legendData, MeshLegendItem, MeshLegendItemRow } from './MeshLegendData';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
-import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
 import { PFColors } from 'components/Pf/PfColors';
+import { KialiIcon } from 'config/KialiIcon';
 
 export interface MeshLegendProps {
-  closeLegend: () => void;
   className?: string;
+  closeLegend: () => void;
 }
 
 const width = '190px';
 
 export class MeshLegend extends React.Component<MeshLegendProps> {
-  render() {
+  render(): React.ReactNode {
     const legendBoxStyle = kialiStyle({
       backgroundColor: PFColors.BackgroundColor100,
       border: `1px solid ${PFColors.BorderColor100}`,
@@ -45,11 +45,12 @@ export class MeshLegend extends React.Component<MeshLegendProps> {
           <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
               <Button id="legend_close" variant={ButtonVariant.plain} onClick={this.props.closeLegend}>
-                <CloseIcon />
+                <KialiIcon.Close />
               </Button>
             </Tooltip>
           </span>
         </div>
+
         <div className={bodyStyle}>
           <div>{this.renderGraphLegendList(legendData)}</div>
         </div>
@@ -57,11 +58,12 @@ export class MeshLegend extends React.Component<MeshLegendProps> {
     );
   }
 
-  renderGraphLegendList(legendData: MeshLegendItem[]) {
+  renderGraphLegendList = (legendData: MeshLegendItem[]): React.ReactNode => {
     const legendColumnHeadingStyle = kialiStyle({
       fontWeight: 'bold',
       paddingTop: '1.25em'
     });
+
     const aStyle = kialiStyle({
       height: '100%'
     });
@@ -71,20 +73,21 @@ export class MeshLegend extends React.Component<MeshLegendProps> {
         {legendData.map((legendItem: MeshLegendItem) => (
           <div key={legendItem.title} className={legendColumnHeadingStyle}>
             {legendItem.title}
+
             {this.renderLegendRowItems(legendItem.data)}
           </div>
         ))}
       </div>
     );
-  }
+  };
 
-  renderLegendRowItems(legendData: MeshLegendItemRow[]) {
+  renderLegendRowItems = (legendData: MeshLegendItemRow[]): React.ReactNode => {
     return (
       <>{legendData.map((legendItemRow: MeshLegendItemRow) => MeshLegend.renderLegendIconAndLabel(legendItemRow))}</>
     );
-  }
+  };
 
-  static renderLegendIconAndLabel(legendItemRow: MeshLegendItemRow) {
+  static renderLegendIconAndLabel = (legendItemRow: MeshLegendItemRow): React.ReactNode => {
     const keyWidth = '70px';
 
     const keyStyle = kialiStyle({
@@ -107,8 +110,9 @@ export class MeshLegend extends React.Component<MeshLegendProps> {
         <span className={keyStyle}>
           <img alt={legendItemRow.label} src={legendItemRow.icon} />
         </span>
+
         <span className={legendItemLabelStyle}>{legendItemRow.label}</span>
       </div>
     );
-  }
+  };
 }

--- a/frontend/src/pages/Mesh/styles/MeshEdge.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshEdge.tsx
@@ -1,5 +1,5 @@
 import { DefaultEdge, Edge, observer, ScaleDetailsLevel, WithSelectionProps } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -30,11 +30,11 @@ const MeshEdgeComponent: React.FC<MeshEdgeProps> = ({ element, ...rest }) => {
 
   let cssClasses: string[] = [];
 
-  const onMouseEnter = () => {
+  const onMouseEnter = (): void => {
     data.onHover(element, true);
   };
 
-  const onMouseLeave = () => {
+  const onMouseLeave = (): void => {
     data.onHover(element, false);
   };
 
@@ -115,14 +115,17 @@ const MeshEdgeComponent: React.FC<MeshEdgeProps> = ({ element, ...rest }) => {
 
   const passedData = React.useMemo(() => {
     const newData = { ...data };
+
     if (detailsLevel !== ScaleDetailsLevel.high) {
       newData.showTag = false;
     }
+
     Object.keys(newData).forEach(key => {
       if (newData[key] === undefined) {
         delete newData[key];
       }
     });
+
     return newData;
   }, [data, detailsLevel]);
 

--- a/frontend/src/pages/Mesh/styles/MeshGroup.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshGroup.tsx
@@ -7,7 +7,7 @@ import {
   ShapeProps,
   WithSelectionProps
 } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import React from 'react';
 

--- a/frontend/src/pages/Mesh/styles/MeshNode.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshNode.tsx
@@ -7,7 +7,7 @@ import {
   useHover,
   WithSelectionProps
 } from '@patternfly/react-topology';
-import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { useDetailsLevel } from '@patternfly/react-topology';
 import * as React from 'react';
 import { PFColors } from 'components/Pf/PfColors';
 import { kialiStyle } from 'styles/StyleUtils';

--- a/frontend/src/pages/Mesh/toolbar/__tests__/__snapshots__/MeshLegend.test.tsx.snap
+++ b/frontend/src/pages/Mesh/toolbar/__tests__/__snapshots__/MeshLegend.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <CloseIcon />
+          <Close />
         </Button>
       </Tooltip>
     </span>

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -54,12 +54,14 @@ import { TimeDurationModal } from '../../components/Time/TimeDurationModal';
 import { TimeDurationIndicator } from '../../components/Time/TimeDurationIndicator';
 import { serverConfig } from '../../config';
 import { ApiResponse } from 'types/Api';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 const appContainerColors = [PFColors.Blue300, PFColors.Green300, PFColors.Purple300, PFColors.Orange300];
 const proxyContainerColor = PFColors.Gold400;
 const spanColor = PFColors.Cyan300;
 
 type ReduxProps = {
+  kiosk: string;
   timeRange: TimeRange;
 };
 
@@ -823,7 +825,12 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     const link =
       `/namespaces/${this.props.namespace}/workloads/${this.props.workload}` +
       `?tab=traces&${URLParam.TRACING_TRACE_ID}=${span.traceID}&${URLParam.TRACING_SPAN_ID}=${span.spanID}`;
-    history.push(link);
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(link);
+    } else {
+      history.push(link);
+    }
   };
 
   private addAccessLogModal = (k: string, v: AccessLog): void => {
@@ -1167,6 +1174,7 @@ const formatDate = (timestamp: string): string => {
 
 const mapStateToProps = (state: KialiAppState): ReduxProps => {
   return {
+    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state)
   };
 };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -106,19 +106,8 @@ const getHeaders = (): Partial<AxiosHeaders> => {
   if (apiProxy) {
     return { 'Content-Type': 'application/x-www-form-urlencoded' };
   } else {
-    return { ...loginHeaders };
+    return { 'Content-Type': 'application/json', ...loginHeaders };
   }
-};
-
-/** Create content type correctly for a given request type */
-const getHeadersWithMethod = (method: HTTP_VERBS): Partial<AxiosHeaders> => {
-  let allHeaders = getHeaders();
-
-  if (method === HTTP_VERBS.PATCH) {
-    allHeaders['Content-Type'] = 'application/json';
-  }
-
-  return allHeaders;
 };
 
 const basicAuth = (username: UserName, password: Password): BasicAuth => {
@@ -134,8 +123,8 @@ const newRequest = <P>(
   return axios.request<P>({
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
-    data: data,
-    headers: getHeadersWithMethod(method) as AxiosHeaders,
+    data: apiProxy ? JSON.stringify(data) : data,
+    headers: getHeaders() as AxiosHeaders,
     params: queryParams
   });
 };
@@ -173,7 +162,7 @@ export const getAuthInfo = async (): Promise<ApiResponse<AuthInfo>> => {
   return newRequest<AuthInfo>(HTTP_VERBS.GET, urls.authInfo, {}, {});
 };
 
-export const checkOpenshiftAuth = async (data: unknown): Promise<ApiResponse<LoginSession>> => {
+export const checkOpenshiftAuth = async (data: string): Promise<ApiResponse<LoginSession>> => {
   return newRequest<LoginSession>(HTTP_VERBS.POST, urls.authenticate, {}, data);
 };
 


### PR DESCRIPTION
### Describe the change

This PR adapts Kiali code to make OSSMC compatible with OCP 4.15:
- Add kiosk redirection to all history modifications (graph context menu, trace tab, etc.)
- Stringify body data when content-type is `application/x-www-form-urlencoded`
- According to [console-dynamic-plugin-sdk](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md#patternfly-dynamic-modules) README, we should avoid non-index imports for any PatternFly packages. Some of the imports are still non-index since they have to be exported correctly from `patternfly-react` library (https://www.github.com/patternfly/patternfly-react/issues/10155)
- Lint issues

### Steps to test the PR

This PR only affects OSSMC, so there should not be any change from Kiali perspective.

### Automation testing

N/A

### Issue reference

Kiali part of https://github.com/kiali/openshift-servicemesh-plugin/issues/284

