### PR TITLE
Correct Kubernetes versions for multi-primary scenarios

### DIFF
--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -65,6 +65,7 @@
   "Kiali home cluster": "Kiali home cluster",
   "Kiali home cluster: {{name}}": "Kiali主集群: {{name}}",
   "Kiali on GitHub": "Kiali on GitHub",
+  "Kubernetes": "Kubernetes",
   "Last": "最近的",
   "List view": "列表视图",
   "Loading...": "Loading...",

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -36,21 +36,24 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
     const clusterDataPlanes = dataPlaneNodes.filter(node => node.getData().cluster === clusterData.cluster);
 
     return (
-      <div style={{ marginBottom: '1rem' }}>
+      <div key={clusterData.id} style={{ marginBottom: '1rem' }}>
         {renderNodeHeader(clusterData, { nameOnly: true, smallSize: false, hideBadge: clusterData.isExternal })}
         <div className={infoStyle}>
-          {!clusterData.isExternal && `${t('Version')}: ${clusterData.version || UNKNOWN}`}
+          {!clusterData.isExternal && `${t('Kubernetes')}: ${clusterData.version || UNKNOWN}`}
           {infraNodes
             .filter(node => node.getData().cluster === clusterData.cluster)
             .sort((in1, in2) => {
               const data1 = in1.getData() as MeshNodeData;
               const data2 = in2.getData() as MeshNodeData;
+
               if (data1.infraType === MeshInfraType.ISTIOD) {
                 return -1;
               }
+
               if (data2.infraType === MeshInfraType.ISTIOD) {
                 return 1;
               }
+
               return data1.infraName.toLowerCase() < data2.infraName.toLowerCase() ? -1 : 1;
             })
             .map(node => renderInfraNodeSummary(node.getData()))}
@@ -62,7 +65,7 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
 
   const renderInfraNodeSummary = (nodeData: MeshNodeData): React.ReactNode => {
     return (
-      <div className={summaryStyle}>
+      <div key={nodeData.id} className={summaryStyle}>
         {renderNodeHeader(nodeData, { nameOnly: true, smallSize: true })}
         <div className={infoStyle}>
           <div>{`${t('Version')}: ${nodeData.version || UNKNOWN}`}</div>
@@ -76,7 +79,7 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
 
   const renderDataPlaneSummary = (nodeData: MeshNodeData, showCanaryInfo: boolean): React.ReactNode => {
     return (
-      <div className={summaryStyle}>
+      <div key={nodeData.id} className={summaryStyle}>
         {renderNodeHeader(nodeData, { nameOnly: true, smallSize: true })}
         <div className={infoStyle}>
           {showCanaryInfo && (

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -72,7 +72,8 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 	for _, cp := range meshDef.ControlPlanes {
 		// add control plane cluster if not already added
 		if _, ok := clusterMap[cp.Cluster.Name]; !ok {
-			_, _, err := addInfra(meshMap, mesh.InfraTypeCluster, cp.Cluster.Name, "", cp.Cluster.Name, cp.Cluster, esVersions[cp.Cluster.Name], false, "", false)
+			k8sVersion := esVersions[fmt.Sprintf("%s-%s", "Kubernetes", cp.Cluster.Name)]
+			_, _, err := addInfra(meshMap, mesh.InfraTypeCluster, cp.Cluster.Name, "", cp.Cluster.Name, cp.Cluster, k8sVersion, false, "", false)
 			mesh.CheckError(err)
 			clusterMap[cp.Cluster.Name] = true
 		}

--- a/status/versions.go
+++ b/status/versions.go
@@ -42,7 +42,7 @@ const (
 )
 
 func getVersions() {
-	components := getKubernetesVersions()
+	components := getKubernetesVersion()
 
 	components = append(components, istioVersion, prometheusVersion)
 
@@ -294,7 +294,7 @@ func prometheusVersion() (*ExternalServiceInfo, error) {
 	return nil, err
 }
 
-func getKubernetesVersions() []externalService {
+func getKubernetesVersion() []externalService {
 	k8sVersions := []externalService{}
 
 	// Use the Kiali Service Account client to get the Kubernetes version

--- a/status/versions.go
+++ b/status/versions.go
@@ -310,14 +310,14 @@ func getKubernetesVersions() []externalService {
 
 		if err != nil {
 			k8sVersions = append(k8sVersions, func() (*ExternalServiceInfo, error) { return nil, err })
+		} else {
+			k8sVersions = append(k8sVersions, func() (*ExternalServiceInfo, error) {
+				return &ExternalServiceInfo{
+					Name:    fmt.Sprintf("%s-%s", "Kubernetes", clusterName),
+					Version: serverVersion.GitVersion,
+				}, nil
+			})
 		}
-
-		k8sVersions = append(k8sVersions, func() (*ExternalServiceInfo, error) {
-			return &ExternalServiceInfo{
-				Name:    fmt.Sprintf("%s-%s", "Kubernetes", clusterName),
-				Version: serverVersion.GitVersion,
-			}, nil
-		})
 	}
 
 	return k8sVersions


### PR DESCRIPTION
### Describe the change

This PR adds support for multi-primary scenarios, providing correct versions for Kubernetes in the mesh page. 

### Steps to test the PR

1. Deploy a multi-primary scenario 
2. Go to Mesh page
3. Verify that Kubernetes versions are the correct ones

![image](https://github.com/kiali/kiali/assets/122779323/65044ad9-a259-4a0c-8286-9178a2ae3714)

![image](https://github.com/kiali/kiali/assets/122779323/46e61db5-e0c9-400f-a411-cdfe2ed2b036)

### Automation testing

N/A

### Issue reference

Fixes #7361 
