### PR TITLE
[Perf] Added script option for delete only

### DIFF
--- a/hack/run-performance-tests.sh
+++ b/hack/run-performance-tests.sh
@@ -129,8 +129,6 @@ deleteNamespaces() {
   jq '.allNamespaces = .namespaces' "$COMMON_PARAMS" > "$COMMON_PARAMS.tmp" && mv "$COMMON_PARAMS.tmp" "$COMMON_PARAMS"
 }
 
-ensureCypressInstalled
-
 if [ "${TESTS_ONLY}" != "true" -a "${DELETE_ONLY}" != "true" ]; then
   infomsg "Install test namespaces"
   createNamespaces
@@ -149,6 +147,8 @@ export CYPRESS_VIDEO=false
 if [ "${SETUP_ONLY}" == "true" ]; then
   exit 0
 fi
+
+ensureCypressInstalled
 
 cd "${SCRIPT_DIR}"/../frontend
 infomsg "Running cypress performance tests"


### PR DESCRIPTION
Added a new option '-do --delete-only' in hack/run-performance-tests.sh.
Necessary for 'create Jenkins Job to run perf cypress tests' subtask https://github.com/kiali/kiali/issues/7247