### PR TITLE
Script for perf tests run and test data creation

### DIFF
--- a/frontend/cypress/fixtures/perf/baselines.json
+++ b/frontend/cypress/fixtures/perf/baselines.json
@@ -11,7 +11,5 @@
   "configListAdd": "2",
   "configListSelected": "2",
   "configDetails": "1",
-  "overview10": "2",
-  "overview50": "2",
-  "overview300": "2"
+  "overview": "2"
 }

--- a/frontend/cypress/fixtures/perf/commonParams.json
+++ b/frontend/cypress/fixtures/perf/commonParams.json
@@ -1,6 +1,6 @@
 {
   "namespaces": "bookinfo,alpha,beta,gamma,sleep",
-  "allNamespaces": "bookinfo,alpha,beta,gamma,sleep,perf-testing-1,perf-testing-2,perf-test-1,perf-test-2,perf-test-1,perf-test-2,perf-test-3,perf-test-4,perf-test-5,perf-test-6,perf-test-7,perf-test-8,perf-test-9,perf-test-10",
+  "allNamespaces": "bookinfo,alpha,beta,gamma,sleep",
   "detailsNs": "bookinfo",
   "workloadName": "productpage-v1",
   "serviceName": "productpage",

--- a/frontend/cypress/fixtures/perf/commonParams.json
+++ b/frontend/cypress/fixtures/perf/commonParams.json
@@ -1,6 +1,6 @@
 {
-  "namespaces": "bookinfo",
-  "allNamespaces": "bookinfo,alpha,beta,gamma,sleep",
+  "namespaces": "bookinfo,alpha,beta,gamma,sleep",
+  "allNamespaces": "bookinfo,alpha,beta,gamma,sleep,perf-testing-1,perf-testing-2,perf-test-1,perf-test-2,perf-test-1,perf-test-2,perf-test-3,perf-test-4,perf-test-5,perf-test-6,perf-test-7,perf-test-8,perf-test-9,perf-test-10",
   "detailsNs": "bookinfo",
   "workloadName": "productpage-v1",
   "serviceName": "productpage",

--- a/frontend/cypress/perf/overviewload.spec.ts
+++ b/frontend/cypress/perf/overviewload.spec.ts
@@ -1,97 +1,54 @@
-import overviewCases from '../fixtures/perf/overviewPage.json';
 import { baselines, compareToBaseline, reportFilePath, visits } from './common';
-
-const createNamespaces = (count: number): void => {
-  cy.log(`Creating ${count} namespaces...`);
-
-  for (let i = 1; i <= count; i++) {
-    const namespaceTemplate = `apiVersion: v1
-kind: Namespace
-metadata:
-  name: perf-testing-${i}
-  labels:
-    kiali.io: perf-testing
-`;
-
-    cy.exec(`printf "${namespaceTemplate}" | kubectl apply -f -`);
-  }
-};
-
-const deleteNamespaces = (): void => {
-  cy.log('Deleting namespaces...');
-
-  // This can take a while to delete. Waiting for 10 mins max.
-  cy.exec('kubectl delete --ignore-not-found=true -l kiali.io=perf-testing ns', { timeout: 600000 });
-};
-
-type OverviewCase = {
-  namespaces: number;
-};
 
 describe('Overview performance tests', () => {
   beforeEach(() => {
     cy.login(Cypress.env('USERNAME'), Cypress.env('PASSWD'));
   });
 
-  // Testing empty namespaces to understand the impact of adding namespaces alone.
-  describe('Overview page with empty namespaces', () => {
+  // Test namespaces should be created before running the perf tests
+  describe('Overview page with namespaces', () => {
     before(() => {
       cy.writeFile(reportFilePath, '\n[Overview page]\n\n', { flag: 'a+' });
     });
 
-    (overviewCases as OverviewCase[]).forEach(testCase => {
-      describe(`Test with ${testCase.namespaces} empty namespaces`, () => {
-        before(() => {
-          createNamespaces(testCase.namespaces);
-        });
+    it('loads the overview page', () => {
+      // Getting an average to smooth out the results.
+      let sum = 0;
 
-        after(() => {
-          deleteNamespaces();
-        });
+      const visitsList = Array.from({ length: visits });
 
-        it('loads the overview page', () => {
-          // Getting an average to smooth out the results.
-          let sum = 0;
+      cy.wrap(visitsList)
+        .each(() => {
+          // Disabling refresh so that we can see how long it takes to load the page without additional requests
+          // being made due to the refresh.
+          cy.visit('/console/overview?refresh=0', {
+            onBeforeLoad(win) {
+              win.performance.mark('start');
+            }
+          })
+            .its('performance')
+            .then(performance => {
+              cy.get('.pf-v5-l-grid').should('be.visible');
 
-          const visitsList = Array.from({ length: visits });
+              cy.get('#loading_kiali_spinner', { timeout: 300000 })
+                .should('not.exist')
+                .then(() => {
+                  performance.mark('end');
+                  performance.measure('initPageLoad', 'start', 'end');
 
-          cy.wrap(visitsList)
-            .each(() => {
-              // Disabling refresh so that we can see how long it takes to load the page without additional requests
-              // being made due to the refresh.
-              cy.visit('/console/overview?refresh=0', {
-                onBeforeLoad(win) {
-                  win.performance.mark('start');
-                }
-              })
-                .its('performance')
-                .then(performance => {
-                  cy.get('.pf-v5-l-grid').should('be.visible');
+                  const measure = performance.getEntriesByName('initPageLoad')[0];
+                  const duration = measure.duration;
 
-                  cy.get('#loading_kiali_spinner', { timeout: 300000 })
-                    .should('not.exist')
-                    .then(() => {
-                      performance.mark('end');
-                      performance.measure('initPageLoad', 'start', 'end');
-
-                      const measure = performance.getEntriesByName('initPageLoad')[0];
-                      const duration = measure.duration;
-
-                      sum += duration;
-                    });
+                  sum += duration;
                 });
-            })
-            .then(() => {
-              sum = sum / visitsList.length;
-
-              const contents = `Namespaces: ${testCase.namespaces}\nInit page load time: ${compareToBaseline(
-                sum,
-                Cypress.env(baselines)[`overview${testCase.namespaces}`]
-              )}\n`;
-              cy.writeFile(reportFilePath, contents, { flag: 'a+' });
             });
+        })
+        .then(() => {
+          sum = sum / visitsList.length;
+
+          const contents = `Init page load time: ${compareToBaseline(sum, Cypress.env(baselines)[`overview`])}\n`;
+          cy.writeFile(reportFilePath, contents, { flag: 'a+' });
         });
-      });
     });
   });
 });

--- a/hack/run-performance-tests.sh
+++ b/hack/run-performance-tests.sh
@@ -114,12 +114,13 @@ deleteData() {
   for ((i = 1; i <= $TEST_DATA; i++)); do
     kubectl delete --ignore-not-found=true -l kiali.io=perf-test ns
   done
+  jq '.allNamespaces = .namespaces' "$COMMON_PARAMS" > "$COMMON_PARAMS.tmp" && mv "$COMMON_PARAMS.tmp" "$COMMON_PARAMS"
 }
 
 ensureCypressInstalled
 
 if [ "${TESTS_ONLY}" != "true" ]; then
-infomsg "Install test data"
+  infomsg "Install test data"
   createData
 fi
 
@@ -136,6 +137,9 @@ infomsg "Running cypress performance tests"
 echo "[Running cypress performance tests for $TEST_DATA namespaces]" > $OUTPUT_FILE
 yarn cypress:run:perf
 
-infomsg "Remove test data"
-deleteData
+if [ "${TESTS_ONLY}" != "true" ]; then
+  infomsg "Remove test data"
+  deleteData
+fi
+
 

--- a/hack/run-performance-tests.sh
+++ b/hack/run-performance-tests.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+infomsg() {
+  echo "[INFO] ${1}"
+}
+
+SETUP_ONLY="false"
+TESTS_ONLY="false"
+TEST_DATA="5"
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -so|--setup-only)
+      SETUP_ONLY="${2}"
+      if [ "${SETUP_ONLY}" != "true" -a "${SETUP_ONLY}" != "false" ]; then
+        echo "--setup-only option must be one of 'true' or 'false'"
+        exit 1
+      fi
+      shift;shift
+      ;;
+    -to|--tests-only)
+      TESTS_ONLY="${2}"
+      if [ "${TESTS_ONLY}" != "true" -a "${TESTS_ONLY}" != "false" ]; then
+        echo "--tests-only option must be one of 'true' or 'false'"
+        exit 1
+      fi
+      shift;shift
+      ;;
+    -td|--test-data)
+      TEST_DATA="${2}"
+      if [[ $2 -le 0 || $2 -ge 1000 ]]; then
+        echo "--test-data option must be is a valid number between 1 and 1000."
+        exit 1
+      fi
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -so|--setup-only <true|false>
+    If true, only setup the test environment and exit without running the tests.
+    Default: false
+  -to|--tests-only <true|false>
+    If true, only run the tests and skip the setup.
+    Default: false
+  -td|--test-data <number>
+    Number of test namespaces created before performance run.
+    Default: "5"
+  -h|--help:
+    This message
+
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "ERROR: Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${SETUP_ONLY}" == "true" -a "${TESTS_ONLY}" == "true" ]; then
+  echo "ERROR: --setup-only and --tests-only cannot both be true. Aborting."
+  exit 1
+fi
+
+
+# print out our settings for debug purposes
+cat <<EOM
+=== SETTINGS ===
+SETUP_ONLY=$SETUP_ONLY
+TESTS_ONLY=$TESTS_ONLY
+TEST_DATA=$TEST_DATA
+=== SETTINGS ===
+EOM
+
+set -e
+
+# Determine where this script is and make it the cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+COMMON_PARAMS="${SCRIPT_DIR}/../frontend/cypress/fixtures/perf/commonParams.json"
+OUTPUT_FILE=${SCRIPT_DIR}/../frontend/cypress/results/performance.txt
+
+ensureCypressInstalled() {
+  cd "${SCRIPT_DIR}"/../frontend
+  if ! yarn cypress --help &> /dev/null; then
+    echo "cypress binary was not detected in your PATH. Did you install the frontend directory? Before running the frontend tests you must run 'make build-ui'."
+    exit 1
+  fi
+  cd -
+}
+
+createData() {
+  ISTIO_INGRESS_IP="$(kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+  # Install demo apps
+  # "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
+  for ((i = 1; i <= $TEST_DATA; i++)); do
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perf-test-${i}
+  labels:
+    kiali.io: perf-test
+    istio-injection: enabled
+EOF
+  jq --arg i "$i" '.allNamespaces += ",perf-test-\($i)"' "$COMMON_PARAMS" > "$COMMON_PARAMS.tmp" && mv "$COMMON_PARAMS.tmp" "$COMMON_PARAMS"
+  done
+}
+
+deleteData() {
+  for ((i = 1; i <= $TEST_DATA; i++)); do
+    kubectl delete --ignore-not-found=true -l kiali.io=perf-test ns
+  done
+}
+
+ensureCypressInstalled
+
+if [ "${TESTS_ONLY}" != "true" ]; then
+infomsg "Install test data"
+  createData
+fi
+
+export CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
+# Recorded video is unusable due to low resources in CI: https://github.com/cypress-io/cypress/issues/4722
+export CYPRESS_VIDEO=false
+
+if [ "${SETUP_ONLY}" == "true" ]; then
+exit 0
+fi
+
+cd "${SCRIPT_DIR}"/../frontend
+infomsg "Running cypress performance tests"
+echo "[Running cypress performance tests for $TEST_DATA namespaces]" > $OUTPUT_FILE
+yarn cypress:run:perf
+
+infomsg "Remove test data"
+deleteData
+

--- a/hack/run-performance-tests.sh
+++ b/hack/run-performance-tests.sh
@@ -81,7 +81,8 @@ set -e
 # Determine where this script is and make it the cwd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 COMMON_PARAMS="${SCRIPT_DIR}/../frontend/cypress/fixtures/perf/commonParams.json"
-OUTPUT_FILE=${SCRIPT_DIR}/../frontend/cypress/results/performance.txt
+OUTPUT_DIR=${SCRIPT_DIR}/../frontend/cypress/results
+OUTPUT_FILE=${OUTPUT_DIR}/performance.txt
 
 ensureCypressInstalled() {
   cd "${SCRIPT_DIR}"/../frontend
@@ -95,7 +96,7 @@ ensureCypressInstalled() {
 createData() {
   ISTIO_INGRESS_IP="$(kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
   # Install demo apps
-  # "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
+  "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
   for ((i = 1; i <= $TEST_DATA; i++)); do
     cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -129,11 +130,12 @@ export CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
 export CYPRESS_VIDEO=false
 
 if [ "${SETUP_ONLY}" == "true" ]; then
-exit 0
+  exit 0
 fi
 
 cd "${SCRIPT_DIR}"/../frontend
 infomsg "Running cypress performance tests"
+mkdir "$OUTPUT_DIR"
 echo "[Running cypress performance tests for $TEST_DATA namespaces]" > $OUTPUT_FILE
 yarn cypress:run:perf
 


### PR DESCRIPTION
### Describe the change

Added a new hack script 'run-performance-tests.sh' which prepares the test data and executes Kiali performance tests.

To run Kiali cypress perf tests now can be done within a single script: `./hack/run-performance-tests.sh -td 10`
where '-td' parameter indicates how many empty 'perf-test-$i' namespaces should be created before testsuite run.

The 'make perf-tests-gui' and 'yarn cypress:perf' endpoints are remaining untouched.

### Issue reference
https://github.com/kiali/kiali/issues/7058
