### PR TITLE
apply same flake protection as we did for issue 7256

### DIFF
--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -60,13 +60,16 @@ Then(
 
 Then('user sees {string} from a remote {string} cluster', (type: string, cluster: string) => {
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const apps = state.cy.nodes(`[cluster="${cluster}"][nodeType="${type}"][namespace="bookinfo"]`).length;
-      assert.isAbove(apps, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const apps = state.cy.nodes(`[cluster="${cluster}"][nodeType="${type}"][namespace="bookinfo"]`).length;
+          assert.isAbove(apps, 0);
+        });
     });
 });
 

--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -60,16 +60,12 @@ Then(
 
 Then('user sees {string} from a remote {string} cluster', (type: string, cluster: string) => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('CytoscapeGraph')
     .should('have.length', '1')
-    .then(() => {
-      cy.getReact('CytoscapeGraph')
-        .should('have.length', '1')
-        .getCurrentState()
-        .then(state => {
-          const apps = state.cy.nodes(`[cluster="${cluster}"][nodeType="${type}"][namespace="bookinfo"]`).length;
-          assert.isAbove(apps, 0);
-        });
+    .getCurrentState()
+    .then(state => {
+      const apps = state.cy.nodes(`[cluster="${cluster}"][nodeType="${type}"][namespace="bookinfo"]`).length;
+      assert.isAbove(apps, 0);
     });
 });
 

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -193,33 +193,29 @@ Given(
   (name: string, type: string, cluster: string) => {
     Step(this, 'user sees a minigraph');
     cy.waitForReact();
-    cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('CytoscapeGraph')
       .should('have.length', '1')
-      .then(() => {
-        cy.getReact('CytoscapeGraph')
-          .should('have.length', '1')
-          .then($graph => {
+      .then($graph => {
+        cy.wrap($graph)
+          .getProps()
+          .then(props => {
+            const graphType = props.graphData.fetchParams.graphType;
+            const { nodeType, isBox } = nodeInfo(type, graphType);
             cy.wrap($graph)
-              .getProps()
-              .then(props => {
-                const graphType = props.graphData.fetchParams.graphType;
-                const { nodeType, isBox } = nodeInfo(type, graphType);
-                cy.wrap($graph)
-                  .getCurrentState()
-                  .then(state => {
-                    cy.wrap(
-                      state.cy
-                        .nodes()
-                        .some(
-                          node =>
-                            node.data('nodeType') === nodeType &&
-                            node.data('namespace') === 'bookinfo' &&
-                            node.data(type) === name &&
-                            node.data('cluster') === cluster &&
-                            node.data('isBox') === isBox
-                        )
-                    ).should('be.true');
-                  });
+              .getCurrentState()
+              .then(state => {
+                cy.wrap(
+                  state.cy
+                    .nodes()
+                    .some(
+                      node =>
+                        node.data('nodeType') === nodeType &&
+                        node.data('namespace') === 'bookinfo' &&
+                        node.data(type) === name &&
+                        node.data('cluster') === cluster &&
+                        node.data('isBox') === isBox
+                    )
+                ).should('be.true');
               });
           });
       });
@@ -230,35 +226,31 @@ When(
   'user clicks on the {string} {string} from the {string} cluster in the graph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('CytoscapeGraph')
       .should('have.length', '1')
-      .then(() => {
-        cy.getReact('CytoscapeGraph')
-          .should('have.length', '1')
-          .then($graph => {
+      .then($graph => {
+        cy.wrap($graph)
+          .getProps()
+          .then(props => {
+            const graphType = props.graphData.fetchParams.graphType;
             cy.wrap($graph)
-              .getProps()
-              .then(props => {
-                const graphType = props.graphData.fetchParams.graphType;
-                cy.wrap($graph)
-                  .getCurrentState()
-                  .then(state => {
-                    const node = state.cy
-                      .nodes()
-                      .toArray()
-                      .find(node => {
-                        const { nodeType, isBox } = nodeInfo(type, graphType);
-                        return (
-                          node.data('nodeType') === nodeType &&
-                          node.data('namespace') === 'bookinfo' &&
-                          node.data(type) === name &&
-                          node.data('cluster') === cluster &&
-                          node.data('isBox') === isBox &&
-                          !node.data('isInaccessible')
-                        );
-                      });
-                    node.emit('tap');
+              .getCurrentState()
+              .then(state => {
+                const node = state.cy
+                  .nodes()
+                  .toArray()
+                  .find(node => {
+                    const { nodeType, isBox } = nodeInfo(type, graphType);
+                    return (
+                      node.data('nodeType') === nodeType &&
+                      node.data('namespace') === 'bookinfo' &&
+                      node.data(type) === name &&
+                      node.data('cluster') === cluster &&
+                      node.data('isBox') === isBox &&
+                      !node.data('isInaccessible')
+                    );
                   });
+                node.emit('tap');
               });
           });
       });

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -193,29 +193,33 @@ Given(
   (name: string, type: string, cluster: string) => {
     Step(this, 'user sees a minigraph');
     cy.waitForReact();
-    cy.getReact('CytoscapeGraph')
+    cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
-      .then($graph => {
-        cy.wrap($graph)
-          .getProps()
-          .then(props => {
-            const graphType = props.graphData.fetchParams.graphType;
-            const { nodeType, isBox } = nodeInfo(type, graphType);
+      .then(() => {
+        cy.getReact('CytoscapeGraph')
+          .should('have.length', '1')
+          .then($graph => {
             cy.wrap($graph)
-              .getCurrentState()
-              .then(state => {
-                cy.wrap(
-                  state.cy
-                    .nodes()
-                    .some(
-                      node =>
-                        node.data('nodeType') === nodeType &&
-                        node.data('namespace') === 'bookinfo' &&
-                        node.data(type) === name &&
-                        node.data('cluster') === cluster &&
-                        node.data('isBox') === isBox
-                    )
-                ).should('be.true');
+              .getProps()
+              .then(props => {
+                const graphType = props.graphData.fetchParams.graphType;
+                const { nodeType, isBox } = nodeInfo(type, graphType);
+                cy.wrap($graph)
+                  .getCurrentState()
+                  .then(state => {
+                    cy.wrap(
+                      state.cy
+                        .nodes()
+                        .some(
+                          node =>
+                            node.data('nodeType') === nodeType &&
+                            node.data('namespace') === 'bookinfo' &&
+                            node.data(type) === name &&
+                            node.data('cluster') === cluster &&
+                            node.data('isBox') === isBox
+                        )
+                    ).should('be.true');
+                  });
               });
           });
       });
@@ -226,31 +230,35 @@ When(
   'user clicks on the {string} {string} from the {string} cluster in the graph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('CytoscapeGraph')
+    cy.getReact('MiniGraphCardComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
-      .then($graph => {
-        cy.wrap($graph)
-          .getProps()
-          .then(props => {
-            const graphType = props.graphData.fetchParams.graphType;
+      .then(() => {
+        cy.getReact('CytoscapeGraph')
+          .should('have.length', '1')
+          .then($graph => {
             cy.wrap($graph)
-              .getCurrentState()
-              .then(state => {
-                const node = state.cy
-                  .nodes()
-                  .toArray()
-                  .find(node => {
-                    const { nodeType, isBox } = nodeInfo(type, graphType);
-                    return (
-                      node.data('nodeType') === nodeType &&
-                      node.data('namespace') === 'bookinfo' &&
-                      node.data(type) === name &&
-                      node.data('cluster') === cluster &&
-                      node.data('isBox') === isBox &&
-                      !node.data('isInaccessible')
-                    );
+              .getProps()
+              .then(props => {
+                const graphType = props.graphData.fetchParams.graphType;
+                cy.wrap($graph)
+                  .getCurrentState()
+                  .then(state => {
+                    const node = state.cy
+                      .nodes()
+                      .toArray()
+                      .find(node => {
+                        const { nodeType, isBox } = nodeInfo(type, graphType);
+                        return (
+                          node.data('nodeType') === nodeType &&
+                          node.data('namespace') === 'bookinfo' &&
+                          node.data(type) === name &&
+                          node.data('cluster') === cluster &&
+                          node.data('isBox') === isBox &&
+                          !node.data('isInaccessible')
+                        );
+                      });
+                    node.emit('tap');
                   });
-                node.emit('tap');
               });
           });
       });

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -14,33 +14,41 @@ Then('user sees a minigraph', () => {
 
 Then('user sees the {string} namespace deployed across the east and west clusters', (namespace: string) => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const namespaceBoxes = state.cy
-        .nodes()
-        .filter(node => node.data('isBox') === 'namespace' && node.data('namespace') === namespace);
-      expect(namespaceBoxes.length).to.equal(2);
-      expect(namespaceBoxes.filter(node => node.data('cluster') === 'east').length).to.equal(1);
-      expect(namespaceBoxes.filter(node => node.data('cluster') === 'west').length).to.equal(1);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const namespaceBoxes = state.cy
+            .nodes()
+            .filter(node => node.data('isBox') === 'namespace' && node.data('namespace') === namespace);
+          expect(namespaceBoxes.length).to.equal(2);
+          expect(namespaceBoxes.filter(node => node.data('cluster') === 'east').length).to.equal(1);
+          expect(namespaceBoxes.filter(node => node.data('cluster') === 'west').length).to.equal(1);
+        });
     });
 });
 
 Then('nodes in the {string} cluster should contain the cluster name in their links', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const nodes = state.cy.nodes().filter(node => node.data('cluster') === cluster);
-      nodes.forEach(node => {
-        const links = node.connectedEdges().filter(edge => edge.data('source') === node.id());
-        links.forEach(link => {
-          const sourceNode = nodes.toArray().find(node => node.id() === link.data('source'));
-          expect(sourceNode.data('cluster')).to.equal(cluster);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const nodes = state.cy.nodes().filter(node => node.data('cluster') === cluster);
+          nodes.forEach(node => {
+            const links = node.connectedEdges().filter(edge => edge.data('source') === node.id());
+            links.forEach(link => {
+              const sourceNode = nodes.toArray().find(node => node.id() === link.data('source'));
+              expect(sourceNode.data('cluster')).to.equal(cluster);
+            });
+          });
         });
-      });
     });
 });
 
@@ -48,27 +56,31 @@ Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('CytoscapeGraph')
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
-      .getCurrentState()
-      .then(state => {
-        const workloadNode = state.cy.nodes().filter(
-          node =>
-            // Apparently workloads are apps for the versioned app graph.
-            node.data('nodeType') === 'app' &&
-            node.data('isBox') === undefined &&
-            node.data('workload') === workload &&
-            node.data('namespace') === namespace &&
-            node.data('cluster') === cluster
-        );
-        expect(workloadNode.length).to.equal(1);
-        cy.wrap(workloadNode.emit('tap')).then(() => {
-          // Wait for the side panel to change.
-          // Note we can't use summary-graph-panel since that
-          // element will get unmounted and disappear when
-          // the context changes but the graph-side-panel does not.
-          cy.get('#graph-side-panel').contains(workload);
-        });
+      .then(() => {
+        cy.getReact('CytoscapeGraph')
+          .should('have.length', '1')
+          .getCurrentState()
+          .then(state => {
+            const workloadNode = state.cy.nodes().filter(
+              node =>
+                // Apparently workloads are apps for the versioned app graph.
+                node.data('nodeType') === 'app' &&
+                node.data('isBox') === undefined &&
+                node.data('workload') === workload &&
+                node.data('namespace') === namespace &&
+                node.data('cluster') === cluster
+            );
+            expect(workloadNode.length).to.equal(1);
+            cy.wrap(workloadNode.emit('tap')).then(() => {
+              // Wait for the side panel to change.
+              // Note we can't use summary-graph-panel since that
+              // element will get unmounted and disappear when
+              // the context changes but the graph-side-panel does not.
+              cy.get('#graph-side-panel').contains(workload);
+            });
+          });
       });
   }
 );

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -145,32 +145,35 @@ Then('the display menu has default settings', () => {
 
 Then('the graph reflects default settings', () => {
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      // no nonDefault edge label info
-      let numEdges = state.cy.edges(`[?responseTime],[?throughput]`).length;
-      assert.equal(numEdges, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          // no nonDefault edge label info
+          let numEdges = state.cy.edges(`[?responseTime],[?throughput]`).length;
+          assert.equal(numEdges, 0);
 
-      // no idle edges, mtls
-      numEdges = state.cy.edges(`[^hasTraffic],[isMTLS > 0]`).length;
-      assert.equal(numEdges, 0);
+          // no idle edges, mtls
+          numEdges = state.cy.edges(`[^hasTraffic],[isMTLS > 0]`).length;
+          assert.equal(numEdges, 0);
 
-      // boxes
-      let numNodes = state.cy.nodes(`[isBox = "app"]`).length;
-      assert.isAbove(numNodes, 0);
-      numNodes = state.cy.nodes(`[isBox = "namespace"]`).length;
-      assert.isAbove(numNodes, 0);
+          // boxes
+          let numNodes = state.cy.nodes(`[isBox = "app"]`).length;
+          assert.isAbove(numNodes, 0);
+          numNodes = state.cy.nodes(`[isBox = "namespace"]`).length;
+          assert.isAbove(numNodes, 0);
 
-      // service nodes
-      numNodes = state.cy.nodes(`[nodeType = "service"]`).length;
-      assert.isAbove(numNodes, 0);
+          // service nodes
+          numNodes = state.cy.nodes(`[nodeType = "service"]`).length;
+          assert.isAbove(numNodes, 0);
 
-      // a variety of not-found tests
-      numNodes = state.cy.nodes(`[isBox = "cluster"],[?isIdle],[?rank],[nodeType = "operation"]`).length;
-      assert.equal(numNodes, 0);
+          // a variety of not-found tests
+          numNodes = state.cy.nodes(`[isBox = "cluster"],[?isIdle],[?rank],[nodeType = "operation"]`).length;
+          assert.equal(numNodes, 0);
+        });
     });
 });
 
@@ -190,13 +193,16 @@ Then('user sees {string} edge labels', (el: string) => {
   }
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numEdges = state.cy.edges(`[${rate}" > 0]`).length;
-      assert.isAbove(numEdges, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numEdges = state.cy.edges(`[${rate}" > 0]`).length;
+          assert.isAbove(numEdges, 0);
+        });
     });
 });
 
@@ -208,13 +214,16 @@ Then('user does not see {string} boxing', (boxByType: string) => {
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numBoxes = state.cy.nodes(`[isBox = "${boxByType.toLowerCase()}"]`).length;
-      assert.equal(numBoxes, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numBoxes = state.cy.nodes(`[isBox = "${boxByType.toLowerCase()}"]`).length;
+          assert.equal(numBoxes, 0);
+        });
     });
 });
 
@@ -229,21 +238,24 @@ Then('idle edges {string} in the graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numEdges = state.cy.edges(`[hasTraffic]`).length;
-      const numIdleEdges = state.cy.edges(`[^hasTraffic]`).length;
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numEdges = state.cy.edges(`[hasTraffic]`).length;
+          const numIdleEdges = state.cy.edges(`[^hasTraffic]`).length;
 
-      if (action === 'appear') {
-        assert.isAbove(numEdges, 0);
-        assert.isAtLeast(numIdleEdges, 0);
-      } else {
-        assert.isAbove(numEdges, 0);
-        assert.equal(numIdleEdges, 0);
-      }
+          if (action === 'appear') {
+            assert.isAbove(numEdges, 0);
+            assert.isAtLeast(numIdleEdges, 0);
+          } else {
+            assert.isAbove(numEdges, 0);
+            assert.equal(numIdleEdges, 0);
+          }
+        });
     });
 });
 
@@ -251,17 +263,20 @@ Then('idle nodes {string} in the graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numNodes = state.cy.nodes(`[?isIdle]`).length;
-      if (action === 'appear') {
-        assert.equal(numNodes, 16);
-      } else {
-        assert.equal(numNodes, 0);
-      }
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numNodes = state.cy.nodes(`[?isIdle]`).length;
+          if (action === 'appear') {
+            assert.equal(numNodes, 16);
+          } else {
+            assert.equal(numNodes, 0);
+          }
+        });
     });
 });
 
@@ -269,17 +284,20 @@ Then('ranks {string} in the graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numNodes = state.cy.nodes(`[rank > 0]`).length;
-      if (action === 'appear') {
-        assert.isAbove(numNodes, 0);
-      } else {
-        assert.equal(numNodes, 0);
-      }
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numNodes = state.cy.nodes(`[rank > 0]`).length;
+          if (action === 'appear') {
+            assert.isAbove(numNodes, 0);
+          } else {
+            assert.equal(numNodes, 0);
+          }
+        });
     });
 });
 
@@ -287,13 +305,16 @@ Then('user does not see service nodes', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numBoxes = state.cy.nodes(`[nodeType = "service"][^isOutside]`).length;
-      assert.equal(numBoxes, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numBoxes = state.cy.nodes(`[nodeType = "service"][^isOutside]`).length;
+          assert.equal(numBoxes, 0);
+        });
     });
 });
 
@@ -301,17 +322,20 @@ Then('security {string} in the graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numEdges = state.cy.edges(`[isMTLS > 0]`).length;
-      if (action === 'appears') {
-        assert.isAbove(numEdges, 0);
-      } else {
-        assert.equal(numEdges, 0);
-      }
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numEdges = state.cy.edges(`[isMTLS > 0]`).length;
+          if (action === 'appears') {
+            assert.isAbove(numEdges, 0);
+          } else {
+            assert.equal(numEdges, 0);
+          }
+        });
     });
 });
 
@@ -353,16 +377,19 @@ Then('the {string} option should {string} and {string}', (option: string, option
 
 Then('only a single cluster box should be visible', () => {
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const clusterBoxes = state.cy.nodes(`[isBox = "cluster"]`).length;
-      assert.equal(clusterBoxes, 0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const clusterBoxes = state.cy.nodes(`[isBox = "cluster"]`).length;
+          assert.equal(clusterBoxes, 0);
 
-      const namespaceBoxes = state.cy.nodes(`[isBox = "namespace"][namespace = "bookinfo"]`).length;
-      assert.equal(namespaceBoxes, 1);
+          const namespaceBoxes = state.cy.nodes(`[isBox = "namespace"][namespace = "bookinfo"]`).length;
+          assert.equal(namespaceBoxes, 1);
+        });
     });
 });
 
@@ -427,20 +454,23 @@ Then(
   'user double-clicks on the {string} {string} from the {string} cluster in the main graph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-
-    cy.getReact('CytoscapeGraph')
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
-      .getCurrentState()
-      .then(state => {
-        let node;
-        if (type === 'app') {
-          node = state.cy.nodes(`[app="${name}"][cluster="${cluster}"][isBox="app"]`);
-        } else if (type === 'service') {
-          node = state.cy.nodes(`[nodeType="service"][cluster="${cluster}"][app="${name}"]`);
-        }
-        // none of the standard cytoscape.js events for double-clicks were not working unfortunately
-        node.emit('tap');
-        node.emit('tap');
+      .then(() => {
+        cy.getReact('CytoscapeGraph')
+          .should('have.length', '1')
+          .getCurrentState()
+          .then(state => {
+            let node;
+            if (type === 'app') {
+              node = state.cy.nodes(`[app="${name}"][cluster="${cluster}"][isBox="app"]`);
+            } else if (type === 'service') {
+              node = state.cy.nodes(`[nodeType="service"][cluster="${cluster}"][app="${name}"]`);
+            }
+            // none of the standard cytoscape.js events for double-clicks were not working unfortunately
+            node.emit('tap');
+            node.emit('tap');
+          });
       });
   }
 );
@@ -459,13 +489,16 @@ When('user {string} {string} traffic option', (action: string, option: string) =
 
 Then('{int} edges appear in the graph', (edges: number) => {
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numEdges = state.cy.edges(`[hasTraffic]`).length;
-      // It can be more, depending on the service version redirection
-      assert.isAtLeast(numEdges, edges);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numEdges = state.cy.edges(`[hasTraffic]`).length;
+          // It can be more, depending on the service version redirection
+          assert.isAtLeast(numEdges, edges);
+        });
     });
 });

--- a/frontend/cypress/integration/common/graph_find_hide.ts
+++ b/frontend/cypress/integration/common/graph_find_hide.ts
@@ -30,19 +30,23 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
     }
   ];
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const unhealthyNodes = state.cy
-        .nodes()
-        .filter((node: any) => node.classes().includes('find'))
-        .map((node: any) => ({
-          app: node.data('app'),
-          version: node.data('version'),
-          namespace: node.data('namespace')
-        }));
-      expect(unhealthyNodes).to.include.deep.members(expectedUnhealthyNodes);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const unhealthyNodes = state.cy
+            .nodes()
+            .filter((node: any) => node.classes().includes('find'))
+            .map((node: any) => ({
+              app: node.data('app'),
+              version: node.data('version'),
+              namespace: node.data('namespace')
+            }));
+          expect(unhealthyNodes).to.include.deep.members(expectedUnhealthyNodes);
+        });
     });
 });
 
@@ -50,11 +54,15 @@ Then('user sees nothing highlighted on the graph', () => {
   cy.contains('Loading Graph').should('not.exist');
 
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      expect(state.cy.nodes().filter((node: any) => node.classes().includes('find')).length).to.equal(0);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          expect(state.cy.nodes().filter((node: any) => node.classes().includes('find')).length).to.equal(0);
+        });
     });
 });
 
@@ -66,16 +74,20 @@ When('user hides unhealthy workloads', () => {
 
 Then('user sees no unhealthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const noUnhealthy = state.cy
-        .nodes()
-        // Unhealthy boxes are fine.
-        .every((node: any) => node.data('healthStatus') !== 'Failure' || node.data('nodeType') === 'box');
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const noUnhealthy = state.cy
+            .nodes()
+            // Unhealthy boxes are fine.
+            .every((node: any) => node.data('healthStatus') !== 'Failure' || node.data('nodeType') === 'box');
 
-      expect(noUnhealthy).to.equal(true);
+          expect(noUnhealthy).to.equal(true);
+        });
     });
 });
 
@@ -99,16 +111,19 @@ When('user selects the preset hide option {string}', (option: string) => {
 
 Then('user sees no healthy workloads on the graph', () => {
   cy.waitForReact();
-
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const noHealthy = state.cy
-        .nodes()
-        .every((node: any) => node.data('healthStatus') !== 'Healthy' || node.data('nodeType') === 'box');
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const noHealthy = state.cy
+            .nodes()
+            .every((node: any) => node.data('healthStatus') !== 'Healthy' || node.data('nodeType') === 'box');
 
-      expect(noHealthy).to.equal(true);
+          expect(noHealthy).to.equal(true);
+        });
     });
 });
 

--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -2,12 +2,16 @@ import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 When('user clicks the {string} {string} node', (svcName: string, nodeType: string) => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const node = state.cy.nodes(`[nodeType="${nodeType}"][${nodeType}="${svcName}"]`);
-      node.emit('tap');
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const node = state.cy.nodes(`[nodeType="${nodeType}"][${nodeType}="${svcName}"]`);
+          node.emit('tap');
+        });
     });
 });
 
@@ -108,29 +112,33 @@ When(
   'user clicks the {string} service node in the {string} namespace in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('CytoscapeGraph')
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
-      .getCurrentState()
-      .then($graph => {
-        const serviceNode = $graph.cy
-          .nodes()
-          .filter(
-            node =>
-              node.data('nodeType') === 'service' &&
-              node.data('isBox') === undefined &&
-              node.data('service') === service &&
-              node.data('namespace') === namespace &&
-              node.data('cluster') === cluster
-          );
-        expect(serviceNode.length).to.equal(1);
-        cy.wrap(serviceNode.emit('tap')).then(() => {
-          // Wait for the side panel to change.
-          // Note we can't use summary-graph-panel since that
-          // element will get unmounted and disappear when
-          // the context changes but the graph-side-panel does not.
-          cy.get('#graph-side-panel').contains(service);
-          cy.wrap(serviceNode).as('contextNode');
-        });
+      .then(() => {
+        cy.getReact('CytoscapeGraph')
+          .should('have.length', '1')
+          .getCurrentState()
+          .then($graph => {
+            const serviceNode = $graph.cy
+              .nodes()
+              .filter(
+                node =>
+                  node.data('nodeType') === 'service' &&
+                  node.data('isBox') === undefined &&
+                  node.data('service') === service &&
+                  node.data('namespace') === namespace &&
+                  node.data('cluster') === cluster
+              );
+            expect(serviceNode.length).to.equal(1);
+            cy.wrap(serviceNode.emit('tap')).then(() => {
+              // Wait for the side panel to change.
+              // Note we can't use summary-graph-panel since that
+              // element will get unmounted and disappear when
+              // the context changes but the graph-side-panel does not.
+              cy.get('#graph-side-panel').contains(service);
+              cy.wrap(serviceNode).as('contextNode');
+            });
+          });
       });
   }
 );

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -117,17 +117,21 @@ Then('user does not see graph traffic menu', () => {
 
 Then('user {string} {string} traffic', (action: string, protocol: string) => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const numEdges = state.cy.edges(`[protocol = "${protocol}"]`).length;
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const numEdges = state.cy.edges(`[protocol = "${protocol}"]`).length;
 
-      if (action === 'sees') {
-        assert.isAbove(numEdges, 0);
-      } else {
-        assert.equal(numEdges, 0);
-      }
+          if (action === 'sees') {
+            assert.isAbove(numEdges, 0);
+          } else {
+            assert.equal(numEdges, 0);
+          }
+        });
     });
 });
 
@@ -215,11 +219,15 @@ Then('user sees selected graph refresh {string}', (refresh: string) => {
 
 Then('user sees a {string} graph', graphType => {
   cy.waitForReact();
-  cy.getReact('CytoscapeGraph')
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
-    .getCurrentState()
-    .then(state => {
-      const globalScratch: CytoscapeGlobalScratchData = state.cy.scratch(CytoscapeGlobalScratchNamespace);
-      assert.equal(globalScratch.graphType, graphType);
+    .then(() => {
+      cy.getReact('CytoscapeGraph')
+        .should('have.length', '1')
+        .getCurrentState()
+        .then(state => {
+          const globalScratch: CytoscapeGlobalScratchData = state.cy.scratch(CytoscapeGlobalScratchNamespace);
+          assert.equal(globalScratch.graphType, graphType);
+        });
     });
 });


### PR DESCRIPTION
In an effort to prevent graph-page-related flakes, add the same wrapping we did to avoid the content-menu flake (#7256), around remaining instances.

Note that this does not apply the same logic to the mini-graph tests, because that code is a bit different.  If we suspect a similar flake in that area, we'll have to do some additional work to apply this kind of logic.

@nrfox Should be a straightforward review.  I ran the tests a few times already, feel free to try again if you like.