### PR TITLE
Fix release test suite images workflow

### DIFF
--- a/.github/workflows/test-images-release.yml
+++ b/.github/workflows/test-images-release.yml
@@ -1,9 +1,8 @@
 name: Release test suite images
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 jobs:
   initialize:
     name: Initialize
@@ -58,7 +57,7 @@ jobs:
     - name: Update integration test image in quay
       run: |
         docker push quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-int-tests:${{ needs.initialize.outputs.images_tag }}
-    
+
     - name: Pull new cypress test image
       run: |
         docker pull quay.io/${{ needs.initialize.outputs.quay_org }}/kiali-cypress-tests:${{ github.ref_name }}


### PR DESCRIPTION
### Describe the change

When a new Kiali version is released, this [workflow](https://github.com/kiali/kiali/blob/master/.github/workflows/test-images-release.yml#L6) should build and publish test images as well however, it didn't work ( because it is triggered by tag pushing, not by release, fixed ).

### Example how that workflow works
Let's imagine we release the following kiali versions in a particular time frame
- Kiali v1.85.0 is released
  -  The workflow creates int and cypress test images with `v1.85.0` and `v1.85` tags.
- Kiali v1.85.1 is released
  -  The workflow creates int and cypress test images with `v1.85.1` tag and update images under `v1.85` tag
- Kiali v1.85.2 is released
  -  The workflow creates int and cypress test images with `v1.85.2` tag and update images under `v1.85` tag


So these test images would exist:
v1.85.0
v1.85.1
v1.85.2
v1.85 (same as v1.85.2, so that tag will contain the latest changes for a major version 1.85, [that one is used in lpinterop pipeline])
  