### PR TITLE
Add APIVersion value to the Istio config object

### DIFF
--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -644,6 +644,7 @@ func (c *kubeCache) GetConfigMap(namespace, name string) (*core_v1.ConfigMap, er
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retCM := cfg.DeepCopy()
 	retCM.Kind = kubernetes.ConfigMapType
+	retCM.APIVersion = kubernetes.ConfigMaps.GroupVersion().String()
 	return retCM, nil
 }
 
@@ -709,6 +710,7 @@ func (c *kubeCache) GetDaemonSets(namespace string) ([]apps_v1.DaemonSet, error)
 		// Do not modify what is returned by the lister since that is shared and will cause data races.
 		d := ds.DeepCopy()
 		d.Kind = kubernetes.DaemonSetType
+		d.APIVersion = kubernetes.DaemonSets.GroupVersion().String()
 		retSets = append(retSets, *d)
 	}
 	return retSets, nil
@@ -728,6 +730,7 @@ func (c *kubeCache) GetDaemonSet(namespace, name string) (*apps_v1.DaemonSet, er
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retDS := ds.DeepCopy()
 	retDS.Kind = kubernetes.DaemonSetType
+	retDS.APIVersion = kubernetes.DaemonSets.GroupVersion().String()
 	return retDS, nil
 }
 
@@ -777,6 +780,7 @@ func (c *kubeCache) GetDaemonSetsWithSelector(namespace string, selectorLabels m
 			// Do not modify what is returned by the lister since that is shared and will cause data races.
 			svc := ds.DeepCopy()
 			svc.Kind = kubernetes.DaemonSetType
+			svc.APIVersion = kubernetes.DaemonSets.GroupVersion().String()
 			retDS = append(retDS, svc)
 		}
 	}
@@ -799,6 +803,7 @@ func (c *kubeCache) GetDeployments(namespace string) ([]apps_v1.Deployment, erro
 		// Do not modify what is returned by the lister since that is shared and will cause data races.
 		d := deployment.DeepCopy()
 		d.Kind = kubernetes.DeploymentType
+		d.APIVersion = kubernetes.Deployments.GroupVersion().String()
 		retDeployments = append(retDeployments, *d)
 	}
 	return retDeployments, nil
@@ -842,6 +847,7 @@ func (c *kubeCache) GetDeploymentsWithSelector(namespace string, labelSelector s
 	for _, ds := range deployments {
 		d := ds.DeepCopy()
 		d.Kind = kubernetes.DeploymentType
+		d.APIVersion = kubernetes.Deployments.GroupVersion().String()
 		retDeployments = append(retDeployments, *d)
 	}
 	return retDeployments, nil
@@ -861,6 +867,7 @@ func (c *kubeCache) GetDeployment(namespace, name string) (*apps_v1.Deployment, 
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retDep := deployment.DeepCopy()
 	retDep.Kind = kubernetes.DeploymentType
+	retDep.APIVersion = kubernetes.Deployments.GroupVersion().String()
 	return retDep, nil
 }
 
@@ -878,6 +885,7 @@ func (c *kubeCache) GetEndpoints(namespace, name string) (*core_v1.Endpoints, er
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retEnd := endpoints.DeepCopy()
 	retEnd.Kind = kubernetes.EndpointsType
+	retEnd.APIVersion = kubernetes.Endpoints.GroupVersion().String()
 	return retEnd, nil
 }
 
@@ -897,6 +905,7 @@ func (c *kubeCache) GetStatefulSets(namespace string) ([]apps_v1.StatefulSet, er
 		// Do not modify what is returned by the lister since that is shared and will cause data races.
 		s := ss.DeepCopy()
 		s.Kind = kubernetes.StatefulSetType
+		s.APIVersion = kubernetes.StatefulSets.GroupVersion().String()
 		retSets = append(retSets, *s)
 	}
 	return retSets, nil
@@ -916,6 +925,7 @@ func (c *kubeCache) GetStatefulSet(namespace, name string) (*apps_v1.StatefulSet
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retSet := statefulSet.DeepCopy()
 	retSet.Kind = kubernetes.StatefulSetType
+	retSet.APIVersion = kubernetes.StatefulSets.GroupVersion().String()
 	return retSet, nil
 }
 
@@ -960,6 +970,7 @@ func (c *kubeCache) GetServices(namespace string, labelSelector string) ([]core_
 	for _, ss := range services {
 		s := ss.DeepCopy()
 		s.Kind = kubernetes.ServiceType
+		s.APIVersion = kubernetes.Services.GroupVersion().String()
 		retServices = append(retServices, *s)
 	}
 	return retServices, nil
@@ -987,6 +998,7 @@ func (c *kubeCache) GetServicesBySelectorLabels(namespace string, selectorLabels
 			// Do not modify what is returned by the lister since that is shared and will cause data races.
 			svc := service.DeepCopy()
 			svc.Kind = kubernetes.ServiceType
+			svc.APIVersion = kubernetes.Services.GroupVersion().String()
 			retServices = append(retServices, *svc)
 		}
 	}
@@ -1007,6 +1019,7 @@ func (c *kubeCache) GetService(namespace, name string) (*core_v1.Service, error)
 	// Do not modify what is returned by the lister since that is shared and will cause data races.
 	retSvc := service.DeepCopy()
 	retSvc.Kind = kubernetes.ServiceType
+	retSvc.APIVersion = kubernetes.Services.GroupVersion().String()
 	return retSvc, nil
 }
 
@@ -1031,6 +1044,7 @@ func (c *kubeCache) GetPods(namespace, labelSelector string) ([]core_v1.Pod, err
 		// Do not modify what is returned by the lister since that is shared and will cause data races.
 		p := pod.DeepCopy()
 		p.Kind = kubernetes.PodType
+		p.APIVersion = kubernetes.Pods.GroupVersion().String()
 		retPods = append(retPods, *p)
 	}
 	return retPods, nil
@@ -1082,6 +1096,7 @@ func (c *kubeCache) GetReplicaSets(namespace string) ([]apps_v1.ReplicaSet, erro
 			// Do not modify what is returned by the lister since that is shared and will cause data races.
 			rs := activeRS.DeepCopy()
 			rs.Kind = kubernetes.ReplicaSetType
+			rs.APIVersion = kubernetes.ReplicaSets.GroupVersion().String()
 			result[i] = *rs
 			i = i + 1
 		}

--- a/kubernetes/cache/kube_cache_test.go
+++ b/kubernetes/cache/kube_cache_test.go
@@ -511,7 +511,8 @@ func TestGetPodTrimmed(t *testing.T) {
 	}
 	want := core_v1.Pod{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "Pod",
+			APIVersion: "v1",
+			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "foo",
@@ -604,7 +605,8 @@ func TestGetServiceTrimmed(t *testing.T) {
 	}
 	want := core_v1.Service{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "Service",
+			APIVersion: "v1",
+			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -8,6 +8,36 @@ import (
 )
 
 const (
+	// Networking
+	DestinationRuleType = "DestinationRule"
+	GatewayType         = "Gateway"
+	EnvoyFilterType     = "EnvoyFilter"
+	SidecarType         = "Sidecar"
+	ServiceEntryType    = "ServiceEntry"
+	VirtualServiceType  = "VirtualService"
+	WorkloadEntryType   = "WorkloadEntry"
+	WorkloadGroupType   = "WorkloadGroup"
+	WasmPluginType      = "WasmPlugin"
+	TelemetryType       = "Telemetry"
+
+	// K8s Networking
+	K8sGatewayType        = "Gateway"
+	K8sGatewayClassType   = "GatewayClass"
+	K8sGRPCRouteType      = "GRPCRoute"
+	K8sHTTPRouteType      = "HTTPRoute"
+	K8sReferenceGrantType = "ReferenceGrant"
+	K8sTCPRouteType       = "TCPRoute"
+	K8sTLSRouteType       = "TLSRoute"
+
+	// Authorization PeerAuthentications
+	AuthorizationPoliciesType = "AuthorizationPolicy"
+
+	// Peer Authentications
+	PeerAuthenticationsType = "PeerAuthentication"
+
+	// Request Authentications
+	RequestAuthenticationsType = "RequestAuthentication"
+
 	// Kubernetes Controllers
 	ConfigMapType             = "ConfigMap"
 	CronJobType               = "CronJob"
@@ -25,71 +55,69 @@ const (
 
 var (
 	// Networking
-
-	DestinationRules    = NetworkingGroupVersionV1.WithKind(DestinationRuleType)
-	DestinationRuleType = "DestinationRule"
-
-	Gateways    = NetworkingGroupVersionV1.WithKind(GatewayType)
-	GatewayType = "Gateway"
-
-	EnvoyFilters    = NetworkingGroupVersionV1Alpha3.WithKind(EnvoyFilterType)
-	EnvoyFilterType = "EnvoyFilter"
-
-	Sidecars    = NetworkingGroupVersionV1.WithKind(SidecarType)
-	SidecarType = "Sidecar"
-
+	DestinationRules = NetworkingGroupVersionV1.WithKind(DestinationRuleType)
+	Gateways         = NetworkingGroupVersionV1.WithKind(GatewayType)
+	EnvoyFilters     = NetworkingGroupVersionV1Alpha3.WithKind(EnvoyFilterType)
+	Sidecars         = NetworkingGroupVersionV1.WithKind(SidecarType)
 	ServiceEntries   = NetworkingGroupVersionV1.WithKind(ServiceEntryType)
-	ServiceEntryType = "ServiceEntry"
-
-	VirtualServices    = NetworkingGroupVersionV1.WithKind(VirtualServiceType)
-	VirtualServiceType = "VirtualService"
-
-	WorkloadEntries   = NetworkingGroupVersionV1.WithKind(WorkloadEntryType)
-	WorkloadEntryType = "WorkloadEntry"
-
-	WorkloadGroups    = NetworkingGroupVersionV1.WithKind(WorkloadGroupType)
-	WorkloadGroupType = "WorkloadGroup"
-
-	WasmPlugins    = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
-	WasmPluginType = "WasmPlugin"
-
-	Telemetries   = TelemetryGroupV1.WithKind(TelemetryType)
-	TelemetryType = "Telemetry"
+	VirtualServices  = NetworkingGroupVersionV1.WithKind(VirtualServiceType)
+	WorkloadEntries  = NetworkingGroupVersionV1.WithKind(WorkloadEntryType)
+	WorkloadGroups   = NetworkingGroupVersionV1.WithKind(WorkloadGroupType)
+	WasmPlugins      = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
+	Telemetries      = TelemetryGroupV1.WithKind(TelemetryType)
 
 	// K8s Networking
-
-	K8sGateways    = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayType)
-	K8sGatewayType = "Gateway"
-
-	K8sGatewayClasses   = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayClassType)
-	K8sGatewayClassType = "GatewayClass"
-
-	K8sGRPCRoutes    = K8sNetworkingGroupVersionV1.WithKind(K8sGRPCRouteType)
-	K8sGRPCRouteType = "GRPCRoute"
-
-	K8sHTTPRoutes    = K8sNetworkingGroupVersionV1.WithKind(K8sHTTPRouteType)
-	K8sHTTPRouteType = "HTTPRoute"
-
-	K8sReferenceGrants    = K8sNetworkingGroupVersionV1.WithKind(K8sReferenceGrantType)
-	K8sReferenceGrantType = "ReferenceGrant"
-
-	K8sTCPRoutes    = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTCPRouteType)
-	K8sTCPRouteType = "TCPRoute"
-
-	K8sTLSRoutes    = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTLSRouteType)
-	K8sTLSRouteType = "TLSRoute"
+	K8sGateways        = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayType)
+	K8sGatewayClasses  = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayClassType)
+	K8sGRPCRoutes      = K8sNetworkingGroupVersionV1.WithKind(K8sGRPCRouteType)
+	K8sHTTPRoutes      = K8sNetworkingGroupVersionV1.WithKind(K8sHTTPRouteType)
+	K8sReferenceGrants = K8sNetworkingGroupVersionV1.WithKind(K8sReferenceGrantType)
+	K8sTCPRoutes       = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTCPRouteType)
+	K8sTLSRoutes       = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTLSRouteType)
 
 	// Authorization PeerAuthentications
-	AuthorizationPolicies     = SecurityGroupVersionV1.WithKind(AuthorizationPoliciesType)
-	AuthorizationPoliciesType = "AuthorizationPolicy"
+	AuthorizationPolicies = SecurityGroupVersionV1.WithKind(AuthorizationPoliciesType)
 
 	// Peer Authentications
-	PeerAuthentications     = SecurityGroupVersionV1.WithKind(PeerAuthenticationsType)
-	PeerAuthenticationsType = "PeerAuthentication"
+	PeerAuthentications = SecurityGroupVersionV1.WithKind(PeerAuthenticationsType)
 
 	// Request Authentications
-	RequestAuthentications     = SecurityGroupVersionV1.WithKind(RequestAuthenticationsType)
-	RequestAuthenticationsType = "RequestAuthentication"
+	RequestAuthentications = SecurityGroupVersionV1.WithKind(RequestAuthenticationsType)
+
+	// Kubernetes Controllers
+	ConfigMaps             = CoreGroupVersionV1.WithKind(ConfigMapType)
+	CronJobs               = BatchGroupVersionV1.WithKind(CronJobType)
+	DaemonSets             = AppsGroupVersionV1.WithKind(DaemonSetType)
+	Deployments            = AppsGroupVersionV1.WithKind(DeploymentType)
+	DeploymentConfigs      = AppsOpenShiftGroupVersionV1.WithKind(DeploymentConfigType)
+	Endpoints              = CoreGroupVersionV1.WithKind(EndpointsType)
+	Jobs                   = BatchGroupVersionV1.WithKind(JobType)
+	Pods                   = CoreGroupVersionV1.WithKind(PodType)
+	ReplicationControllers = CoreGroupVersionV1.WithKind(ReplicationControllerType)
+	ReplicaSets            = AppsGroupVersionV1.WithKind(ReplicaSetType)
+	Services               = CoreGroupVersionV1.WithKind(ServiceType)
+	StatefulSets           = AppsGroupVersionV1.WithKind(StatefulSetType)
+
+	// Group Versions
+	CoreGroupVersionV1 = schema.GroupVersion{
+		Group:   "",
+		Version: "v1",
+	}
+
+	BatchGroupVersionV1 = schema.GroupVersion{
+		Group:   "batch",
+		Version: "v1",
+	}
+
+	AppsGroupVersionV1 = schema.GroupVersion{
+		Group:   "apps",
+		Version: "v1",
+	}
+
+	AppsOpenShiftGroupVersionV1 = schema.GroupVersion{
+		Group:   "apps.openshift.io",
+		Version: "v1",
+	}
 
 	NetworkingGroupVersionV1Alpha3 = schema.GroupVersion{
 		Group:   "networking.istio.io",
@@ -131,6 +159,7 @@ var (
 		Version: "v1",
 	}
 
+	// Resources
 	ResourceTypesToAPI = map[string]schema.GroupVersionKind{
 		DestinationRules.String(): DestinationRules,
 		EnvoyFilters.String():     EnvoyFilters,


### PR DESCRIPTION
### Describe the change

The `apiVersion` value is added to the Istio config object in those use cases when the value is not cached previously (e.g., the Istio object is created outside of Kiali using `kubectl`.

I have also fixed some typo for ReferenceGrant `version`, whose value is `v1beta1`, not `v1`.

### Steps to test the PR

1. Create any Istio config object from kubectl, for example this simple AuthorizationPolicy:
```
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: test
  namespace: bookinfo
  labels: {}
  annotations: {}
spec: {}
```
2. From your browser, open the Network section of Chrome/Firefox Dev Tools (click F12 + Network tab)
3. Navigate to the `Istio Config` page
4. In the Network tab section, click on the request `config?validate=true`
5. Verify that the `apiVersion` value of the AuthorizationPolicy is present in the response

![image](https://github.com/kiali/kiali/assets/122779323/88717653-98fa-46cd-b710-c54efe93d199)

### Automation testing

N/A

### Issue reference

Fixes #7452 
