### PR TITLE
Remove ambient tests from jenkins pipeline tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "build:prod": "sh -ac '. ./.env.downstream; npm run build:kiali'",
     "precypress:run:junit": "npm run cypress:delete:reports",
     "cypress": "cypress open -e TAGS=\"not @multi-cluster and not @ambient\"",
+    "cypress:ambient": "cypress open -e TAGS=\"@ambient\"",
     "cypress:multi-cluster": "cypress open -e TAGS=\"@multi-cluster and not @multi-primary\"",
     "cypress:multi-primary": "cypress open -e TAGS=\"@multi-cluster and @multi-primary\"",
     "cypress:perf": "cypress open --config-file cypress-perf.config.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "cypress:run:perf": "cypress run --config-file cypress-perf.config.ts",
     "cypress:run:tracing": "cypress run -e TAGS=\"@tracing\"",
     "cypress:run:test-group:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"${TEST_GROUP}\"",
-    "cypress:run:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"not @crd-validation and not @multi-cluster\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@crd-validation and not @multi-cluster\"",
+    "cypress:run:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"not @crd-validation and not @multi-cluster and not @ambient\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@crd-validation and not @multi-cluster and not @ambient\"",
     "cypress:delete:reports": "rm cypress/results/* || true",
     "cypress:combine:reports": "jrm cypress/results/combined-report.xml \"cypress/results/*.xml\"",
     "lint": "eslint --ext js,ts,tsx src",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "build:kiali": "npm run i18n && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false EXTEND_ESLINT=true react-scripts build --profile",
     "build:prod": "sh -ac '. ./.env.downstream; npm run build:kiali'",
     "precypress:run:junit": "npm run cypress:delete:reports",
-    "cypress": "cypress open -e TAGS=\"not @multi-cluster\"",
+    "cypress": "cypress open -e TAGS=\"not @multi-cluster and not @ambient\"",
     "cypress:multi-cluster": "cypress open -e TAGS=\"@multi-cluster and not @multi-primary\"",
     "cypress:multi-primary": "cypress open -e TAGS=\"@multi-cluster and @multi-primary\"",
     "cypress:perf": "cypress open --config-file cypress-perf.config.ts",


### PR DESCRIPTION
### Describe the change

Remove ambient tests from jenkins pipeline tests, as Ambient requires another environment.

### Steps to test the PR

Run yarn cypress:run:junit, `@ambient `tests should not run.

### Automation testing

N/A

### Issue reference


