### PR TITLE
[hack] update with new sail stuff

### DIFF
--- a/hack/istio/sail/func-minio.sh
+++ b/hack/istio/sail/func-minio.sh
@@ -50,6 +50,7 @@ delete_minio() {
   ${OC} delete --ignore-not-found=true secret --namespace ${MINIO_NAMESPACE} ${MINIO_SECRET_NAME}
 }
 
+# see https://grafana.com/docs/tempo/latest/setup/tanka/
 _define_minio_yaml() {
   MINIO_YAML="$(cat <<EOM
 ---
@@ -95,7 +96,7 @@ spec:
           claimName: minio-pv-claim
       initContainers:
       - name: create-buckets
-        image: quay.io/official-images/busybox:1.28
+        image: quay.io/jitesoft/alpine:latest
         command:
           - "sh"
           - "-c"


### PR DESCRIPTION
Some things have changed with Sail operator. This updates the hack scripts to work with it.

To test:

1. Start an OpenShift cluster (e.g. `hack/crc-openshift.sh start`)
2. Use `oc` to log into the cluster as a kubeadmin user
3. Install the operators for Sail, Kiali, Tempo, etc.: `hack/istio/sail/install-ossm-release.sh install-operators`
4. Install a Istio, Kiali, Prometheus, etc. etc.: `hack/istio/sail/install-ossm-release.sh install-istio`
5. See that everything eventually installs successfully: `hack/istio/sail/install-ossm-release.sh status`
6. Bring up the Kiali UI in a browser: `hack/istio/sail/install-ossm-release.sh kiali-ui`
7. See that you can get to the UI and things look OK

When you are done, you can delete everything except the operators with: `hack/istio/sail/install-ossm-release.sh delete-istio`

After Istio and all other components are removed, you can then delete the operators which takes you back to a clean slate:  `hack/istio/sail/install-ossm-release.sh delete-operators`