### PR TITLE
[CI] Fix default tracing settings

### DIFF
--- a/hack/istio/multicluster/split-bookinfo.sh
+++ b/hack/istio/multicluster/split-bookinfo.sh
@@ -10,6 +10,8 @@
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source ${SCRIPT_DIR}/env.sh $*
 
+set -euo pipefail
+
 if [ "${BOOKINFO_ENABLED}" != "true" ]; then
   echo "Will not install bookinfo demo"
   return 0

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -191,7 +191,7 @@ setup_kind_tempo() {
     local hub_arg="--image-hub default"
   fi
   
-  "${SCRIPT_DIR}"/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true" ${hub_arg:-} -a "prometheus grafana" -s values.meshConfig.extensionProviders[0].zipkin.service="tempo-cr-distributor.tempo.svc.cluster.local"
+  "${SCRIPT_DIR}"/istio/install-istio-via-istioctl.sh --reduce-resources true --client-exe-path "$(which kubectl)" -cn "cluster-default" -mid "mesh-default" -net "network-default" -gae "true" ${hub_arg:-} -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-cr-distributor.tempo:9411"
 
   infomsg "Pushing the images into the cluster..."
   make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali


### PR DESCRIPTION
### Describe the change

Updates the tracing settings for the CI environment so that remote traces will properly send to `zipkin.istio-system:9411`.

### Steps to test the PR

N/A

### Automation testing

Should fix primary-remote CI job.

### Issue reference

Fixes #7387 
