### PR TITLE
Don't use kiali login headers with api proxy (OSSMC)

### DIFF
--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -104,10 +104,13 @@ const loginHeaders = config.login.headers;
 /**  Helpers to Requests */
 
 const getHeaders = (urlEncoded?: boolean): Partial<AxiosHeaders> => {
-  if (apiProxy || urlEncoded) {
+  if (apiProxy) {
+    return { 'Content-Type': 'application/x-www-form-urlencoded' };
+  } else if (urlEncoded) {
     return { 'Content-Type': 'application/x-www-form-urlencoded', ...loginHeaders };
+  } else {
+    return { 'Content-Type': 'application/json', ...loginHeaders };
   }
-  return { 'Content-Type': 'application/json', ...loginHeaders };
 };
 
 const basicAuth = (username: UserName, password: Password): BasicAuth => {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -86,9 +86,9 @@ interface Namespaces {
 type QueryParams<T> = T & ClusterParam;
 
 /**
- * Some platforms defines a proxy to the internal Kiali backend (like Openshift Console)
+ * OSSMC plugin needs a service api proxy to communicate with the Kiali backend
  * https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md#delivering-plugins
- * API Proxy defined by the platform is added before url request
+ * API Proxy defined by the plugin is added before the url request
  * This environment variable is not defined in standalone Kiali application
  */
 const apiProxy = process.env.API_PROXY ?? null;
@@ -105,6 +105,7 @@ const loginHeaders = config.login.headers;
 
 const getHeaders = (urlEncoded?: boolean): Partial<AxiosHeaders> => {
   if (apiProxy) {
+    // apiProxy is used by OSSMC, which doesn't need Kiali login headers (and can cause CORS issues)
     return { 'Content-Type': 'application/x-www-form-urlencoded' };
   } else if (urlEncoded) {
     return { 'Content-Type': 'application/x-www-form-urlencoded', ...loginHeaders };


### PR DESCRIPTION
### Describe the change

OSSMC shows weird CORS issues because Kiali login header is present in the HTTP requests to the Kiali server. This Kiali login header can be removed for those requests performed with an API proxy like OSSMC because it has a different login process. 

### Steps to test the PR

This PR does not affect Kiali standalone, only OSSMC. Kiali should work as expected.

