### PR TITLE
Initial load graph or mesh on componentDidMount

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -375,15 +375,15 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
     if (urlTrace !== this.props.trace?.traceID) {
       this.props.setTraceId(urlTrace);
     }
+
+    // Ensure we initialize the graph. We wait for the toolbar to render and
+    // ensure all redux props are updated with URL settings.
+    // That in turn ensures the initial fetchParams are correct.
+    setTimeout(() => this.loadGraphDataFromBackend(), 0);
   }
 
   componentDidUpdate(prev: GraphPageProps): void {
     const curr = this.props;
-
-    // Ensure we initialize the graph. We wait for the first update so that
-    // the toolbar can render and ensure all redux props are updated with URL
-    // settings. That in turn ensures the initial fetchParams are correct.
-    const isInitialLoad = !this.state.graphData.timestamp;
 
     const activeNamespacesChanged = !arrayEquals(
       prev.activeNamespaces,
@@ -396,7 +396,6 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
       this.props.onNamespaceChange();
     }
     if (
-      isInitialLoad ||
       activeNamespacesChanged ||
       prev.boxByCluster !== curr.boxByCluster ||
       prev.boxByNamespace !== curr.boxByNamespace ||

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -359,15 +359,15 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
     } else {
       HistoryManager.setParam(URLParam.GRAPH_LAYOUT, this.props.layout.name);
     }
+
+    // Ensure we initialize the graph. We wait for the toolbar to render and
+    // ensure all redux props are updated with URL settings.
+    // That in turn ensures the initial fetchParams are correct.
+    setTimeout(() => this.loadGraphDataFromBackend(), 0);
   }
 
   componentDidUpdate(prev: GraphPagePropsPF): void {
     const curr = this.props;
-
-    // Ensure we initialize the graph. We wait for the first update so that
-    // the toolbar can render and ensure all redux props are updated with URL
-    // settings. That in turn ensures the initial fetchParams are correct.
-    const isInitialLoad = !this.state.graphData.timestamp;
 
     if (curr.summaryData?.summaryType === 'graph') {
       this.controller = curr.summaryData.summaryTarget;
@@ -383,8 +383,8 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
     if (activeNamespacesChanged) {
       this.props.onNamespaceChange();
     }
+
     if (
-      isInitialLoad ||
       activeNamespacesChanged ||
       prev.boxByCluster !== curr.boxByCluster ||
       prev.boxByNamespace !== curr.boxByNamespace ||


### PR DESCRIPTION
### Describe the change

The initial loading of the mesh and graph data is performed in the `componentDidUpdate` method to ensure that everything is set before the mesh loads. The issue is that the `componentDidUpdate` method is not called in OSSMC during the initial mesh load, so the page displays the `Loading` message until the user performs an action that triggers the componentDidUpdate method.

![image](https://github.com/kiali/kiali/assets/122779323/bbe4023d-f0f6-41a1-8fc8-1b70f25ae114)

This PR also sets some missing redux properties in the mesh page and fix lint issues.

### Steps to test the PR

This PR only affects OSSMC. Kiali standalone should work as usual.

### Automation testing

N/A

### Issue reference

https://github.com/kiali/openshift-servicemesh-plugin/issues/308
