### PR TITLE
Prevent accessibility failures in ServiceEntry and WorkloadEntry appenders

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -90,7 +90,7 @@ func ParseAppenders(o graph.TelemetryOptions) (appenders []graph.Appender, final
 	}
 	if _, ok := requestedAppenders[WorkloadEntryAppenderName]; ok || o.Appenders.All {
 		a := WorkloadEntryAppender{
-			GraphType: o.GraphType,
+			AccessibleNamespaces: o.AccessibleNamespaces,
 		}
 		appenders = append(appenders, a)
 	}
@@ -192,7 +192,9 @@ func ParseAppenders(o graph.TelemetryOptions) (appenders []graph.Appender, final
 	}
 
 	// The finalizer order is important
-	// always run the outsider finalizer
+
+	// always run the outsider finalizer first, this alloes other finalizers to
+	// utilize graph.isInaccessible and graph.isOutside metatdata values.
 	finalizers = append(finalizers, &OutsiderAppender{
 		AccessibleNamespaces: o.AccessibleNamespaces,
 		Namespaces:           o.Namespaces,


### PR DESCRIPTION
Fixes #7305 
Fixes #7349

Add accessibility checks in ServiceEntry and WorkloadEntry appenders, to protect against business-layer auth failures when asking for config info.

Additionally:
- add tests
- fix IsFinalizer() return value in WorkloadEntry appender.  It's not a finalizer, it's a namespace appender.
- remove unnecessary appender param for WorkloadEntry appender
- add missing GraphType appender param in service_entry_test.go tests -

Testing
I think a code review is sufficient as I've added unit tests for the problem scenarios.  Of course it's possible to set it up for real, if you want to do it.  For the Service Entry issue the source node needs to be in an inaccessible cluster or namespace.  For the Workload Entry, the WE node itself needs to be in an inaccessible cluster, although the namespace would likely need to be accessible.