### PR TITLE
Setup keycloak and openid auth in multi-primary CI pipeline

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -131,7 +131,11 @@ function ensureMulticlusterApplicationsAreHealthy(): void {
     'api/clusters/apps?namespaces=bookinfo&clusterName=west&health=true&istioResources=true&rateInterval=60s'
   ).then(resp => {
     const has_http_200 = resp.body.applications.some(
-      app => app.name === 'reviews' && app.cluster === 'west' && app.health.requests.inbound.http['200'] > 0
+      app =>
+        app.name === 'reviews' &&
+        app.cluster === 'west' &&
+        app.health.requests.inbound.http !== undefined &&
+        app.health.requests.inbound.http['200'] > 0
     );
     if (has_http_200) {
       cy.log("'reviews' app in 'west' cluster is healthy enough.");

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -68,7 +68,6 @@ ISTIO_TAG=""
 
 # Certs directory where you want the generates cert files to be written
 CERTS_DIR="/tmp/istio-multicluster-certs"
-KEYCLOAK_CERTS_DIR=${CERTS_DIR}/keycloak
 
 # The default Mesh and Network identifiers
 MESH_ID="mesh-hack"
@@ -130,7 +129,8 @@ MINIKUBE_CPU=""
 MINIKUBE_DISK=""
 MINIKUBE_MEMORY=""
 
-# Keycloak settings. Openshift only.
+# Keycloak settings.
+KEYCLOAK_ADDRESS=""
 KEYCLOAK_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD:-keycloak-password}"
 KEYCLOAK_KUBE_CLIENT_SECRET="${KEYCLOAK_KUBE_CLIENT_SECRET:-kube-client-secret}"
 KIALI_USER_PASSWORD="${KIALI_USER_PASSWORD:-kiali}"
@@ -195,6 +195,10 @@ while [[ $# -gt 0 ]]; do
       CLUSTER2_USER="$2"
       shift;shift
       ;;
+    -cd|--certs-dir)
+      CERTS_DIR="$2"
+      shift;shift
+      ;;
     -dorp|--docker-or-podman)
       [ "${2:-}" != "docker" -a "${2:-}" != "podman" ] && echo "-dorp must be 'docker' or 'podman'" && exit 1
       DORP="$2"
@@ -219,6 +223,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -it|--istio-tag)
       ISTIO_TAG="$2"
+      shift;shift
+      ;;
+    -ka|--keycloak-address)
+      KEYCLOAK_ADDRESS="$2"
       shift;shift
       ;;
     -kas|--kiali-auth-strategy)
@@ -337,6 +345,7 @@ Valid command line arguments:
   -c2n|--cluster2-name <name>: The name of cluster2 (Default: west)
   -c2p|--cluster2-password <name>: If cluster2 is OpenShift, this is the password used to log in (Default: kiali)
   -c2u|--cluster2-username <name>: If cluster2 is OpenShift, this is the username used to log in (Default: kiali)
+  -cd|--certs-dir <dir>: Directory where the keycloak certs are located. (Default: /tmp/istio-multicluster-certs)
   -dorp|--docker-or-podman <docker|podman>: What image registry client to use (Default: podman)
   -gr|--gateway-required <bool>: If a gateway is required to cross between networks, set this to true
   -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
@@ -360,6 +369,7 @@ Valid command line arguments:
   -k1ws|--kiali1-web-schema <schema>: If specified, this will be the #1 Kaili setting for spec.server.web_schema.
   -k2wf|--kiali2-web-fqdn <fqdn>: If specified, this will be the #2 Kaili setting for spec.server.web_fqdn.
   -k2ws|--kiali2-web-schema <schema>: If specified, this will be the #2 Kaili setting for spec.server.web_schema.
+  -ka|--keycloak-address <ip or host name>: Address of the keycloak idp.
   -kcs|--keycloak-client-secret <password>: Client secret for the openshift kube client in keycloak.
   -kdp|--keycloak-db-password <password>: Password for the keycloak database.
   -kup|--kiali-user-password <password>: Password for the kiali user in keycloak.
@@ -386,6 +396,8 @@ HELPMSG
       ;;
   esac
 done
+
+KEYCLOAK_CERTS_DIR=${CERTS_DIR}/keycloak
 
 if [ "${ISTIO_DIR}" == "" ]; then
   # Go to the main output directory and try to find an Istio there.
@@ -509,6 +521,7 @@ fi
 # Export all variables so child scripts pick them up
 export BOOKINFO_ENABLED \
        BOOKINFO_NAMESPACE \
+       CERTS_DIR \
        CLIENT_EXE_NAME \
        CLUSTER1_CONTEXT \
        CLUSTER1_NAME \
@@ -529,6 +542,7 @@ export BOOKINFO_ENABLED \
        KIALI_CREATE_REMOTE_CLUSTER_SECRETS \
        KIALI_ENABLED \
        KIALI_USE_DEV_IMAGE \
+       KEYCLOAK_CERTS_DIR \
        MANAGE_KIND \
        MANAGE_MINIKUBE \
        MANUAL_MESH_NETWORK_CONFIG \
@@ -545,6 +559,7 @@ cat <<EOM
 === SETTINGS ===
 BOOKINFO_ENABLED=$BOOKINFO_ENABLED
 BOOKINFO_NAMESPACE=$BOOKINFO_NAMESPACE
+CERTS_DIR=$CERTS_DIR
 CLIENT_EXE_NAME=$CLIENT_EXE_NAME
 CLUSTER1_CONTEXT=$CLUSTER1_CONTEXT
 CLUSTER1_NAME=$CLUSTER1_NAME
@@ -561,6 +576,7 @@ ISTIO_DIR=$ISTIO_DIR
 ISTIO_NAMESPACE=$ISTIO_NAMESPACE
 ISTIO_HUB=$ISTIO_HUB
 ISTIO_TAG=$ISTIO_TAG
+KEYCLOAK_CERTS_DIR=$KEYCLOAK_CERTS_DIR
 KIALI_AUTH_STRATEGY=$KIALI_AUTH_STRATEGY
 KIALI_CREATE_REMOTE_CLUSTER_SECRETS=$KIALI_CREATE_REMOTE_CLUSTER_SECRETS
 KIALI_ENABLED=$KIALI_ENABLED

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -141,11 +141,48 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
   fi
 
-  echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
-  "${SCRIPT_DIR}"/../../start-kind.sh --name "${CLUSTER1_NAME}" --load-balancer-range "255.70-255.84" --image "${KIND_NODE_IMAGE}"
+  if [ "${KIALI_AUTH_STRATEGY}" == "openid" ]; then
+    "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" create-ca
+  
+    # Given: 172.18.0.0/16 this should return 172.18
+    beginning_subnet_octets=$(docker network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}' | cut -d'.' -f1,2)
+    lb_range_start="255.70"
+    lb_range_end="255.84"
 
-  echo "==== START KIND FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
-  "${SCRIPT_DIR}"/../../start-kind.sh --name "${CLUSTER2_NAME}" --load-balancer-range "255.85-255.98" --image "${KIND_NODE_IMAGE}"
+    KEYCLOAK_ADDRESS="${beginning_subnet_octets}.${lb_range_start}"
+
+    echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+    "${SCRIPT_DIR}"/../../start-kind.sh \
+      --name "${CLUSTER1_NAME}" \
+      --load-balancer-range "${lb_range_start}-${lb_range_end}" \
+      --image "${KIND_NODE_IMAGE}" \
+      --enable-keycloak true \
+      --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}" \
+      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube
+
+    "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" -kip "${KEYCLOAK_ADDRESS}" deploy
+
+    echo "==== START KIND FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+    "${SCRIPT_DIR}"/../../start-kind.sh \
+      --name "${CLUSTER2_NAME}" \
+      --load-balancer-range "255.85-255.98" \
+      --image "${KIND_NODE_IMAGE}" \
+      --enable-keycloak true \
+      --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}" \
+      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube
+  else
+    echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
+    "${SCRIPT_DIR}"/../../start-kind.sh \
+      --name "${CLUSTER1_NAME}" \
+      --load-balancer-range "255.70-255.84" \
+      --image "${KIND_NODE_IMAGE}"
+
+    echo "==== START KIND FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
+    "${SCRIPT_DIR}"/../../start-kind.sh \
+      --name "${CLUSTER2_NAME}" \
+      --load-balancer-range "255.85-255.98" \
+      --image "${KIND_NODE_IMAGE}"
+  fi
 fi
 
 # Setup the certificates

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -143,7 +143,9 @@ if [ "${MANAGE_KIND}" == "true" ]; then
 
   if [ "${KIALI_AUTH_STRATEGY}" == "openid" ]; then
     "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" create-ca
-  
+
+    docker network create kind || true
+
     # Given: 172.18.0.0/16 this should return 172.18
     beginning_subnet_octets=$(docker network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}' | cut -d'.' -f1,2)
     lb_range_start="255.70"

--- a/hack/istio/multicluster/start-minikube.sh
+++ b/hack/istio/multicluster/start-minikube.sh
@@ -47,10 +47,7 @@ else
 fi
 
 # Generate root CA for keycloak/oidc.
-openssl genrsa -out "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem 2048
-
-openssl req -x509 -new -nodes -key "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem \
-  -days 3650 -sha256 -out "${KEYCLOAK_CERTS_DIR}"/root-ca.pem -subj "/CN=kube-ca"
+"${SCRIPT_DIR}"/../../keycloak.sh create-ca --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}"
 
 # First start a minikube cluster without kubernetes to both copy over the certs and get the IP
 echo "==== START MINIKUBE FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT} without kubernetes"

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# This script contains utilties for setting up keycloak in a kiali dev environment.
+
+set -e
+
+KEYCLOAK_CERTS_DIR=""
+KEYCLOAK_EXTERNAL_IP=""
+
+infomsg() {
+  echo "[INFO] ${1}"
+}
+
+_CMD=""
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    create-ca) _CMD="create-ca"; shift ;;
+    deploy) _CMD="deploy"; shift ;;
+    -kcd|--keycloak-certs-dir)    KEYCLOAK_CERTS_DIR="$2";    shift;shift; ;;
+    -kip|--keycloak-external-ip)    KEYCLOAK_EXTERNAL_IP="$2";    shift;shift; ;;
+    -h|--help)
+      cat <<HELPMSG
+
+$0 [option...] command
+
+Valid options:
+  -kcd|--keycloak-certs-dir
+      Directory where the keycloak certs will be stored.
+      Required for all commands.
+  -kip|--keycloak-external-ip
+      External IP address for the keycloak service.
+      Required for the 'deploy' command.
+
+The command must be one of:
+  create-ca:        create the root CA for keycloak.
+  deploy:           deploy keycloak.
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Fail if the keycloak certs dir is not set.
+if [ -z "${KEYCLOAK_CERTS_DIR}" ]; then
+  echo "KEYCLOAK_CERTS_DIR must be set. Aborting."
+  exit 1
+fi
+
+if [ "$_CMD" = "create-ca" ]; then
+  echo "Creating CA for keycloak. Files will be stored at '${KEYCLOAK_CERTS_DIR}'"
+
+  # Generate root CA for keycloak/oidc.
+  openssl genrsa -out "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem 2048
+
+  openssl req -x509 -new -nodes -key "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem \
+    -days 3650 -sha256 -out "${KEYCLOAK_CERTS_DIR}"/root-ca.pem -subj "/CN=kube-ca"
+elif [ "$_CMD" = "deploy" ]; then
+  echo "Deploying keycloak..."
+
+  # Check that either ip or hostname is set and abort if not
+  if [ -z "${KEYCLOAK_EXTERNAL_IP}" ]; then
+    echo "KEYCLOAK_EXTERNAL_IP must be set. Aborting."
+    exit 1
+  fi
+
+  KEYCLOAK_EXTERNAL_ADDRESS="${KEYCLOAK_EXTERNAL_IP}"
+  
+  # create the namespace first 
+  kubectl get ns keycloak || kubectl create ns keycloak
+
+  # TODO: IP vs. hostname
+
+  cat <<EOF > "${KEYCLOAK_CERTS_DIR}"/req.cnf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+IP.1 = ${KEYCLOAK_EXTERNAL_ADDRESS}
+EOF
+
+  # generate private key
+  openssl genrsa -out "${KEYCLOAK_CERTS_DIR}"/key.pem 2048
+
+  # create certificate signing request
+  openssl req -new -key "${KEYCLOAK_CERTS_DIR}"/key.pem -out "${KEYCLOAK_CERTS_DIR}"/csr.pem \
+    -subj "/CN=kube-ca" \
+    -addext "subjectAltName = IP:${KEYCLOAK_EXTERNAL_ADDRESS}" \
+    -sha256 -config "${KEYCLOAK_CERTS_DIR}"/req.cnf
+
+  # create certificate
+  openssl x509 -req -in "${KEYCLOAK_CERTS_DIR}"/csr.pem \
+    -CA "${KEYCLOAK_CERTS_DIR}"/root-ca.pem -CAkey "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem \
+    -CAcreateserial -sha256 -out "${KEYCLOAK_CERTS_DIR}"/cert.pem -days 3650 \
+    -extensions v3_req -extfile "${KEYCLOAK_CERTS_DIR}"/req.cnf
+  
+  # create kube secret from the certs
+  kubectl create secret tls keycloak-tls --cert="${KEYCLOAK_CERTS_DIR}"/cert.pem --key="${KEYCLOAK_CERTS_DIR}"/key.pem -n keycloak
+
+  echo "Creating keycloak deployment"
+  helm upgrade --install --wait --timeout 15m \
+  --namespace keycloak \
+  --repo https://charts.bitnami.com/bitnami keycloak keycloak \
+  --reuse-values --values - <<EOF
+auth:
+  createAdminUser: true
+  adminUser: admin
+  adminPassword: admin
+  managementUser: manager
+  managementPassword: manager
+image:
+  tag: 21.1.2-debian-11-r4
+proxyAddressForwarding: true
+postgresql:
+  enabled: true
+tls:
+  enabled: true
+  usePem: true
+  existingSecret: keycloak-tls
+service:
+  type: LoadBalancer
+EOF
+
+  echo "Keycloak deployed. Waiting for the keycloak ingress to be ready..."
+  kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' -n keycloak service/keycloak
+fi

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -318,8 +318,8 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_MULTI_PRIMARY}" ]; then
   fi
   
   ensureKialiServerReady
-  # We now need a kiali-aes-cookie to be able to talk to the API.
-  # ensureMulticlusterApplicationsAreHealthy
+  # We now need a kiali-aes-cookie to be able to talk to the API so checks for the applications
+  # being healthy have moved into the frontend tests where it's easier to get the cookie.
 
   export CYPRESS_BASE_URL="${KIALI_URL}"
   export CYPRESS_CLUSTER1_CONTEXT="kind-east"

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -301,6 +301,8 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_PRIMARY_REMOTE}" ]; then
   export CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
   # Recorded video is unusable due to low resources in CI: https://github.com/cypress-io/cypress/issues/4722
   export CYPRESS_VIDEO=false
+  export CYPRESS_USERNAME="kiali"
+  export CYPRESS_PASSWD="kiali"
 
   if [ "${SETUP_ONLY}" == "true" ]; then
     exit 0
@@ -312,17 +314,21 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_MULTI_PRIMARY}" ]; then
   ensureCypressInstalled
 
   if [ "${TESTS_ONLY}" == "false" ]; then
-    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "multi-primary" ${ISTIO_VERSION_ARG}
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "multi-primary" ${ISTIO_VERSION_ARG} --auth-strategy openid
   fi
   
   ensureKialiServerReady
-  ensureMulticlusterApplicationsAreHealthy
+  # We now need a kiali-aes-cookie to be able to talk to the API.
+  # ensureMulticlusterApplicationsAreHealthy
 
   export CYPRESS_BASE_URL="${KIALI_URL}"
   export CYPRESS_CLUSTER1_CONTEXT="kind-east"
   export CYPRESS_CLUSTER2_CONTEXT="kind-west"
   export CYPRESS_NUM_TESTS_KEPT_IN_MEMORY=0
   export CYPRESS_VIDEO=false
+  export CYPRESS_AUTH_PROVIDER="keycloak"
+  export CYPRESS_USERNAME="kiali"
+  export CYPRESS_PASSWD="kiali"
 
   if [ "${SETUP_ONLY}" == "true" ]; then
     exit 0


### PR DESCRIPTION
### Describe the change

Adds keycloak and deploys kiali with `openid` auth in the CI pipeline so that multi-cluster access tests can be performed.

### Steps to test the PR

1. Setup environment
   ```hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true```
2. Visit kiali url and login to keycloak with `kiali:kiali`

### Automation testing

If current automation passes then all is well.

### Issue reference

Fixes #7021 
