### PR TITLE
Fix meshpage cypress issue

### DIFF
--- a/frontend/cypress/integration/common/mesh_test.ts
+++ b/frontend/cypress/integration/common/mesh_test.ts
@@ -19,10 +19,12 @@ Before(() => {
 });
 
 When('user closes mesh tour', () => {
+  cy.waitForReact();
   cy.get('div[role="dialog"]').find('button[aria-label="Close"]').click();
 });
 
 When('user opens mesh tour', () => {
+  cy.waitForReact();
   cy.get('button#mesh-tour').click();
 });
 
@@ -32,7 +34,7 @@ When('user selects cluster mesh node', () => {
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
-      const controller = state.meshRefs.controller as Visualization;
+      const controller = state.meshRefs.getController() as Visualization;
       assert.isTrue(controller.hasGraph());
       const { nodes } = elems(controller);
       const node = nodes.find(n => (n.getData() as MeshNodeData).infraType === MeshInfraType.CLUSTER);
@@ -48,7 +50,7 @@ When('user selects mesh node with label {string}', (label: string) => {
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
-      const controller = state.meshRefs.controller as Visualization;
+      const controller = state.meshRefs.getController() as Visualization;
       assert.isTrue(controller.hasGraph());
       const { nodes } = elems(controller);
       const node = nodes.find(n => n.getLabel() === label);
@@ -58,12 +60,24 @@ When('user selects mesh node with label {string}', (label: string) => {
     });
 });
 
+When('user sees mesh side panel', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-mesh')
+    .should('be.visible')
+    .within(div => {
+      cy.contains('Mesh Name: Istio Mesh');
+    });
+});
+
 Then('user sees cluster side panel', () => {
+  cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-cluster').should('be.visible');
 });
 
 Then('user sees control plane side panel', () => {
+  cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-control-plane')
     .should('be.visible')
@@ -80,6 +94,7 @@ Then('user sees control plane side panel', () => {
 });
 
 Then('user sees data plane side panel', () => {
+  cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-data-plane')
     .should('be.visible')
@@ -94,7 +109,7 @@ Then('user sees expected mesh infra', () => {
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
-      const controller = state.meshRefs.controller;
+      const controller = state.meshRefs.getController() as Visualization;
       assert.isTrue(controller.hasGraph());
       const { nodes, edges } = elems(controller);
       assert.equal(nodes.length, 8, 'Unexpected number of infra nodes');
@@ -109,16 +124,8 @@ Then('user sees expected mesh infra', () => {
     });
 });
 
-Then('user sees mesh side panel', () => {
-  cy.get('#loading_kiali_spinner').should('not.exist');
-  cy.get('#target-panel-mesh')
-    .should('be.visible')
-    .within(div => {
-      cy.contains('Mesh Name: Istio Mesh');
-    });
-});
-
 Then('user {string} mesh tour', (action: string) => {
+  cy.waitForReact();
   if (action === 'sees') {
     cy.get('div[role="dialog"]').find('span').contains('Shortcuts').should('exist');
   } else {
@@ -127,6 +134,7 @@ Then('user {string} mesh tour', (action: string) => {
 });
 
 Then('user sees {string} namespace side panel', (name: string) => {
+  cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-namespace')
     .should('be.visible')
@@ -136,6 +144,7 @@ Then('user sees {string} namespace side panel', (name: string) => {
 });
 
 Then('user sees {string} node side panel', (name: string) => {
+  cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-node')
     .should('be.visible')

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -21,8 +21,8 @@ Feature: Kiali Mesh page
     Then user "does not see" mesh tour
 
   Scenario: See mesh
-    Then user sees mesh side panel
-    And user sees expected mesh infra
+    When user sees mesh side panel
+    Then user sees expected mesh infra
 
   Scenario: Test istiod
     When user selects mesh node with label "istiod"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -138,7 +138,7 @@
     "axios-mock-adapter": "^1.22.0",
     "cypress": "^13.6.1",
     "cypress-multi-reporters": "^1.6.0",
-    "cypress-react-selector": "^2.3.20",
+    "cypress-react-selector": "^3.0.0",
     "enzyme": "3.11.0",
     "enzyme-to-json": "3.4.4",
     "husky": "^8.0.3",

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -411,7 +411,7 @@ const TopologyContent: React.FC<{
 
     if (initialGraph) {
       console.debug('mesh onReady');
-      onReady({ controller: controller, setSelectedIds: setSelectedIds });
+      onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
     }
 
     // notify that the graph has been updated

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -84,7 +84,7 @@ export type MeshData = {
 // MeshRefs are passed back from the graph when it is ready, to allow for
 // other components, or test code, to manipulate the graph programatically.
 export type MeshRefs = {
-  controller: Controller;
+  getController: () => Controller;
   setSelectedIds: (values: string[]) => void;
 };
 
@@ -220,7 +220,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
         <FlexView className={conStyle} column={true}>
           <div>
             <MeshToolbar
-              controller={this.state.meshRefs?.controller}
+              controller={this.state.meshRefs?.getController()}
               disabled={this.state.meshData.isLoading}
               elementsChanged={this.state.meshData.elementsChanged}
               onToggleHelp={this.toggleHelp}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4907,10 +4907,10 @@ cypress-multi-reporters@^1.6.0:
     debug "^4.1.1"
     lodash "^4.17.15"
 
-cypress-react-selector@^2.3.20:
-  version "2.3.20"
-  resolved "https://registry.yarnpkg.com/cypress-react-selector/-/cypress-react-selector-2.3.20.tgz#a4d9ac439bdd601d50f1a6ab2ac7ba5691822b0a"
-  integrity sha512-S5msxVyk1TgtA//V/uVrb/kyWH4yRSVkBReaCDiG0OVT5DNhNTJwXkWeTn79zkS31Gtqckaq3Uq/Ap/oHjiblg==
+cypress-react-selector@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-react-selector/-/cypress-react-selector-3.0.0.tgz#e86018fffea07ba40c7a1f467a89b475a83cbcae"
+  integrity sha512-AQCgwbcMDkIdYcf6knvLxqzBnejahIbJPHqUhARi8k+QbM8sgUBDds98PaHJVMdPiX2J8RJjXHmUMPD8VerPSw==
   dependencies:
     resq "1.10.2"
 
@@ -11811,7 +11811,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13358,8 +13365,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13372,6 +13378,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/make/Makefile.ui.mk
+++ b/make/Makefile.ui.mk
@@ -21,6 +21,9 @@ yarn-start:
 cypress-run:
 	@cd ${ROOTDIR}/frontend && yarn cypress:run --headless --config numTestsKeptInMemory=0,video=false
 
+cypress-selected:
+	@cd ${ROOTDIR}/frontend && yarn cypress:run:selected --headless --config numTestsKeptInMemory=0,video=false
+
 ## cypress-gui: Opens the cypress GUI letting you pick which frontend integration tests to run locally.
 cypress-gui:
 	@cd ${ROOTDIR}/frontend && yarn cypress


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/7374

- Fix meshpage cypress issue caused by excessively large state (i.e. the  PFT controller object.
- Add `make cypress-selected` command for convenience
- update cypress-react-selector to 3.0 as it is supposed to the version for Cypress 10+ (we are on cypress 13). Note that this project seems unmaintained, but there is currently no obvious alternative.
