### PR TITLE
[Perf] Added perf baselines for 50 namespaces.

### DIFF
--- a/frontend/cypress/fixtures/perf/baselines.json
+++ b/frontend/cypress/fixtures/perf/baselines.json
@@ -1,15 +1,15 @@
 {
-  "workloadListAll": "2",
-  "workloadListSelected": "2",
-  "workloadDetails": "1",
-  "serviceListAll": "2",
-  "serviceListSelected": "2",
-  "serviceDetails": "1",
-  "appListAll": "2",
-  "appListSelected": "2",
-  "appDetails": "1",
-  "configListAdd": "2",
-  "configListSelected": "2",
+  "workloadListAll": "1.2",
+  "workloadListSelected": "0.8",
+  "workloadDetails": "0.7",
+  "serviceListAll": "1",
+  "serviceListSelected": "0.5",
+  "serviceDetails": "0.8",
+  "appListAll": "1",
+  "appListSelected": "0.8",
+  "appDetails": "0.8",
+  "configListAll": "0.8",
+  "configListSelected": "0.5",
   "configDetails": "1",
-  "overview": "2"
+  "overview": "1.3"
 }

--- a/frontend/cypress/perf/istioconfigsload.spec.ts
+++ b/frontend/cypress/perf/istioconfigsload.spec.ts
@@ -23,7 +23,7 @@ describe('Istio Configs performance tests', () => {
     it('Measures All Namespaces Istio Configs load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       measureListsLoadTime(
         'All Namespaces Istio Configs',
-        Cypress.env(baselines).configListAdd,
+        Cypress.env(baselines).configListAll,
         configsUrlAllNamespaces
       );
     });


### PR DESCRIPTION
Performance baselines are updated to include the results of perf tests run on OCP environment with 50 namespaces, each has 1 service and 2 workloads.
The OCP performance environment is not stable and the results can be different.
Testing was done to compare Kiali pages performance before and after the improvements.
The baselines are relative and are including the best results with less timeouts.

https://github.com/kiali/kiali/issues/7097
