### PR TITLE
New KIA0107 for ServiceAccounts on remote cluster

### DIFF
--- a/business/checkers/authorization/principals_checker.go
+++ b/business/checkers/authorization/principals_checker.go
@@ -12,8 +12,9 @@ import (
 )
 
 type PrincipalsChecker struct {
+	Cluster             string
 	AuthorizationPolicy *security_v1beta.AuthorizationPolicy
-	ServiceAccounts     []string
+	ServiceAccounts     map[string][]string
 }
 
 const (
@@ -56,11 +57,17 @@ func (pc PrincipalsChecker) validateFromField(ruleIdx int, from []*api_security_
 		}
 
 		for i, p := range f.Source.Principals {
-			if !pc.hasMatchingServiceAccount(p) {
-				valid = false
+			if !pc.hasMatchingServiceAccount(pc.ServiceAccounts[pc.Cluster], p) {
 				path := fmt.Sprintf("spec/rules[%d]/from[%d]/source/principals[%d]", ruleIdx, fromIdx, i)
-				validation := models.Build("authorizationpolicy.source.principalnotfound", path)
-				checks = append(checks, &validation)
+				if pc.hasMatchingRemoteServiceAccount(p) {
+					valid = true
+					validation := models.Build("authorizationpolicy.source.principalremote", path)
+					checks = append(checks, &validation)
+				} else {
+					valid = false
+					validation := models.Build("authorizationpolicy.source.principalnotfound", path)
+					checks = append(checks, &validation)
+				}
 			}
 		}
 	}
@@ -68,11 +75,12 @@ func (pc PrincipalsChecker) validateFromField(ruleIdx int, from []*api_security_
 	return checks, valid
 }
 
-func (pc PrincipalsChecker) hasMatchingServiceAccount(principal string) bool {
+func (pc PrincipalsChecker) hasMatchingServiceAccount(serviceAccounts []string, principal string) bool {
 	if principal == wildCardMatch {
 		return true
 	}
-	for _, sa := range pc.ServiceAccounts {
+
+	for _, sa := range serviceAccounts {
 		if (strings.HasPrefix(principal, wildCardMatch) || strings.HasSuffix(principal, wildCardMatch)) && regexpFromPrincipal(principal).MatchString(sa) {
 			// Prefix match: “abc*” will match on value “abc” and “abcd”.
 			// Suffix match: “*abc” will match on value “abc” and “xabc”.
@@ -82,6 +90,16 @@ func (pc PrincipalsChecker) hasMatchingServiceAccount(principal string) bool {
 		}
 	}
 
+	return false
+}
+
+func (pc PrincipalsChecker) hasMatchingRemoteServiceAccount(principal string) bool {
+	// should check among remote cluster's service accounts
+	for cluster, sas := range pc.ServiceAccounts {
+		if cluster != pc.Cluster && pc.hasMatchingServiceAccount(sas, principal) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/business/checkers/authorization/principals_checker.go
+++ b/business/checkers/authorization/principals_checker.go
@@ -12,8 +12,8 @@ import (
 )
 
 type PrincipalsChecker struct {
-	Cluster             string
 	AuthorizationPolicy *security_v1beta.AuthorizationPolicy
+	Cluster             string
 	ServiceAccounts     map[string][]string
 }
 
@@ -59,12 +59,11 @@ func (pc PrincipalsChecker) validateFromField(ruleIdx int, from []*api_security_
 		for i, p := range f.Source.Principals {
 			if !pc.hasMatchingServiceAccount(pc.ServiceAccounts[pc.Cluster], p) {
 				path := fmt.Sprintf("spec/rules[%d]/from[%d]/source/principals[%d]", ruleIdx, fromIdx, i)
+				valid = false
 				if pc.hasMatchingRemoteServiceAccount(p) {
-					valid = true
 					validation := models.Build("authorizationpolicy.source.principalremote", path)
 					checks = append(checks, &validation)
 				} else {
-					valid = false
 					validation := models.Build("authorizationpolicy.source.principalnotfound", path)
 					checks = append(checks, &validation)
 				}

--- a/business/checkers/authorization/principals_checker_test.go
+++ b/business/checkers/authorization/principals_checker_test.go
@@ -6,17 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
 )
 
 func TestPresentServiceAccount(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
 	assert := assert.New(t)
 
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}),
-		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+		Cluster:             config.DefaultClusterID,
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
 	// Well configured object
@@ -29,7 +34,8 @@ func TestRegexPrincipalFound(t *testing.T) {
 
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"*local/ns/bookinfo/sa/default*", "*.local/ns/bookinfo/sa/test*"}),
-		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"},
+		Cluster:             config.DefaultClusterID,
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"}},
 	}.Check()
 
 	// regex matches
@@ -42,7 +48,8 @@ func TestRegexPrincipalNotFound(t *testing.T) {
 
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"*wronglocal/ns/bookinfo/sa/default*", "*.local/ns/bookinfo/sa/test1*"}),
-		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"},
+		Cluster:             config.DefaultClusterID,
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"}},
 	}.Check()
 
 	assert.False(valid)
@@ -61,7 +68,8 @@ func TestEmptyPrincipals(t *testing.T) {
 
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{}),
-		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+		Cluster:             config.DefaultClusterID,
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
 	// Well configured object
@@ -74,7 +82,8 @@ func TestNotPresentServiceAccount(t *testing.T) {
 
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong", "test"}),
-		ServiceAccounts:     []string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"},
+		Cluster:             config.DefaultClusterID,
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
 	// Wrong host is not present
@@ -89,12 +98,30 @@ func TestNotPresentServiceAccount(t *testing.T) {
 	assert.Equal("spec/rules[0]/from[0]/source/principals[1]", vals[1].Path)
 }
 
+func TestRemoteClusterServiceAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}),
+		Cluster:             "east",
+		ServiceAccounts:     map[string][]string{"west": {"cluster.local/ns/bookinfo/sa/default"}, "east": {"cluster.local/ns/bookinfo/sa/test"}},
+	}.Check()
+
+	// service account is on remote cluster
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.Error(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.principalremote", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
+}
+
 func TestEmptyServiceAccount(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong"}),
-		ServiceAccounts:     []string{},
+		ServiceAccounts:     map[string][]string{},
 	}.Check()
 
 	// Wrong host is not present

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -152,6 +152,11 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Service Account not found for this principal",
 		Severity: ErrorSeverity,
 	},
+	"authorizationpolicy.source.principalremote": {
+		Code:     "KIA0107",
+		Message:  "Service Account for this principal is on remote cluster",
+		Severity: WarningSeverity,
+	},
 	"authorizationpolicy.to.wrongmethod": {
 		Code:     "KIA0102",
 		Message:  "Only HTTP methods and fully-qualified gRPC names are allowed",


### PR DESCRIPTION
### Describe the change
Actual for multicluster mode only. Kiali does not have validations for multicluster configs.
Currently, when ServiceAccount is created on a workload on remote cluster and the access is configured by spiffe: https://spiffe.io/docs/latest/try/getting-started-k8s/
Kiali is complaining on AuthPolicy that the ServiceAccount for the principal is not found. But in fact the SA exists.
Added a support of checking SA existence on remote clusters, and if exists, show warning message only on principals that "Service Account for this principal is on remote cluster"
![Screenshot from 2024-04-05 10-47-57](https://github.com/kiali/kiali/assets/604313/48b3a47a-2f6c-42cf-953e-a9ee0755a05a)

### Steps to test the PR

Create a multicluster environment.

On `east` cluster create a Deployment with 'serviceAccountName', like in a SPIRE described in steps here: https://istio.io/latest/docs/ops/integrations/spire/

On `west` cluster create  AuthPolicy which points to a ServiceAccount on `east` cluster:
```
apiVersion: security.istio.io/v1beta1
kind: AuthorizationPolicy
metadata:
  name: productpage-viewer
  namespace: bookinfo
spec:
  rules:
  - from:
    - source:
        principals:
        - cluster.local/ns/east/sa/default
  selector:
    matchLabels:
      app: productpage
```
The AuthorizationPolicy will show a Warning message instead of Error that the ServiceAccount is found on remote cluster.
When referring to a ServiceAccount which does not exit, the original Error message is still shown.

TBD An Epic to support SPIRE Integration to Istio in Kiali as well: https://github.com/kiali/kiali/issues/7261


### Automation testing

Unit tests added.

### Issue reference
https://github.com/kiali/kiali/issues/7152
