### PR TITLE
K8sGRPCRoute updated to released v1

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -195,7 +195,7 @@ func (in *IstioConfigService) getIstioConfigList(ctx context.Context, cluster st
 		Telemetries:      []*v1alpha1.Telemetry{},
 
 		K8sGateways:        []*k8s_networking_v1.Gateway{},
-		K8sGRPCRoutes:      []*k8s_networking_v1alpha2.GRPCRoute{},
+		K8sGRPCRoutes:      []*k8s_networking_v1.GRPCRoute{},
 		K8sHTTPRoutes:      []*k8s_networking_v1.HTTPRoute{},
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{},
 		K8sTCPRoutes:       []*k8s_networking_v1alpha2.TCPRoute{},
@@ -507,10 +507,10 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, cluster
 			istioConfigDetail.K8sGateway.APIVersion = kubernetes.K8sApiNetworkingVersionV1
 		}
 	case kubernetes.K8sGRPCRoutes:
-		istioConfigDetail.K8sGRPCRoute, err = in.userClients[cluster].GatewayAPI().GatewayV1alpha2().GRPCRoutes(namespace).Get(ctx, object, getOpts)
+		istioConfigDetail.K8sGRPCRoute, err = in.userClients[cluster].GatewayAPI().GatewayV1().GRPCRoutes(namespace).Get(ctx, object, getOpts)
 		if err == nil {
 			istioConfigDetail.K8sGRPCRoute.Kind = kubernetes.K8sActualGRPCRouteType
-			istioConfigDetail.K8sGRPCRoute.APIVersion = kubernetes.K8sApiNetworkingVersionV1Alpha2
+			istioConfigDetail.K8sGRPCRoute.APIVersion = kubernetes.K8sApiNetworkingVersionV1
 		}
 	case kubernetes.K8sHTTPRoutes:
 		istioConfigDetail.K8sHTTPRoute, err = in.userClients[cluster].GatewayAPI().GatewayV1().HTTPRoutes(namespace).Get(ctx, object, getOpts)
@@ -636,7 +636,7 @@ func (in *IstioConfigService) DeleteIstioConfigDetail(ctx context.Context, clust
 	case kubernetes.K8sGateways:
 		err = userClient.GatewayAPI().GatewayV1().Gateways(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.K8sGRPCRoutes:
-		err = userClient.GatewayAPI().GatewayV1alpha2().GRPCRoutes(namespace).Delete(ctx, name, delOpts)
+		err = userClient.GatewayAPI().GatewayV1().GRPCRoutes(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.K8sHTTPRoutes:
 		err = userClient.GatewayAPI().GatewayV1().HTTPRoutes(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.K8sReferenceGrants:
@@ -718,8 +718,8 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 		istioConfigDetail.K8sGateway = &k8s_networking_v1.Gateway{}
 		istioConfigDetail.K8sGateway, err = userClient.GatewayAPI().GatewayV1().Gateways(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
 	case kubernetes.K8sGRPCRoutes:
-		istioConfigDetail.K8sGRPCRoute = &k8s_networking_v1alpha2.GRPCRoute{}
-		istioConfigDetail.K8sGRPCRoute, err = userClient.GatewayAPI().GatewayV1alpha2().GRPCRoutes(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
+		istioConfigDetail.K8sGRPCRoute = &k8s_networking_v1.GRPCRoute{}
+		istioConfigDetail.K8sGRPCRoute, err = userClient.GatewayAPI().GatewayV1().GRPCRoutes(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
 	case kubernetes.K8sHTTPRoutes:
 		istioConfigDetail.K8sHTTPRoute = &k8s_networking_v1.HTTPRoute{}
 		istioConfigDetail.K8sHTTPRoute, err = userClient.GatewayAPI().GatewayV1().HTTPRoutes(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)

--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -77,7 +77,9 @@ Before({ tags: '@gateway-api' }, () => {
     if (result.code !== 0) {
       cy.log('Gateway API not found. Enabling it now.');
 
-      cy.exec('kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0" | kubectl apply -f -;')
+      cy.exec(
+        'kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0" | kubectl apply -f -;'
+      )
         .its('code')
         .should('eq', 0);
     }

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -365,7 +365,7 @@ if [ "${AMBIENT_ENABLED}" == "true" ]; then
     # Verify Gateway API
     echo "Verifying that Gateway API is installed; if it is not then it will be installed now."
     $CLIENT_EXE get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-      { $CLIENT_EXE kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.0.0" | $CLIENT_EXE apply -f -; }
+      { $CLIENT_EXE kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0" | $CLIENT_EXE apply -f -; }
     # Create Waypoint proxy
     echo "Create Waypoint proxy"
     ${ISTIOCTL} x waypoint apply -n ${NAMESPACE}

--- a/hack/istio/multicluster/setup-external-controlplane.sh
+++ b/hack/istio/multicluster/setup-external-controlplane.sh
@@ -294,7 +294,7 @@ cat ${ISTIO_DIR}/samples/addons/prometheus.yaml | sed "s/istio-system/external-i
 
 # There's no istio on the remote cluster so install gateway CRDs. 
 kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.1.0" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
 
 # Configure Prometheus federation
 # Open up remote prom for scraping by the centralized prom.

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -105,8 +105,8 @@ type KubeCache interface {
 
 	GetK8sGateway(namespace, name string) (*gatewayapi_v1.Gateway, error)
 	GetK8sGateways(namespace, labelSelector string) ([]*gatewayapi_v1.Gateway, error)
-	GetK8sGRPCRoute(namespace, name string) (*gatewayapi_v1alpha2.GRPCRoute, error)
-	GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewayapi_v1alpha2.GRPCRoute, error)
+	GetK8sGRPCRoute(namespace, name string) (*gatewayapi_v1.GRPCRoute, error)
+	GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewayapi_v1.GRPCRoute, error)
 	GetK8sHTTPRoute(namespace, name string) (*gatewayapi_v1.HTTPRoute, error)
 	GetK8sHTTPRoutes(namespace, labelSelector string) ([]*gatewayapi_v1.HTTPRoute, error)
 	GetK8sReferenceGrant(namespace, name string) (*gatewayapi_v1beta1.ReferenceGrant, error)
@@ -146,7 +146,7 @@ type cacheLister struct {
 	envoyFilterLister       istionet_v1alpha3_listers.EnvoyFilterLister
 	gatewayLister           istionet_v1beta1_listers.GatewayLister
 	k8sgatewayLister        k8s_v1_listers.GatewayLister
-	k8sgrpcrouteLister      k8s_v1alpha2_listers.GRPCRouteLister
+	k8sgrpcrouteLister      k8s_v1_listers.GRPCRouteLister
 	k8shttprouteLister      k8s_v1_listers.HTTPRouteLister
 	k8sreferencegrantLister k8s_v1beta1_listers.ReferenceGrantLister
 	k8stcprouteLister       k8s_v1alpha2_listers.TCPRouteLister
@@ -421,8 +421,8 @@ func (c *kubeCache) createGatewayInformers(namespace string) gateway.SharedInfor
 		c.hasGatewayAPIStarted = true
 
 		if c.client.IsExpGatewayAPI() {
-			lister.k8sgrpcrouteLister = sharedInformers.Gateway().V1alpha2().GRPCRoutes().Lister()
-			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1alpha2().GRPCRoutes().Informer().HasSynced)
+			lister.k8sgrpcrouteLister = sharedInformers.Gateway().V1().GRPCRoutes().Lister()
+			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1().GRPCRoutes().Informer().HasSynced)
 
 			lister.k8stcprouteLister = sharedInformers.Gateway().V1alpha2().TCPRoutes().Lister()
 			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1alpha2().TCPRoutes().Informer().HasSynced)
@@ -1643,7 +1643,7 @@ func (c *kubeCache) GetK8sGateways(namespace, labelSelector string) ([]*gatewaya
 	return retK8sGateways, nil
 }
 
-func (c *kubeCache) GetK8sGRPCRoute(namespace, name string) (*gatewayapi_v1alpha2.GRPCRoute, error) {
+func (c *kubeCache) GetK8sGRPCRoute(namespace, name string) (*gatewayapi_v1.GRPCRoute, error) {
 	if err := checkIstioAPIsExist(c.client); err != nil {
 		return nil, err
 	}
@@ -1665,7 +1665,7 @@ func (c *kubeCache) GetK8sGRPCRoute(namespace, name string) (*gatewayapi_v1alpha
 	return retG, nil
 }
 
-func (c *kubeCache) GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewayapi_v1alpha2.GRPCRoute, error) {
+func (c *kubeCache) GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewayapi_v1.GRPCRoute, error) {
 	if err := checkIstioAPIsExist(c.client); err != nil {
 		return nil, err
 	}
@@ -1674,7 +1674,7 @@ func (c *kubeCache) GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewa
 	if err != nil {
 		return nil, err
 	}
-	k8sGRPCRoutes := []*gatewayapi_v1alpha2.GRPCRoute{}
+	k8sGRPCRoutes := []*gatewayapi_v1.GRPCRoute{}
 	// Read lock will prevent the cache from being refreshed while we are reading from the lister
 	// but it won't prevent other routines from reading from the lister.
 	defer c.cacheLock.RUnlock()
@@ -1704,7 +1704,7 @@ func (c *kubeCache) GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewa
 		}
 	}
 
-	var retK8sGRPCRoutes []*gatewayapi_v1alpha2.GRPCRoute
+	var retK8sGRPCRoutes []*gatewayapi_v1.GRPCRoute
 	for _, hr := range k8sGRPCRoutes {
 		hrCopy := hr.DeepCopy()
 		hrCopy.Kind = kubernetes.K8sGRPCRouteType

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -236,6 +236,7 @@ func (in *K8SClient) IsGatewayAPI() bool {
 			K8sActualGatewayType:   K8sActualGateways,
 			K8sGatewayClassType:    K8sActualGatewayClasses,
 			K8sActualHTTPRouteType: K8sActualHTTPRoutes,
+			K8sActualGRPCRouteType: K8sActualGRPCRoutes,
 		}
 		v1beta1Types := map[string]string{
 			K8sActualReferenceGrantType: K8sActualReferenceGrants,
@@ -256,9 +257,8 @@ func (in *K8SClient) IsExpGatewayAPI() bool {
 	}
 	if in.isExpGatewayAPI == nil {
 		v1alpha2Types := map[string]string{
-			K8sActualGRPCRouteType: K8sActualGRPCRoutes,
-			K8sActualTCPRouteType:  K8sActualTCPRoutes,
-			K8sActualTLSRouteType:  K8sActualTLSRoutes,
+			K8sActualTCPRouteType: K8sActualTCPRoutes,
+			K8sActualTLSRouteType: K8sActualTLSRoutes,
 		}
 		isGatewayAPIV1Alpha2 := checkGatewayAPIs(in, K8sNetworkingGroupVersionV1Alpha2.String(), v1alpha2Types)
 		in.isExpGatewayAPI = &isGatewayAPIV1Alpha2

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -195,7 +195,7 @@ var (
 		Telemetries:      TelemetryGroupV1Alpha1.Group,
 
 		K8sGateways:        K8sNetworkingGroupVersionV1.Group,
-		K8sGRPCRoutes:      K8sNetworkingGroupVersionV1Alpha2.Group,
+		K8sGRPCRoutes:      K8sNetworkingGroupVersionV1.Group,
 		K8sHTTPRoutes:      K8sNetworkingGroupVersionV1.Group,
 		K8sReferenceGrants: K8sNetworkingGroupVersionV1.Group,
 		K8sTCPRoutes:       K8sNetworkingGroupVersionV1Alpha2.Group,

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -27,7 +27,7 @@ type IstioConfigList struct {
 	Telemetries      []*v1alpha1.Telemetry                 `json:"telemetries"`
 
 	K8sGateways        []*k8s_networking_v1.Gateway             `json:"k8sGateways"`
-	K8sGRPCRoutes      []*k8s_networking_v1alpha2.GRPCRoute     `json:"k8sGRPCRoutes"`
+	K8sGRPCRoutes      []*k8s_networking_v1.GRPCRoute           `json:"k8sGRPCRoutes"`
 	K8sHTTPRoutes      []*k8s_networking_v1.HTTPRoute           `json:"k8sHTTPRoutes"`
 	K8sReferenceGrants []*k8s_networking_v1beta1.ReferenceGrant `json:"k8sReferenceGrants"`
 	K8sTCPRoutes       []*k8s_networking_v1alpha2.TCPRoute      `json:"k8sTCPRoutes"`
@@ -81,7 +81,7 @@ func (i *IstioConfigList) ConvertToResponse() {
 		i.K8sGateways = []*k8s_networking_v1.Gateway{}
 	}
 	if i.K8sGRPCRoutes == nil {
-		i.K8sGRPCRoutes = []*k8s_networking_v1alpha2.GRPCRoute{}
+		i.K8sGRPCRoutes = []*k8s_networking_v1.GRPCRoute{}
 	}
 	if i.K8sHTTPRoutes == nil {
 		i.K8sHTTPRoutes = []*k8s_networking_v1.HTTPRoute{}
@@ -129,7 +129,7 @@ type IstioConfigDetails struct {
 	Telemetry             *v1alpha1.Telemetry                    `json:"telemetry"`
 
 	K8sGateway        *k8s_networking_v1.Gateway             `json:"k8sGateway"`
-	K8sGRPCRoute      *k8s_networking_v1alpha2.GRPCRoute     `json:"k8sGRPCRoute"`
+	K8sGRPCRoute      *k8s_networking_v1.GRPCRoute           `json:"k8sGRPCRoute"`
 	K8sHTTPRoute      *k8s_networking_v1.HTTPRoute           `json:"k8sHTTPRoute"`
 	K8sReferenceGrant *k8s_networking_v1beta1.ReferenceGrant `json:"k8sReferenceGrant"`
 	K8sTCPRoute       *k8s_networking_v1alpha2.TCPRoute      `json:"k8sTCPRoute"`
@@ -292,7 +292,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			filtered[ns].EnvoyFilters = []*networking_v1alpha3.EnvoyFilter{}
 			filtered[ns].Gateways = []*networking_v1beta1.Gateway{}
 			filtered[ns].K8sGateways = []*k8s_networking_v1.Gateway{}
-			filtered[ns].K8sGRPCRoutes = []*k8s_networking_v1alpha2.GRPCRoute{}
+			filtered[ns].K8sGRPCRoutes = []*k8s_networking_v1.GRPCRoute{}
 			filtered[ns].K8sHTTPRoutes = []*k8s_networking_v1.HTTPRoute{}
 			filtered[ns].K8sReferenceGrants = []*k8s_networking_v1beta1.ReferenceGrant{}
 			filtered[ns].K8sTCPRoutes = []*k8s_networking_v1alpha2.TCPRoute{}


### PR DESCRIPTION
### Describe the change

Explanation of what this PR does
K8sGRPCRoute is updated to v1 which comes with K8s GW API v1.1.0 CRDs.

### Steps to test the PR

- Apply K8s GW CRDs v1.1.0. `kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0"`
- Create GRPCRoute v1alpha2:
```
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: GRPCRoute
metadata:
  name: example-route
spec:
  parentRefs:
  - name: example-gateway
  hostnames:
  - "example.com"
  rules:
  - backendRefs:
    - name: example-svc
      port: 50051
```

- Load Kiali. Make sure that GRPCRoute created loading fine in Kiali Istio Config YAML editor. It should change it to v1.
- Update/View/Delete the GRPCRoute, it should work fine.

### Automation testing

Existing cypress and e2e tests are updated to support v1 in v1.1.0.

### Issue reference
https://github.com/kiali/kiali/issues/7355

Blocked by https://github.com/kiali/kiali/pull/7359
