### PR TITLE
[hack] for extension metrics R&D

### DIFF
--- a/hack/istio/skupper/demo-emit-metrics-deployment/Dockerfile
+++ b/hack/istio/skupper/demo-emit-metrics-deployment/Dockerfile
@@ -1,0 +1,9 @@
+# To build:  podman build -t demo-extension-metrics-server:latest .
+# To run:    podman run -it --rm -p 9090:9090 demo-extension-metrics-server:latest
+# To access: curl http://localhost:9090
+
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN yum install -y nc
+COPY emit-metrics.sh /metrics-server/
+RUN chmod +x /metrics-server/emit-metrics.sh
+CMD ["/metrics-server/emit-metrics.sh"]

--- a/hack/istio/skupper/demo-emit-metrics-deployment/Makefile
+++ b/hack/istio/skupper/demo-emit-metrics-deployment/Makefile
@@ -1,0 +1,34 @@
+DORP = podman
+IMAGE_NAME = demo-extension-metrics-server:latest
+QUAY_IMAGE_NAME = quay.io/kiali/${IMAGE_NAME}
+DEMO_NAMESPACE ?= extension-metrics-demo
+
+build:
+	${DORP} build -t ${QUAY_IMAGE_NAME} .
+
+# This will allow you to run the script locally. This is just to test that the script works and so you can
+# confirm the metrics defined in the ConfigMap yaml are what you want them to be. Just access the endpoint
+# via curl http://localhost:9090 and look at the metrics that are returned.
+run:
+	@echo "Extracing metrics.txt from ConfigMap from k8s.yaml and storing to /tmp/metrics.txt"
+	@cat ./k8s.yaml | sed -n '/^  metrics.txt: |/,$$p' | sed -e 's/^  metrics.txt: |//' -e 's/^  //' | sed '/^$$/d' | sed 's/^[[:space:]]*//' > /tmp/metrics.txt
+	@echo "Starting metric server. To access, run 'curl http://localhost:9090'"
+	${DORP} run -it --rm -p 9090:9090 -v /tmp/metrics.txt:/tmp/metrics.txt ${QUAY_IMAGE_NAME}
+
+# Builds and pushes a new image to quay. You only need to do this if you change the script itself or the Dockerfile.
+# You do not need to build or push the image if you are only changing the Deployment yaml or the metrics in the ConfigMap yaml.
+push-quay: build
+	${DORP} push ${QUAY_IMAGE_NAME}
+
+# Deploy the demo app to any namespace you choose. The namespace is defined in the env var DEMO_NAMESPACE.
+deploy:
+	kubectl get namespace ${DEMO_NAMESPACE} &> /dev/null || kubectl create namespace ${DEMO_NAMESPACE}
+	kubectl apply -f ./k8s.yaml -n ${DEMO_NAMESPACE}
+
+# Undeploy the demo app. The namespace where the app is expected to be is defined in the env var DEMO_NAMESPACE.
+undeploy:
+	kubectl delete --ignore-not-found=true -f ./k8s.yaml -n ${DEMO_NAMESPACE}
+
+# After changing the k8s.yaml (e.g. the metrics in the ConfigMap), this will redeploy everything and restart the pod.
+redeploy: deploy
+	kubectl rollout restart deployment -n ${DEMO_NAMESPACE}

--- a/hack/istio/skupper/demo-emit-metrics-deployment/emit-metrics.sh
+++ b/hack/istio/skupper/demo-emit-metrics-deployment/emit-metrics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+METRICS_PORT="${METRICS_PORT:-9090}"
+METRICS_FILE="${METRICS_FILE:-/tmp/metrics.txt}"
+
+if [ ! -f "${METRICS_FILE}" ]; then
+  echo "ERROR: Missing metrics file: ${METRICS_FILE}"
+  exit 1
+fi
+
+# read in the metrics file and escape double quotes so they are retained in the output
+METRICS="$(cat ${METRICS_FILE} | sed 's/"/\\"/g')"
+
+echo "Metrics server will listen on port [${METRICS_PORT}]"
+
+while true; do
+  METRICS_RESPONSE=$(eval "echo -e \"${METRICS}\"")
+  echo -e "HTTP/1.1 200 OK\nContent-Type: text/plain\n\n${METRICS_RESPONSE}" | nc -l -p ${METRICS_PORT}
+done

--- a/hack/istio/skupper/demo-emit-metrics-deployment/k8s.yaml
+++ b/hack/istio/skupper/demo-emit-metrics-deployment/k8s.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-extension-metrics-server
+  labels:
+    app: demo-extension-metrics-server
+    app.kubernetes.io/name: demo-extension-metrics-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-extension-metrics-server
+  template:
+    metadata:
+      labels:
+        app: demo-extension-metrics-server
+        app.kubernetes.io/name: demo-extension-metrics-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9090"
+    spec:
+      containers:
+      - name: demo-extension-metrics-server
+        image: quay.io/kiali/demo-extension-metrics-server:latest
+        ports:
+        - containerPort: 9090
+        env:
+        - name: METRICS_PORT
+          value: "9090"
+        - name: METRICS_FILE
+          value: "/tmp/metrics.txt"
+        volumeMounts:
+        - name: metrics-volume
+          mountPath: /tmp/metrics.txt
+          subPath: metrics.txt
+      volumes:
+      - name: metrics-volume
+        configMap:
+          name: metrics-configmap
+      serviceAccountName: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-extension-metrics-service
+  labels:
+    app: demo-extension-metrics-server
+    app.kubernetes.io/name: demo-extension-metrics-server
+spec:
+  selector:
+    app: demo-extension-metrics-server
+  ports:
+  - protocol: TCP
+    port: 9090
+    targetPort: 9090
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-configmap
+data:
+  metrics.txt: |
+    # HELP metric1 Help text for metric
+    # TYPE metric1 gauge
+    metric1{label1="foo",label2="bar"} $(shuf -i 5-10 -n 1)
+    # HELP metric2 Help text for metric
+    # TYPE metric2 counter
+    metric2{label1="foo",label2="bar",label3="splat"} $(shuf -i 1-100 -n 1)
+    # HELP metric3 Help text for metric
+    # TYPE metric3 counter
+    metric3{label1="foo",label2="bar",label3="splat",label4="wotgorilla"} $(shuf -i 50-150 -n 1)


### PR DESCRIPTION
This is a small demo app (docker container and some k8s resources) that will be useful when doing the extensions metrics work in Kiali graph generator/appenders.

The Makefile provides some basically commands for dev workflow. The idea is we can define a series of metrics timeseries and labels, see how Kiali graphs them. Then we can change the metrics with different names or labels and see how well Kiali graphs those. In other words, this allows us to do quick dev cycles as we try to determine what good extension metrics would look like.

This is going to be useful for the skupper integration work.

Dev cycle would look like this:

1. Edit `k8s.yaml`, specifically the metric definitions in the ConfigMap.
2. Run `make deploy` to get the simple app installed. Prometheus will immediately scrape the endpoints. We can put this in or out of the mesh depending on what we are testing.
3. Look at the metrics within Prometheus UI or the graph within Kiali UI.
4. Make adjustments to the Kiali code.
5. Make adjustments to the metrics in the k8s.yaml ConfigMap
6. Redeploy the simple demo app via `make redeploy` so it picks up the new metrics and starts emitting them to Prometheus.
7. Rinse, repeat.