### PR TITLE
Update cluster tag for traces

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,10 +93,6 @@ const (
 	FeatureLogView FeatureName = "logs-tab"
 )
 
-const (
-	IstioClusterTag string = "istio.cluster_id"
-)
-
 func (fn FeatureName) IsValid() error {
 	switch fn {
 	case FeatureLogView:

--- a/config/config.go
+++ b/config/config.go
@@ -93,6 +93,10 @@ const (
 	FeatureLogView FeatureName = "logs-tab"
 )
 
+const (
+	IstioClusterTag string = "istio.cluster_id"
+)
+
 func (fn FeatureName) IsValid() error {
 	switch fn {
 	case FeatureLogView:

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -282,7 +282,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 	// 'cluster' in tags is used to query in tracing by cluster in multi-cluster mode
 	// while 'Cluster' in models.TracingQuery can have default cluster
 	if values.Get("clusterName") != "" {
-		q.Tags[config.IstioClusterTag] = values.Get("clusterName")
+		q.Tags[models.IstioClusterTag] = values.Get("clusterName")
 	}
 
 	return q, nil

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -282,7 +282,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 	// 'cluster' in tags is used to query in tracing by cluster in multi-cluster mode
 	// while 'Cluster' in models.TracingQuery can have default cluster
 	if values.Get("clusterName") != "" {
-		q.Tags["cluster"] = values.Get("clusterName")
+		q.Tags[config.IstioClusterTag] = values.Get("clusterName")
 	}
 
 	return q, nil

--- a/models/tracing.go
+++ b/models/tracing.go
@@ -6,6 +6,10 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
+const (
+	IstioClusterTag string = "istio.cluster_id"
+)
+
 type TracingInfo struct {
 	Enabled              bool               `json:"enabled"`
 	Integration          bool               `json:"integration"`

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -56,7 +56,7 @@ func NewJaegerClient(client http.Client, baseURL *url.URL) (jaegerClient *Jaeger
 	// if cluster exists in tags, use it
 	query := models.TracingQuery{}
 	tags := map[string]string{
-		config.IstioClusterTag: conf.KubernetesConfig.ClusterName,
+		models.IstioClusterTag: conf.KubernetesConfig.ClusterName,
 	}
 	query.Tags = tags
 	query.End = time.Now()
@@ -161,7 +161,7 @@ func prepareQuery(u *url.URL, jaegerServiceName string, query models.TracingQuer
 	var tags = util.CopyStringMap(query.Tags)
 
 	if ignoreCluster {
-		delete(tags, config.IstioClusterTag)
+		delete(tags, models.IstioClusterTag)
 	}
 	if len(tags) > 0 {
 		// Tags must be json encoded

--- a/tracing/jaeger/http_client.go
+++ b/tracing/jaeger/http_client.go
@@ -56,7 +56,7 @@ func NewJaegerClient(client http.Client, baseURL *url.URL) (jaegerClient *Jaeger
 	// if cluster exists in tags, use it
 	query := models.TracingQuery{}
 	tags := map[string]string{
-		"cluster": conf.KubernetesConfig.ClusterName,
+		config.IstioClusterTag: conf.KubernetesConfig.ClusterName,
 	}
 	query.Tags = tags
 	query.End = time.Now()
@@ -161,7 +161,7 @@ func prepareQuery(u *url.URL, jaegerServiceName string, query models.TracingQuer
 	var tags = util.CopyStringMap(query.Tags)
 
 	if ignoreCluster {
-		delete(tags, "cluster")
+		delete(tags, config.IstioClusterTag)
 	}
 	if len(tags) > 0 {
 		// Tags must be json encoded

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -249,7 +249,7 @@ func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, q
 
 	if len(query.Tags) > 0 {
 		for k, v := range query.Tags {
-			if k != "cluster" && oc.ClusterTag {
+			if k != config.IstioClusterTag && oc.ClusterTag {
 				tag := TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
 				queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
 			}

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -249,7 +249,7 @@ func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, q
 
 	if len(query.Tags) > 0 {
 		for k, v := range query.Tags {
-			if k != config.IstioClusterTag && oc.ClusterTag {
+			if k != models.IstioClusterTag && oc.ClusterTag {
 				tag := TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
 				queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
 			}


### PR DESCRIPTION
### Describe the change

The cluster tag in tracing was "cluster". When Istio added the cluster id tag, it was named istio.cluster_id. https://istio.io/latest/news/releases/1.21.x/announcing-1.21/change-notes/#telemetry

### Steps to test the PR

- Start a multi cluster environment. Ex. `hack/run-integration-tests.sh --test-suite frontend-primary-remote --setup-only true`
- Go to workloads/bookinfo/reviews-v1 from cluster east: Should have traces. 
- Go to workloads/bookinfo/reviews-v1 from cluster west: Should not have traces. 

This message should NOT appear: 

![image](https://github.com/kiali/kiali/assets/49480155/3a345437-e68d-40a2-95f8-205421b618a6)

In master code, reviews-v1 from west cluster has traces, because they are not filtered by cluster. 

### Automation testing

N/A

### Issue reference

Fixes #7384 
