### PR TITLE
Improve hack scripts for Ambient

### DIFF
--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -287,12 +287,14 @@ Feature: Kiali Graph page - Display menu
   Scenario: User sees tcp traffic
     When user graphs "bookinfo" namespaces
     Then user sees the "bookinfo" namespace
+    Then user opens traffic menu
+    And user "disables" "http" traffic option
     Then 6 edges appear in the graph
 
   @ambient
-  Scenario: User sees no http traffic
+  Scenario: User sees http traffic
     When user graphs "bookinfo" namespaces
     Then user sees the "bookinfo" namespace
     Then user opens traffic menu
     And user "disables" "tcp" traffic option
-    Then user sees empty graph
+    Then 2 edges appear in the graph

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -374,7 +374,7 @@ $CLIENT_EXE get pods -n ${NAMESPACE}
 
 if [ "${AMBIENT_ENABLED}" == "true" ]; then
   echo "Sidecar injection was not performed. Ambient support will be enabled."
-  ${CLIENT_EXE} label namespace ${NAMESPACE} istio.io/dataplane-mode=ambient
+  ${CLIENT_EXE} label namespace ${NAMESPACE} istio.io/dataplane-mode=ambient istio.io/dataplane-mode=ambient
   # It could also be applied to service account
   if [ "${WAYPOINT}" == "true" ]; then
     # Create Waypoint proxy

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -288,7 +288,7 @@ if [ "${WAYPOINT}" == "true" ]; then
 
   fi
 
-  for NS in ${AMBIENT_NS}
+  for NS in "${AMBIENT_NS[@]}"
   do
     ${ISTIOCTL} x waypoint apply -n ${NS} --enroll-namespace
     echo "Create Waypoint proxy for ${NS}"

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -211,7 +211,7 @@ ensureBookinfoGraphReady() {
       fi
       sleep 1
     else
-      sleep 5
+      sleep 30
       break
     fi
 


### PR DESCRIPTION
### Describe the change

Updated bookinfo and travel portal demo

### Steps to test the PR
Deploy demos in Ambient mesh: 

- `hack/istio/install-travel-agency-demo.sh -c kubectl -di travel-agency`
- `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

![image](https://github.com/kiali/kiali/assets/49480155/de0b713b-e56e-4dc1-ae2e-be42936d293e)
![image](https://github.com/kiali/kiali/assets/49480155/a7eeb67e-2dc8-4efb-8c93-eba3cd394dd9)

To include also waypoint in travel agency: 

- `hack/istio/install-travel-agency-demo.sh -c kubectl -di travel-agency,travel-portal -w true`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #7402 
