### PR TITLE
[v1.73] Use quay image for nginx-unprivileged in remote istiod test

### DIFF
--- a/tests/integration/assets/remote-istiod/proxy-patch.yaml
+++ b/tests/integration/assets/remote-istiod/proxy-patch.yaml
@@ -19,5 +19,5 @@ spec:
               }
               EOF
               nginx -g "daemon off;"
-          image: nginxinc/nginx-unprivileged
+          image: quay.io/nginx/nginx-unprivileged
           name: nginx


### PR DESCRIPTION
### Describe the change

Use quay image for nginx-unprivileged in remote istiod test instead of docker 
