### PR TITLE
Fix cypress login on openshift

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
 
       // This name is non-standard and might change based on your environment hence the separate
       // env variable.
-      config.env.AUTH_PROVIDER = config.env.AUTH_PROVIDER || 'my_htpasswd_provider';
       config.env.AUTH_STRATEGY = await getAuthStrategy(config.baseUrl!, config.env.ALLOW_INSECURE_KIALI_API);
 
       return config;

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -5,6 +5,11 @@ const PASSWD = Cypress.env('PASSWD'); // CYPRESS_PASSWD to the user
 const KUBEADMIN_IDP = Cypress.env('AUTH_PROVIDER'); // CYPRESS_AUTH_PROVIDER to the user
 const auth_strategy = Cypress.env('AUTH_STRATEGY');
 
+Given('all sessions are cleared', () => {
+  Cypress.session.clearAllSavedSessions();
+  Cypress.session.clearCurrentSessionData();
+});
+
 Given('user opens base url', () => {
   cy.visit('/');
   cy.log(auth_strategy);
@@ -19,7 +24,7 @@ Given('user opens base url', () => {
 });
 
 Given('user clicks my_htpasswd_provider', () => {
-  if (auth_strategy === 'openshift') {
+  if (auth_strategy === 'openshift' && KUBEADMIN_IDP !== '' && KUBEADMIN_IDP !== undefined) {
     cy.exec('kubectl get user').then(result => {
       if (result.stderr !== 'No resources found') {
         cy.log(`Log in using auth provider: ${KUBEADMIN_IDP}`);
@@ -46,6 +51,7 @@ Given('user fill in username and password', () => {
 Given('user does not fill in username and password', () => {
   if (auth_strategy === 'openshift') {
     cy.log('Log in with empty credentials');
+    cy.get('#inputUsername').clear();
     cy.get('button[type="submit"]').click();
   }
 });

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -117,7 +117,7 @@ Then('user fills in a valid password', () => {
 });
 
 Then('user sees the Overview page', () => {
-  cy.get('div[data-test="overview-app-health"]').should('exist');
+  cy.url().should('include', 'overview');
 });
 
 Then('the server will return a login error', () => {

--- a/frontend/cypress/integration/featureFiles/kiali_login.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_login.feature
@@ -6,7 +6,8 @@ Feature: Kiali login
   User wants to login to Kiali and see landing page
 
   Background:
-    Given user opens base url
+    Given all sessions are cleared
+    And user opens base url
 
   Scenario: Try to log in without filling the username and password
     And user clicks my_htpasswd_provider

--- a/frontend/cypress/integration/featureFiles/kiali_login.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_login.feature
@@ -32,6 +32,7 @@ Feature: Kiali login
   @openshift
   Scenario: Openshift login shows error message when code exchange fails
     And the server will return a login error
+    And user clicks my_htpasswd_provider
     And user fills in a valid password
     Then user sees an error message on the login form
     And the error description is in the url

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -118,7 +118,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
         cy.intercept('/api/tracing').as('getTracing');
         cy.intercept('/api/auth/info').as('getAuthInfo');
 
-        cy.visit('');
+        cy.visit('/');
         const authProvider = Cypress.env('AUTH_PROVIDER');
         if (authProvider !== '' && authProvider !== undefined) {
           cy.contains(authProvider).should('be.visible').click();
@@ -186,7 +186,15 @@ Cypress.Commands.add('login', (username: string, password: string) => {
         });
       }
     },
-    { cacheAcrossSpecs: true }
+    {
+      cacheAcrossSpecs: true,
+      validate: () => {
+        // For some reason validate is needed to preserve the kiali-token-aes cookie.
+        if (auth_strategy === 'openshift') {
+          cy.getCookie('kiali-token-aes').should('exist');
+        }
+      }
+    }
   );
 });
 


### PR DESCRIPTION
### Describe the change

Validates cookie is present in `cy.session`. Fixes `my_htpasswd_provider` environments.

### Steps to test the PR

Deploy kiali on openshift. Run cypress with:
```
CYPRESS_BASE_URL=<kiali_route>
CYPRESS_USERNAME=<username>
CYPRESS_PASSWD=<pass>
```

### Automation testing

Fixes existing tests.
