### PR TITLE
Adjust flex css value in overview page for OSSMC

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -83,7 +83,8 @@ import { IstioConfigList } from 'types/IstioConfigList';
 const gridStyleCompact = kialiStyle({
   backgroundColor: PFColors.BackgroundColor200,
   paddingBottom: '1.25rem',
-  marginTop: 0
+  marginTop: 0,
+  flex: '1'
 });
 
 const gridStyleList = kialiStyle({
@@ -91,7 +92,8 @@ const gridStyleList = kialiStyle({
   // The VirtualTable component has a different style than cards
   // We need to adjust the grid style if we are on compact vs list view
   padding: '0 !important',
-  marginTop: 0
+  marginTop: 0,
+  flex: '1'
 });
 
 const cardGridStyle = kialiStyle({


### PR DESCRIPTION
### Describe the change

This PR adds the `flex` CSS value to the overview page, ensuring that the background color in the OSSMC overview page expands to cover the entire height.

Before:

![image](https://github.com/kiali/kiali/assets/122779323/32918615-60c7-4de1-809f-8bb5cd3ead1d)

Now:

![image](https://github.com/kiali/kiali/assets/122779323/aca94513-4fb6-40ce-81f7-282b887f1d91)

This change is already in v1.73 branch, but it is not present in `master` branch:
https://github.com/kiali/kiali/blob/823746f51ab53e2aee2194172eda560a7a6fa32b/frontend/src/pages/Overview/OverviewPage.tsx#L85

### Steps to test the PR

This change does not affect Kiali.

### Automation testing

N/A
