### PR TITLE
Skipp KIA0701 check for waypoint proxy generated service

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -48,7 +48,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, len(validations) == 0
 	}
 	// Ignoring waypoint Services as auto-generated
-	if p.isWaypoint(p.Service) {
+	if config.IsWaypoint(p.Service.Labels) {
 		log.Tracef("Skipping Port matching check for waypoint Service %s from Namespace %s", p.Service.Name, p.Service.Namespace)
 		return validations, len(validations) == 0
 	}
@@ -63,11 +63,6 @@ func (p PortMappingChecker) hasMatchingPodsWithSidecar(service v1.Service) bool 
 	sPods := models.Pods{}
 	sPods.Parse(kubernetes.FilterPodsByService(&service, p.Pods))
 	return sPods.HasIstioSidecar()
-}
-
-// IsWaypoint returns true if the service is a waypoint proxy
-func (p PortMappingChecker) isWaypoint(service v1.Service) bool {
-	return service.Labels[config.WaypointLabel] == config.WaypointLabelValue
 }
 
 func (p PortMappingChecker) findMatchingDeployment(selectors map[string]string) *apps_v1.Deployment {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1286,7 +1286,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 
 		}
-		if w.IsAmbient && w.Labels[config.WaypointLabel] != config.WaypointLabelValue {
+		if w.IsAmbient && !config.IsWaypoint(w.Labels) {
 			// If Ambient is enabled for workload, check if it has a Waypoint proxy
 			w.WaypointWorkloads = in.getWaypointsForWorkload(ctx, namespace, *w)
 		}
@@ -1928,7 +1928,7 @@ func (in *WorkloadService) listWaypointWorkloadsForSA(ctx context.Context, names
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
 	for _, workload := range wlist {
-		if workload.Labels[config.WaypointLabel] != "istio.io-mesh-controller" {
+		if !config.IsWaypoint(workload.Labels) {
 			for _, pod := range workload.Pods {
 				if pod.ServiceAccountName == sa {
 					workloadslist = append(workloadslist, *workload)
@@ -1951,7 +1951,7 @@ func (in *WorkloadService) listWaypointWorkloadsForNamespace(ctx context.Context
 	var workloadslist []models.Workload
 	// Get service Account name for each pod from the workload
 	for _, workload := range wlist {
-		if workload.Labels[config.WaypointLabel] != "istio.io-mesh-controller" {
+		if !config.IsWaypoint(workload.Labels) {
 			workloadslist = append(workloadslist, *workload)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1168,6 +1168,11 @@ func IsFeatureDisabled(featureName FeatureName) bool {
 	return false
 }
 
+// IsWaypoint returns true if the labels contain a waypoint proxy
+func IsWaypoint(labels map[string]string) bool {
+	return labels[WaypointLabel] == WaypointLabelValue
+}
+
 // GetSafeClusterName checks the input value provides a default cluster name if it's empty
 func GetSafeClusterName(cluster string) string {
 	if cluster == "" {

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -57,7 +57,7 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 			log.Tracef("Error getting waypoint proxy: Workload %s was not found", n.Workload)
 			continue
 		}
-		if workload.Labels[config.WaypointLabel] == config.WaypointLabelValue {
+		if config.IsWaypoint(workload.Labels) {
 			waypoinList = append(waypoinList, workload.Name)
 			if !a.ShowWaypoints {
 				delete(trafficMap, n.ID)

--- a/models/pod.go
+++ b/models/pod.go
@@ -14,9 +14,7 @@ type Pods []*Pod
 
 const AmbientAnnotation = "ambient.istio.io/redirection"
 const AmbientAnnotationEnabled = "enabled"
-const WaypointLabel = "gateway.istio.io/managed"
 const IstioProxy = "istio-proxy"
-const WaypointLabelValue = "istio.io-mesh-controller"
 
 // Pod holds a subset of v1.Pod data that is meaningful in Kiali
 type Pod struct {
@@ -218,7 +216,7 @@ func (pod *Pod) AmbientEnabled() bool {
 
 // IsWaypoint returns true if the pod is a waypoint proxy
 func (pod *Pod) IsWaypoint() bool {
-	return pod.Labels[config.WaypointLabel] == config.WaypointLabelValue
+	return config.IsWaypoint(pod.Labels)
 }
 
 // HasNativeSidecar returns true if the pod has istio-proxy init containers


### PR DESCRIPTION
### Describe the change

Skips 'KIA0701 Deployment exposing same port as Service not found' for generated 'waypoint' service.

![image](https://github.com/kiali/kiali/assets/604313/2f0d9709-11c0-4d8e-a91d-99efa8e1a532)


### Automation testing

Unit testing.


