### PR TITLE
Service list backend request per cluster

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -183,7 +183,7 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 	}
 
 	// Convert to Kiali model
-	services := in.buildServiceList(cluster, models.Namespace{Name: criteria.Namespace}, svcs, rSvcs, pods, deployments, istioConfigList, criteria)
+	services := in.buildServiceList(cluster, criteria.Namespace, svcs, rSvcs, pods, deployments, istioConfigList, criteria)
 
 	// Check if we need to add health
 
@@ -220,7 +220,7 @@ func getDRKialiScenario(dr []*networking_v1beta1.DestinationRule) string {
 	return scenario
 }
 
-func (in *SvcService) buildServiceList(cluster string, namespace models.Namespace, svcs []core_v1.Service, rSvcs []*kubernetes.RegistryService, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList, criteria ServiceCriteria) *models.ServiceList {
+func (in *SvcService) buildServiceList(cluster string, namespace string, svcs []core_v1.Service, rSvcs []*kubernetes.RegistryService, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList, criteria ServiceCriteria) *models.ServiceList {
 	services := []models.ServiceOverview{}
 	validations := models.IstioValidations{}
 	if !criteria.IncludeOnlyDefinitions {

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -49,12 +49,14 @@ func TestServiceListParsing(t *testing.T) {
 	serviceList, err := svc.GetServiceList(context.TODO(), criteria)
 	require.NoError(err)
 
-	require.Equal("Namespace", serviceList.Namespace.Name)
+	require.Equal("Namespace", serviceList.Namespace)
 	require.Len(serviceList.Services, 2)
 	serviceNames := []string{serviceList.Services[0].Name, serviceList.Services[1].Name}
 
 	assert.Contains(serviceNames, "reviews")
 	assert.Contains(serviceNames, "httpbin")
+	assert.Equal("Namespace", serviceList.Services[0].Namespace)
+	assert.Equal("Namespace", serviceList.Services[1].Namespace)
 }
 
 func TestParseRegistryServices(t *testing.T) {

--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -43,7 +43,7 @@ When(
   'there is traffic routing for the {string} service in the {string} namespace and in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.request({
-      url: `api/namespaces/${namespace}/services`,
+      url: `api/clusters/services?namespaces=${namespace}`,
       qs: { clusterName: cluster, istioResources: true, onlyDefinitions: false }
     }).then(response => {
       cy.wrap(response).its('status').should('eq', 200);
@@ -175,7 +175,7 @@ Then(
   'there is no traffic routing for the {string} service in the {string} namespace and in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.request({
-      url: `api/namespaces/${namespace}/services`,
+      url: `api/clusters/services?namespaces=${namespace}`,
       qs: { clusterName: cluster, istioResources: true, onlyDefinitions: false }
     }).then(response => {
       cy.wrap(response).its('status').should('eq', 200);

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -123,6 +123,7 @@ const conf = {
       clustersApps: () => `api/clusters/apps`,
       clustersHealth: () => `api/clusters/health`,
       clustersMetrics: () => `api/clusters/metrics`,
+      clustersServices: () => `api/clusters/services`,
       clustersTls: () => `api/clusters/tls`,
       configValidations: () => `api/istio/validations`,
       crippledFeatures: 'api/crippled',

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -160,7 +160,6 @@ const conf = {
       podEnvoyProxyResourceEntries: (namespace: string, pod: string, resource: string) =>
         `api/namespaces/${namespace}/pods/${pod}/config_dump/${resource}`,
       serverConfig: `api/config`,
-      services: (namespace: string) => `api/namespaces/${namespace}/services`,
       service: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}`,
       serviceGraphElements: (namespace: string, service: string) =>
         `api/namespaces/${namespace}/services/${service}/graph`,

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -140,18 +140,14 @@ class ServiceListPageComponent extends FilterComponent.Component<
     toggles: ActiveTogglesInfo,
     rateInterval: number
   ): void {
-    const health = toggles.get('health') ? 'true' : 'false';
-    const istioResources = toggles.get('istioResources') ? 'true' : 'false';
-    const onlyDefinitions = toggles.get('configuration') ? 'false' : 'true'; // !configuration => onlyDefinitions
-
     const servicesPromises = clusters.map(cluster =>
       API.getClustersServices(
         this.props.activeNamespaces.map(ns => ns.name).join(','),
         {
-          health: health,
-          istioResources: istioResources,
+          health: toggles.get('health') ?? true,
+          istioResources: toggles.get('istioResources') ?? true,
           rateInterval: `${String(rateInterval)}s`,
-          onlyDefinitions: onlyDefinitions
+          onlyDefinitions: toggles.get('configuration') !== undefined ? !toggles.get('configuration') : false // !configuration => onlyDefinitions
         },
         cluster
       )

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -23,7 +23,7 @@ import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 import { validationKey } from '../../types/IstioConfigList';
 import { ServiceHealth } from '../../types/Health';
 import { RefreshNotifier } from '../../components/Refresh/RefreshNotifier';
-import { isMultiCluster } from 'config';
+import { isMultiCluster, serverConfig } from 'config';
 
 type ServiceListPageState = FilterComponent.State<ServiceListItem>;
 
@@ -96,10 +96,13 @@ class ServiceListPageComponent extends FilterComponent.Component<
 
     const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const activeToggles: ActiveTogglesInfo = Toggles.getToggles();
-    const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
+    const uniqueClusters = new Set<string>();
+    Object.keys(serverConfig.clusters).forEach(cluster => {
+      uniqueClusters.add(cluster);
+    });
 
-    if (namespacesSelected.length !== 0) {
-      this.fetchServices(namespacesSelected, activeFilters, activeToggles, this.props.duration);
+    if (this.props.activeNamespaces.length !== 0) {
+      this.fetchServices(Array.from(uniqueClusters), activeFilters, activeToggles, this.props.duration);
     } else {
       this.setState({ listItems: [] });
     }
@@ -111,14 +114,14 @@ class ServiceListPageComponent extends FilterComponent.Component<
         name: service.name,
         istioSidecar: service.istioSidecar,
         istioAmbient: service.istioAmbient,
-        namespace: data.namespace.name,
+        namespace: service.namespace,
         cluster: service.cluster,
-        health: ServiceHealth.fromJson(data.namespace.name, service.name, service.health, {
+        health: ServiceHealth.fromJson(service.namespace, service.name, service.health, {
           rateInterval: rateInterval,
           hasSidecar: service.istioSidecar,
           hasAmbient: service.istioAmbient
         }),
-        validation: this.getServiceValidation(service.name, data.namespace.name, data.validations),
+        validation: this.getServiceValidation(service.name, service.namespace, data.validations),
         additionalDetailSample: service.additionalDetailSample,
         labels: service.labels ?? {},
         ports: service.ports ?? {},
@@ -132,18 +135,26 @@ class ServiceListPageComponent extends FilterComponent.Component<
   }
 
   fetchServices(
-    namespaces: string[],
+    clusters: string[],
     filters: ActiveFiltersInfo,
     toggles: ActiveTogglesInfo,
     rateInterval: number
   ): void {
-    const servicesPromises = namespaces.map(ns =>
-      API.getServices(ns, {
-        health: toggles.get('health') ?? true,
-        istioResources: toggles.get('istioResources') ?? true,
-        rateInterval: `${String(rateInterval)}s`,
-        onlyDefinitions: toggles.get('configuration') !== undefined ? !toggles.get('configuration') : false // !configuration => onlyDefinitions
-      })
+    const health = toggles.get('health') ? 'true' : 'false';
+    const istioResources = toggles.get('istioResources') ? 'true' : 'false';
+    const onlyDefinitions = toggles.get('configuration') ? 'false' : 'true'; // !configuration => onlyDefinitions
+
+    const servicesPromises = clusters.map(cluster =>
+      API.getClustersServices(
+        this.props.activeNamespaces.map(ns => ns.name).join(','),
+        {
+          health: health,
+          istioResources: istioResources,
+          rateInterval: `${String(rateInterval)}s`,
+          onlyDefinitions: onlyDefinitions
+        },
+        cluster
+      )
     );
 
     this.promises

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -449,8 +449,20 @@ export const getClustersTls = (namespaces: string, cluster?: string): Promise<Ap
   return newRequest<[TLSStatus]>(HTTP_VERBS.GET, urls.clustersTls(), queryParams, {});
 };
 
-export const getServices = (namespace: string, params?: ServiceListQuery): Promise<ApiResponse<ServiceList>> => {
-  return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), params, {});
+export const getClustersServices = (
+  namespaces: string,
+  params: ServiceListQuery,
+  cluster?: string
+): Promise<ApiResponse<ServiceList>> => {
+  const queryParams: QueryParams<ServiceListQuery & Namespaces> = {
+    ...params,
+    namespaces: namespaces
+  };
+
+  if (cluster) {
+    queryParams.clusterName = cluster;
+  }
+  return newRequest<ServiceList>(HTTP_VERBS.GET, urls.clustersServices(), queryParams, {});
 };
 
 export const getServiceMetrics = (

--- a/frontend/src/services/__tests__/ApiMethods.test.ts
+++ b/frontend/src/services/__tests__/ApiMethods.test.ts
@@ -1,5 +1,6 @@
 import * as API from '../Api';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
+import { ServiceListQuery } from '../../types/ServiceList';
 
 describe('#GetErrorString', () => {
   it('should return an error message with status', () => {
@@ -105,8 +106,8 @@ describe.skip('#Test Methods return a Promise', () => {
     evaluatePromise(result);
   });
 
-  it('#getServices', () => {
-    const result = API.getServices('istio-system');
+  it('#getClustersServices', () => {
+    const result = API.getClustersServices('istio-system', {} as ServiceListQuery);
     evaluatePromise(result);
   });
 

--- a/frontend/src/types/ServiceList.ts
+++ b/frontend/src/types/ServiceList.ts
@@ -1,11 +1,10 @@
-import { Namespace } from './Namespace';
 import { ServiceHealth } from './Health';
 import { Validations, ObjectValidation, ObjectReference } from './IstioObjects';
 import { AdditionalItem } from './Workload';
 
 export interface ServiceList {
-  namespace: Namespace;
-  services: ServiceOverview[];
+  cluster?: string;
+  services: ServiceListItem[];
   validations: Validations;
 }
 

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -189,7 +189,7 @@ func addLabels(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo
 	for _, n := range trafficMap {
 		if serviceList, ok := serviceLists[n.Cluster]; ok {
 			// make sure service nodes have the defined app label so it can be used for app grouping in the UI.
-			if n.NodeType == graph.NodeTypeService && n.Namespace == serviceList.Namespace.Name && n.App == "" {
+			if n.NodeType == graph.NodeTypeService && n.Namespace == serviceList.Namespace && n.App == "" {
 				// For service nodes that are a service entries, use the `hosts` property of the SE to find
 				// a matching Kubernetes Svc for adding missing labels
 				if _, ok := n.Metadata[graph.IsServiceEntry]; ok {

--- a/models/service.go
+++ b/models/service.go
@@ -61,6 +61,17 @@ type ServiceOverview struct {
 	Health ServiceHealth `json:"health,omitempty"`
 }
 
+type ClusterServices struct {
+	// Cluster where the services live in
+	// required: true
+	// example: east
+	Cluster string `json:"cluster"`
+	// Services list for namespaces of a single cluster
+	// required: true
+	Services    []ServiceOverview `json:"services"`
+	Validations IstioValidations  `json:"validations"`
+}
+
 type ServiceList struct {
 	Namespace   Namespace         `json:"namespace"`
 	Services    []ServiceOverview `json:"services"`

--- a/models/service.go
+++ b/models/service.go
@@ -73,7 +73,7 @@ type ClusterServices struct {
 }
 
 type ServiceList struct {
-	Namespace   Namespace         `json:"namespace"`
+	Namespace   string            `json:"namespace"`
 	Services    []ServiceOverview `json:"services"`
 	Validations IstioValidations  `json:"validations"`
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -354,9 +354,9 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 			handlers.IstioConfigCreate,
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/services services serviceList
+		// swagger:route GET /clusters/services services serviceList
 		// ---
-		// Endpoint to get the details of a given service
+		// Endpoint to get the list of services for a given cluster
 		//
 		//     Produces:
 		//     - application/json
@@ -368,10 +368,10 @@ func NewRoutes(conf *config.Config, kialiCache cache.KialiCache, clientFactory k
 		//      200: serviceListResponse
 		//
 		{
-			"ServiceList",
+			"ClustersServices",
 			"GET",
-			"/api/namespaces/{namespace}/services",
-			handlers.ServiceList,
+			"/api/clusters/services",
+			handlers.ClustersServices,
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/services/{service} services serviceDetails

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -61,7 +61,7 @@ func servicesListNoRegistryServices(t *testing.T) {
 
 	// Now, create a Service Entry (Part of th
 	require.NotNil(serviceList.Validations)
-	require.Equal(kiali.BOOKINFO, serviceList.Namespace.Name)
+	require.Equal(kiali.BOOKINFO, serviceList.Services[0].Namespace)
 
 	// Cleanup
 	deleteSe := utils.DeleteFile("../assets/bookinfo-service-entry-external.yaml", "bookinfo")

--- a/tests/integration/tests/services_test.go
+++ b/tests/integration/tests/services_test.go
@@ -27,6 +27,7 @@ func TestServicesList(t *testing.T) {
 		if service.Name == "productpage" {
 			require.True(service.IstioSidecar)
 			require.True(service.AppLabel)
+			require.Equal(kiali.BOOKINFO, service.Namespace)
 			require.NotNil(service.Health)
 			require.NotNil(service.Health.Requests)
 			require.NotNil(service.Health.Requests.Outbound)
@@ -34,7 +35,6 @@ func TestServicesList(t *testing.T) {
 		}
 	}
 	require.NotNil(serviceList.Validations)
-	require.Equal(kiali.BOOKINFO, serviceList.Namespace.Name)
 }
 
 func TestServiceDetails(t *testing.T) {

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -273,9 +273,8 @@ func ApplicationDetails(name, namespace string) (*models.App, int, error) {
 }
 
 func ServicesList(namespace string) (*ServiceListJson, error) {
-	url := fmt.Sprintf("%s/api/namespaces/%s/services", client.kialiURL, namespace)
+	url := fmt.Sprintf("%s/api/clusters/services?namespaces=%s", client.kialiURL, namespace)
 	serviceList := new(ServiceListJson)
-
 	_, err := getRequestAndUnmarshalInto(url, serviceList)
 	if err == nil {
 		return serviceList, nil


### PR DESCRIPTION
### Describe the change

In Service list page, there was sending a REST API request to retrieve services per namespace, which was causing to filter per cluster which contains the provided namespace.
Now Optimized to send Service list request to REST API per cluster with providing selected namespaces list.

### Steps to test the PR

Create a set of namespaces:
`for i in {1..200}; do kubectl create ns test-$i; done`
Open the Service list page and select all services.
Compare the loading time between before and now.
Check if Health and Configuration fields are loading correctly: There was a bug here which was mirroring one cluster's Configuration to another one when two Services with same name/namespace.

### Automation testing

Added unit tests. Added integration tests.

### Issue reference
https://github.com/kiali/kiali/issues/4832