### PR TITLE
[pft] Improve focus node handling

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -421,7 +421,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
       this.loadGraphDataFromBackend();
     }
 
-    if (!!this.focusSelector) {
+    if (this.focusSelector) {
       this.focusSelector = undefined;
       unsetFocusSelector();
     }

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -57,8 +57,10 @@ export type NodeData = DecoratedGraphNodeData & {
   badgeTextColor?: string;
   column?: number;
   component?: React.ReactNode;
+  hasSpans?: Span[];
   icon?: React.ReactNode;
   isFind?: boolean;
+  isFocus?: boolean;
   isHighlighted?: boolean;
   isSelected?: boolean;
   isUnhighlighted?: boolean;

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -47,7 +47,7 @@ import { GraphToolbarActions } from '../../actions/GraphToolbarActions';
 import { PFColors } from 'components/Pf/PfColors';
 import { TourActions } from 'actions/TourActions';
 import { arrayEquals } from 'utils/Common';
-import { isKioskMode, getFocusSelector, getTraceId, getClusterName } from 'utils/SearchParamUtils';
+import { isKioskMode, getFocusSelector, getTraceId, getClusterName, unsetFocusSelector } from 'utils/SearchParamUtils';
 import { Badge, Chip } from '@patternfly/react-core';
 import { toRangeString } from 'components/Time/Utils';
 import { replayBorder } from 'components/Time/Replay';
@@ -293,7 +293,10 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
     this.controller = undefined;
     this.errorBoundaryRef = React.createRef();
     const focusNodeId = getFocusSelector();
-    this.focusNode = focusNodeId ? { id: focusNodeId, isSelected: true } : undefined;
+    if (focusNodeId) {
+      this.focusNode = { id: focusNodeId, isSelected: true } as FocusNode;
+      unsetFocusSelector();
+    }
     this.graphDataSource = new GraphDataSource();
 
     this.state = {

--- a/frontend/src/pages/GraphPF/styles/styleGroup.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleGroup.tsx
@@ -3,6 +3,7 @@ import {
   DefaultGroup,
   Node,
   observer,
+  Rect,
   ScaleDetailsLevel,
   ShapeProps,
   WithSelectionProps
@@ -10,8 +11,12 @@ import {
 import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import React from 'react';
+import { kialiStyle } from 'styles/StyleUtils';
 
 const ICON_PADDING = 20;
+
+const ColorFocus = PFColors.Blue200;
+const OverlayWidth = 40;
 
 export enum DataTypes {
   Default
@@ -26,6 +31,11 @@ type StyleGroupProps = {
   getCollapsedShape?: (node: Node) => React.FC<ShapeProps>;
   onCollapseChange?: (group: Node, collapsed: boolean) => void;
 } & WithSelectionProps;
+
+const focusOverlayStyle = kialiStyle({
+  strokeWidth: OverlayWidth,
+  stroke: ColorFocus
+});
 
 const StyleGroupComponent: React.FC<StyleGroupProps> = ({
   collapsedHeight = 75,
@@ -71,8 +81,20 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
     );
   };
 
+  const boxRef = React.useRef<Rect | null>(null);
+  boxRef.current = element.getBounds();
+
   return (
     <g style={{ opacity: opacity }} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      {data.isFocus && (
+        <rect
+          className={focusOverlayStyle}
+          x={boxRef.current.x}
+          y={boxRef.current.y}
+          width={boxRef.current.width}
+          height={boxRef.current.height}
+        />
+      )}
       <DefaultGroup
         element={element}
         collapsedWidth={collapsedWidth}

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -58,19 +58,25 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
   const ShapeComponent = getShapeComponent(element);
 
   const ColorFind = PFColors.Gold400;
+  const ColorFocus = PFColors.Blue200;
   const ColorSpan = PFColors.Purple200;
   const OverlayOpacity = 0.3;
   const OverlayWidth = 40;
 
-  const traceOverlayStyle = kialiStyle({
-    strokeWidth: OverlayWidth,
-    stroke: ColorSpan,
-    strokeOpacity: OverlayOpacity
-  });
-
   const findOverlayStyle = kialiStyle({
     strokeWidth: OverlayWidth,
     stroke: ColorFind,
+    strokeOpacity: OverlayOpacity
+  });
+
+  const focusOverlayStyle = kialiStyle({
+    strokeWidth: OverlayWidth,
+    stroke: ColorFocus
+  });
+
+  const traceOverlayStyle = kialiStyle({
+    strokeWidth: OverlayWidth,
+    stroke: ColorSpan,
     strokeOpacity: OverlayOpacity
   });
 
@@ -109,6 +115,7 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
         <ShapeComponent className={traceOverlayStyle} width={width} height={height} element={element} />
       )}
       {data.isFind && <ShapeComponent className={findOverlayStyle} width={width} height={height} element={element} />}
+      {data.isFocus && <ShapeComponent className={focusOverlayStyle} width={width} height={height} element={element} />}
       <DefaultNode
         element={element}
         {...rest}

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -33,7 +33,6 @@ import { layoutFactory } from './layouts/layoutFactory';
 import { TimeInMilliseconds } from 'types/Common';
 import { HistoryManager, URLParam } from 'app/History';
 import { TourStop } from 'components/Tour/TourStop';
-import { getFocusSelector, unsetFocusSelector } from 'utils/SearchParamUtils';
 import { meshComponentFactory } from './components/meshComponentFactory';
 import { MeshData, MeshRefs } from './MeshPage';
 import { MeshInfraType, MeshTarget } from 'types/Mesh';
@@ -79,12 +78,6 @@ export function getLayoutByName(layoutName: string): Layout {
     default:
       return KialiDagreGraph.getLayout();
   }
-}
-
-// TODO: Implement some sort of focus when provided
-export interface FocusNode {
-  id: string;
-  isSelected?: boolean;
 }
 
 // The is the main graph rendering component
@@ -388,21 +381,6 @@ const TopologyContent: React.FC<{
 
       // set decorators
       nodes.forEach(n => setNodeAttachments(n));
-
-      const focusNodeId = getFocusSelector();
-      if (focusNodeId) {
-        const focusNode = nodes.find(n => n.getId() === focusNodeId);
-        if (focusNode) {
-          const data = focusNode.getData() as NodeData;
-          data.isSelected = true;
-          setSelectedIds([focusNode.getId()]);
-          focusNode.setData({ ...(focusNode.getData() as NodeData) });
-        }
-        unsetFocusSelector();
-      }
-
-      // pre-select node if provided
-      // - Currently no pre-selection
     };
 
     const initialGraph = !controller.hasGraph();
@@ -562,7 +540,6 @@ const TopologyContent: React.FC<{
 };
 
 export const Mesh: React.FC<{
-  focusNode?: FocusNode;
   isMiniMesh: boolean;
   layout: Layout;
   meshData: MeshData;

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -17,7 +17,7 @@ import {
 import { KialiAppState } from '../../store/Store';
 import { PFColors } from 'components/Pf/PfColors';
 import { TourActions } from 'actions/TourActions';
-import { isKioskMode, getFocusSelector } from 'utils/SearchParamUtils';
+import { isKioskMode } from 'utils/SearchParamUtils';
 import { Chip } from '@patternfly/react-core';
 import { EMPTY_MESH_DATA, MeshDataSource, MeshFetchParams } from '../../services/MeshDataSource';
 import { KialiDispatch } from 'types/Redux';
@@ -32,7 +32,7 @@ import {
   MeshDefinition,
   MeshTarget
 } from 'types/Mesh';
-import { FocusNode, Mesh, getLayoutByName } from './Mesh';
+import { Mesh, getLayoutByName } from './Mesh';
 import { MeshActions } from 'actions/MeshActions';
 import { MeshLegend } from './MeshLegend';
 import { MeshToolbarActions } from 'actions/MeshToolbarActions';
@@ -134,14 +134,11 @@ const MeshErrorBoundaryFallback = (): JSX.Element => {
 
 class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
   private readonly errorBoundaryRef: any;
-  private focusNode?: FocusNode;
   private meshDataSource: MeshDataSource;
 
   constructor(props: MeshPageProps) {
     super(props);
     this.errorBoundaryRef = React.createRef();
-    const focusNodeId = getFocusSelector();
-    this.focusNode = focusNodeId ? { id: focusNodeId, isSelected: true } : undefined;
     this.meshDataSource = new MeshDataSource();
 
     this.state = {
@@ -244,13 +241,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
                   isLoading={this.state.meshData.isLoading}
                   isMiniMesh={false}
                 >
-                  <Mesh
-                    {...this.props}
-                    focusNode={this.focusNode}
-                    isMiniMesh={false}
-                    meshData={this.state.meshData}
-                    onReady={this.handleReady}
-                  />
+                  <Mesh {...this.props} isMiniMesh={false} meshData={this.state.meshData} onReady={this.handleReady} />
                 </EmptyMeshLayout>
               </div>
             </ErrorBoundary>
@@ -260,7 +251,6 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
                 duration={this.props.duration}
                 isPageVisible={this.props.isPageVisible}
                 istioAPIEnabled={this.props.istioAPIEnabled}
-                onFocus={this.onFocus}
                 refreshInterval={this.props.refreshInterval}
                 target={this.props.target}
                 updateTime={this.state.meshData.timestamp / 1000}
@@ -271,11 +261,6 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
       </>
     );
   }
-
-  // TODO Focus...
-  private onFocus = (focusNode: FocusNode): void => {
-    console.debug(`onFocus(${focusNode})`);
-  };
 
   private handleReady = (refs: MeshRefs): void => {
     this.setState({ meshRefs: refs });

--- a/frontend/src/pages/Mesh/target/TargetPanel.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanel.tsx
@@ -4,7 +4,6 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { KialiAppState } from 'store/Store';
 import { TourStop } from 'components/Tour/TourStop';
-import { FocusNode } from 'pages/GraphPF/GraphPF';
 import { classes } from 'typestyle';
 import { PFColors } from 'components/Pf/PfColors';
 import { MeshInfraType, MeshTarget, MeshType } from 'types/Mesh';
@@ -31,7 +30,6 @@ type ReduxProps = {
 type TargetPanelProps = ReduxProps &
   TargetPanelCommonProps & {
     isPageVisible: boolean;
-    onFocus?: (focusNode: FocusNode) => void;
   };
 
 const mainStyle = kialiStyle({


### PR DESCRIPTION
To help the user locate the focus node add an animation, in addition to selecting the node.
- change things so that the focusNode is passed into the graph (so that the graph code does not itself process URL params)
- remove focusNode code from MeshPage, can bring it back in its correct form if/when needed.
- also, remove some commented code

closes https://github.com/kiali/kiali/issues/7444

To test:
- node graph a regular node and return to main graph
- repeat for box node