### PR TITLE
[1.73] Fix cypress cache folder in test image

### DIFF
--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -23,6 +23,10 @@ COPY frontend/ $HOME/
 
 WORKDIR $HOME
 
+# Use cypress cache in home folder, not under root
+RUN mkdir .cache
+ENV CYPRESS_CACHE_FOLDER=$HOME/.cache
+
 # Install Cypress dependencies.
 RUN yarn install --frozen-lockfile
 


### PR DESCRIPTION
### Describe the change

By default, the cypress cache folder is under /root/.cache folder which causes permission error in LPTINTEROP/OpenShift CI pipelines

