### PR TITLE
[hack] support unique domain names for CRC clusters to enable multiple clusters on the same network

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -16,6 +16,7 @@
 #     services: outputs all known service endpoints (excluding internal openshift services)
 #       expose: creates firewalld rules so remote clients can access the cluster
 #     unexpose: removes firewalld rules so remote clients cannot access the cluster
+# changedomain: change the cluster to use an nip.io domain rather than "crc.testing".
 #
 # This script accepts several options - see --help for details.
 #
@@ -680,7 +681,7 @@ The command must be one of:
   * sshoc: Provides a command line prompt with root access inside the CRC VM. Logs in via oc debug.
   * routes: Outputs URLs for all known routes.
   * services: Outputs URLs for all known service endpoints (excluding internal openshift services).
-  * expose: Creates firewalld rules so remote clients can access the cluster.
+  * expose: Creates firewalld rules so remote clients can access the cluster. Do not use in conjunction with changedomain.
   * unexpose: Removes firewalld rules so remote clients cannot access the cluster.
   * changedomain: Changes the CRC cluster base domain name from 'crc.testing' to a unique 'nip.io' name.
 

--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -157,7 +157,7 @@ get_status() {
     fi
     echo "====================================================================="
     echo "kubeadmin password: $(cat ${CRC_KUBEADMIN_PASSWORD_FILE})"
-    echo "$(${CRC_COMMAND} console --credentials)"
+    echo "$(${CRC_COMMAND} console --credentials | sed 's/crc.testing/'${OPENSHIFT_BASE_DOMAIN_NAME}'/')"
     echo "====================================================================="
     echo "To push images to the image repo you need to log in."
     echo "You can use docker or podman, and you can use kubeadmin or kiali user."

--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -161,10 +161,10 @@ get_status() {
     echo "====================================================================="
     echo "To push images to the image repo you need to log in."
     echo "You can use docker or podman, and you can use kubeadmin or kiali user."
-    echo "  oc login -u kubeadmin -p $(cat ${CRC_KUBEADMIN_PASSWORD_FILE}) ${OPENSHIFT_API_SERVER_URL:-<api url>}"
+    echo "  oc login -u kubeadmin -p $(cat ${CRC_KUBEADMIN_PASSWORD_FILE}) --server ${OPENSHIFT_API_SERVER_URL:-<api url>}"
     echo '  docker login -u kubeadmin -p $(oc whoami -t)' ${EXTERNAL_IMAGE_REGISTRY:-<image registry>}
     echo "or"
-    echo "  oc login -u kiali -p kiali ${OPENSHIFT_API_SERVER_URL:-<api url>}"
+    echo "  oc login -u kiali -p kiali --server ${OPENSHIFT_API_SERVER_URL:-<api url>}"
     echo '  podman login --tls-verify=false -u kiali -p $(oc whoami -t)' ${EXTERNAL_IMAGE_REGISTRY:-<image registry>}
     echo "====================================================================="
   else
@@ -323,7 +323,7 @@ wait_for_cluster_operators() {
   while true; do
 
     infomsg "Waiting for the cluster operators to be ready..."
-    sleep 5
+    sleep 10
 
     local co_status
     co_status=$(${CRC_OC} get clusteroperators --no-headers 2> /dev/null)
@@ -488,7 +488,10 @@ EOF
 
   infomsg "The API server URL has changed. Logging out of the obsolete session"
   ${CRC_OC} logout
-  infomsg "Log back into the cluster via: oc login -u <username> -p <password> https://api.${BASE_DOMAIN}:6443"
+  infomsg "Using the CRC oc client to login as kubeadmin"
+  ${CRC_OC} login -u kubeadmin -p $(cat ${CRC_KUBEADMIN_PASSWORD_FILE}) --server https://api.${BASE_DOMAIN}:6443
+
+  infomsg "Log back into the cluster via: oc login -u <username> -p <password> --server https://api.${BASE_DOMAIN}:6443"
 }
 
 # Change to the directory where this script is and set our environment


### PR DESCRIPTION
_tl;dr This allows you to use CRC to run multiple OpenShift clusters on a local network. Very useful for multi-cluster work._

This is a very useful enhancement to the CRC hack script.

We already had a command "expose" and "unexpose" which exposes the CRC cluster to remote machines on the local network. This allows you to access the OpenShift cluster via a browser or an oc/kubectl client running anywhere on the network (not just from the same box where CRC is running). This uses firewall rules.

However, the problem is you can only have one CRC cluster on your network because CRC fixes the domain name to "crc.testing". So if I want to start two CRC clusters, one on machine "foo" and one on machine "bar" they both bind to "crc.testing" and therefore only one can be exposed to remote machines on the network.

This PR introduces a new command "changedomain" which changes the domain of a running CRC cluster from the default `crc.testing` to an nip.io hostname unique to the IP address of the host machine (so, for example, `192.168.1.10.nip.io`). This command will also configure HAProxy so remote machines can access the CRC cluster using that new domain name.

If you have the firewalld service already running, this new command will add some firewall rules to open up the ports necessary to access the CRC cluster (technically, it just runs the "expose" command for you at the end).

==

To test:

1. Start CRC normally: `hack/crc-openshift.sh start`
2. Change the domain: `hack/crc-openshift.sh changedomain`
3. Get the IP address of your host machine (e.g. `IP_ADDR=$(hostname -I | awk '{print $1}')`).
4. Log into the OpenShift server using the new domain: `oc login -u kiali -p kiali https://api.${IP_ADDR}.nip.io:6443`
5. Confirm the server you connected to is using that nip.io domain: `oc whoami --show-server`
6. Confirm you can access the cluster: `oc get ns`
7. Now go to another machine on your local network and run that same login command from step 4. Run steps 5 and 6 to confirm it all works.