### PR TITLE
Fixed validations for details, load configs for all namespaces

### DIFF
--- a/business/checkers/virtualservices/no_gateway_checker_test.go
+++ b/business/checkers/virtualservices/no_gateway_checker_test.go
@@ -131,6 +131,26 @@ func TestFoundGateway(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestFoundRemoteGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	virtualService := data.AddGatewaysToVirtualService([]string{"remote/my-gateway", "mesh"}, data.CreateVirtualService())
+	gatewayNames := kubernetes.GatewayNames([]*networking_v1beta1.Gateway{
+		data.CreateEmptyGateway("my-gateway", "remote", make(map[string]string)),
+	})
+
+	checker := NoGatewayChecker{
+		VirtualService: virtualService,
+		GatewayNames:   gatewayNames,
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestFoundGatewayTwoPartNaming(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -8,6 +8,8 @@ import (
 	networking_v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security_v1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/business/references"
 	"github.com/kiali/kiali/config"
@@ -419,7 +421,7 @@ func (in *IstioValidationsService) fetchIstioConfigList(ctx context.Context, rVa
 		IncludeK8sGateways:            true,
 		IncludeK8sReferenceGrants:     true,
 	}
-	istioConfigMap, err := in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, namespace, criteria)
+	istioConfigMap, err := in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, meta_v1.NamespaceAll, criteria)
 	if err != nil {
 		errChan <- err
 		return

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -285,8 +285,8 @@ Feature: Kiali Istio Config page
   @bookinfo-app
   @sleep-app
   Scenario: VirtualService references to Gateway
-    Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
-    And there is a "foo" Gateway on "bookinfo" namespace for "productpage.local" hosts on HTTP port 80 with "app=productpage" labels selector
+    Given there is a "foo" Gateway on "bookinfo" namespace for "productpage.local" hosts on HTTP port 80 with "app=productpage" labels selector
+    And there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the VirtualService applies to "sleep" hosts
     And the VirtualService references "bookinfo/foo" gateways
     When user selects the "sleep" namespace

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -284,6 +284,17 @@ Feature: Kiali Istio Config page
   @crd-validation
   @bookinfo-app
   @sleep-app
+  Scenario: VirtualService references to Gateway
+    Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
+    And there is a "foo" Gateway on "bookinfo" namespace for "productpage.local" hosts on HTTP port 80 with "app=productpage" labels selector
+    And the VirtualService applies to "sleep" hosts
+    And the VirtualService references "bookinfo/foo" gateways
+    When user selects the "sleep" namespace
+    Then the "foo" "VirtualService" of the "sleep" namespace should have a "success"
+
+  @crd-validation
+  @bookinfo-app
+  @sleep-app
   Scenario: KIA1104 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the route of the VirtualService has weight 10


### PR DESCRIPTION
### Describe the change

There was a regression in Istio config details validations that only local namespace objects are loaded, now it loads config objects for all namespaces.

### Steps to test the PR

1. Create a gateway
2. Create a virtual service in a different namespace and map it that gateway

### Automation testing

Added unit and cypress tests.

### Issue reference
https://github.com/kiali/kiali/issues/7287
