### PR TITLE
[hack] be able to run tests whose name is a subset of another test

### DIFF
--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -426,7 +426,7 @@ do
     echo "/*** BEGIN MOLECULE TEST: $t ***/"
   fi
 
-  if [[ "${SKIP_TESTS}" == *"$t"* ]]; then
+  if [[ " ${SKIP_TESTS} " == *" $t "* ]]; then
     printf '%s' "$(dim 'skipped')"
     continue;
   fi


### PR DESCRIPTION
Right now we have tests "ossmconsole-config-values-test" and "config-values-test". The way the bash test works right now is that config-values-test is being skipped when only ossmconsole-config-values-test should be skipped. This commit fixes that flaw.