### PR TITLE
Fix the apiVersion of ReferenceGrant in the Kiali wizard

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -522,7 +522,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, cluster
 		istioConfigDetail.K8sReferenceGrant, err = in.userClients[cluster].GatewayAPI().GatewayV1beta1().ReferenceGrants(namespace).Get(ctx, object, getOpts)
 		if err == nil {
 			istioConfigDetail.K8sReferenceGrant.Kind = kubernetes.K8sActualReferenceGrantType
-			istioConfigDetail.K8sReferenceGrant.APIVersion = kubernetes.K8sApiNetworkingVersionV1
+			istioConfigDetail.K8sReferenceGrant.APIVersion = kubernetes.K8sApiNetworkingVersionV1Beta1
 		}
 	case kubernetes.K8sTCPRoutes:
 		istioConfigDetail.K8sTCPRoute, err = in.userClients[cluster].GatewayAPI().GatewayV1alpha2().TCPRoutes(namespace).Get(ctx, object, getOpts)

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -194,9 +194,10 @@ export const KIALI_WIZARD_LABEL = 'kiali_wizard';
 export const KIALI_RELATED_LABEL = 'kiali_wizard_related';
 
 // Wizard don't operate with EnvoyFilters so they can use the v1 version
-export const ISTIO_NETWORKING_VERSION = 'networking.istio.io/v1';
-export const ISTIO_SECURITY_VERSION = 'security.istio.io/v1';
-export const GATEWAY_NETWORKING_VERSION = 'gateway.networking.k8s.io/v1';
+const ISTIO_NETWORKING_VERSION = 'networking.istio.io/v1';
+const ISTIO_SECURITY_VERSION = 'security.istio.io/v1';
+const GATEWAY_NETWORKING_VERSION = 'gateway.networking.k8s.io/v1';
+const GATEWAY_NETWORKING_VERSION_BETA = 'gateway.networking.k8s.io/v1beta1';
 
 export const fqdnServiceName = (serviceName: string, namespace: string): string => {
   return `${serviceName}.${namespace}.${serverConfig.istioIdentityDomain}`;
@@ -2145,7 +2146,7 @@ export const buildK8sReferenceGrant = (
 ): K8sReferenceGrant => {
   const k8sReferenceGrant: K8sReferenceGrant = {
     kind: 'ReferenceGrant',
-    apiVersion: GATEWAY_NETWORKING_VERSION,
+    apiVersion: GATEWAY_NETWORKING_VERSION_BETA,
     metadata: {
       name: name,
       namespace: namespace,


### PR DESCRIPTION
### Describe the change

This PR fixes the `apiVersion` value of the Gateway API Reference Grant object in the Kiali wizard.

### Steps to test the PR

1. Navigate to the Istio Config page
2. Click on Actions -> K8sReferenceGrant
3. Fulfill the wizard form and click on the `Preview` button
4. Check that the `apiVersion` value is the correct one `gateway.networking.k8s.io/v1beta1`

![image](https://github.com/kiali/kiali/assets/122779323/5d943ae4-5f96-4841-b3f4-724db5c674f2)


### Automation testing

N/A

### Issue reference

Fixes #7463 
