### PR TITLE
Remove login actions for OAuth

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -132,6 +132,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
 
         // Wait for post login routes to be loaded. Otherwise cypress redirects you back to the home page
         // which causes other tests to fail: https://github.com/cypress-io/cypress/issues/1713.
+        cy.url().should('include', '/console/overview');
         cy.wait('@getNamespaces');
         cy.wait('@getConfig');
         cy.wait('@getStatus');


### PR DESCRIPTION
### Describe the change

These login actions are (probably) no longer needed and they mess with the URL post login which is causing the cypress tests to fail and probably unnecessary redirects for users.

### Steps to test the PR

Perform a successful login/logout with openshift/openid auth strategies. Session timeout should also work as expected.

### Automation testing

Fixes current automation.