### PR TITLE
[v1.73] Add kiosk support to all Kiali links

### DIFF
--- a/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/frontend/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -5,6 +5,8 @@ import { serverConfig } from '../../config';
 import { NEW_ISTIO_RESOURCE } from '../../pages/IstioConfigNew/IstioConfigNewPage';
 import { K8SGATEWAY } from '../../pages/IstioConfigNew/K8sGatewayForm';
 import { groupMenuStyle } from 'styles/DropdownStyles';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
+import { store } from 'store/ConfigStore';
 
 type Props = {};
 
@@ -38,7 +40,14 @@ export class IstioActionsNamespaceDropdown extends React.Component<Props, State>
   };
 
   onClickCreate = (type: string) => {
-    history.push('/istio/new/' + type);
+    const kiosk = store.getState().globalState.kiosk;
+    const newUrl = `/istio/new/${type}`;
+
+    if (isParentKiosk(kiosk)) {
+      kioskContextMenuAction(newUrl);
+    } else {
+      history.push(newUrl);
+    }
   };
 
   render() {

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -40,6 +40,7 @@ import { bindActionCreators } from 'redux';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { timeRangeSelector } from '../../store/Selectors';
 import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type MetricsState = {
   cluster?: string;
@@ -66,6 +67,7 @@ type CustomMetricsProps = RouteComponentProps<{}> & {
 
 type ReduxProps = {
   jaegerIntegration: boolean;
+  kiosk: string;
   timeRange: TimeRange;
   setTimeRange: (range: TimeRange) => void;
 };
@@ -207,9 +209,14 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
     } else if ('traceId' in datum) {
       const traceId = datum.traceId;
       const spanId = datum.spanId;
-      history.push(
-        `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`
-      );
+
+      const traceUrl = `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(traceUrl);
+      } else {
+        history.push(traceUrl);
+      }
     }
   };
 
@@ -366,6 +373,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
 const mapStateToProps = (state: KialiAppState) => {
   return {
     jaegerIntegration: state.jaegerState.info ? state.jaegerState.info.integration : false,
+    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state)
   };
 };

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -31,6 +31,7 @@ import { refreshIntervalSelector, timeRangeSelector } from 'store/Selectors';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { KialiCrippledFeatures } from 'types/ServerConfig';
 import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type MetricsState = {
   crippledFeatures?: KialiCrippledFeatures;
@@ -60,6 +61,7 @@ type IstioMetricsProps = ObjectId &
 
 type ReduxProps = {
   jaegerIntegration: boolean;
+  kiosk: string;
   timeRange: TimeRange;
   refreshInterval: IntervalInMilliseconds;
   setTimeRange: (range: TimeRange) => void;
@@ -252,9 +254,14 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
           : this.props.objectType === MetricsObjectTypes.SERVICE
           ? 'services'
           : 'workloads';
-      history.push(
-        `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`
-      );
+
+      const traceUrl = `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(traceUrl);
+      } else {
+        history.push(traceUrl);
+      }
     }
   };
 
@@ -413,6 +420,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
 const mapStateToProps = (state: KialiAppState) => {
   return {
     jaegerIntegration: state.jaegerState.info ? state.jaegerState.info.integration : false,
+    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state),
     refreshInterval: refreshIntervalSelector(state)
   };

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -45,11 +45,13 @@ import { GraphSecondaryMasthead } from './GraphSecondaryMasthead';
 import { INITIAL_USER_SETTINGS_STATE } from 'reducers/UserSettingsState';
 import { GraphReset } from './GraphReset';
 import { GraphFindPF } from './GraphFindPF';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
   edgeLabels: EdgeLabelMode[];
   graphType: GraphType;
+  kiosk: string;
   node?: NodeParamsType;
   rankBy: RankMode[];
   replayActive: boolean;
@@ -261,7 +263,14 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
       !this.props.summaryData ||
       (this.props.summaryData.summaryType !== 'node' && this.props.summaryData.summaryType !== 'box')
     ) {
-      history.push(`/${route}/namespaces`);
+      const returnUrl = `/${route}/namespaces`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(returnUrl);
+      } else {
+        history.push(returnUrl);
+      }
+
       return;
     }
 
@@ -269,7 +278,14 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
       ? this.props.summaryData!.summaryTarget.getId()
       : `node[id = "${this.props.summaryData!.summaryTarget.data(NodeAttr.id)}"]`;
     this.props.setNode(undefined);
-    history.push(`/${route}/namespaces?focusSelector=${encodeURI(selector)}`);
+
+    const returnUrl = `/${route}/namespaces?focusSelector=${encodeURI(selector)}`;
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(returnUrl);
+    } else {
+      history.push(returnUrl);
+    }
   };
 }
 
@@ -277,6 +293,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   activeNamespaces: activeNamespacesSelector(state),
   edgeLabels: edgeLabelsSelector(state),
   graphType: graphTypeSelector(state),
+  kiosk: state.globalState.kiosk,
   node: state.graph.node,
   rankBy: state.graph.toolbarState.rankBy,
   replayActive: replayActiveSelector(state),

--- a/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
+++ b/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
@@ -25,17 +25,18 @@ import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUt
 import { history } from '../../../app/History';
 import { GraphNodeDoubleTapEvent } from 'components/CytoscapeGraph/CytoscapeGraph';
 import { serverConfig } from '../../../config';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type ContextMenuOptionPF = ContextMenuOption & {
-  altClickHandler?: (node: GraphElement) => void;
+  altClickHandler?: (node: GraphElement, kiosk: string) => void;
   node?: GraphElement;
 };
 
-const doubleTapHandler = (node: GraphElement) => {
-  handleDoubleTap(node);
+const doubleTapHandler = (node: GraphElement, kiosk: string) => {
+  handleDoubleTap(node, kiosk);
 };
 
-const nodeContextMenu = (node: GraphElement): React.ReactElement[] => {
+const nodeContextMenu = (node: GraphElement, kiosk: string): React.ReactElement[] => {
   const options = getOptions(node.getData());
   const optionsPF = options.map(o => o as ContextMenuOptionPF);
   const nodeData = node.getData() as DecoratedGraphNodeData;
@@ -71,11 +72,11 @@ const nodeContextMenu = (node: GraphElement): React.ReactElement[] => {
     return (
       // TODO: fix kiosk param
       !!o.altClickHandler ? (
-        <ContextMenuItem key={`option-${i}`} onClick={() => o.altClickHandler!(o.node!)}>
+        <ContextMenuItem key={`option-${i}`} onClick={() => o.altClickHandler!(o.node!, kiosk)}>
           {o.text}
         </ContextMenuItem>
       ) : (
-        <ContextMenuItem key={`option-${i}`} onClick={() => clickHandler(o, '')}>
+        <ContextMenuItem key={`option-${i}`} onClick={() => clickHandler(o, kiosk)}>
           {o.text} {o.target === '_blank' && <ExternalLinkAltIcon />}
         </ContextMenuItem>
       )
@@ -87,7 +88,7 @@ const nodeContextMenu = (node: GraphElement): React.ReactElement[] => {
 
 // This is temporary until the PFT graph properly handles DoubleTap.  Until then
 // we offer a ContextMenu option for what would normally be handled via DoubleTap.
-const handleDoubleTap = (doubleTapNode: GraphElement) => {
+const handleDoubleTap = (doubleTapNode: GraphElement, kiosk: string) => {
   const dtNodeData = doubleTapNode.getData() as DecoratedGraphNodeData;
   const graphData = doubleTapNode.getGraph().getData().graphData;
 
@@ -169,7 +170,7 @@ const handleDoubleTap = (doubleTapNode: GraphElement) => {
   // Instead, assume that the user wants more details for the node and do a
   // redirect to the details page.
   if (sameNode) {
-    handleDoubleTapSameNode(targetNode);
+    handleDoubleTapSameNode(targetNode, kiosk);
     return;
   }
 
@@ -194,11 +195,17 @@ const handleDoubleTap = (doubleTapNode: GraphElement) => {
   };
 
   // To ensure updated components get the updated URL, update the URL first and then the state
-  history.push(makeNodeGraphUrlFromParams(urlParams, true));
+  const nodeGraphUrl = makeNodeGraphUrlFromParams(urlParams, true);
+
+  if (isParentKiosk(kiosk)) {
+    kioskContextMenuAction(nodeGraphUrl);
+  } else {
+    history.push(nodeGraphUrl);
+  }
 };
 
 // This allows us to navigate to the service details page when zoomed in on nodes
-const handleDoubleTapSameNode = (targetNode: NodeParamsType) => {
+const handleDoubleTapSameNode = (targetNode: NodeParamsType, kiosk: string) => {
   const makeAppDetailsPageUrl = (namespace: string, nodeType: string, name?: string): string => {
     return `/namespaces/${namespace}/${nodeType}/${name}`;
   };
@@ -212,20 +219,22 @@ const handleDoubleTapSameNode = (targetNode: NodeParamsType) => {
   } else {
     urlNodeType = 'applications';
   }
+
   const detailsPageUrl = makeAppDetailsPageUrl(targetNode.namespace.name, urlNodeType, name);
-  // todo deal with kiosk
-  //if (isParentKiosk(this.props.kiosk)) {
-  //  kioskContextMenuAction(detailsPageUrl);
-  //} else {
-  history.push(detailsPageUrl);
-  //}
-  //return;
+
+  if (isParentKiosk(kiosk)) {
+    kioskContextMenuAction(detailsPageUrl);
+  } else {
+    history.push(detailsPageUrl);
+  }
 };
 
 export const stylesComponentFactory: ComponentFactory = (
   kind: ModelKind,
   type: string
 ): React.FunctionComponent<any> | undefined => {
+  const kiosk = store.getState().globalState.kiosk;
+
   switch (kind) {
     case ModelKind.edge:
       return withSelection({ multiSelect: false, controlled: false })(StyleEdge as any);
@@ -233,7 +242,7 @@ export const stylesComponentFactory: ComponentFactory = (
       return withPanZoom()(GraphComponent);
     case ModelKind.node: {
       return withDragNode(nodeDragSourceSpec('node', true, true))(
-        withContextMenu(e => nodeContextMenu(e))(
+        withContextMenu(e => nodeContextMenu(e, kiosk))(
           withSelection({ multiSelect: false, controlled: false })((type === 'group' ? StyleGroup : StyleNode) as any)
         )
       );

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -48,7 +48,7 @@ import { RenderHeader } from '../../components/Nav/Page/RenderHeader';
 import { ErrorMsg } from '../../types/ErrorMsg';
 import { ErrorSection } from '../../components/ErrorSection/ErrorSection';
 import { RefreshNotifier } from '../../components/Refresh/RefreshNotifier';
-import { isParentKiosk } from '../../components/Kiosk/KioskActions';
+import { isParentKiosk, kioskContextMenuAction } from '../../components/Kiosk/KioskActions';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { basicTabStyle } from 'styles/TabStyles';
@@ -234,7 +234,13 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
 
   backToList = () => {
     // Back to list page
-    history.push(`/${Paths.ISTIO}?namespaces=${this.props.istioConfigId.namespace}`);
+    const backUrl = `/${Paths.ISTIO}?namespaces=${this.props.istioConfigId.namespace}`;
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(backUrl);
+    } else {
+      history.push(backUrl);
+    }
   };
 
   canDelete = () => {

--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -71,11 +71,13 @@ import { ConfigPreviewItem, IstioConfigPreview } from 'components/IstioConfigPre
 import { isValid } from 'utils/Common';
 import { ClusterDropdown } from './ClusterDropdown';
 import { NamespaceDropdown } from '../../components/NamespaceDropdown';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 type Props = {
   objectType: string;
   activeNamespaces: Namespace[];
   activeClusters: MeshCluster[];
+  kiosk: string;
   namespacesPerCluster?: Map<string, string[]>;
 };
 
@@ -344,7 +346,13 @@ class IstioConfigNewPageComponent extends React.Component<Props, State> {
   backToList = () => {
     this.setState(initState(), () => {
       // Back to list page
-      history.push(`/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.map(n => n.name).join(',')}`);
+      const backUrl = `/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.map(n => n.name).join(',')}`;
+
+      if (isParentKiosk(this.props.kiosk)) {
+        kioskContextMenuAction(backUrl);
+      } else {
+        history.push(backUrl);
+      }
     });
   };
 
@@ -556,6 +564,7 @@ const mapStateToProps = (state: KialiAppState) => {
   return {
     activeClusters: activeClustersSelector(state),
     activeNamespaces: activeNamespacesSelector(state),
+    kiosk: state.globalState.kiosk,
     namespacesPerCluster: namespacesPerClusterSelector(state)
   };
 };

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -52,12 +52,14 @@ import { KioskElement } from '../../components/Kiosk/KioskElement';
 import { TimeDurationModal } from '../../components/Time/TimeDurationModal';
 import { TimeDurationIndicator } from '../../components/Time/TimeDurationIndicator';
 import { serverConfig } from '../../config';
+import { isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 
 const appContainerColors = [PFColors.Blue300, PFColors.Green300, PFColors.Purple300, PFColors.Orange300];
 const proxyContainerColor = PFColors.Gold400;
 const spanColor = PFColors.Cyan300;
 
 type ReduxProps = {
+  kiosk: string;
   timeRange: TimeRange;
 };
 
@@ -751,7 +753,12 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     const link =
       `/namespaces/${this.props.namespace}/workloads/${this.props.workload}` +
       `?tab=traces&${URLParam.JAEGER_TRACE_ID}=${span.traceID}&${URLParam.JAEGER_SPAN_ID}=${span.spanID}`;
-    history.push(link);
+
+    if (isParentKiosk(this.props.kiosk)) {
+      kioskContextMenuAction(link);
+    } else {
+      history.push(link);
+    }
   };
 
   private addAccessLogModal = (k: string, v: AccessLog) => {
@@ -1076,6 +1083,7 @@ const formatDate = (timestamp: string): string => {
 
 const mapStateToProps = (state: KialiAppState) => {
   return {
+    kiosk: state.globalState.kiosk,
     timeRange: timeRangeSelector(state)
   };
 };

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -78,18 +78,8 @@ const getHeaders = () => {
   if (apiProxy) {
     return { 'Content-Type': 'application/x-www-form-urlencoded' };
   } else {
-    return { ...loginHeaders };
+    return { 'Content-Type': 'application/json', ...loginHeaders };
   }
-};
-
-/** Create content type correctly for a given request type */
-const getHeadersWithMethod = (method: HTTP_VERBS) => {
-  let allHeaders = getHeaders();
-  if (method === HTTP_VERBS.PATCH) {
-    allHeaders['Content-Type'] = 'application/json';
-  }
-
-  return allHeaders;
 };
 
 const basicAuth = (username: UserName, password: Password) => {
@@ -100,8 +90,8 @@ const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: 
   return axios.request<P>({
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
-    data: data,
-    headers: getHeadersWithMethod(method),
+    data: apiProxy ? JSON.stringify(data) : data,
+    headers: getHeaders(),
     params: queryParams
   });
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2049,23 +2049,10 @@
     victory-voronoi-container "^36.6.7"
     victory-zoom-container "^36.6.7"
 
-"@patternfly/react-core@4.276.6":
+"@patternfly/react-core@4.276.6", "@patternfly/react-core@^4.276.6":
   version "4.276.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.6.tgz#fa39aa61022f70bf350b2efc660bdeb096bda447"
   integrity sha512-G0K+378jf9jw9g+hCAoKnsAe/UGTRspqPeuAYypF2FgNr+dC7dUpc7/VkNhZBVqSJzUWVEK8NyXcqkfi0IemIg==
-  dependencies:
-    "@patternfly/react-icons" "^4.93.6"
-    "@patternfly/react-styles" "^4.92.6"
-    "@patternfly/react-tokens" "^4.94.6"
-    focus-trap "6.9.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "^2.0.0"
-
-"@patternfly/react-core@^4.276.6":
-  version "4.276.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.8.tgz#7ef52830dcdda954bd5bec40132da6eef49aba6f"
-  integrity sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==
   dependencies:
     "@patternfly/react-icons" "^4.93.6"
     "@patternfly/react-styles" "^4.92.6"
@@ -4842,15 +4829,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@3.0.10:
+csstype@3.0.10, csstype@^3.0.2:
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
   integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
-
-csstype@^3.0.2:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
-  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 cy-node-html-label@2.0.0:
   version "2.0.0"
@@ -8564,11 +8546,6 @@ lodash-es@^4.17.11, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -10188,16 +10165,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
-prop-types@^15.7.0, prop-types@^15.8.1:
+prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10426,7 +10394,7 @@ react-flexview@4.0.3:
   dependencies:
     prop-types "^15.5.6"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13038,6 +13006,7 @@ workerpool@6.2.1:
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Partial backport of https://github.com/kiali/kiali/pull/7224 (only those changes that affect v1.73 and PF4):

- Add kiosk redirection to all history modifications (graph context menu, trace tab, etc.)
- Stringify body data when content-type is application/x-www-form-urlencoded

### Issue reference

https://github.com/kiali/openshift-servicemesh-plugin/issues/284