### PR TITLE
Adding HTTPS and TLS into K8s Gateway creation wizard

### DIFF
--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -53,6 +53,25 @@ Feature: Kiali Istio Config wizard
 
   @gateway-api
   @bookinfo-app
+  Scenario: Create a K8s Gateway HTTPS scenario
+    When user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
+    And user clicks in the "K8sGateway" Istio config actions
+    And user sees the "Create K8sGateway" config wizard
+    And user adds listener
+    And user types "k8sapigateway" in the "name" input
+    And user types "listener" in the "addName_0" input
+    And user checks validation of the hostname "addHostname_0" input
+    And user types "website.com" in the "addHostname_0" input
+    And user types "443" in the "addPort_0" input
+    And user chooses "HTTPS" mode from the "addPortProtocol_0" select
+    And the preview button should be disabled
+    And user types "cert" in the "tls-certificate_0" input
+    And user previews the configuration
+    And user creates the istio config
+    Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
+
+  @gateway-api
+  @bookinfo-app
   Scenario: Create a K8s Reference Grant scenario
     When user deletes k8sreferencegrant named "k8srefgrant" and the resource is no longer available
     And user clicks in the "K8sReferenceGrant" Istio config actions

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -65,7 +65,7 @@ Feature: Kiali Istio Config wizard
     And user types "443" in the "addPort_0" input
     And user chooses "HTTPS" mode from the "addPortProtocol_0" select
     And the preview button should be disabled
-    And user types "cert" in the "tls-certificate_0" input
+    And user types "cert" in the "tlsCert_0" input
     And user previews the configuration
     And user creates the istio config
     Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -983,7 +983,8 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
                         matchLabels: {}
                       }
                     }
-                  }
+                  },
+                  tls: null
                 }
               ]
             }
@@ -2154,9 +2155,9 @@ export const addAnnotations = (istioObject: IstioObject, value: { [key: string]:
   istioObject.metadata.annotations = value;
 };
 
-export const getTLS = (tls?: K8sGatewayTLS): K8sGatewayTLS | undefined => {
+export const getTLS = (tls?: K8sGatewayTLS | null): K8sGatewayTLS | null => {
   if (!tls) {
-    return undefined;
+    return null;
   }
   return {
     certificateRefs: tls.certificateRefs.map(c => ({

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -16,6 +16,7 @@ import {
   HTTPRouteDestination,
   IstioObject,
   K8sGateway,
+  K8sGatewayTLS,
   K8sHTTPHeaderFilter,
   K8sHTTPMatch,
   K8sHTTPRequestMirrorFilter,
@@ -1878,7 +1879,8 @@ export const buildK8sGateway = (
               matchLabels: s.allowedRoutes.namespaces.selector?.matchLabels
             }
           }
-        }
+        },
+        tls: getTLS(s.tls)
       })),
       addresses: state.addresses.map(s => ({
         type: s.type,
@@ -2150,4 +2152,16 @@ export const addLabels = (istioObject: IstioObject, value: { [key: string]: stri
 
 export const addAnnotations = (istioObject: IstioObject, value: { [key: string]: string }): void => {
   istioObject.metadata.annotations = value;
+};
+
+export const getTLS = (tls?: K8sGatewayTLS): K8sGatewayTLS | undefined => {
+  if (!tls) {
+    return undefined;
+  }
+  return {
+    certificateRefs: tls.certificateRefs.map(c => ({
+      kind: 'Secret',
+      name: c.name
+    }))
+  };
 };

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -25,7 +25,6 @@ import {
   K8sHTTPRouteMatch,
   K8sHTTPRouteRequestRedirect,
   K8sReferenceGrant,
-  Listener,
   LoadBalancerSettings,
   Operation,
   OutlierDetection,
@@ -984,8 +983,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
                         matchLabels: {}
                       }
                     }
-                  },
-                  tls: null
+                  }
                 }
               ]
             }
@@ -1869,33 +1867,7 @@ export const buildK8sGateway = (
     spec: {
       // Default for istio scenarios, user may change it editing YAML
       gatewayClassName: state.gatewayClass,
-      listeners: state.listeners.map(s => {
-        const listener: Listener = {
-          name: s.name,
-          port: s.port,
-          protocol: s.protocol,
-          hostname: s.hostname,
-          allowedRoutes: {
-            namespaces: {
-              from: s.allowedRoutes.namespaces.from
-            }
-          }
-        };
-
-        if (s.allowedRoutes.namespaces.from === 'Selector' && s.allowedRoutes.namespaces.selector?.matchLabels) {
-          listener.allowedRoutes.namespaces.selector = {
-            matchLabels: s.allowedRoutes!.namespaces.selector?.matchLabels
-          };
-        }
-
-        const tls = getTLS(s.tls);
-
-        if (tls) {
-          listener.tls = tls;
-        }
-
-        return listener;
-      })
+      listeners: state.listeners
     }
   };
 

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -16,7 +16,6 @@ import {
   HTTPRouteDestination,
   IstioObject,
   K8sGateway,
-  K8sGatewayTLS,
   K8sHTTPHeaderFilter,
   K8sHTTPMatch,
   K8sHTTPRequestMirrorFilter,
@@ -2142,16 +2141,4 @@ export const addLabels = (istioObject: IstioObject, value: { [key: string]: stri
 
 export const addAnnotations = (istioObject: IstioObject, value: { [key: string]: string }): void => {
   istioObject.metadata.annotations = value;
-};
-
-export const getTLS = (tls?: K8sGatewayTLS | null): K8sGatewayTLS | null => {
-  if (!tls) {
-    return null;
-  }
-  return {
-    certificateRefs: tls.certificateRefs.map(c => ({
-      kind: 'Secret',
-      name: c.name
-    }))
-  };
 };

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -19,10 +19,10 @@ type ListenerBuilderProps = {
 export const protocols = ['HTTP', 'HTTPS'];
 // protocols which could require certificate
 export const protocolsCert = ['HTTPS'];
-export const allowedRoutes = ['All', 'Selector', 'Same'];
-export const tlsModes = ['Terminate'];
-// TLS mode which require ceritificate cuttently one
-export const tlsModesCert = ['Terminate'];
+export const SELECTOR = 'Selector';
+export const allowedRoutes = ['All', SELECTOR, 'Same'];
+export const TERMINATE = 'Terminate';
+export const tlsModes = [TERMINATE];
 
 export const isValidName = (name: string): boolean => {
   return name !== undefined && name.length > 0;
@@ -32,7 +32,7 @@ export const isValidHostname = (hostname: string): boolean => {
   return hostname !== undefined && hostname.length > 0 && isK8sGatewayHostValid(hostname);
 };
 
-export const isValidTLS = (protocol: string, tls: K8sGatewayTLS | null): boolean => {
+export const isValidTLS = (protocol: string, tls?: K8sGatewayTLS | null): boolean => {
   const tlsRequired = protocolsCert.includes(protocol);
   if (!tls || !tlsRequired) {
     return true;
@@ -53,7 +53,7 @@ export const isValidPort = (port: string): boolean => {
 };
 
 export const isValidSelector = (selector: string): boolean => {
-  return selector.length === 0 || typeof addSelectorLabels(selector) !== 'undefined';
+  return selector.length === 0 || addSelectorLabels(selector)[0];
 };
 
 export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerBuilderProps) => {
@@ -179,6 +179,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
           <TextInput
             id={`addSelectorLabels_${props.index}`}
             name="addSelectorLabels"
+            isDisabled={props.listener.from !== SELECTOR}
             onChange={onAddSelectorLabels}
             validated={isValid(isValidSelector(props.listener.sSelectorLabels))}
           />
@@ -209,7 +210,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
               </FormSelect>
             </FormGroup>
           </Td>
-          {(props.listener.tlsMode === tlsMode.TERMINATE && (
+          {props.listener.tlsMode === TERMINATE && (
             <Td colSpan={4}>
               <FormGroup
                 label="TLS Certificate"

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -181,7 +181,9 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
             name="addSelectorLabels"
             isDisabled={props.listener.from !== SELECTOR}
             onChange={onAddSelectorLabels}
-            validated={isValid(isValidSelector(props.listener.sSelectorLabels))}
+            validated={isValid(
+              props.listener.from === SELECTOR ? isValidSelector(props.listener.sSelectorLabels) : undefined
+            )}
           />
         </Td>
         <Td>

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -199,7 +199,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
             <FormGroup label="TLS Mode" fieldId="addTlsMode" style={{ margin: '0.5rem 0' }}>
               <FormSelect
                 value={props.listener.tlsMode}
-                id="addTlsMode_${props.index}"
+                id={`addTlsMode_${props.index}`}
                 name="addTlsMode"
                 onChange={onAddTlsMode}
               >
@@ -221,7 +221,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
                   value={props.listener.tlsCert}
                   isRequired={true}
                   type="text"
-                  id="tlsCert_${props.index}"
+                  id={`tlsCert_${props.index}`}
                   aria-describedby="server-certificate"
                   name="tls-certificate"
                   onChange={onAddTlsCert}

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -53,7 +53,7 @@ export const isValidPort = (port: string): boolean => {
 };
 
 export const isValidSelector = (selector: string): boolean => {
-  return selector.length === 0 || addSelectorLabels(selector)[0];
+  return addSelectorLabels(selector)[0];
 };
 
 export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerBuilderProps) => {

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -204,29 +204,27 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
               </FormSelect>
             </FormGroup>
           </Td>
-        </Tr>
-      )}
-      {showTls && tlsModesCert.includes(props.listener.tlsMode) && (
-        <Tr>
-          <Td colSpan={2}>
-            <FormGroup
-              label="TLS Certificate"
-              style={{ margin: '0.5rem 0' }}
-              isRequired={true}
-              fieldId="server-certificate"
-            >
-              <TextInput
-                value={props.listener.tlsCert}
+          {tlsModesCert.includes(props.listener.tlsMode) && (
+            <Td colSpan={4}>
+              <FormGroup
+                label="TLS Certificate"
+                style={{ margin: '0.5rem 0' }}
                 isRequired={true}
-                type="text"
-                id="tls-certificate"
-                aria-describedby="server-certificate"
-                name="tls-certificate"
-                onChange={onAddTlsCert}
-                validated={isValid(props.listener.tlsCert.length > 0)}
-              />
-            </FormGroup>
-          </Td>
+                fieldId="server-certificate"
+              >
+                <TextInput
+                  value={props.listener.tlsCert}
+                  isRequired={true}
+                  type="text"
+                  id="tls-certificate"
+                  aria-describedby="server-certificate"
+                  name="tls-certificate"
+                  onChange={onAddTlsCert}
+                  validated={isValid(props.listener.tlsCert.length > 0)}
+                />
+              </FormGroup>
+            </Td>
+          )}
         </Tr>
       )}
     </>

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -209,7 +209,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
               </FormSelect>
             </FormGroup>
           </Td>
-          {tlsModesCert.includes(props.listener.tlsMode) && (
+          {(props.listener.tlsMode === tlsMode.TERMINATE && (
             <Td colSpan={4}>
               <FormGroup
                 label="TLS Certificate"

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -32,7 +32,7 @@ export const isValidHostname = (hostname: string): boolean => {
   return hostname !== undefined && hostname.length > 0 && isK8sGatewayHostValid(hostname);
 };
 
-export const isValidTLS = (protocol: string, tls?: K8sGatewayTLS | null): boolean => {
+export const isValidTLS = (protocol: string, tls?: K8sGatewayTLS): boolean => {
   const tlsRequired = protocolsCert.includes(protocol);
   if (!tls || !tlsRequired) {
     return true;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -32,7 +32,7 @@ export const isValidHostname = (hostname: string): boolean => {
   return hostname !== undefined && hostname.length > 0 && isK8sGatewayHostValid(hostname);
 };
 
-export const isValidTLS = (protocol: string, tls?: K8sGatewayTLS): boolean => {
+export const isValidTLS = (protocol: string, tls: K8sGatewayTLS | null): boolean => {
   const tlsRequired = protocolsCert.includes(protocol);
   if (!tls || !tlsRequired) {
     return true;
@@ -195,8 +195,8 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
       </Tr>
       {showTls && (
         <Tr>
-          <Td>
-            <FormGroup label="TLS Mode" isRequired={true} fieldId="addTlsMode" style={{ margin: '0.5rem 0' }}>
+          <Td colSpan={2}>
+            <FormGroup label="TLS Mode" fieldId="addTlsMode" style={{ margin: '0.5rem 0' }}>
               <FormSelect value={props.listener.tlsMode} id="addTlsMode" name="addTlsMode" onChange={onAddTlsMode}>
                 {tlsModes.map((option, index) => (
                   <FormSelectOption isDisabled={false} key={`p_${index}`} value={option} label={option} />
@@ -208,7 +208,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
       )}
       {showTls && tlsModesCert.includes(props.listener.tlsMode) && (
         <Tr>
-          <Td>
+          <Td colSpan={2}>
             <FormGroup
               label="TLS Certificate"
               style={{ margin: '0.5rem 0' }}

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -39,7 +39,7 @@ export const isValidTLS = (protocol: string, tls: K8sGatewayTLS | null): boolean
   }
 
   for (const cert of tls.certificateRefs) {
-    const certsValid = tlsRequired ? cert.name !== undefined && cert.name.length > 0 : true;
+    const certsValid = tlsRequired ? cert.name?.length > 0 : true;
     if (!certsValid) {
       return false;
     }

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerBuilder.tsx
@@ -197,7 +197,12 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
         <Tr>
           <Td colSpan={2}>
             <FormGroup label="TLS Mode" fieldId="addTlsMode" style={{ margin: '0.5rem 0' }}>
-              <FormSelect value={props.listener.tlsMode} id="addTlsMode" name="addTlsMode" onChange={onAddTlsMode}>
+              <FormSelect
+                value={props.listener.tlsMode}
+                id="addTlsMode_${props.index}"
+                name="addTlsMode"
+                onChange={onAddTlsMode}
+              >
                 {tlsModes.map((option, index) => (
                   <FormSelectOption isDisabled={false} key={`p_${index}`} value={option} label={option} />
                 ))}
@@ -216,7 +221,7 @@ export const ListenerBuilder: React.FC<ListenerBuilderProps> = (props: ListenerB
                   value={props.listener.tlsCert}
                   isRequired={true}
                   type="text"
-                  id="tls-certificate"
+                  id="tlsCert_${props.index}"
                   aria-describedby="server-certificate"
                   name="tls-certificate"
                   onChange={onAddTlsCert}

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -5,7 +5,15 @@ import { PFColors } from '../../../components/Pf/PfColors';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Listener } from '../../../types/IstioObjects';
 import { ListenerForm } from '../K8sGatewayForm';
-import { ListenerBuilder, allowedRoutes, protocols, tlsModes, protocolsCert, TERMINATE } from './ListenerBuilder';
+import {
+  ListenerBuilder,
+  allowedRoutes,
+  protocols,
+  tlsModes,
+  protocolsCert,
+  TERMINATE,
+  SELECTOR
+} from './ListenerBuilder';
 import { KialiIcon } from 'config/KialiIcon';
 
 type ListenerListProps = {
@@ -157,9 +165,12 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       port: Number(listenerForm.port),
       name: listenerForm.name,
       protocol: listenerForm.protocol,
-      allowedRoutes: { namespaces: { from: listenerForm.from, selector: { matchLabels: selector } } },
-      tls: null
+      allowedRoutes: { namespaces: { from: listenerForm.from } }
     };
+
+    if (listenerForm.from === SELECTOR) {
+      listener.allowedRoutes.namespaces.selector = { matchLabels: selector };
+    }
 
     if (protocolsCert.includes(listenerForm.protocol) && listenerForm.tlsMode === TERMINATE) {
       listener.tls = {

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -57,7 +57,7 @@ const columns: ThProps[] = [
 
 export const addSelectorLabels = (value: string): [boolean, {}] => {
   if (value.length === 0) {
-    return [true, {}];
+    return [false, {}];
   }
 
   let result = true;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -114,8 +114,7 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       port: 70000,
       name: '',
       protocol: protocols[0],
-      allowedRoutes: { namespaces: { from: allowedRoutes[0], selector: { matchLabels: {} } } },
-      tls: null
+      allowedRoutes: { namespaces: { from: allowedRoutes[0] } }
     };
 
     const lf = props.listeners;

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -5,7 +5,7 @@ import { PFColors } from '../../../components/Pf/PfColors';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Listener } from '../../../types/IstioObjects';
 import { ListenerForm } from '../K8sGatewayForm';
-import { ListenerBuilder, allowedRoutes, protocols } from './ListenerBuilder';
+import { ListenerBuilder, allowedRoutes, protocols, tlsModes } from './ListenerBuilder';
 import { KialiIcon } from 'config/KialiIcon';
 
 type ListenerListProps = {
@@ -55,9 +55,9 @@ const columns: ThProps[] = [
   }
 ];
 
-export const addSelectorLabels = (value: string) => {
+export const addSelectorLabels = (value: string): {} => {
   if (value.length === 0) {
-    return;
+    return {};
   }
 
   value = value.trim();
@@ -97,6 +97,8 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       isHostValid: false,
       from: allowedRoutes[0],
       isLabelSelectorValid: false,
+      tlsMode: tlsModes[0],
+      tlsCertName: '',
       sSelectorLabels: ''
     };
 

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -5,7 +5,7 @@ import { PFColors } from '../../../components/Pf/PfColors';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Listener } from '../../../types/IstioObjects';
 import { ListenerForm } from '../K8sGatewayForm';
-import { ListenerBuilder, allowedRoutes, protocols, tlsModes } from './ListenerBuilder';
+import { ListenerBuilder, allowedRoutes, protocols, tlsModes, protocolsCert, tlsModesCert } from './ListenerBuilder';
 import { KialiIcon } from 'config/KialiIcon';
 
 type ListenerListProps = {
@@ -98,7 +98,7 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       from: allowedRoutes[0],
       isLabelSelectorValid: false,
       tlsMode: tlsModes[0],
-      tlsCertName: '',
+      tlsCert: '',
       sSelectorLabels: ''
     };
 
@@ -155,6 +155,17 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       protocol: listenerForm.protocol,
       allowedRoutes: { namespaces: { from: listenerForm.from, selector: { matchLabels: selector } } }
     };
+
+    if (protocolsCert.includes(listenerForm.protocol) && tlsModesCert.includes(listenerForm.tlsMode)) {
+      listener.tls = {
+        certificateRefs: [
+          {
+            kind: 'Secret',
+            name: listenerForm.tlsCert
+          }
+        ]
+      };
+    }
 
     return listener;
   };

--- a/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm/ListenerList.tsx
@@ -110,7 +110,8 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       port: 70000,
       name: '',
       protocol: protocols[0],
-      allowedRoutes: { namespaces: { from: allowedRoutes[0], selector: { matchLabels: {} } } }
+      allowedRoutes: { namespaces: { from: allowedRoutes[0], selector: { matchLabels: {} } } },
+      tls: null
     };
 
     const lf = props.listeners;
@@ -153,7 +154,8 @@ export const ListenerList: React.FC<ListenerListProps> = (props: ListenerListPro
       port: Number(listenerForm.port),
       name: listenerForm.name,
       protocol: listenerForm.protocol,
-      allowedRoutes: { namespaces: { from: listenerForm.from, selector: { matchLabels: selector } } }
+      allowedRoutes: { namespaces: { from: listenerForm.from, selector: { matchLabels: selector } } },
+      tls: null
     };
 
     if (protocolsCert.includes(listenerForm.protocol) && tlsModesCert.includes(listenerForm.tlsMode)) {

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { AddressList } from './GatewayForm/AddressList';
 import { Address, Listener, MAX_PORT, MIN_PORT } from '../../types/IstioObjects';
-import { ListenerList } from './GatewayForm/ListenerList';
-import { isValidHostname, isValidName, isValidTLS } from './GatewayForm/ListenerBuilder';
+import { addSelectorLabels, ListenerList } from './GatewayForm/ListenerList';
+import { isValidHostname, isValidName, isValidTLS, SELECTOR } from './GatewayForm/ListenerBuilder';
 import { isValidAddress } from './GatewayForm/AddressBuilder';
 import { serverConfig } from '../../config';
 
@@ -34,7 +34,10 @@ export const initK8sGateway = (): K8sGatewayState => ({
 
 export const isK8sGatewayStateValid = (g: K8sGatewayState): boolean => {
   return (
-    g.listeners.length > 0 && validListeners(g.listeners) && (g.addresses.length === 0 || validAddresses(g.addresses))
+    g.listeners.length > 0 &&
+    validListeners(g.listeners) &&
+    validListenerForms(g.listenersForm) &&
+    (g.addresses.length === 0 || validAddresses(g.addresses))
   );
 };
 
@@ -61,6 +64,12 @@ const validListeners = (listeners: Listener[]): boolean => {
       isValidHostname(e.hostname) &&
       isValidTLS(e.protocol, e.tls)
     );
+  });
+};
+
+const validListenerForms = (listenersForm: ListenerForm[]): boolean => {
+  return listenersForm.every((e: ListenerForm) => {
+    return e.from === SELECTOR ? addSelectorLabels(e.sSelectorLabels)[0] : true;
   });
 };
 

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -3,7 +3,7 @@ import { FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core'
 import { AddressList } from './GatewayForm/AddressList';
 import { Address, Listener, MAX_PORT, MIN_PORT } from '../../types/IstioObjects';
 import { ListenerList } from './GatewayForm/ListenerList';
-import { isValidHostname, isValidName } from './GatewayForm/ListenerBuilder';
+import { isValidHostname, isValidName, isValidTLS } from './GatewayForm/ListenerBuilder';
 import { isValidAddress } from './GatewayForm/AddressBuilder';
 import { serverConfig } from '../../config';
 
@@ -47,7 +47,7 @@ export type ListenerForm = {
   port: string;
   protocol: string;
   sSelectorLabels: string;
-  tlsCertName: string;
+  tlsCert: string;
   tlsMode: string;
 };
 
@@ -58,7 +58,8 @@ const validListeners = (listeners: Listener[]): boolean => {
       typeof e.port !== 'undefined' &&
       e.port >= MIN_PORT &&
       e.port <= MAX_PORT &&
-      isValidHostname(e.hostname)
+      isValidHostname(e.hostname) &&
+      isValidTLS(e.protocol, e.tls)
     );
   });
 };

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -47,6 +47,8 @@ export type ListenerForm = {
   port: string;
   protocol: string;
   sSelectorLabels: string;
+  tlsCertName: string;
+  tlsMode: string;
 };
 
 const validListeners = (listeners: Listener[]): boolean => {
@@ -73,7 +75,7 @@ export class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
     this.state = initK8sGateway();
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.setState(this.props.k8sGateway);
   }
 
@@ -85,7 +87,7 @@ export class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
     this.setState({ addresses: addresses }, () => this.props.onChange(this.state));
   };
 
-  onChangeGatewayClass = (_event: React.FormEvent, value: string) => {
+  onChangeGatewayClass = (_event: React.FormEvent, value: string): void => {
     this.setState(
       {
         gatewayClass: value
@@ -94,7 +96,7 @@ export class K8sGatewayForm extends React.Component<Props, K8sGatewayState> {
     );
   };
 
-  render() {
+  render(): React.ReactNode {
     return (
       <>
         {serverConfig.gatewayAPIClasses.length > 1 && (

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -783,6 +783,7 @@ export interface Listener {
   name: string;
   port: number;
   protocol: string;
+  tls?: K8sGatewayTLS;
 }
 
 export interface Address {
@@ -842,6 +843,16 @@ export interface K8sGatewaySpec {
   addresses?: Address[];
   gatewayClassName: string;
   listeners?: Listener[];
+}
+
+export interface K8sGatewayTLS {
+  certificateRefs: K8sGatewayTLSCertRef[];
+}
+
+export interface K8sGatewayTLSCertRef {
+  group?: string;
+  kind: string;
+  name: string;
 }
 
 export interface K8sGRPCRouteSpec extends K8sCommonRouteSpec {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -783,7 +783,7 @@ export interface Listener {
   name: string;
   port: number;
   protocol: string;
-  tls?: K8sGatewayTLS;
+  tls: K8sGatewayTLS | null;
 }
 
 export interface Address {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -783,7 +783,7 @@ export interface Listener {
   name: string;
   port: number;
   protocol: string;
-  tls?: K8sGatewayTLS | null;
+  tls?: K8sGatewayTLS;
 }
 
 export interface Address {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -783,7 +783,7 @@ export interface Listener {
   name: string;
   port: number;
   protocol: string;
-  tls: K8sGatewayTLS | null;
+  tls?: K8sGatewayTLS | null;
 }
 
 export interface Address {
@@ -801,7 +801,7 @@ export interface LabelSelector {
 
 export interface FromNamespaces {
   from: string;
-  selector: LabelSelector;
+  selector?: LabelSelector;
 }
 
 export interface ParentRef {
@@ -853,6 +853,7 @@ export interface K8sGatewayTLSCertRef {
   group?: string;
   kind: string;
   name: string;
+  namespace?: string;
 }
 
 export interface K8sGRPCRouteSpec extends K8sCommonRouteSpec {


### PR DESCRIPTION
### Describe the change
In K8s Gateway creation wizard, added support of 'HTTPS'  protocol and 'TLS Certificate' input.
Done in a scope of GRPC Routing https://gateway-api.sigs.k8s.io/guides/grpc-routing/

![Screenshot from 2024-05-23 14-47-13](https://github.com/kiali/kiali/assets/604313/42a0c8f2-c5e7-4c6b-a6f9-a626a0472b10)

### Steps to test the PR

Istio config list -> Actions -> Create K8sGateway.
Add listener.
Choose HTTPS.
New row appears for TLS params. Currently only 'Terminate' is supported.
Add TLS Certificate.
Preview and save.
In create config object should be 'tls:' field with Kind and name. The 'Terminate' default mode value is not shown, considered as default for 'HTTPS'.
Regression testing: Make sure that "HTTP" protocol mode creation is also working fine.

### Automation testing

cypress test added

### Issue reference
https://github.com/kiali/kiali/issues/7223
Parent epic https://github.com/kiali/kiali/issues/7355
