### PR TITLE
Added missing tls option OPTIONAL_MUTUAL

### DIFF
--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -42,7 +42,7 @@ const columns: ThProps[] = [
 ];
 
 export const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
-const tlsModes = ['PASSTHROUGH', 'SIMPLE', 'MUTUAL', 'AUTO_PASSTHROUGH', 'ISTIO_MUTUAL'];
+const tlsModes = ['PASSTHROUGH', 'SIMPLE', 'MUTUAL', 'AUTO_PASSTHROUGH', 'ISTIO_MUTUAL', 'OPTIONAL_MUTUAL'];
 
 export const areValidHosts = (hosts: string[]): boolean => {
   if (hosts.length === 0) {


### PR DESCRIPTION
### Describe the change
Original issue https://github.com/kiali/kiali/issues/7315 failure is caused by 'client-go@v0.28.3' library inconsistency used in Kiali v1.82, but it is fixed in Kiali v1.84.

However the missing option 'OPTIONAL_MUTUAL' is added in 'Istio Config List -> Actions -> Create Gateway'  wizard:
![Screenshot from 2024-04-29 14-51-36](https://github.com/kiali/kiali/assets/604313/cd2b7602-4b49-4cc8-8828-dd90281ee12e)
