### PR TITLE
Wait for istiod deployment to be ready after updating it

### DIFF
--- a/tests/integration/tests/remote_istiod_test.go
+++ b/tests/integration/tests/remote_istiod_test.go
@@ -70,6 +70,8 @@ func TestRemoteIstiod(t *testing.T) {
 		}
 		_, err = kubeClient.AppsV1().Deployments(originalConf.IstioNamespace).Update(ctx, istiod, metav1.UpdateOptions{})
 		require.NoError(err)
+
+		require.NoError(kube.WaitForDeploymentReady(ctx, kubeClient, originalConf.IstioNamespace, istioDeploymentName))
 	})
 
 	// Expose the istiod /debug endpoints by adding a proxy to the pod.

--- a/tests/integration/utils/kube/util.go
+++ b/tests/integration/utils/kube/util.go
@@ -1,0 +1,47 @@
+package kube
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiali/kiali/log"
+)
+
+// WaitForDeploymentReady waits for a deployment to be fully rolled out and ready.
+func WaitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) error {
+	timeout := 5 * time.Minute
+	pollInterval := 10 * time.Second
+
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			log.Debug("The deployment has not observed the latest spec update yet.")
+			return false, nil
+		}
+
+		if deployment.Status.Replicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be fully rolled out (%d/%d replicas)", deployment.Status.Replicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		if deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be updated (%d/%d replicas)", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		return true, nil
+	})
+}


### PR DESCRIPTION
### Describe the change

Previously we were updating the istiod but then not waiting for it to be ready before the next test started causing the next test to fail. This change will wait for the istiod to be ready before the next test starts.

### Automation testing

If automation passes and the flake goes away then this change worked.

### Issue reference

Fixes #7134 
