### PR TITLE
Flaky assertion fix

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -522,19 +522,19 @@ Then('the AuthorizationPolicy should have a {string}', function (healthStatus: s
 Then(
   'the {string} {string} of the {string} namespace should have a {string}',
   (crdInstanceName: string, crdName: string, namespace: string, healthStatus: string) => {
-      cy.request('GET', `${Cypress.config('baseUrl')}/api/istio/config?refresh=0`);
-      cy.get('[data-test="refresh-button"]').click();
-      ensureKialiFinishedLoading();
+    cy.request('GET', `${Cypress.config('baseUrl')}/api/istio/config?refresh=0`);
+    cy.get('[data-test="refresh-button"]').click();
+    ensureKialiFinishedLoading();
 
-      cy.get(`[data-test=VirtualItem_Ns${namespace}_${crdName.toLowerCase()}_${crdInstanceName}] span.pf-v5-c-icon`, {
-        timeout: 40000
-      })
-        .should('be.visible')
-        .hasCssVar('color', `--pf-v5-global--${healthStatus}-color--100`);
+    cy.get(`[data-test=VirtualItem_Ns${namespace}_${crdName.toLowerCase()}_${crdInstanceName}] span.pf-v5-c-icon`, {
+      timeout: 40000
+    })
+      .should('be.visible')
+      .hasCssVar('color', `--pf-v5-global--${healthStatus}-color--100`);
   }
 );
 
-After({ tags: '@istio-page and @crd-validation' }, () => {
+After({ tags: '@istio-config and @crd-validation' }, () => {
   cy.exec('kubectl delete PeerAuthentications,DestinationRules,AuthorizationPolicies,Sidecars --all --all-namespaces', {
     failOnNonZeroExit: false
   });

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -519,7 +519,7 @@ Then('the AuthorizationPolicy should have a {string}', function (healthStatus: s
   ).hasCssVar('color', `--pf-v5-global--${healthStatus}-color--100`);
 });
 
-function waitUntilConfigIsVisible(attempt: number, crdInstanceName: string, crdName: string, namespace: string):void {
+function waitUntilConfigIsVisible(attempt: number, crdInstanceName: string, crdName: string, namespace: string): void {
   if (attempt === 0) {
     return;
   }
@@ -560,9 +560,15 @@ After({ tags: '@istio-config and @crd-validation' }, () => {
     failOnNonZeroExit: false
   });
 
-  cy.exec('kubectl delete Gateways,VirtualServices foo foo-route bar -n bookinfo', { failOnNonZeroExit: false });
-  cy.exec('kubectl delete Gateways,VirtualServices foo foo-route bar -n sleep', { failOnNonZeroExit: false });
-  cy.exec('kubectl delete Gateways,VirtualServices foo foo-route bar -n istio-system', { failOnNonZeroExit: false });
+  cy.exec('kubectl delete gateways.networking.istio.io,Gateways,VirtualServices foo foo-route bar -n bookinfo', {
+    failOnNonZeroExit: false
+  });
+  cy.exec('kubectl delete gateways.networking.istio.io,Gateways,VirtualServices foo foo-route bar -n sleep', {
+    failOnNonZeroExit: false
+  });
+  cy.exec('kubectl delete gateways.networking.istio.io,Gateways,VirtualServices foo foo-route bar -n istio-system', {
+    failOnNonZeroExit: false
+  });
 });
 
 Then('user sees all the Istio Config toggles', () => {

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -529,7 +529,6 @@ function waitUntilConfigIsVisible(attempt: number, crdInstanceName: string, crdN
   let found = false;
   cy.get('tr')
     .each($row => {
-      console.log($row);
       const dataTestAttr = $row[0].attributes.getNamedItem('data-test');
       if (dataTestAttr !== null) {
         if (dataTestAttr.value === `VirtualItem_Ns${namespace}_${crdName.toLowerCase()}_${crdInstanceName}`) {

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -522,7 +522,6 @@ Then('the AuthorizationPolicy should have a {string}', function (healthStatus: s
 Then(
   'the {string} {string} of the {string} namespace should have a {string}',
   (crdInstanceName: string, crdName: string, namespace: string, healthStatus: string) => {
-    it('loading config list', { retries: 3 }, () => {
       cy.request('GET', `${Cypress.config('baseUrl')}/api/istio/config?refresh=0`);
       cy.get('[data-test="refresh-button"]').click();
       ensureKialiFinishedLoading();
@@ -532,7 +531,6 @@ Then(
       })
         .should('be.visible')
         .hasCssVar('color', `--pf-v5-global--${healthStatus}-color--100`);
-    });
   }
 );
 

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -281,6 +281,7 @@ Feature: Kiali Istio Config wizard
 
   @gateway-api
   @bookinfo-app
+  @selected
   Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference. Then delete one of them and the reference should be gone.
     When user deletes k8sgateway named "gatewayapi-1" and the resource is no longer available
     And user deletes k8sgateway named "gatewayapi-2" and the resource is no longer available
@@ -317,6 +318,7 @@ Feature: Kiali Istio Config wizard
     When user is at the "istio" page
     And viewing the detail for "gatewayapi-2"
     And choosing to delete it
+    And user selects the "bookinfo" namespace
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace
     And the "gatewayapi-1" "K8sGateway" of the "bookinfo" namespace should have a "success"
     When viewing the detail for "gatewayapi-1"

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -281,7 +281,6 @@ Feature: Kiali Istio Config wizard
 
   @gateway-api
   @bookinfo-app
-  @selected
   Scenario: Create multiple K8s Gateways with colliding hostnames and port combinations and check for a reference. Then delete one of them and the reference should be gone.
     When user deletes k8sgateway named "gatewayapi-1" and the resource is no longer available
     And user deletes k8sgateway named "gatewayapi-2" and the resource is no longer available


### PR DESCRIPTION
### Describe the change

Related to #7237.

I have not found a reliable way to reproduce the failure, but I have encountered it multiple times both on upstream OCP and Kind. Occasionally, the code inside the Mocha hook was not executed at all and the test passed even though it should detect a failure. This piece of code is tied to most of the CRD validation tests in Cypress.

### Steps to test the PR

Create a minimal Istio gateway in Kiali and insert this scenario in the `istio_config.feature` file:
```
  @bookinfo-app
  @selected
  Scenario: delete me later
    When user selects the "bookinfo" namespace
    Then the "foo" "Gateway" of the "bookinfo" namespace should have a "danger"
```
Run the `yarn cypress:selected` command and the test should fail.

When doing the same procedure against the master branch, there is a chance that the scenario will pass instead of failing.

### Issue reference
#7237 
