### PR TITLE
Identify waypoint proxies

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1896,12 +1896,15 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 	}
 
 	// Is the namespace labeled?
-	ns, ok := in.cache.GetNamespace(workload.Cluster, in.userClients[workload.Cluster].GetToken(), workload.Namespace)
-	waypointName, ok := ns.Labels[config.WaypointUseLabel]
+	ns, found := in.cache.GetNamespace(workload.Cluster, in.userClients[workload.Cluster].GetToken(), workload.Namespace)
 
-	if ok {
-		found = true
-		waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "namespace"})
+	if found {
+		waypointName, ok := ns.Labels[config.WaypointUseLabel]
+
+		if ok {
+			found = true
+			waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "namespace"})
+		}
 	}
 
 	var services []models.ServiceOverview

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1896,12 +1896,9 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 	}
 
 	// Is the namespace labeled?
-	ns, errNs := in.userClients[workload.Cluster].GetNamespace(workload.Namespace)
-	if errNs != nil {
-		log.Errorf("Error fetching namespace")
-		return nil, false
-	}
-	waypointName, ok := ns.ObjectMeta.GetLabels()[config.WaypointUseLabel]
+	ns, ok := in.cache.GetNamespace(workload.Cluster, in.userClients[workload.Cluster].GetToken(), workload.Namespace)
+	waypointName, ok := ns.Labels[config.WaypointUseLabel]
+
 	if ok {
 		found = true
 		waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "namespace"})

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1927,7 +1927,7 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 	}
 	if len(services) > 0 {
 		for _, svc := range services {
-			waypointName, ok = svc.Labels[config.WaypointUseLabel]
+			waypointName, ok := svc.Labels[config.WaypointUseLabel]
 			if ok {
 				found = true
 				waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "service"})

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1869,14 +1869,8 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			}
 			// If the pod is a waypoint proxy, check if it is attached to a namespace or to a service account, and get the affected workloads
 			if pod.IsWaypoint() {
-				// Get waypoint workloads from a namespace
-				if pod.Labels["istio.io/gateway-name"] == "namespace" {
-					w.WaypointWorkloads = append(w.WaypointWorkloads, in.listWaypointWorkloadsForNamespace(ctx, criteria.Namespace)...)
-				} else {
-					// Get waypoint workloads from a service account
-					sa := pod.Annotations["istio.io/for-service-account"]
-					w.WaypointWorkloads = append(w.WaypointWorkloads, in.listWaypointWorkloadsForSA(ctx, criteria.Namespace, sa)...)
-				}
+				// Get waypoint workloads
+				w.WaypointWorkloads = append(w.WaypointWorkloads, in.listWaypointWorkloads(ctx, pod.Name, criteria.Cluster)...)
 			}
 		}
 
@@ -1887,74 +1881,130 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 	return wl, kubernetes.NewNotFound(criteria.WorkloadName, "Kiali", "Workload")
 }
 
-// Get the Waypoint proxies for a workload
-func (in *WorkloadService) getWaypointsForWorkload(ctx context.Context, namespace string, workload models.Workload) []models.Workload {
-	nsWaypoints, err := in.fetchWorkloads(ctx, namespace, fmt.Sprintf("%s=%s", config.WaypointLabel, config.WaypointLabelValue))
-	if err != nil {
-		log.Errorf("Error fetching namespace waypoints: %v", err)
-		return nil
+// Check the waypoint name if a pod is enrolled
+func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload models.Workload) ([]models.Waypoint, bool) {
+	found := false
+	waypointNames := make([]models.Waypoint, 0)
+
+	// Is the pod labeled?
+	for _, pod := range workload.Pods {
+		waypointName, ok := pod.Labels[config.WaypointUseLabel]
+		if ok {
+			found = true
+			waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "pod"})
+		}
 	}
 
-	var waypoints []models.Workload
-	// Get service Account name for each pod from the workload
-	for _, nsWaypoint := range nsWaypoints {
-		for _, pod := range nsWaypoint.Pods {
-			if pod.Labels["istio.io/gateway-name"] == "namespace" {
-				waypoints = append(waypoints, *nsWaypoint)
-				break
-			} else {
-				// Get waypoint workloads from a service account
-				sa := pod.Annotations["istio.io/for-service-account"]
-				for _, pod := range workload.Pods {
-					if pod.ServiceAccountName == sa {
-						waypoints = append(waypoints, *nsWaypoint)
-						break
-					}
-				}
+	// Is the namespace labeled?
+	ns, errNs := in.userClients[workload.Cluster].GetNamespace(workload.Namespace)
+	if errNs != nil {
+		log.Errorf("Error fetching namespace")
+		return nil, false
+	}
+	waypointName, ok := ns.ObjectMeta.GetLabels()[config.WaypointUseLabel]
+	if ok {
+		found = true
+		waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "namespace"})
+	}
+
+	var services []models.ServiceOverview
+	// Is the service labeled?
+	if len(workload.Services) == 0 {
+		serviceCriteria := ServiceCriteria{
+			Cluster:                workload.Cluster,
+			Namespace:              workload.Namespace,
+			ServiceSelector:        labels.Set(workload.Labels).String(),
+			IncludeHealth:          false,
+			IncludeOnlyDefinitions: true,
+		}
+		svc, err := in.businessLayer.Svc.GetServiceList(ctx, serviceCriteria)
+		if err != nil {
+			log.Errorf("Error fetching services %s", err.Error())
+		}
+		services = svc.Services
+	} else {
+		services = workload.Services
+	}
+	if services != nil && len(services) > 0 {
+		for _, svc := range services {
+			waypointName, ok = svc.Labels[config.WaypointUseLabel]
+			if ok {
+				found = true
+				waypointNames = append(waypointNames, models.Waypoint{Name: waypointName, Type: "service"})
 			}
 		}
 	}
-	return waypoints
+
+	return waypointNames, found
 }
 
-// Return the list of workloads binded to a service account, valid when the waypoint proxy is applied to a service account
-// TODO: This is scoped by namespace
-func (in *WorkloadService) listWaypointWorkloadsForSA(ctx context.Context, namespace string, sa string) []models.Workload {
-	wlist, err := in.fetchWorkloads(ctx, namespace, "")
-	if err != nil {
-		log.Errorf("Error fetching workloads")
-	}
-
+// Get the Waypoint proxy for a workload
+// TODO: We might use the cache to improve performance
+func (in *WorkloadService) getWaypointForWorkload(ctx context.Context, namespace string, workload models.Workload) []models.Workload {
 	var workloadslist []models.Workload
-	// Get service Account name for each pod from the workload
-	for _, workload := range wlist {
-		if !config.IsWaypoint(workload.Labels) {
-			for _, pod := range workload.Pods {
-				if pod.ServiceAccountName == sa {
-					workloadslist = append(workloadslist, *workload)
-					break
 
-				}
-			}
-		}
+	// Get Waypoint list names
+	waypoints, found := in.isWorkloadEnrolled(ctx, workload)
+	if !found {
+		return workloadslist
 	}
+
+	for _, waypoint := range waypoints {
+		// TODO: Can the waypoint be on a different ns?
+		wkd, err := in.fetchWorkload(ctx, WorkloadCriteria{Cluster: workload.Cluster, Namespace: namespace, WorkloadName: waypoint.Name, WorkloadType: ""})
+		if err != nil {
+			log.Errorf("Error fetching workloads %s", err.Error())
+			return nil
+		}
+		if wkd != nil {
+			workloadslist = append(workloadslist, *wkd)
+		}
+		return workloadslist
+	}
+
 	return workloadslist
 }
 
 // Return the list of workloads when the waypoint proxy is applied per namespace
-func (in *WorkloadService) listWaypointWorkloadsForNamespace(ctx context.Context, namespace string) []models.Workload {
-	wlist, err := in.fetchWorkloads(ctx, namespace, "")
-	if err != nil {
-		log.Errorf("Error fetching workloads")
+func (in *WorkloadService) listWaypointWorkloads(ctx context.Context, name, cluster string) []models.Workload {
+
+	// Get all the workloads for a namespaces labeled
+	labelSelector := fmt.Sprintf("%s=%s", config.WaypointUseLabel, name)
+	nslist, errNs := in.userClients[cluster].GetNamespaces(labelSelector)
+	if errNs != nil {
+		log.Errorf("Error fetching namespaces by selector %s", labelSelector)
 	}
 
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
+<<<<<<< HEAD
 	for _, workload := range wlist {
 		if !config.IsWaypoint(workload.Labels) {
 			workloadslist = append(workloadslist, *workload)
+=======
+	for _, ns := range nslist {
+		workloadList, err := in.fetchWorkloads(ctx, ns.Name, "")
+		if err != nil {
+			log.Errorf("Error fetching workloads for namespace %s", ns)
+>>>>>>> cf683f32d (Identify waypoint proxies)
 		}
+		for _, wk := range workloadList {
+			// Is there any annotation that disables?
+			workloadslist = append(workloadslist, *wk)
+		}
+
 	}
+
+	// Get annotated workloads
+	wlist, err := in.fetchWorkloads(ctx, meta_v1.NamespaceAll, labelSelector)
+	if err != nil {
+		log.Errorf("Error fetching workloads for namespace label selector %s", labelSelector)
+	}
+	for _, workload := range wlist {
+		// Is there any annotation that disables?
+		workloadslist = append(workloadslist, *workload)
+	}
+
 	return workloadslist
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1925,7 +1925,7 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 	} else {
 		services = workload.Services
 	}
-	if services != nil && len(services) > 0 {
+	if len(services) > 0 {
 		for _, svc := range services {
 			waypointName, ok = svc.Labels[config.WaypointUseLabel]
 			if ok {
@@ -1940,7 +1940,7 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 
 // Get the Waypoint proxy for a workload
 // TODO: We might use the cache to improve performance
-func (in *WorkloadService) getWaypointForWorkload(ctx context.Context, namespace string, workload models.Workload) []models.Workload {
+func (in *WorkloadService) getWaypointsForWorkload(ctx context.Context, namespace string, workload models.Workload) []models.Workload {
 	var workloadslist []models.Workload
 
 	// Get Waypoint list names
@@ -1959,7 +1959,6 @@ func (in *WorkloadService) getWaypointForWorkload(ctx context.Context, namespace
 		if wkd != nil {
 			workloadslist = append(workloadslist, *wkd)
 		}
-		return workloadslist
 	}
 
 	return workloadslist
@@ -1977,16 +1976,11 @@ func (in *WorkloadService) listWaypointWorkloads(ctx context.Context, name, clus
 
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
-<<<<<<< HEAD
-	for _, workload := range wlist {
-		if !config.IsWaypoint(workload.Labels) {
-			workloadslist = append(workloadslist, *workload)
-=======
+
 	for _, ns := range nslist {
 		workloadList, err := in.fetchWorkloads(ctx, ns.Name, "")
 		if err != nil {
-			log.Errorf("Error fetching workloads for namespace %s", ns)
->>>>>>> cf683f32d (Identify waypoint proxies)
+			log.Errorf("Error fetching workloads for namespace %s", ns.Name)
 		}
 		for _, wk := range workloadList {
 			// Is there any annotation that disables?

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1896,9 +1896,9 @@ func (in *WorkloadService) isWorkloadEnrolled(ctx context.Context, workload mode
 	}
 
 	// Is the namespace labeled?
-	ns, found := in.cache.GetNamespace(workload.Cluster, in.userClients[workload.Cluster].GetToken(), workload.Namespace)
+	ns, foundNS := in.cache.GetNamespace(workload.Cluster, in.userClients[workload.Cluster].GetToken(), workload.Namespace)
 
-	if found {
+	if foundNS {
 		waypointName, ok := ns.Labels[config.WaypointUseLabel]
 
 		if ok {

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ const (
 	AmbientAnnotationEnabled = "enabled"
 	WaypointLabel            = "gateway.istio.io/managed"
 	WaypointLabelValue       = "istio.io-mesh-controller"
+	WaypointUseLabel         = "istio.io/use-waypoint"
 )
 
 // TracingProvider is the type of tracing provider that Kiali will connect to.

--- a/config/config.go
+++ b/config/config.go
@@ -345,6 +345,7 @@ type IstioLabels struct {
 	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
 	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
 	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
+	AmbientWaypointUseLabel    string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
@@ -761,6 +762,7 @@ func NewConfig() (c *Config) {
 			AmbientNamespaceLabelValue: "ambient",
 			AmbientWaypointLabel:       WaypointLabel,
 			AmbientWaypointLabelValue:  WaypointLabelValue,
+			AmbientWaypointUseLabel:    WaypointUseLabel,
 			AppLabelName:               "app",
 			InjectionLabelName:         "istio-injection",
 			InjectionLabelRev:          "istio.io/rev",

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -274,6 +274,10 @@ func FakeIstioAnnotations() map[string]string {
 	return map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}
 }
 
+func FakeIstioAmbientAnnotations() map[string]string {
+	return map[string]string{"ambient.istio.io/redirection": "enabled", "sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}
+}
+
 func FakeNamespace(name string) *core_v1.Namespace {
 	return &core_v1.Namespace{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/models/pod.go
+++ b/models/pod.go
@@ -35,6 +35,11 @@ type Pod struct {
 	ServiceAccountName  string            `json:"serviceAccountName"`
 }
 
+type Waypoint struct {
+	Name string
+	Type string
+}
+
 // Reference holds some information on the pod creator
 type Reference struct {
 	Name string `json:"name"`


### PR DESCRIPTION
### Describe the change

The labels for the waypoint proxies had changed: 

- Not using `pod.Labels["istio.io/gateway-name"] == "namespace"` or `pod.Annotations["istio.io/for-service-account"]`
- It is using `stio.io/use-waypoint` equals to the waypoint name. The label can be placed: 
  - In the namespace
  - In the service
  - In the workload

### Steps to test the PR

- Use Istio > 1.22.rc
- Install Istio Ambient: 
`istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install Kiali
- Install bookinfo with Ambient and a waypoint proxy: 
`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Apply different waypoint proxies and check if Kiali identifies them correctly: 
  - namespace
  - pod
  - service

https://istio.io/latest/docs/ambient/usage/waypoint/
```
kubectl label pod -l version=v1,app=productpage -n bookinfo istio.io/use-waypoint=waypoint
kubectl label service reviews -n bookinfo istio.io/use-waypoint=waypoint
```

![image](https://github.com/kiali/kiali/assets/49480155/5de4990a-f0bd-4209-b735-96fc5c8f3343)

### Automation testing

Added end to end testing to tests: 

- waypoint proxie is identified correctly. 
- workload is enrolled by pod
- workload is enrolled by ns
- workload is enrolled by service

### Issue reference

#7350 
