### PR TITLE
Fix index out of bounds

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -587,7 +587,7 @@ func parseZtunnelLine(line string) *LogEntry {
 
 	msgSplit := strings.Split(line, "\t")
 
-	if len(msgSplit) < 4 {
+	if len(msgSplit) < 5 {
 		log.Debugf("Error splitting log line [%s]", line)
 		entry.Message = line
 		return &entry


### PR DESCRIPTION
### Describe the change

Fix for index out of bounds when trying to parse ztunnel log line. 

### Steps to test the PR

Install Istio ambient 1.22 dev: 
- `minikube start`
- `istio/download-istio.sh -div 1.22-dev`
- `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient -it default -ih default`
- `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg`
- Install kiali

Access one of the workloads logs and select ztunnel. No error 500 should be found:

![image](https://github.com/kiali/kiali/assets/49480155/7c262780-a880-428c-8266-8da7f14ae75d)


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
