### PR TITLE
Fix graph issue with excluded namespaces

### DIFF
--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -25,8 +25,8 @@ import { getServiceDetailsUpdateLabel, hasServiceDetailsTrafficRouting } from '.
 
 type ReduxProps = {
   duration: DurationInSeconds;
-  tracingInfo?: TracingInfo;
   kiosk: string;
+  tracingInfo?: TracingInfo;
   updateTime: TimeInMilliseconds;
 };
 
@@ -70,7 +70,7 @@ const hrStyle = kialiStyle({
 });
 
 type Props = NodeContextMenuProps & ReduxProps;
-type LinkParams = { namespace: string; type: string; name: string; cluster?: string };
+type LinkParams = { cluster?: string; name: string; namespace: string; type: string };
 
 function getLinkParamsForNode(node: DecoratedGraphNodeData): LinkParams | undefined {
   let cluster = node.cluster;
@@ -103,10 +103,10 @@ function getLinkParamsForNode(node: DecoratedGraphNodeData): LinkParams | undefi
       break;
   }
 
-  return type && name ? { namespace, type, name, cluster } : undefined;
+  return type && name && name !== 'unknown' ? { namespace, type, name, cluster } : undefined;
 }
 
-export function NodeContextMenuComponent(props: Props) {
+export function NodeContextMenuComponent(props: Props): React.ReactElement | null {
   const [serviceDetails, gateways, peerAuthentications, isServiceDetailsLoading] = useServiceDetailForGraphNode(
     props,
     true,
@@ -126,7 +126,7 @@ export function NodeContextMenuComponent(props: Props) {
     }
   }
 
-  function createMenuItem(href: string, title: string, target: string = '_self', external: boolean = false) {
+  function createMenuItem(href: string, title: string, target = '_self', external = false): React.ReactElement {
     const commonLinkProps = {
       className: contextMenuItemLink,
       children: title,
@@ -166,11 +166,11 @@ export function NodeContextMenuComponent(props: Props) {
     );
   }
 
-  function onClick(_e: React.MouseEvent<HTMLAnchorElement>) {
+  function onClick(_e: React.MouseEvent<HTMLAnchorElement>): void {
     props.contextMenu.hide(0);
   }
 
-  function handleClickWizard(e: React.MouseEvent<HTMLAnchorElement>, eventKey: WizardAction) {
+  function handleClickWizard(e: React.MouseEvent<HTMLAnchorElement>, eventKey: WizardAction): void {
     e.preventDefault();
     props.contextMenu.hide(0);
 
@@ -186,7 +186,7 @@ export function NodeContextMenuComponent(props: Props) {
     }
   }
 
-  function handleDeleteTrafficRouting(e: React.MouseEvent<HTMLAnchorElement>) {
+  function handleDeleteTrafficRouting(e: React.MouseEvent<HTMLAnchorElement>): void {
     e.preventDefault();
     props.contextMenu.hide(0);
 
@@ -195,7 +195,7 @@ export function NodeContextMenuComponent(props: Props) {
     }
   }
 
-  function renderHeader() {
+  function renderHeader(): React.ReactElement {
     return (
       <>
         {props.isBox ? getTitle(props.isBox) : getTitle(props.nodeType)}
@@ -210,7 +210,7 @@ export function NodeContextMenuComponent(props: Props) {
     );
   }
 
-  function renderWizardActionItem(eventKey: string) {
+  function renderWizardActionItem(eventKey: string): React.ReactElement {
     const enabledItem =
       !hasServiceDetailsTrafficRouting(serviceDetails) ||
       (hasServiceDetailsTrafficRouting(serviceDetails) && updateLabel === eventKey);
@@ -229,7 +229,7 @@ export function NodeContextMenuComponent(props: Props) {
       );
     } else {
       return (
-        <div key={eventKey} className={contextMenuItem} data-test={eventKey + '_action'}>
+        <div key={eventKey} className={contextMenuItem} data-test={`${eventKey}_action`}>
           <a
             href="#"
             rel="noreferrer noopener"
@@ -243,7 +243,7 @@ export function NodeContextMenuComponent(props: Props) {
     }
   }
 
-  function renderDeleteTrafficRoutingItem() {
+  function renderDeleteTrafficRoutingItem(): React.ReactElement {
     if (
       !canDelete(serviceDetails?.istioPermissions) ||
       !hasServiceDetailsTrafficRouting(serviceDetails) /*|| props.isDisabled*/
@@ -272,7 +272,7 @@ export function NodeContextMenuComponent(props: Props) {
     }
   }
 
-  function renderWizardsItems() {
+  function renderWizardsItems(): React.ReactElement | null {
     if (isServiceDetailsLoading) {
       return (
         <>
@@ -300,7 +300,7 @@ export function NodeContextMenuComponent(props: Props) {
     return null;
   }
 
-  function renderFullContextMenu(linkParams: LinkParams) {
+  function renderFullContextMenu(linkParams: LinkParams): React.ReactElement {
     // The getOptionsFromLinkParams function can potentially return a blank list if the
     // node associated to the context menu is for a remote cluster with no accessible Kialis.
     // That would lead to an empty menu. Here, we assume that whoever is the host/parent component,
@@ -345,13 +345,13 @@ const getTracingURL = (namespace: string, namespaceSelector: boolean, tracingURL
 };
 
 export type ContextMenuOption = {
-  text: string;
-  url: string;
   external?: boolean;
   target?: string;
+  text: string;
+  url: string;
 };
 
-export const clickHandler = (o: ContextMenuOption, kiosk: string) => {
+export const clickHandler = (o: ContextMenuOption, kiosk: string): void => {
   if (o.external) {
     window.open(o.url, o.target);
   } else {
@@ -377,7 +377,7 @@ const getOptionsFromLinkParams = (linkParams: LinkParams, tracingInfo?: TracingI
   let detailsPageUrl = `/namespaces/${namespace}/${type}/${name}`;
   let concat = '?';
   if (cluster && isMultiCluster) {
-    detailsPageUrl += '?clusterName=' + cluster;
+    detailsPageUrl += `?clusterName=${cluster}`;
     concat = '&';
   }
 
@@ -411,7 +411,7 @@ const getOptionsFromLinkParams = (linkParams: LinkParams, tracingInfo?: TracingI
   return options;
 };
 
-const mapStateToProps = (state: KialiAppState) => ({
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
   duration: durationSelector(state),
   updateTime: state.graph.updateTime,
   tracingInfo: state.tracingState.info,

--- a/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -17,6 +17,7 @@ export type EdgeContextMenuProps = DecoratedGraphEdgeData & ContextMenuProps;
 export type EdgeContextMenuComponentType = React.ComponentType<EdgeContextMenuProps>;
 export type NodeContextMenuProps = DecoratedGraphNodeData &
   ContextMenuProps & {
+    onDeleteTrafficRouting?: (key: string, serviceDetails: ServiceDetailsInfo) => void;
     onLaunchWizard?: (
       key: WizardAction,
       mode: WizardMode,
@@ -25,7 +26,6 @@ export type NodeContextMenuProps = DecoratedGraphNodeData &
       gateways: string[],
       peerAuths: PeerAuthentication[]
     ) => void;
-    onDeleteTrafficRouting?: (key: string, serviceDetails: ServiceDetailsInfo) => void;
   };
 export type NodeContextMenuComponentType = React.ComponentType<NodeContextMenuProps>;
 export type ContextMenuComponentType = EdgeContextMenuComponentType | NodeContextMenuComponentType;
@@ -67,15 +67,15 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     this.isHover = undefined;
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     document.addEventListener('mouseup', this.handleDocumentMouseUp);
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     document.removeEventListener('mouseup', this.handleDocumentMouseUp);
   }
 
-  render() {
+  render(): React.ReactElement {
     return (
       <div className="hidden">
         <div ref={this.contextMenuRef} />
@@ -84,7 +84,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
   }
 
   // Add cy listener for context menu events on nodes and edges
-  connectCy(cy: Cy.Core) {
+  connectCy(cy: Cy.Core): void {
     cy.on('cxttapstart', 'node,edge', (event: Cy.EventObject) => {
       event.preventDefault();
       if (event.target) {
@@ -95,7 +95,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
   }
 
   // Connects cy to this component
-  handleContextMenu(elem: Cy.NodeSingular | Cy.EdgeSingular, isHover: boolean) {
+  handleContextMenu(elem: Cy.NodeSingular | Cy.EdgeSingular, isHover: boolean): void {
     const contextMenuType = elem.isNode() ? this.props.contextMenuNodeComponent : this.props.contextMenuEdgeComponent;
 
     if (contextMenuType) {
@@ -103,7 +103,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     }
   }
 
-  hideContextMenu(isHover: boolean | undefined) {
+  hideContextMenu(isHover: boolean | undefined): void {
     const currentContextMenu = this.getCurrentContextMenu();
     if (currentContextMenu) {
       if (!isHover || this.isHover) {
@@ -114,12 +114,12 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     }
   }
 
-  private handleDocumentMouseUp = (event: MouseEvent) => {
+  private handleDocumentMouseUp = (event: MouseEvent): void => {
     if (event.button === 2) {
       // Ignore mouseup of right button
       return;
     }
-    const currentContextMenu = this.getCurrentContextMenu();
+    const currentContextMenu: Instance | undefined = this.getCurrentContextMenu();
     if (currentContextMenu) {
       // Allow interaction in our popper component (Selecting and copying) without it disappearing
       if (event.target && currentContextMenu.popper.contains(event.target as Node)) {
@@ -135,13 +135,18 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     target: Cy.NodeSingular | Cy.EdgeSingular,
     isHover: boolean,
     isNode: boolean
-  ) {
+  ): void {
     // Don't let a hover trump a non-hover context menu
     if (isHover && this.isHover === false) {
       return;
     }
     // If there is no valid context menu just return
     if (!isHover && (target.isEdge() || getOptions({ ...target.data() }).length === 0)) {
+      return;
+    }
+
+    // Is valid data?
+    if (target.data().namespace === 'unknown') {
       return;
     }
 
@@ -204,23 +209,23 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     });
   }
 
-  private getCurrentContextMenu() {
+  private getCurrentContextMenu(): Instance | undefined {
     return this.contextMenuRef?.current?._contextMenu;
   }
 
-  private setCurrentContextMenu(current: TippyInstance) {
+  private setCurrentContextMenu(current: TippyInstance): void {
     this.contextMenuRef!.current!._contextMenu = current;
   }
 
-  private addContextMenuEventListener() {
+  private addContextMenuEventListener(): void {
     document.addEventListener('contextmenu', this.handleContextMenuEvent);
   }
 
-  private removeContextMenuEventListener() {
+  private removeContextMenuEventListener(): void {
     document.removeEventListener('contextmenu', this.handleContextMenuEvent);
   }
 
-  private handleContextMenuEvent = (event: MouseEvent) => {
+  private handleContextMenuEvent = (event: MouseEvent): boolean => {
     // Disable the context menu in popper
     const currentContextMenu = this.getCurrentContextMenu();
     if (currentContextMenu) {
@@ -231,7 +236,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     return true;
   };
 
-  private tippyDistance(_target: Cy.NodeSingular | Cy.EdgeSingular) {
+  private tippyDistance(_target: Cy.NodeSingular | Cy.EdgeSingular): number {
     return 10;
   }
 }

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -52,8 +52,8 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 		} else {
 			workloadName = n.App
 		}
-		workload, found := getWorkload(n.Cluster, n.Namespace, workloadName, globalInfo)
-		if !found {
+		workload, err := getWorkloadItem(n.Cluster, n.Namespace, workloadName, globalInfo)
+		if err != nil {
 			log.Tracef("Error getting waypoint proxy: Workload %s was not found", n.Workload)
 			continue
 		}

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -18,6 +18,7 @@ const (
 	defaultCluster = "Kubernetes"
 	appName        = "productpage"
 	appNamespace   = "ambientNamespace"
+	kubeNamespace  = "kube-system"
 )
 
 func setupWorkloadEntries(t *testing.T) *business.Layer {
@@ -66,9 +67,21 @@ func setupWorkloadEntries(t *testing.T) *business.Layer {
 			},
 		}}
 
+	k8spod5 := &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "workloadC",
+			Namespace:   kubeNamespace,
+			Labels:      map[string]string{"apps": "workloadB", "version": "v2"},
+			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: core_v1.PodSpec{
+			Containers: []core_v1.Container{
+				{Name: "workloadB", Image: "whatever"},
+			},
+		}}
+
 	ns := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}}
 
-	k8s := kubetest.NewFakeK8sClient(k8spod1, k8spod2, k8spod3, k8spod4, ns)
+	k8s := kubetest.NewFakeK8sClient(k8spod1, k8spod2, k8spod3, k8spod4, k8spod5, ns)
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	conf.KubernetesConfig.ClusterName = defaultCluster
@@ -88,8 +101,6 @@ func workloadEntriesTrafficMap() map[string]*graph.Node {
 
 	// VersionedApp graph
 	trafficMap := make(map[string]*graph.Node)
-
-	// 1 service, 3 workloads. v1 and v2 are workload entries. v3 is a waypoint proxy but with no labels. v4 has the right labels.
 
 	// Service node
 	n0, _ := graph.NewNode(defaultCluster, appNamespace, appName, appNamespace, "", "", "", graph.GraphTypeVersionedApp)
@@ -112,6 +123,38 @@ func workloadEntriesTrafficMap() map[string]*graph.Node {
 	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	n0.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	n0.AddEdge(n4).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	// Need to put some metadata in here to ensure it gets counted as a workload
+
+	return trafficMap
+}
+
+func workloadEntriesTrafficMapExcludedNs() map[string]*graph.Node {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = defaultCluster
+	config.Set(conf)
+
+	// VersionedApp graph
+	trafficMap := workloadEntriesTrafficMap()
+
+	// 1 service, 3 workloads. v1 and v2 are workload entries. v3 is a waypoint proxy but with no labels. v4 has the right labels.
+
+	// Service node
+	n0, _ := graph.NewNode(defaultCluster, kubeNamespace, "kube-dns", kubeNamespace, "", "", "", graph.GraphTypeVersionedApp)
+	// v1 Workload
+	n1, _ := graph.NewNode(defaultCluster, kubeNamespace, "kube-dns", kubeNamespace, "corens-v1", appName, "v1", graph.GraphTypeVersionedApp)
+	// v2 Workload
+	n2, _ := graph.NewNode(defaultCluster, kubeNamespace, "kube-dns", kubeNamespace, "kube-apiserver", appName, "v2", graph.GraphTypeVersionedApp)
+	// v3 Workload with waypoint name
+	n3, _ := graph.NewNode(defaultCluster, kubeNamespace, "kube-dns", kubeNamespace, "kube-proxy", appName, "v2", graph.GraphTypeVersionedApp)
+
+	trafficMap[n0.ID] = n0
+	trafficMap[n1.ID] = n1
+	trafficMap[n2.ID] = n2
+	trafficMap[n3.ID] = n3
+
+	n0.AddEdge(n1).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
+	n0.AddEdge(n3).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 	// Need to put some metadata in here to ensure it gets counted as a workload
 
 	return trafficMap
@@ -159,6 +202,37 @@ func TestIsWaypoint(t *testing.T) {
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(5, len(trafficMap))
+
+	waypointWorkloadID, _, _ := graph.Id(defaultCluster, appNamespace, appName, appNamespace, "namespace-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
+	waypointNode, found := trafficMap[waypointWorkloadID]
+	assert.True(found)
+	assert.Contains(waypointNode.Metadata, graph.IsWaypoint)
+
+	fakeWaypointWorkloadID, _, _ := graph.Id(defaultCluster, appNamespace, appName, appNamespace, "fake-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
+	fakeWaypointNode, found := trafficMap[fakeWaypointWorkloadID]
+	assert.True(found)
+	assert.NotContains(fakeWaypointNode.Metadata, graph.IsWaypoint)
+}
+
+func TestIsWaypointExcludedNs(t *testing.T) {
+	assert := require.New(t)
+
+	businessLayer := setupWorkloadEntries(t)
+	trafficMap := workloadEntriesTrafficMapExcludedNs()
+
+	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo.Business = businessLayer
+	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
+
+	assert.Equal(9, len(trafficMap))
+
+	// Run the appender...
+
+	a := AmbientAppender{ShowWaypoints: true}
+
+	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(9, len(trafficMap))
 
 	waypointWorkloadID, _, _ := graph.Id(defaultCluster, appNamespace, appName, appNamespace, "namespace-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
 	waypointNode, found := trafficMap[waypointWorkloadID]

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -392,6 +392,17 @@ func getWorkload(cluster, namespace, workloadName string, gi *graph.AppenderGlob
 	return nil, false
 }
 
+func getWorkloadItem(cluster, namespace, workloadName string, gi *graph.AppenderGlobalInfo) (*models.Workload, error) {
+	if workloadName == "" || workloadName == graph.Unknown {
+		return nil, fmt.Errorf("workload name or workload does not exist")
+	}
+
+	criteria := business.WorkloadCriteria{Cluster: cluster, Namespace: namespace, WorkloadName: workloadName, IncludeIstioResources: false, IncludeHealth: false}
+	wk, err := gi.Business.Workload.GetWorkload(context.TODO(), criteria)
+
+	return wk, err
+}
+
 func getAppWorkloads(cluster, namespace, app, version string, gi *graph.AppenderGlobalInfo) []models.WorkloadListItem {
 	cfg := config.Get()
 	appLabel := cfg.IstioLabels.AppLabelName


### PR DESCRIPTION
### Describe the change

Doesn't fail if node is not accessible for graph

### Steps to test the PR

- Install istio 1.22 with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install Kiali
- Install bookinfo and include in Ambient: `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Add some workload in one namespace excluded for Kiali with traffic for a selected namespace. An easy way is to label the `istio-system` namespace with the Ambient label (`kubectl label ns istio-sytem istio.io/dataplane-mode=ambient`)
- Go to the Traffic graph and select bookinfo an istio-system namespaces. The graph should be seen, no errors in the log. In master, there should be a stack trace error, and sometimes, the "Cannot generate graph" message (It doesn't appear always)

### Automation testing
Added unit test.

### Issue reference
Fixes https://github.com/kiali/kiali/issues/7448 
