### PR TITLE
Add support for external deployment cluster in mesh cypress test

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -112,9 +112,10 @@ Then('user sees expected mesh infra', () => {
       const controller = state.meshRefs.getController() as Visualization;
       assert.isTrue(controller.hasGraph());
       const { nodes, edges } = elems(controller);
-      assert.equal(nodes.length, 8, 'Unexpected number of infra nodes');
-      assert.equal(edges.length, 5, 'Unexpected number of infra edges');
       const nodeNames = nodes.map(n => n.getLabel());
+      const nodesLength = nodeNames.some(n => n === 'External Deployments') ? 9 : 8;
+      assert.equal(nodes.length, nodesLength, 'Unexpected number of infra nodes');
+      assert.equal(edges.length, 5, 'Unexpected number of infra edges');
       assert.isTrue(nodeNames.some(n => n === 'Data Plane'));
       assert.isTrue(nodeNames.some(n => n === 'Grafana'));
       assert.isTrue(nodeNames.some(n => n.startsWith('istiod')));


### PR DESCRIPTION
### Describe the change

In some environments, external services (such as tracing, metric store, etc.) can be deployed outside of the mesh (external deployments). This PR adds support for executing mesh cypress tests in such environments.

### Automation testing

Mesh page cypress test
