### PR TITLE
Added new validation check on HTTP/GRPC Route parentRef Service

### DIFF
--- a/business/checkers/k8sgrpcroutes/no_host_checker.go
+++ b/business/checkers/k8sgrpcroutes/no_host_checker.go
@@ -22,31 +22,42 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 	valid := true
 
+	for i, ref := range n.K8sGRPCRoute.Spec.ParentRefs {
+		if ref.Kind == nil || string(*ref.Kind) != kubernetes.ServiceType {
+			continue
+		}
+		valid = n.checkReference(ref.Namespace, ref.Name, &validations, fmt.Sprintf("spec/parentRefs[%d]/name", i)) && valid
+	}
+
 	for k, grpcRoute := range n.K8sGRPCRoute.Spec.Rules {
 		for i, ref := range grpcRoute.BackendRefs {
 			if ref.Kind == nil || string(*ref.Kind) != "Service" {
 				continue
 			}
-			namespace := n.K8sGRPCRoute.Namespace
-			if ref.Namespace != nil && string(*ref.Namespace) != "" {
-				namespace = string(*ref.Namespace)
-			}
-			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
-			// service name should not be set in fqdn format
-			// if the grpc route is referencing to a service from the same namespace, then service should exist there
-			// if the grpc route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
-			if strings.Contains(string(ref.Name), ".") ||
-				(namespace == n.K8sGRPCRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
-				(namespace != n.K8sGRPCRoute.Namespace && (!n.checkReferenceGrant(n.K8sGRPCRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {
-				path := fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)
-				validation := models.Build("k8sroutes.nohost.namenotfound", path)
-				validations = append(validations, &validation)
-				valid = false
-			}
+			valid = n.checkReference(ref.Namespace, ref.Name, &validations, fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)) && valid
 		}
 	}
 
 	return validations, valid
+}
+
+func (n NoHostChecker) checkReference(refNamespace *k8s_networking_v1.Namespace, refName k8s_networking_v1.ObjectName, validations *[]*models.IstioCheck, location string) bool {
+	namespace := n.K8sGRPCRoute.Namespace
+	if refNamespace != nil && string(*refNamespace) != "" {
+		namespace = string(*refNamespace)
+	}
+	fqdn := kubernetes.GetHost(string(refName), namespace, n.Namespaces.GetNames())
+	//service name should not be set in fqdn format
+	// if the http route is referencing to a service from the same namespace, then service should exist there
+	// if the http route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
+	if strings.Contains(string(refName), ".") ||
+		(namespace == n.K8sGRPCRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
+		(namespace != n.K8sGRPCRoute.Namespace && (!n.checkReferenceGrant(n.K8sGRPCRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {
+		validation := models.Build("k8sroutes.nohost.namenotfound", location)
+		*validations = append(*validations, &validation)
+		return false
+	}
+	return true
 }
 
 func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {

--- a/business/checkers/k8sgrpcroutes/no_host_checker.go
+++ b/business/checkers/k8sgrpcroutes/no_host_checker.go
@@ -48,8 +48,8 @@ func (n NoHostChecker) checkReference(refNamespace *k8s_networking_v1.Namespace,
 	}
 	fqdn := kubernetes.GetHost(string(refName), namespace, n.Namespaces.GetNames())
 	//service name should not be set in fqdn format
-	// if the http route is referencing to a service from the same namespace, then service should exist there
-	// if the http route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
+	// if the grpc route is referencing to a service from the same namespace, then service should exist there
+	// if the grpc route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
 	if strings.Contains(string(refName), ".") ||
 		(namespace == n.K8sGRPCRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
 		(namespace != n.K8sGRPCRoute.Namespace && (!n.checkReferenceGrant(n.K8sGRPCRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {

--- a/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
@@ -36,7 +36,7 @@ func TestMissingK8sGateways(t *testing.T) {
 	config.Set(conf)
 
 	checker := NoK8sGatewayChecker{
-		K8sGRPCRoute: data.AddParentRefToGRPCRoute("gateway2", "bookinfo2",
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("gateway2", "bookinfo2",
 			data.CreateGRPCRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 		GatewayNames: make(map[string]struct{}),
 	}
@@ -59,7 +59,7 @@ func TestValidAndMissingK8sGateway(t *testing.T) {
 	var empty struct{}
 
 	checker := NoK8sGatewayChecker{
-		K8sGRPCRoute: data.AddParentRefToGRPCRoute("correctgw", "bookinfo2",
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("correctgw", "bookinfo2",
 			data.CreateGRPCRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 		GatewayNames: map[string]struct{}{"correctgw": empty},
 	}

--- a/business/checkers/k8shttproutes/no_host_checker.go
+++ b/business/checkers/k8shttproutes/no_host_checker.go
@@ -22,31 +22,42 @@ func (n NoHostChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 	valid := true
 
+	for i, ref := range n.K8sHTTPRoute.Spec.ParentRefs {
+		if ref.Kind == nil || string(*ref.Kind) != kubernetes.ServiceType {
+			continue
+		}
+		valid = n.checkReference(ref.Namespace, ref.Name, &validations, fmt.Sprintf("spec/parentRefs[%d]/name", i)) && valid
+	}
+
 	for k, httpRoute := range n.K8sHTTPRoute.Spec.Rules {
 		for i, ref := range httpRoute.BackendRefs {
-			if ref.Kind == nil || string(*ref.Kind) != "Service" {
+			if ref.Kind == nil || string(*ref.Kind) != kubernetes.ServiceType {
 				continue
 			}
-			namespace := n.K8sHTTPRoute.Namespace
-			if ref.Namespace != nil && string(*ref.Namespace) != "" {
-				namespace = string(*ref.Namespace)
-			}
-			fqdn := kubernetes.GetHost(string(ref.Name), namespace, n.Namespaces.GetNames())
-			//service name should not be set in fqdn format
-			// if the http route is referencing to a service from the same namespace, then service should exist there
-			// if the http route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
-			if strings.Contains(string(ref.Name), ".") ||
-				(namespace == n.K8sHTTPRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
-				(namespace != n.K8sHTTPRoute.Namespace && (!n.checkReferenceGrant(n.K8sHTTPRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {
-				path := fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)
-				validation := models.Build("k8sroutes.nohost.namenotfound", path)
-				validations = append(validations, &validation)
-				valid = false
-			}
+			valid = n.checkReference(ref.Namespace, ref.Name, &validations, fmt.Sprintf("spec/rules[%d]/backendRefs[%d]/name", k, i)) && valid
 		}
 	}
 
 	return validations, valid
+}
+
+func (n NoHostChecker) checkReference(refNamespace *k8s_networking_v1.Namespace, refName k8s_networking_v1.ObjectName, validations *[]*models.IstioCheck, location string) bool {
+	namespace := n.K8sHTTPRoute.Namespace
+	if refNamespace != nil && string(*refNamespace) != "" {
+		namespace = string(*refNamespace)
+	}
+	fqdn := kubernetes.GetHost(string(refName), namespace, n.Namespaces.GetNames())
+	//service name should not be set in fqdn format
+	// if the http route is referencing to a service from the same namespace, then service should exist there
+	// if the http route is referencing to a service from other namespace, then a ReferenceGrant should exist to cross namespace reference, and the service should exist in remote namespace
+	if strings.Contains(string(refName), ".") ||
+		(namespace == n.K8sHTTPRoute.Namespace && !n.checkDestination(fqdn.String(), namespace)) ||
+		(namespace != n.K8sHTTPRoute.Namespace && (!n.checkReferenceGrant(n.K8sHTTPRoute.Namespace, namespace) || !n.checkDestination(fqdn.String(), namespace))) {
+		validation := models.Build("k8sroutes.nohost.namenotfound", location)
+		*validations = append(*validations, &validation)
+		return false
+	}
+	return true
 }
 
 func (n NoHostChecker) checkDestination(sHost string, itemNamespace string) bool {

--- a/business/checkers/k8shttproutes/no_host_checker_test.go
+++ b/business/checkers/k8shttproutes/no_host_checker_test.go
@@ -26,7 +26,7 @@ func TestValidRefHost(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.True(valid)
@@ -45,15 +45,19 @@ func TestMissingGrant(t *testing.T) {
 
 	vals, valid := NoHostChecker{
 		RegistryServices: append(registryService1, registryService2...),
-		K8sHTTPRoute:     data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:     data.AddServiceParentRefToHTTPRoute("reviews", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
+	assert.Len(vals, 2)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[0]))
-	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+	assert.Equal("spec/parentRefs[1]/name", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[1]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[1].Path)
 }
 
 func TestWrongGrant(t *testing.T) {
@@ -69,15 +73,18 @@ func TestWrongGrant(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
+	assert.Len(vals, 2)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[0]))
-	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+	assert.Equal("spec/parentRefs[1]/name", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[1]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[1].Path)
 }
 
 func TestValidRefHostDefaultNs(t *testing.T) {
@@ -93,7 +100,7 @@ func TestValidRefHostDefaultNs(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "", data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.True(valid)
@@ -113,15 +120,18 @@ func TestInvalidRefHostDefaultNs(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "", data.AddBackendRefToHTTPRoute("reviews", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
+	assert.Len(vals, 2)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[0]))
-	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+	assert.Equal("spec/parentRefs[1]/name", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[1]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[1].Path)
 }
 
 func TestNoValidRefHost(t *testing.T) {
@@ -137,19 +147,24 @@ func TestNoValidRefHost(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo2"}))),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("ratings", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo2"})))),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Len(vals, 2)
+	assert.Len(vals, 3)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[0]))
-	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+	assert.Equal("spec/parentRefs[1]/name", vals[0].Path)
 
 	assert.Equal(models.ErrorSeverity, vals[1].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[1]))
-	assert.Equal("spec/rules[1]/backendRefs[0]/name", vals[1].Path)
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[1].Path)
+
+	assert.Equal(models.ErrorSeverity, vals[2].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[2]))
+	assert.Equal("spec/rules[1]/backendRefs[0]/name", vals[2].Path)
 }
 
 func TestInvalidRefHostFQDN(t *testing.T) {
@@ -165,13 +180,16 @@ func TestInvalidRefHostFQDN(t *testing.T) {
 	vals, valid := NoHostChecker{
 		RegistryServices:   append(registryService1, registryService2...),
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
-		K8sHTTPRoute:       data.AddBackendRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"})),
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.AddBackendRefToHTTPRoute("reviews.bookinfo.svc.cluster.local", "", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 
 	assert.False(valid)
 	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
+	assert.Len(vals, 2)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[0]))
-	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[0].Path)
+	assert.Equal("spec/parentRefs[1]/name", vals[0].Path)
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[1]))
+	assert.Equal("spec/rules[0]/backendRefs[0]/name", vals[1].Path)
 }

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
@@ -36,7 +36,7 @@ func TestMissingK8sGateways(t *testing.T) {
 	config.Set(conf)
 
 	checker := NoK8sGatewayChecker{
-		K8sHTTPRoute: data.AddParentRefToHTTPRoute("gateway2", "bookinfo2",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("gateway2", "bookinfo2",
 			data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 		GatewayNames: make(map[string]struct{}),
 	}
@@ -59,7 +59,7 @@ func TestValidAndMissingK8sGateway(t *testing.T) {
 	var empty struct{}
 
 	checker := NoK8sGatewayChecker{
-		K8sHTTPRoute: data.AddParentRefToHTTPRoute("correctgw", "bookinfo2",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("correctgw", "bookinfo2",
 			data.CreateHTTPRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
 		GatewayNames: map[string]struct{}{"correctgw": empty},
 	}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -275,7 +275,7 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"k8sroutes.nohost.namenotfound": {
 		Code:     "KIA1402",
-		Message:  "BackendRef on rule doesn't have a valid service (Service name not found)",
+		Message:  "Reference doesn't have a valid service (Service name not found)",
 		Severity: ErrorSeverity,
 	},
 	"k8sroutes.nok8sgateway": {

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -19,13 +19,25 @@ func CreateEmptyHTTPRoute(name string, namespace string, hosts []string) *k8s_ne
 }
 
 func CreateHTTPRoute(name string, namespace string, gateway string, hosts []string) *k8s_networking_v1.HTTPRoute {
-	return AddParentRefToHTTPRoute(gateway, namespace, CreateEmptyHTTPRoute(name, namespace, hosts))
+	return AddGatewayParentRefToHTTPRoute(gateway, namespace, CreateEmptyHTTPRoute(name, namespace, hosts))
 }
 
-func AddParentRefToHTTPRoute(name, namespace string, rt *k8s_networking_v1.HTTPRoute) *k8s_networking_v1.HTTPRoute {
+func AddGatewayParentRefToHTTPRoute(name, namespace string, rt *k8s_networking_v1.HTTPRoute) *k8s_networking_v1.HTTPRoute {
 	ns := k8s_networking_v1.Namespace(namespace)
 	group := k8s_networking_v1.Group(kubernetes.K8sNetworkingGroupVersionV1.Group)
 	kind := k8s_networking_v1.Kind(kubernetes.K8sActualGatewayType)
+	rt.Spec.ParentRefs = append(rt.Spec.ParentRefs, k8s_networking_v1.ParentReference{
+		Name:      k8s_networking_v1.ObjectName(name),
+		Namespace: &ns,
+		Group:     &group,
+		Kind:      &kind})
+	return rt
+}
+
+func AddServiceParentRefToHTTPRoute(name, namespace string, rt *k8s_networking_v1.HTTPRoute) *k8s_networking_v1.HTTPRoute {
+	ns := k8s_networking_v1.Namespace(namespace)
+	group := k8s_networking_v1.Group("core")
+	kind := k8s_networking_v1.Kind(kubernetes.ServiceType)
 	rt.Spec.ParentRefs = append(rt.Spec.ParentRefs, k8s_networking_v1.ParentReference{
 		Name:      k8s_networking_v1.ObjectName(name),
 		Namespace: &ns,
@@ -66,13 +78,25 @@ func CreateEmptyGRPCRoute(name string, namespace string, hosts []string) *k8s_ne
 }
 
 func CreateGRPCRoute(name string, namespace string, gateway string, hosts []string) *k8s_networking_v1.GRPCRoute {
-	return AddParentRefToGRPCRoute(gateway, namespace, CreateEmptyGRPCRoute(name, namespace, hosts))
+	return AddGatewayParentRefToGRPCRoute(gateway, namespace, CreateEmptyGRPCRoute(name, namespace, hosts))
 }
 
-func AddParentRefToGRPCRoute(name, namespace string, rt *k8s_networking_v1.GRPCRoute) *k8s_networking_v1.GRPCRoute {
+func AddGatewayParentRefToGRPCRoute(name, namespace string, rt *k8s_networking_v1.GRPCRoute) *k8s_networking_v1.GRPCRoute {
 	ns := k8s_networking_v1.Namespace(namespace)
 	group := k8s_networking_v1.Group(kubernetes.K8sNetworkingGroupVersionV1.Group)
 	kind := k8s_networking_v1.Kind(kubernetes.K8sActualGatewayType)
+	rt.Spec.ParentRefs = append(rt.Spec.ParentRefs, k8s_networking_v1.ParentReference{
+		Name:      k8s_networking_v1.ObjectName(name),
+		Namespace: &ns,
+		Group:     &group,
+		Kind:      &kind})
+	return rt
+}
+
+func AddServiceParentRefToGRPCRoute(name, namespace string, rt *k8s_networking_v1.GRPCRoute) *k8s_networking_v1.GRPCRoute {
+	ns := k8s_networking_v1.Namespace(namespace)
+	group := k8s_networking_v1.Group("core")
+	kind := k8s_networking_v1.Kind(kubernetes.ServiceType)
 	rt.Spec.ParentRefs = append(rt.Spec.ParentRefs, k8s_networking_v1.ParentReference{
 		Name:      k8s_networking_v1.ObjectName(name),
 		Namespace: &ns,

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -193,7 +193,7 @@ func TestK8sHTTPRoutesServicesError(t *testing.T) {
 	require.Equal("k8shttproute", config.IstioValidation.ObjectType)
 	require.NotEmpty(config.IstioValidation.Checks)
 	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	require.Equal("BackendRef on rule doesn't have a valid service (Service name not found)", config.IstioValidation.Checks[0].Message)
+	require.Equal("Reference doesn't have a valid service (Service name not found)", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sGRPCRoutesGatewaysError(t *testing.T) {

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -248,7 +248,7 @@ func TestK8sGRPCRoutesServicesError(t *testing.T) {
 	require.Equal("k8sgrpcroute", config.IstioValidation.ObjectType)
 	require.NotEmpty(config.IstioValidation.Checks)
 	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	require.Equal("BackendRef on rule doesn't have a valid service (Service name not found)", config.IstioValidation.Checks[0].Message)
+	require.Equal("Reference doesn't have a valid service (Service name not found)", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sReferenceGrantsFromNamespaceError(t *testing.T) {


### PR DESCRIPTION
### Describe the change

K8s HTTPRoute and GRPCRoute 'parentRef' field now can accept 'Service' kind of references.
Extended KIA1402 "Reference doesn't have a valid service (Service name not found)" validation message to support "spec/parentRefs[n]/name".

![Screenshot from 2024-06-12 17-35-26](https://github.com/kiali/kiali/assets/604313/912dfca0-066b-4ed3-a614-dc8d9042b488)


### Steps to test the PR

Modify any K8s HTTPRoute to have a parentRef to a Service which does not exist:
```
kind: HTTPRoute
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: details
  namespace: bookinfo
spec:
  parentRefs:
    - group: core
      kind: Service
      namespace: bookinfo
      name: details_wrong
      port: 9080
  hostnames:
    - details.bookinfo.svc.cluster.local
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - group: ''
          kind: Service
          name: details
          port: 9080
          weight: 100
```

### Automation testing

backend tests updated

### Issue reference
https://github.com/kiali/kiali/issues/7355
