### PR TITLE
Fix URL for Tempo urls with paths for trace IDs

### DIFF
--- a/business/tracing.go
+++ b/business/tracing.go
@@ -331,6 +331,14 @@ func spanMatchesWorkload(span *jaegerModels.Span, namespace, workload string) bo
 				}
 			}
 		}
+		// For Tempo Traces
+		if tag.Key == "hostname" {
+			if v, ok := tag.Value.(string); ok {
+				if strings.HasPrefix(v, workload) {
+					return true
+				}
+			}
+		}
 	}
 	// Tag not found => try with 'hostname' in process' tags
 	if span.Process != nil {

--- a/tracing/jaeger/model/types.go
+++ b/tracing/jaeger/model/types.go
@@ -4,7 +4,7 @@ import (
 	jaegerModels "github.com/kiali/kiali/tracing/jaeger/model/json"
 )
 
-type structuredError struct {
+type StructuredError struct {
 	Code    int    `json:"code,omitempty"`
 	Msg     string `json:"msg"`
 	TraceID string `json:"traceID,omitempty"`
@@ -16,14 +16,14 @@ type TracingServices struct {
 
 type TracingResponse struct {
 	Data               []jaegerModels.Trace `json:"data"`
-	Errors             []structuredError    `json:"errors"`
+	Errors             []StructuredError    `json:"errors"`
 	FromAllClusters    bool                 `json:"fromAllClusters"`
 	TracingServiceName string               `json:"tracingServiceName"`
 }
 
 type TracingSingleTrace struct {
 	Data   jaegerModels.Trace `json:"data"`
-	Errors []structuredError  `json:"errors"`
+	Errors []StructuredError  `json:"errors"`
 }
 
 type TracingSpan struct {

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -79,10 +79,11 @@ func (oc OtelHTTPClient) GetTraceDetailHTTP(client http.Client, endpoint *url.UR
 		errorTrace = append(errorTrace, model.StructuredError{TraceID: traceID, Code: code, Msg: errorMsg})
 		return &model.TracingSingleTrace{Errors: errorTrace}, errors.New(errorMsg)
 	}
-	// Tempo would return "200 OK" when trace is not found, with an empty response
+
 	if len(resp) == 0 {
-		return nil, nil
+		return nil, errors.New("empty body response")
 	}
+
 	responseOtel, _ := unmarshalSingleTrace(resp, &u)
 
 	response, err := convertSingleTrace(responseOtel, traceID)

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -72,7 +72,7 @@ func (oc OtelHTTPClient) GetAppTracesHTTP(client http.Client, baseURL *url.URL, 
 // GetTraceDetailHTTP get one trace by trace ID
 func (oc OtelHTTPClient) GetTraceDetailHTTP(client http.Client, endpoint *url.URL, traceID string) (*model.TracingSingleTrace, error) {
 	u := *endpoint
-	u.Path = "/api/traces/" + traceID
+	u.Path = path.Join(u.Path, "/api/traces/", traceID)
 	resp, code, reqError := makeRequest(client, u.String(), nil)
 	if reqError != nil {
 		log.Errorf("API Tempo query error: %s [code: %d, URL: %v]", reqError, code, u)
@@ -277,7 +277,7 @@ func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, q
 		}
 	}
 
-	selects := []string{"status", ".service_name", ".node_id", ".component", ".upstream_cluster", ".http.method", ".response_flags"}
+	selects := []string{"status", ".service_name", ".node_id", ".component", ".upstream_cluster", ".http.method", ".response_flags", "resource.hostname"}
 	trace := TraceQL{operator1: Subquery{queryPart}, operand: AND, operator2: Subquery{}}
 	queryQL := fmt.Sprintf("%s| %s", printOperator(trace), printSelect(selects))
 


### PR DESCRIPTION
### Describe the change

- Fix url for Tempo api trace ID 
- Use hostname tag to see if the workload is related to a span, in order for Tempo to be able to get the Kiali traces correctly

![image](https://github.com/kiali/kiali/assets/49480155/c6a6dca1-bcd4-4f18-ac17-8c3aac2cff89)

- Better error handling: 

![image](https://github.com/kiali/kiali/assets/49480155/cdecb938-fc78-45c1-8576-c7180873da83)


### Steps to test the PR

- Test that everything works fine setting the environment with `istio/tempo/install-tempo-env.sh -c kubectl -ik true`.
- For this particular error and urls with subpaths, it can be tested with a grafana cloud datasource: 

```
 tracing:
    enabled: true
    provider: "tempo"
    in_cluster_url: https://tempo-prod-10-prod-eu-west-2.grafana.net/tempo
    url: https://tempo-prod-10-prod-eu-west-2.grafana.net/tempo
    use_grpc: false
    query_timeout: 40
    whitelist_istio_system:
    - jaeger-query
    - istio-ingressgateway
    namespace: istio-system
    port: 443
    service: tracing
    health_check_url: "https://tempo-prod-10-prod-eu-west-2.grafana.net"
    auth:
      insecure_skip_verify: true
      password: TOKEN
      type: basic
      use_kiali_token: false
      username: 825501
```

In order to test error handling, go to an url with an incorrect traceID (e.x. http://localhost:3000/console/namespaces/bookinfo/workloads/productpage-v1?duration=60&refresh=0&tab=traces&rangeDuration=1800&traceId=123), an error should be seen like the following: 

![image](https://github.com/kiali/kiali/assets/49480155/da857bc0-0393-4c17-84a8-c145c8938f62)


### Automation testing

It should be already covered.

### Issue reference

https://github.com/kiali/kiali/issues/7220
