### PR TITLE
Don't force parallel edges to be straight

### DIFF
--- a/frontend/src/pages/GraphPF/elements/extendedBaseEdge.ts
+++ b/frontend/src/pages/GraphPF/elements/extendedBaseEdge.ts
@@ -1,6 +1,8 @@
 import { BaseEdge, Point } from '@patternfly/react-topology';
 
-// This extends BaseEdge to eliminate Bendpoints (mainly because Dagre layout does not provide an option to use or not use bendpoints).
+// This extends BaseEdge to eliminate Bendpoints when possible (mainly because Dagre layout
+// does not provide an option to use or not use bendpoints). Bendpoints must be honored when
+// we have multiple edges (i.e. different protocols) between the same two nodes.
 // Kiali graphs tend to have a lot of nodes and boxes, and look cleaner with straight edges.
 
 //TODO: Possibly make this optional
@@ -10,10 +12,26 @@ import { BaseEdge, Point } from '@patternfly/react-topology';
 
 export class ExtendedBaseEdge extends BaseEdge {
   getBendpoints(): Point[] {
+    if (this.hasParallelEdge()) {
+      return super.getBendpoints();
+    }
     return [];
   }
 
   setBendpoints(_points: Point[]): void {
-    super.setBendpoints([]);
+    super.setBendpoints(this.hasParallelEdge() ? _points : []);
+  }
+
+  private hasParallelEdge(): boolean {
+    const sourceEdges = this.getSource()
+      .getSourceEdges()
+      .filter(e => e.getTarget() === this.getTarget());
+
+    if (sourceEdges.length < 2) {
+      return false;
+    }
+
+    const targets = new Set(sourceEdges.map(e => e.getTarget().getId()));
+    return targets.size < sourceEdges.length;
   }
 }

--- a/frontend/src/pages/Mesh/elements/extendedBaseEdge.ts
+++ b/frontend/src/pages/Mesh/elements/extendedBaseEdge.ts
@@ -1,6 +1,8 @@
 import { BaseEdge, Point } from '@patternfly/react-topology';
 
-// This extends BaseEdge to eliminate Bendpoints (mainly because Dagre layout does not provide an option to use or not use bendpoints).
+// This extends BaseEdge to eliminate Bendpoints when possible (mainly because Dagre layout
+// does not provide an option to use or not use bendpoints). Bendpoints must be honored when
+// we have multiple edges (i.e. different protocols) between the same two nodes.
 // Kiali graphs tend to have a lot of nodes and boxes, and look cleaner with straight edges.
 
 //TODO: Possibly make this optional
@@ -10,10 +12,26 @@ import { BaseEdge, Point } from '@patternfly/react-topology';
 
 export class ExtendedBaseEdge extends BaseEdge {
   getBendpoints(): Point[] {
+    if (this.hasParallelEdge()) {
+      return super.getBendpoints();
+    }
     return [];
   }
 
   setBendpoints(_points: Point[]): void {
-    super.setBendpoints([]);
+    super.setBendpoints(this.hasParallelEdge() ? _points : []);
+  }
+
+  private hasParallelEdge(): boolean {
+    const sourceEdges = this.getSource()
+      .getSourceEdges()
+      .filter(e => e.getTarget() === this.getTarget());
+
+    if (sourceEdges.length < 2) {
+      return false;
+    }
+
+    const targets = new Set(sourceEdges.map(e => e.getTarget().getId()));
+    return targets.size < sourceEdges.length;
   }
 }


### PR DESCRIPTION
Fixes #7418 

In the early days of the PFT graph dev we overrode PFT's bendpoints to force straight edges, like we have in Cytoscape.  But in the case that the same source and dest nodes (a -> b) has parallel edges (typically edges with different protocols), the removal of bendpoints caused the edges to bothe be straight, thus overlaying. This adds a check to allow bendpoints in this situation.

before:
![image](https://github.com/kiali/kiali/assets/2104052/70ab8b22-ab52-4471-ba63-2266b60bdc75)

after:
![image](https://github.com/kiali/kiali/assets/2104052/9f43d72d-ed1d-4ab4-8542-08ca5c376d44)
