### PR TITLE
[hack] bring back kiali in MC scripts

### DIFF
--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -52,7 +52,7 @@ ISTIO_DIR=""
 DORP="${DORP:-podman}"
 
 # The namespace where Istio will be found - this namespace must be the same on both clusters
-ISTIO_NAMESPACE="istio-system"
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
 
 # If you want to pull Istio images from a different image repository than what the hack script
 # will tell Istio to pull from, then set that hub name here. If you set this to "default",
@@ -75,11 +75,11 @@ NETWORK1_ID="network-east"
 NETWORK2_ID="network-west"
 
 # Deploy a single kiali or a kiali per cluster
-SINGLE_KIALI="true"
+SINGLE_KIALI="${SINGLE_KIALI:-true}"
 
 # Create kiali remote secrets so kiali can access the different clusters
 # When left empty, this will be true if SINGLE_KIALI is true or false otherwise.
-KIALI_CREATE_REMOTE_CLUSTER_SECRETS=""
+KIALI_CREATE_REMOTE_CLUSTER_SECRETS="${KIALI_CREATE_REMOTE_CLUSTER_SECRETS:-}"
 
 # If a gateway is required to cross the networks, set this to true and one will be created
 # See: https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
@@ -89,39 +89,39 @@ CROSSNETWORK_GATEWAY_REQUIRED="true"
 MANUAL_MESH_NETWORK_CONFIG=""
 
 # The names of each cluster
-CLUSTER1_NAME="east"
-CLUSTER2_NAME="west"
+CLUSTER1_NAME="${CLUSTER1_NAME:-east}"
+CLUSTER2_NAME="${CLUSTER2_NAME:-west}"
 
 # If using Kubernetes, these are the kube context names used to connect to the clusters
 # If using OpenShift, these are the URLs to the API login server (e.g. "https://api.server-name.com:6443")
-CLUSTER1_CONTEXT=""
-CLUSTER2_CONTEXT=""
+CLUSTER1_CONTEXT="${CLUSTER1_CONTEXT:-}"
+CLUSTER2_CONTEXT="${CLUSTER2_CONTEXT:-}"
 
 # if using OpenShift, these are the credentials needed to log on to the clusters
-CLUSTER1_USER="kiali"
-CLUSTER1_PASS="kiali"
-CLUSTER2_USER="kiali"
-CLUSTER2_PASS="kiali"
+CLUSTER1_USER="${CLUSTER1_USER:-kiali}"
+CLUSTER1_PASS="${CLUSTER1_PASS:-kiali}"
+CLUSTER2_USER="${CLUSTER2_USER:-kiali}"
+CLUSTER2_PASS="${CLUSTER2_PASS:-kiali}"
 
 # Should Kiali be installed? This installs the last release of Kiali via the kiali-server helm chart.
 # If you want another version, you must disable this and install what you want manually.
-KIALI_ENABLED="true"
+KIALI_ENABLED="${KIALI_ENABLED:-true}"
 
 # When installing Kiali, this will determine if a released image is used or if a local dev image is to be pushed and used.
-KIALI_USE_DEV_IMAGE="false"
+KIALI_USE_DEV_IMAGE="${KIALI_USE_DEV_IMAGE:-false}"
 
 # Sets the auth strategy for kiali. If "openid" is used then keycloak is provisioned for the auth provider.
-KIALI_AUTH_STRATEGY="openid"
+KIALI_AUTH_STRATEGY="${KIALI_AUTH_STRATEGY:-openid}"
 
 # Should Bookinfo demo be installed? If so, where?
 BOOKINFO_ENABLED="true"
 BOOKINFO_NAMESPACE="bookinfo"
 
 # If true and client exe is kubectl, then two minikube instances will be installed/uninstalled by these scripts
-MANAGE_MINIKUBE="true"
+MANAGE_MINIKUBE="${MANAGE_MINIKUBE:-true}"
 
 # If true and client exe is kubectl, then two kind instances will be installed/uninstalled by these scripts
-MANAGE_KIND="false"
+MANAGE_KIND="${MANAGE_KIND:-false}"
 
 # Minikube options - these are ignored if MANAGE_MINIKUBE is false
 MINIKUBE_DRIVER="kvm2"
@@ -130,21 +130,21 @@ MINIKUBE_DISK=""
 MINIKUBE_MEMORY=""
 
 # Keycloak settings.
-KEYCLOAK_ADDRESS=""
+KEYCLOAK_ADDRESS="${KEYCLOAK_ADDRESS:-}"
 KEYCLOAK_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD:-keycloak-password}"
 KEYCLOAK_KUBE_CLIENT_SECRET="${KEYCLOAK_KUBE_CLIENT_SECRET:-kube-client-secret}"
 KIALI_USER_PASSWORD="${KIALI_USER_PASSWORD:-kiali}"
 
 # Some settings that can be configured when helm installing the two Kiali instances.
-KIALI1_WEB_FQDN=""
-KIALI1_WEB_SCHEMA=""
-KIALI2_WEB_FQDN=""
-KIALI2_WEB_SCHEMA=""
+KIALI1_WEB_FQDN="${KIALI1_WEB_FQDN:-}"
+KIALI1_WEB_SCHEMA="${KIALI1_WEB_SCHEMA:-}"
+KIALI2_WEB_FQDN="${KIALI2_WEB_FQDN:-}"
+KIALI2_WEB_SCHEMA="${KIALI2_WEB_SCHEMA:-}"
 
 # Used by the Kiali deployment functions, this declares what Kiali Server Helm Charts to use.
 # The user should set this to a tarball if a different helm chart should be used.
 # e.g. /source/helm-charts/_output/charts/kiali-server-1.64.0-SNAPSHOT.tgz
-KIALI_SERVER_HELM_CHARTS="kiali-server"
+KIALI_SERVER_HELM_CHARTS="${KIALI_SERVER_HELM_CHARTS:-kiali-server}"
 
 # process command line args
 while [[ $# -gt 0 ]]; do

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -240,4 +240,6 @@ source ${SCRIPT_DIR}/setup-tracing.sh
 source ${SCRIPT_DIR}/split-bookinfo.sh
 
 # Install Kiali if enabled
-source ${SCRIPT_DIR}/deploy-kiali.sh
+if [ "${KIALI_ENABLED}" == "true" ]; then
+  source ${SCRIPT_DIR}/deploy-kiali.sh
+fi

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -241,5 +241,9 @@ source ${SCRIPT_DIR}/split-bookinfo.sh
 
 # Install Kiali if enabled
 if [ "${KIALI_ENABLED}" == "true" ]; then
+  if [ -z "${KEYCLOAK_ADDRESS}" ]; then
+    echo "Keycloak is not available for this cluster setup. Switching Kial to 'anonymous' mode."
+    export KIALI_AUTH_STRATEGY="anonymous"
+  fi
   source ${SCRIPT_DIR}/deploy-kiali.sh
 fi

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -238,3 +238,6 @@ source ${SCRIPT_DIR}/setup-tracing.sh
 
 # Install bookinfo across cluster if enabled
 source ${SCRIPT_DIR}/split-bookinfo.sh
+
+# Install Kiali if enabled
+source ${SCRIPT_DIR}/deploy-kiali.sh

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -76,6 +76,10 @@ ${CLIENT_EXE} apply --context=${CLUSTER1_CONTEXT} -n ${ISTIO_NAMESPACE} -f $EXPO
 
 # Install Kiali in both clusters if enabled
 if [ "${KIALI_ENABLED}" == "true" ]; then
+  if [ -z "${KEYCLOAK_ADDRESS}" ]; then
+    echo "Keycloak is not available for this cluster setup. Switching Kial to 'anonymous' mode."
+    export KIALI_AUTH_STRATEGY="anonymous"
+  fi
   source ${SCRIPT_DIR}/deploy-kiali.sh
 fi
 

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -74,6 +74,9 @@ ${CLIENT_EXE} apply --context=${CLUSTER1_CONTEXT} -n ${ISTIO_NAMESPACE} -f $EXPO
 EXPOSE_SERVICES_YAML="${ISTIO_DIR}/samples/multicluster/expose-services.yaml"
 ${CLIENT_EXE} apply --context=${CLUSTER1_CONTEXT} -n ${ISTIO_NAMESPACE} -f $EXPOSE_SERVICES_YAML
 
+# Install Kiali in both clusters if enabled
+source ${SCRIPT_DIR}/deploy-kiali.sh
+
 # Cluster West
 switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
 

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -75,7 +75,9 @@ EXPOSE_SERVICES_YAML="${ISTIO_DIR}/samples/multicluster/expose-services.yaml"
 ${CLIENT_EXE} apply --context=${CLUSTER1_CONTEXT} -n ${ISTIO_NAMESPACE} -f $EXPOSE_SERVICES_YAML
 
 # Install Kiali in both clusters if enabled
-source ${SCRIPT_DIR}/deploy-kiali.sh
+if [ "${KIALI_ENABLED}" == "true" ]; then
+  source ${SCRIPT_DIR}/deploy-kiali.sh
+fi
 
 # Cluster West
 switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -276,6 +276,7 @@ setup_kind_multicluster() {
   local cluster2_name
   if [ "${MULTICLUSTER}" == "${MULTI_PRIMARY}" ]; then
     "${SCRIPT_DIR}"/istio/multicluster/install-multi-primary.sh \
+      --kiali-enabled false \
       --manage-kind true \
       --certs-dir "${certs_dir}" \
       -dorp docker \
@@ -289,7 +290,7 @@ setup_kind_multicluster() {
     kubectl rollout status deployment prometheus -n istio-system --context kind-east
     kubectl rollout status deployment prometheus -n istio-system --context kind-west
   elif [ "${MULTICLUSTER}" == "${PRIMARY_REMOTE}" ]; then 
-    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --manage-kind true -dorp docker --istio-dir "${istio_dir}" ${hub_arg:-}
+    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --kiali-enabled false --manage-kind true -dorp docker --istio-dir "${istio_dir}" ${hub_arg:-}
     cluster1_context="kind-east"
     cluster2_context="kind-west"
     cluster1_name="east"


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7313

I do not know why these were removed. We have all the kiali options for these hack scripts but they are now ignored - kiali is never deployed even if enabled.

These were removed in the following commits:

* https://github.com/kiali/kiali/commit/804f21ebe3d93be9f167353b81895ce7044c7e44#diff-ae968abe0209eefd78f858f137a2e418a056ec6e02965d2214bcb46c8a978efeL77-L78
* https://github.com/kiali/kiali/commit/d8631a1d8814f2c025ce6ca460de147aa810368b#diff-b53029271ec37bbeb86a1eb29db8fd5e77a74f0fda8dac3d7d22109fcb11fdf3L203-L204