### PR TITLE
Avoid empty matches adding

### DIFF
--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { K8sRules, MOVE_TYPE, K8sRule } from './K8sRequestRouting/K8sRules';
 import { K8sRuleBuilder } from './K8sRequestRouting/K8sRuleBuilder';
 import { K8sRouteBackendRef } from './K8sTrafficShifting';
-import { EXACT, PATH, METHOD, GET, HEADERS, QUERY_PARAMS, GRPC } from './K8sRequestRouting/K8sMatchBuilder';
+import { EXACT, PATH, METHOD, GET, HEADERS, QUERY_PARAMS } from './K8sRequestRouting/K8sMatchBuilder';
 import { getDefaultBackendRefs, getDefaultService } from './WizardActions';
 import { ServiceOverview } from '../../types/ServiceList';
 import { REMOVE, REQ_MOD, RESP_MOD, SET, HTTP, SC301, REQ_RED, REQ_MIR } from './K8sRequestRouting/K8sFilterBuilder';
@@ -48,6 +48,7 @@ const MSG_HOSTNAME_NON_EMPTY = 'Hostname is incorrect';
 const MSG_PORT_NON_EMPTY = 'Port is incorrect';
 const MSG_QUERY_NAME_NON_EMPTY = 'Query name must be non empty';
 const MSG_QUERY_VALUE_NON_EMPTY = 'Query value must be non empty';
+const MSG_VALUE_NON_EMPTY = 'Value must be non empty';
 
 export class K8sRequestRouting extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -110,25 +111,37 @@ export class K8sRequestRouting extends React.Component<Props, State> {
 
   onAddMatch = (): void => {
     this.setState(prevState => {
-      if (this.state.matchValue !== '') {
-        let newMatch: string;
-        if (prevState.category === PATH) {
-          newMatch = `${prevState.category} ${prevState.operator} ${prevState.matchValue}`;
-        } else if (prevState.category === HEADERS) {
-          newMatch = `${prevState.category} [${prevState.headerName}] ${prevState.operator} ${prevState.matchValue}`;
-        } else if (prevState.category === QUERY_PARAMS) {
-          newMatch = `${prevState.category} ${prevState.queryParamName} ${prevState.operator} ${prevState.matchValue}`;
-        } else if (prevState.category === METHOD || this.props.protocol === GRPC) {
-          newMatch = `${prevState.category} ${prevState.methodName} ${prevState.operator} ${prevState.methodService}`;
+      let newMatch = '';
+      let validationMsg = '';
+      if (prevState.category === METHOD && this.props.protocol === HTTP) {
+        newMatch = `${prevState.category} ${prevState.operator}`;
+      } else {
+        if (this.state.matchValue !== '') {
+          if (prevState.category === PATH) {
+            newMatch = `${prevState.category} ${prevState.operator} ${prevState.matchValue}`;
+          } else if (prevState.category === HEADERS) {
+            newMatch = `${prevState.category} [${prevState.headerName}] ${prevState.operator} ${prevState.matchValue}`;
+          } else if (prevState.category === QUERY_PARAMS) {
+            newMatch = `${prevState.category} ${prevState.queryParamName} ${prevState.operator} ${prevState.matchValue}`;
+          } else {
+            // prevState.category === METHOD && this.props.protocol === GRPC
+            newMatch = `${prevState.category} ${prevState.methodName} ${prevState.operator} ${prevState.methodService}`;
+          }
         } else {
-          newMatch = `${prevState.category} ${prevState.operator}`;
+          if (prevState.category === HEADERS) {
+            validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
+          } else {
+            // for the rest of categories display general message
+            validationMsg = MSG_VALUE_NON_EMPTY;
+          }
         }
-        if (!prevState.matches.includes(newMatch)) {
-          prevState.matches.push(newMatch);
-        }
+      }
+      if (newMatch !== '' && !prevState.matches.includes(newMatch)) {
+        prevState.matches.push(newMatch);
       }
       return {
         matches: prevState.matches,
+        validationMsg: validationMsg,
         headerName: '',
         queryParamName: '',
         matchValue: ''

--- a/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting.tsx
@@ -110,20 +110,22 @@ export class K8sRequestRouting extends React.Component<Props, State> {
 
   onAddMatch = (): void => {
     this.setState(prevState => {
-      let newMatch: string;
-      if (prevState.category === PATH) {
-        newMatch = `${prevState.category} ${prevState.operator} ${prevState.matchValue}`;
-      } else if (prevState.category === HEADERS) {
-        newMatch = `${prevState.category} [${prevState.headerName}] ${prevState.operator} ${prevState.matchValue}`;
-      } else if (prevState.category === QUERY_PARAMS) {
-        newMatch = `${prevState.category} ${prevState.queryParamName} ${prevState.operator} ${prevState.matchValue}`;
-      } else if (prevState.category === METHOD || this.props.protocol === GRPC) {
-        newMatch = `${prevState.category} ${prevState.methodName} ${prevState.operator} ${prevState.methodService}`;
-      } else {
-        newMatch = `${prevState.category} ${prevState.operator}`;
-      }
-      if (!prevState.matches.includes(newMatch)) {
-        prevState.matches.push(newMatch);
+      if (this.state.matchValue !== '') {
+        let newMatch: string;
+        if (prevState.category === PATH) {
+          newMatch = `${prevState.category} ${prevState.operator} ${prevState.matchValue}`;
+        } else if (prevState.category === HEADERS) {
+          newMatch = `${prevState.category} [${prevState.headerName}] ${prevState.operator} ${prevState.matchValue}`;
+        } else if (prevState.category === QUERY_PARAMS) {
+          newMatch = `${prevState.category} ${prevState.queryParamName} ${prevState.operator} ${prevState.matchValue}`;
+        } else if (prevState.category === METHOD || this.props.protocol === GRPC) {
+          newMatch = `${prevState.category} ${prevState.methodName} ${prevState.operator} ${prevState.methodService}`;
+        } else {
+          newMatch = `${prevState.category} ${prevState.operator}`;
+        }
+        if (!prevState.matches.includes(newMatch)) {
+          prevState.matches.push(newMatch);
+        }
       }
       return {
         matches: prevState.matches,

--- a/frontend/src/components/IstioWizards/RequestRouting.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting.tsx
@@ -2,30 +2,30 @@ import * as React from 'react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import { Rules, MOVE_TYPE, Rule } from './RequestRouting/Rules';
 import { RuleBuilder } from './RequestRouting/RuleBuilder';
-import { ANYTHING, EXACT, HEADERS, PRESENCE, REGEX } from './RequestRouting/MatchBuilder';
+import { EXACT, HEADERS } from './RequestRouting/MatchBuilder';
 import { MSG_WEIGHTS_NOT_VALID, WorkloadWeight } from './TrafficShifting';
 import { getDefaultWeights } from './WizardActions';
 import { FaultInjectionRoute } from './FaultInjection';
 import { TimeoutRetryRoute } from './RequestTimeouts';
 
 type Props = {
-  serviceName: string;
-  workloads: WorkloadOverview[];
   initRules: Rule[];
   onChange: (valid: boolean, rules: Rule[]) => void;
+  serviceName: string;
+  workloads: WorkloadOverview[];
 };
 
 type State = {
   category: string;
-  operator: string;
-  workloadWeights: WorkloadWeight[];
-  matches: string[];
+  faultInjectionRoute: FaultInjectionRoute;
   headerName: string;
   matchValue: string;
-  faultInjectionRoute: FaultInjectionRoute;
-  timeoutRetryRoute: TimeoutRetryRoute;
+  matches: string[];
+  operator: string;
   rules: Rule[];
+  timeoutRetryRoute: TimeoutRetryRoute;
   validationMsg: string;
+  workloadWeights: WorkloadWeight[];
 };
 
 const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
@@ -37,7 +37,7 @@ export class RequestRouting extends React.Component<Props, State> {
     super(props);
     this.state = {
       category: HEADERS,
-      operator: PRESENCE,
+      operator: EXACT,
       workloadWeights: getDefaultWeights(this.props.workloads),
       faultInjectionRoute: {
         workloads: [],
@@ -79,7 +79,7 @@ export class RequestRouting extends React.Component<Props, State> {
     };
   }
 
-  isMatchesIncluded = (rules: Rule[], rule: Rule) => {
+  isMatchesIncluded = (rules: Rule[], rule: Rule): boolean => {
     let found = false;
     for (let i = 0; i < rules.length; i++) {
       const item = rules[i];
@@ -100,7 +100,7 @@ export class RequestRouting extends React.Component<Props, State> {
       return false;
     }
     const matchAll: number = this.matchAllIndex(rules);
-    let isValid: boolean = true;
+    let isValid = true;
     for (let index = 0; index < this.state.rules.length; index++) {
       isValid = matchAll === -1 || index <= matchAll;
       if (!isValid) {
@@ -110,21 +110,15 @@ export class RequestRouting extends React.Component<Props, State> {
     return isValid;
   };
 
-  onAddMatch = () => {
+  onAddMatch = (): void => {
     this.setState(prevState => {
-      let newMatch: string;
       if (this.state.matchValue !== '') {
-        newMatch =
-          prevState.category +
-          (prevState.category === HEADERS ? ' [' + prevState.headerName + '] ' : ' ') +
-          prevState.operator +
-          ' ' +
-          prevState.matchValue;
-      } else {
-        newMatch = prevState.category + ' [' + prevState.headerName + '] ' + REGEX + ' ' + ANYTHING;
-      }
-      if (!prevState.matches.includes(newMatch)) {
-        prevState.matches.push(newMatch);
+        const newMatch = `${prevState.category}${prevState.category === HEADERS ? ` [${prevState.headerName}] ` : ' '}${
+          prevState.operator
+        } ${prevState.matchValue}`;
+        if (!prevState.matches.includes(newMatch)) {
+          prevState.matches.push(newMatch);
+        }
       }
       return {
         matches: prevState.matches,
@@ -134,7 +128,7 @@ export class RequestRouting extends React.Component<Props, State> {
     });
   };
 
-  onAddRule = () => {
+  onAddRule = (): void => {
     this.setState(
       prevState => {
         const newWorkloadWeights: WorkloadWeight[] = [];
@@ -190,7 +184,7 @@ export class RequestRouting extends React.Component<Props, State> {
     );
   };
 
-  onRemoveMatch = (matchToRemove: string) => {
+  onRemoveMatch = (matchToRemove: string): void => {
     this.setState(prevState => {
       return {
         matches: prevState.matches.filter(m => matchToRemove !== m),
@@ -199,7 +193,7 @@ export class RequestRouting extends React.Component<Props, State> {
     });
   };
 
-  onRemoveRule = (index: number) => {
+  onRemoveRule = (index: number): void => {
     this.setState(
       prevState => {
         prevState.rules.splice(index, 1);
@@ -212,12 +206,12 @@ export class RequestRouting extends React.Component<Props, State> {
     );
   };
 
-  onHeaderNameChange = (headerName: string) => {
+  onHeaderNameChange = (headerName: string): void => {
     let validationMsg = '';
     if (this.state.matchValue !== '' && headerName === '') {
       validationMsg = MSG_HEADER_NAME_NON_EMPTY;
     }
-    if (this.state.matchValue === '' && headerName !== '' && this.state.operator !== PRESENCE) {
+    if (this.state.matchValue === '' && headerName !== '') {
       validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
     }
     this.setState({
@@ -226,7 +220,7 @@ export class RequestRouting extends React.Component<Props, State> {
     });
   };
 
-  onMatchValueChange = (matchValue: string) => {
+  onMatchValueChange = (matchValue: string): void => {
     let validationMsg = '';
     if (this.state.category === HEADERS) {
       if (this.state.headerName === '' && matchValue !== '') {
@@ -245,14 +239,14 @@ export class RequestRouting extends React.Component<Props, State> {
     });
   };
 
-  onSelectWeights = (valid: boolean, workloads: WorkloadWeight[]) => {
+  onSelectWeights = (valid: boolean, workloads: WorkloadWeight[]): void => {
     this.setState({
       workloadWeights: workloads,
       validationMsg: !valid ? MSG_WEIGHTS_NOT_VALID : ''
     });
   };
 
-  onMoveRule = (index: number, move: MOVE_TYPE) => {
+  onMoveRule = (index: number, move: MOVE_TYPE): void => {
     this.setState(
       prevState => {
         const sourceRule = prevState.rules[index];
@@ -269,7 +263,7 @@ export class RequestRouting extends React.Component<Props, State> {
   };
 
   matchAllIndex = (rules: Rule[]): number => {
-    let matchAll: number = -1;
+    let matchAll = -1;
     for (let index = 0; index < rules.length; index++) {
       const rule = rules[index];
       if (rule.matches.length === 0) {
@@ -280,7 +274,7 @@ export class RequestRouting extends React.Component<Props, State> {
     return matchAll;
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     if (this.props.initRules.length > 0) {
       this.setState(
         {
@@ -291,7 +285,7 @@ export class RequestRouting extends React.Component<Props, State> {
     }
   }
 
-  render() {
+  render(): React.ReactNode {
     return (
       <>
         <RuleBuilder
@@ -302,10 +296,9 @@ export class RequestRouting extends React.Component<Props, State> {
           isValid={this.state.validationMsg === ''}
           onSelectCategory={(category: string) => {
             this.setState(prevState => {
-              // PRESENCE operator only applies to HEADERS
               return {
                 category: category,
-                operator: prevState.operator === PRESENCE && category !== HEADERS ? EXACT : prevState.operator
+                operator: prevState.operator
               };
             });
           }}

--- a/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
@@ -14,15 +14,15 @@ import {
 
 type MatchBuilderProps = {
   category: string;
-  operator: string;
   headerName: string;
-  matchValue: string;
   isValid: boolean;
-  onSelectCategory: (category: string) => void;
-  onHeaderNameChange: (value: string) => void;
-  onSelectOperator: (operator: string) => void;
-  onMatchValueChange: (value: string) => void;
+  matchValue: string;
   onAddMatch: () => void;
+  onHeaderNameChange: (value: string) => void;
+  onMatchValueChange: (value: string) => void;
+  onSelectCategory: (category: string) => void;
+  onSelectOperator: (operator: string) => void;
+  operator: string;
 };
 
 export const HEADERS = 'headers';
@@ -37,10 +37,6 @@ export const EXACT = 'exact';
 export const PREFIX = 'prefix';
 export const REGEX = 'regex';
 
-// Pseudo operator
-export const PRESENCE = 'is present';
-export const ANYTHING = '^.*$';
-
 const opOptions: string[] = [EXACT, PREFIX, REGEX];
 
 const placeholderText = {
@@ -54,8 +50,6 @@ const placeholderText = {
 export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderProps) => {
   const [isMatchDropdown, setIsMatchDropdown] = React.useState<boolean>(false);
   const [isOperatorDropdown, setIsOperatorDropdown] = React.useState<boolean>(false);
-
-  const renderOpOptions: string[] = props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
 
   return (
     <InputGroup>
@@ -77,14 +71,14 @@ export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderPro
           <DropdownList>
             {matchOptions.map((mode, index) => (
               <DropdownItem
-                key={mode + '_' + index}
+                key={`${mode}_${index}`}
                 value={mode}
                 component="button"
                 onClick={() => {
                   props.onSelectCategory(mode);
                   setIsMatchDropdown(!isMatchDropdown);
                 }}
-                data-test={'requestmatching-header-' + mode}
+                data-test={`requestmatching-header-${mode}`}
               >
                 {mode}
               </DropdownItem>
@@ -118,16 +112,16 @@ export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderPro
           onOpenChange={(isOpen: boolean) => setIsOperatorDropdown(isOpen)}
         >
           <DropdownList>
-            {renderOpOptions.map((op, index) => (
+            {opOptions.map((op, index) => (
               <DropdownItem
-                key={op + '_' + index}
+                key={`${op}_${index}`}
                 value={op}
                 component="button"
                 onClick={() => {
                   props.onSelectOperator(op);
                   setIsOperatorDropdown(!isOperatorDropdown);
                 }}
-                data-test={'requestmatching-match-' + op}
+                data-test={`requestmatching-match-${op}`}
               >
                 {op}
               </DropdownItem>
@@ -136,19 +130,17 @@ export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderPro
         </Dropdown>
       </InputGroupItem>
 
-      {props.operator !== PRESENCE && (
-        <TextInput
-          id="match-value-id"
-          value={props.matchValue}
-          onChange={(_, value) => props.onMatchValueChange(value)}
-          placeholder={placeholderText[props.category]}
-        />
-      )}
+      <TextInput
+        id="match-value-id"
+        value={props.matchValue}
+        onChange={(_, value) => props.onMatchValueChange(value)}
+        placeholder={placeholderText[props.category]}
+      />
 
       <InputGroupItem>
         <Button
           variant={ButtonVariant.secondary}
-          disabled={!props.isValid}
+          isDisabled={!props.isValid}
           onClick={props.onAddMatch}
           data-test="add-match"
         >

--- a/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
+++ b/frontend/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
@@ -37,6 +37,10 @@ export const EXACT = 'exact';
 export const PREFIX = 'prefix';
 export const REGEX = 'regex';
 
+// Pseudo operator
+export const PRESENCE = 'presents';
+export const ANYTHING = '{}';
+
 const opOptions: string[] = [EXACT, PREFIX, REGEX];
 
 const placeholderText = {
@@ -50,6 +54,7 @@ const placeholderText = {
 export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderProps) => {
   const [isMatchDropdown, setIsMatchDropdown] = React.useState<boolean>(false);
   const [isOperatorDropdown, setIsOperatorDropdown] = React.useState<boolean>(false);
+  const renderOpOptions: string[] = props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
 
   return (
     <InputGroup>
@@ -112,7 +117,7 @@ export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderPro
           onOpenChange={(isOpen: boolean) => setIsOperatorDropdown(isOpen)}
         >
           <DropdownList>
-            {opOptions.map((op, index) => (
+            {renderOpOptions.map((op, index) => (
               <DropdownItem
                 key={`${op}_${index}`}
                 value={op}
@@ -130,12 +135,14 @@ export const MatchBuilder: React.FC<MatchBuilderProps> = (props: MatchBuilderPro
         </Dropdown>
       </InputGroupItem>
 
-      <TextInput
-        id="match-value-id"
-        value={props.matchValue}
-        onChange={(_, value) => props.onMatchValueChange(value)}
-        placeholder={placeholderText[props.category]}
-      />
+      {props.operator !== PRESENCE && (
+        <TextInput
+          id="match-value-id"
+          value={props.matchValue}
+          onChange={(_, value) => props.onMatchValueChange(value)}
+          placeholder={placeholderText[props.category]}
+        />
+      )}
 
       <InputGroupItem>
         <Button

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -65,6 +65,7 @@ import { K8sRouteBackendRef } from './K8sTrafficShifting';
 import { QUERY_PARAMS, PATH, HEADERS, METHOD } from './K8sRequestRouting/K8sMatchBuilder';
 import { ServiceOverview } from '../../types/ServiceList';
 import { ADD, SET, REQ_MOD, RESP_MOD, REQ_RED, REQ_MIR } from './K8sRequestRouting/K8sFilterBuilder';
+import { ANYTHING, PRESENCE } from './RequestRouting/MatchBuilder';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -207,7 +208,7 @@ const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
   const matchHeaders: HTTPMatchRequest = { headers: {} };
   // Headers are grouped
   matches
-    .filter(match => match.startsWith('headers'))
+    .filter(match => match.startsWith(HEADERS))
     .forEach(match => {
       // match follows format:  headers [<header-name>] <op> <value>
       const i0 = match.indexOf('[');
@@ -217,14 +218,18 @@ const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
       const j1 = match.indexOf(' ', i1 + 1);
       const op = match.substring(i1 + 1, j1).trim();
       const value = match.substring(j1 + 1).trim();
-      matchHeaders.headers![headerName] = { [op]: value };
+      if (op === PRESENCE) {
+        matchHeaders.headers![headerName] = {};
+      } else {
+        matchHeaders.headers![headerName] = { [op]: value };
+      }
     });
   if (Object.keys(matchHeaders.headers || {}).length > 0) {
     matchRequests.push(matchHeaders);
   }
   // Rest of matches
   matches
-    .filter(match => !match.startsWith('headers'))
+    .filter(match => !match.startsWith(HEADERS))
     .forEach(match => {
       // match follows format: <name> <op> <value>
       const i = match.indexOf(' ');
@@ -444,7 +449,10 @@ const buildK8sHTTPRouteFilter = (filters: string[]): K8sHTTPRouteFilter[] => {
   return routeFilter;
 };
 
-const parseStringMatch = (value: StringMatch): string => {
+const parseStringMatch = (value: StringMatch | string): string => {
+  if (typeof value === 'string') {
+    return `${PRESENCE} ${ANYTHING}`;
+  }
   if (value.exact) {
     return `exact ${value.exact}`;
   }
@@ -463,7 +471,11 @@ const parseHttpMatchRequest = (httpMatchRequest: HTTPMatchRequest): string[] => 
   if (httpMatchRequest.headers) {
     Object.keys(httpMatchRequest.headers).forEach(headerName => {
       const value = httpMatchRequest.headers![headerName];
-      matches.push(`headers [${headerName}] ${parseStringMatch(value)}`);
+      if (Object.keys(value).length === 0) {
+        matches.push(`headers [${headerName}] ${parseStringMatch(ANYTHING)}`);
+      } else {
+        matches.push(`headers [${headerName}] ${parseStringMatch(value)}`);
+      }
     });
   }
   if (httpMatchRequest.uri) {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -625,7 +625,7 @@ export interface Destination {
 export interface HTTPMatchRequest {
   authority?: StringMatch;
   gateways?: string[];
-  headers?: { [key: string]: StringMatch };
+  headers?: { [key: string]: StringMatch | string };
   ignoreUriCase?: boolean;
   method?: StringMatch;
   name?: string;


### PR DESCRIPTION
### Describe the change

For Routing Wizards:

- Request Routing
- K8s HTTP Routing
- K8s GRPC Routing 

Made impossible to create Rule on empty "Header Name/Value" combination by default.

### Steps to test the PR

Go To above mentioned routing wizards.
It should be impossible to add "Add Rule" on empty Header.

### Automation testing

n/a

### Issue reference

There is a bigger task of refactoring the wizards, so this solution is temporary for fixing issue:  https://github.com/kiali/kiali/issues/7447
