### PR TITLE
Hide Enable auto injection menu action for Ambient NS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,10 +340,10 @@ func (lt *LoginToken) Obfuscate() {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AmbientNamespaceLabel      string
-	AmbientNamespaceLabelValue string
-	AmbientWaypointLabel       string
-	AmbientWaypointLabelValue  string
+	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
+	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
+	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
+	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`

--- a/frontend/src/components/IstioWizards/WorkloadWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadWizardDropdown.tsx
@@ -21,27 +21,27 @@ import { renderDisabledDropdownOption } from 'utils/DropdownUtils';
 interface Props {
   namespace: string;
   onChange: () => void;
-  workload: Workload;
   statusState: StatusState;
+  workload: Workload;
 }
 
 export const WorkloadWizardDropdown: React.FC<Props> = (props: Props) => {
   const [isActionsOpen, setIsActionsOpen] = React.useState<boolean>(false);
   const [showWizard, setShowWizard] = React.useState<boolean>(false);
 
-  const onActionsSelect = () => {
+  const onActionsSelect = (): void => {
     setIsActionsOpen(!isActionsOpen);
   };
 
-  const onActionsToggle = (isOpen: boolean) => {
+  const onActionsToggle = (isOpen: boolean): void => {
     setIsActionsOpen(isOpen);
   };
 
-  const onWizardToggle = (isOpen: boolean) => {
+  const onWizardToggle = (isOpen: boolean): void => {
     setShowWizard(isOpen);
   };
 
-  const onAction = (key: string) => {
+  const onAction = (key: string): void => {
     switch (key) {
       case WIZARD_ENABLE_AUTO_INJECTION:
       case WIZARD_DISABLE_AUTO_INJECTION:
@@ -58,10 +58,10 @@ export const WorkloadWizardDropdown: React.FC<Props> = (props: Props) => {
           props.workload.cluster
         )
           .then(_ => {
-            AlertUtils.add('Workload ' + props.workload.name + ' updated', 'default', MessageType.SUCCESS);
+            AlertUtils.add(`Workload ${props.workload.name} updated`, 'default', MessageType.SUCCESS);
           })
           .catch(error => {
-            AlertUtils.addError('Could not update workload ' + props.workload.name, error);
+            AlertUtils.addError(`Could not update workload ${props.workload.name}`, error);
           })
           .finally(() => {
             setShowWizard(false);
@@ -73,7 +73,7 @@ export const WorkloadWizardDropdown: React.FC<Props> = (props: Props) => {
     }
   };
 
-  const onChangeAnnotations = (annotations: { [key: string]: string }) => {
+  const onChangeAnnotations = (annotations: { [key: string]: string }): void => {
     const jsonInjectionPatch = buildAnnotationPatch(annotations);
 
     API.updateWorkload(
@@ -85,10 +85,10 @@ export const WorkloadWizardDropdown: React.FC<Props> = (props: Props) => {
       props.workload.cluster
     )
       .then(_ => {
-        AlertUtils.add('Workload ' + props.workload.name + ' updated', 'default', MessageType.SUCCESS);
+        AlertUtils.add(`Workload ${props.workload.name} updated`, 'default', MessageType.SUCCESS);
       })
       .catch(error => {
-        AlertUtils.addError('Could not update workload ' + props.workload.name, error);
+        AlertUtils.addError(`Could not update workload ${props.workload.name}`, error);
       })
       .finally(() => {
         setShowWizard(false);
@@ -99,7 +99,7 @@ export const WorkloadWizardDropdown: React.FC<Props> = (props: Props) => {
   const renderDropdownItems = (): JSX.Element[] => {
     const items: JSX.Element[] = [];
 
-    if (serverConfig.kialiFeatureFlags.istioInjectionAction) {
+    if (serverConfig.kialiFeatureFlags.istioInjectionAction && !props.workload.istioAmbient) {
       const enableAction = (
         <DropdownItem
           data-test={WIZARD_ENABLE_AUTO_INJECTION}

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -82,6 +82,8 @@ const defaultServerConfig: ComputedServerConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientNamespaceLabel: 'istio.io/dataplane-mode',
+    ambientNamespaceLabelValue: 'ambient',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -810,7 +810,16 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
     // RBAC allow more fine granularity but Kiali won't check that in detail.
 
     if (serverConfig.istioNamespace !== nsInfo.name) {
-      if (serverConfig.kialiFeatureFlags.istioInjectionAction && !serverConfig.kialiFeatureFlags.istioUpgradeAction) {
+      if (
+        !(
+          serverConfig.ambientEnabled &&
+          nsInfo.labels &&
+          nsInfo.labels[serverConfig.istioLabels.ambientNamespaceLabel] ===
+            serverConfig.istioLabels.ambientNamespaceLabelValue
+        ) &&
+        serverConfig.kialiFeatureFlags.istioInjectionAction &&
+        !serverConfig.kialiFeatureFlags.istioUpgradeAction
+      ) {
         namespaceActions.push({
           isGroup: false,
           isSeparator: true

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -171,6 +171,8 @@ export const serverRateConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientNamespaceLabel: 'istio.io/dataplane-mode',
+    ambientNamespaceLabelValue: 'ambient',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -2,6 +2,8 @@ import { DurationInSeconds } from './Common';
 import { MeshCluster } from './Mesh';
 
 export type IstioLabelKey =
+  | 'ambientNamespaceLabel'
+  | 'ambientNamespaceLabelValue'
   | 'ambientWaypointLabel'
   | 'ambientWaypointLabelValue'
   | 'appLabelName'

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -91,6 +91,8 @@ export const healthConfig = {
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
+    ambientNamespaceLabel: 'istio.io/dataplane-mode',
+    ambientNamespaceLabelValue: 'ambient',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',


### PR DESCRIPTION
### Describe the change
Hide Enable auto injection menu action for Ambient NS

### Steps to test the PR
1. Install Ambient mesh
2. Add namespace to Ambient
3. "Enable Auto injection" menu option should not be in the actions for the NS card
![image](https://github.com/kiali/kiali/assets/49480155/c030a17b-6014-4bb9-9a43-419aceb221eb)

5. Go to a workload in Ambient: The "Enable Auto injection" menu option should not be there: 
![image](https://github.com/kiali/kiali/assets/49480155/ee9b1d85-f448-46b8-b9fa-773f83053508)

6. The option should be in a ns with no Ambient annotations: 
![image](https://github.com/kiali/kiali/assets/49480155/edd6c728-06e9-4223-8500-23fb05495677)

 
### Automation testing

N/A

### Issue reference

Fixes #7420 
