### PR TITLE
Fix tracing for tempo CI job

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -473,6 +473,12 @@ if [ "${NETWORK}" != "" ]; then
   NETWORK_OPTION="--set values.global.network=${NETWORK}"
 fi
 
+ZIPKIN_SERVICE_OPTION="--set values.meshConfig.extensionProviders[0].zipkin.service=zipkin.${NAMESPACE}.svc.cluster.local"
+if [[ "${CUSTOM_INSTALL_SETTINGS}" == *"values.meshConfig.extensionProviders[0].zipkin.service"* ]]; then
+  echo "Custom settings are set: ${CUSTOM_INSTALL_SETTINGS}"
+  ZIPKIN_SERVICE_OPTION=""
+fi
+
 for s in \
    "${IMAGE_HUB_OPTION}" \
    "${IMAGE_TAG_OPTION}" \
@@ -484,7 +490,7 @@ for s in \
    "--set values.gateways.istio-ingressgateway.enabled=${ISTIO_INGRESSGATEWAY_ENABLED}" \
    "--set values.meshConfig.enableTracing=true" \
    "--set values.meshConfig.extensionProviders[0].name=zipkin" \
-   "--set values.meshConfig.extensionProviders[0].zipkin.service=zipkin.${NAMESPACE}.svc.cluster.local" \
+   "${ZIPKIN_SERVICE_OPTION}" \
    "--set values.meshConfig.extensionProviders[0].zipkin.port=9411" \
    "--set values.meshConfig.accessLogFile=/dev/stdout" \
    "${CNI_OPTIONS}" \

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -189,7 +189,7 @@ setup_kind_tempo() {
     local hub_arg="--image-hub default"
   fi
   
-  "${SCRIPT_DIR}"/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true" ${hub_arg:-} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-cr-distributor.tempo:9411"
+  "${SCRIPT_DIR}"/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true" ${hub_arg:-} -a "prometheus grafana" -s values.meshConfig.extensionProviders[0].zipkin.service="tempo-cr-distributor.tempo.svc.cluster.local"
 
   infomsg "Pushing the images into the cluster..."
   make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali


### PR DESCRIPTION
Re-enables tracing for tempo CI job.

Follow up to #7356 
