### PR TITLE
Fix deploy-kiali.sh testing user roles

### DIFF
--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -151,7 +151,14 @@ deploy_kiali() {
     # Create the kiali user
     curl -k -L https://"${KEYCLOAK_ADDRESS}"/admin/realms/kube/users -H "Authorization: Bearer $TOKEN_KEY" -d '{"username": "kiali", "enabled": true, "credentials": [{"type": "password", "value": "kiali"}]}' -H 'Content-Type: application/json'
   
-    # Create a clusterrolebinding so that the kiali oidc user can view and edit resources in kiali.
+    # Create a clusterrole and clusterrolebinding so that the kiali oidc user can view and edit resources in kiali.
+    # It needs read-write permissions for the tests to create and delete resources so we have to do
+    # this helm templating to create the role with write permissions since only when you are using
+    # anonymous auth do you get a role with write permissions. For testing we want a role that does
+    # potentially all the things kiali can do so that's why we reuse the kiali role rather than
+    # having to maintain a whole separate role just for the testing user.
+    helm template --show-only "templates/role.yaml" --set deployment.instance_name=kiali-testing-user --set auth.strategy=anonymous kiali-server "${KIALI_SERVER_HELM_CHARTS}" | kubectl apply --context "${CLUSTER1_CONTEXT}" -f -
+    helm template --show-only "templates/role.yaml" --set deployment.instance_name=kiali-testing-user --set auth.strategy=anonymous kiali-server "${KIALI_SERVER_HELM_CHARTS}" | kubectl apply --context "${CLUSTER2_CONTEXT}" -f -
     kubectl apply --context "${CLUSTER1_CONTEXT}" -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -160,16 +167,13 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali-testing-user
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: oidc:kiali
 EOF
 
-    # Copy the kiali-viewer cluster role to the west cluster
-    kubectl get clusterrole kiali -o yaml --context "${CLUSTER1_CONTEXT}" | kubectl apply --context "${CLUSTER2_CONTEXT}" -f -
-    
     # Create a clusterrolebinding in the west cluster so that the kiali oidc user can view resources in kiali.
     kubectl apply --context "${CLUSTER2_CONTEXT}" -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
@@ -179,7 +183,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali-testing-user
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
### Describe the change

Due to recent helm chart changes, the `kiali` clusterrole no longer gets created when using the oauth strategy. The CI tests relied on this role to be present to give the testing user permissions to login and interact with kiali. This change generates the old `kiali` clusterrole from helm directly rather than relying on it being present in the cluster.

### Steps to test the PR

`./hack/run-integration-tests.sh --test-suite frontend-multi-primary`

### Automation testing

Multi-primary tests pass.