### PR TITLE
Support TP releases for OSSM versions

### DIFF
--- a/status/versions.go
+++ b/status/versions.go
@@ -25,7 +25,7 @@ var (
 	// Example Istio dev version is:
 	//   1.5-alpha.dbd2aca8887fb42c2bb358417621a78de372f906-dbd2aca8887fb42c2bb358417621a78de372f906-Clean
 	//   1.10-dev-65a124dc2ab69f91331298fbf6d9b4335abcf0fd-Clean
-	ossmVersionExpr          = regexp.MustCompile(`(?:OSSM_|openshift-service-mesh-)([0-9]+\.[0-9]+\.[0-9]+)`)
+	ossmVersionExpr          = regexp.MustCompile(`(?:OSSM_|openshift-service-mesh-)([0-9]+\.[0-9]+\.[0-9]+(?:-tp\.[0-9]+)?)`)
 	istioDevVersionExpr      = regexp.MustCompile(`(\d+\.\d+)-alpha\.([[:alnum:]]+)-.*|(\d+\.\d+)-dev-([[:alnum:]]+)-.*`)
 	istioRCVersionExpr       = regexp.MustCompile(`(\d+\.\d+.\d+)-((?:alpha|beta|rc|RC)\.\d+)`)
 	istioSnapshotVersionExpr = regexp.MustCompile(`istio-release-([0-9]+\.[0-9]+)(-[0-9]{8})`)

--- a/status/versions_test.go
+++ b/status/versions_test.go
@@ -34,6 +34,21 @@ func TestParseIstioRawVersion(t *testing.T) {
 			version:    "1.1.99",
 		},
 		{
+			rawVersion: "OSSM_3.0.0-tp.1-ed90e14d3473bc3fe54f98298eb16664002d14d1-Clean",
+			name:       "OpenShift Service Mesh",
+			version:    "3.0.0-tp.1",
+		},
+		{
+			rawVersion: "OSSM_3.3.3-tp.10-ed90e14d3473bc3fe54f98298eb16664002d14d1-Clean",
+			name:       "OpenShift Service Mesh",
+			version:    "3.3.3-tp.10",
+		},
+		{
+			rawVersion: "OSSM_3.0.0-ed90e14d3473bc3fe54f98298eb16664002d14d1-Clean",
+			name:       "OpenShift Service Mesh",
+			version:    "3.0.0",
+		},
+		{
 			rawVersion: "foo-istio-1.2.3-bar",
 			name:       "Istio",
 			version:    "1.2.3",


### PR DESCRIPTION
OSSM releases with 'TP' inside version were ignoring 'TP'. Now it is also included.

Issue: OSSM-6425