### PR TITLE
Fix sleep yaml for s390x

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -79,7 +79,7 @@ if [ "${DELETE_SLEEP}" == "true" ]; then
   echo "Deleting the 'sleep' app in the 'sleep' namespace..."
   # s390x specific images for curl in sleep.yaml (OSSM-6012)
   if [ "${ARCH}" == "s390x" ]; then
-    sed -i.bak "s;curlimages/curl;curlimages/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml 
+    sed -i.bak -E '/curlimages\/curl:8\.4\.0/! s;curlimages/curl;curlimages/curl:8.4.0;g' ${ISTIO_DIR}/samples/sleep/sleep.yaml 
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
   else
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
@@ -137,6 +137,10 @@ users:
 SCC
   fi
 
+  if [ "${ARCH}" == "s390x" ]; then
+    echo "Using s390x specific images for curl in sleep.yaml"
+    sed -i.bak -E '/curlimages\/curl:8\.4\.0/! s;curlimages/curl;curlimages/curl:8.4.0;g' ${ISTIO_DIR}/samples/sleep/sleep.yaml 
+  fi
   ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
 
   sleep 4


### PR DESCRIPTION
I added the sed command before applying the YAML and I also added a regex check to make sure the script can be run multiple times.

This needs to be backported to 1.73.