### PR TITLE
A follow-up for https://github.com/kiali/kiali/issues/7448

### DIFF
--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -103,13 +103,13 @@ function getLinkParamsForNode(node: DecoratedGraphNodeData): LinkParams | undefi
       break;
   }
 
-  return type && name && name !== 'unknown' ? { namespace, type, name, cluster } : undefined;
+  return type && name ? { namespace, type, name, cluster } : undefined;
 }
 
 export function NodeContextMenuComponent(props: Props): React.ReactElement | null {
   const [serviceDetails, gateways, peerAuthentications, isServiceDetailsLoading] = useServiceDetailForGraphNode(
     props,
-    true,
+    !props.isInaccessible,
     props.duration,
     props.updateTime
   );
@@ -324,15 +324,19 @@ export function NodeContextMenuComponent(props: Props): React.ReactElement | nul
     );
   }
 
+  if (props.isInaccessible) {
+    props.contextMenu.disable();
+    return null;
+  }
+
   // render()
   if (props.isHover) {
     return <div className={contextMenu}>{renderHeader()}</div>;
   }
 
   const linkParams = getLinkParamsForNode(props);
-
-  // Disable context menu if we are dealing with an aggregate (currently has no detail) or an inaccessible node
-  if (!linkParams || props.isInaccessible) {
+  // Disable context menu if we are dealing with an aggregate (currently has no detail)
+  if (!linkParams) {
     props.contextMenu.disable();
     return null;
   }

--- a/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -368,6 +368,9 @@ export const clickHandler = (o: ContextMenuOption, kiosk: string): void => {
 };
 
 export const getOptions = (node: DecoratedGraphNodeData, tracingInfo?: TracingInfo): ContextMenuOption[] => {
+  if (node.isInaccessible) {
+    return [];
+  }
   const linkParams = getLinkParamsForNode(node);
   if (!linkParams) {
     return [];

--- a/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/frontend/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -145,11 +145,6 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
       return;
     }
 
-    // Is valid data?
-    if (target.data().namespace === 'unknown') {
-      return;
-    }
-
     // hide any existing context menu
     this.hideContextMenu(isHover);
 

--- a/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
+++ b/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
@@ -37,16 +37,16 @@ const doubleTapHandler = (node: GraphElement, kiosk: string): void => {
 };
 
 const nodeContextMenu = (node: GraphElement, kiosk: string): React.ReactElement[] => {
-  const options = getOptions(node.getData());
-  const optionsPF = options.map(o => o as ContextMenuOptionPF);
   const nodeData = node.getData() as DecoratedGraphNodeData;
-  if (
-    !(
-      nodeData.isInaccessible ||
-      nodeData.isServiceEntry ||
-      (nodeData.nodeType === NodeType.BOX && nodeData.isBox !== BoxByType.APP)
-    )
-  ) {
+
+  if (nodeData.isInaccessible) {
+    return [];
+  }
+
+  const options = getOptions(nodeData);
+  const optionsPF = options.map(o => o as ContextMenuOptionPF);
+
+  if (!(nodeData.isServiceEntry || (nodeData.nodeType === NodeType.BOX && nodeData.isBox !== BoxByType.APP))) {
     optionsPF.unshift(
       nodeData.isOutside
         ? ({

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -15,7 +15,8 @@ const WaypointSuffix = "waypoint"
 // and then, checking the labels
 // handleWaypoint removes the waypoint proxies when ShowWaypoint is false
 type AmbientAppender struct {
-	ShowWaypoints bool
+	AccessibleNamespaces graph.AccessibleNamespaces
+	ShowWaypoints        bool
 }
 
 // Name implements Appender
@@ -45,6 +46,11 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 	waypoinList := []string{}
 
 	for _, n := range trafficMap {
+		// skip if the node is not in an accessible namespace, we can't do the checking
+		if !a.nodeOK(n) {
+			continue
+		}
+
 		// It could be a waypoint proxy
 		var workloadName string
 		if n.Workload != "" {
@@ -83,6 +89,13 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 		}
 		n.Edges = graphEdge
 	}
+}
+
+// nodeOK returns true if we have access to its workload info
+func (a *AmbientAppender) nodeOK(node *graph.Node) bool {
+	key := graph.GetClusterSensitiveKey(node.Cluster, node.Namespace)
+	_, ok := a.AccessibleNamespaces[key]
+	return ok
 }
 
 func contains(slice []string, str string) bool {

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -174,7 +175,14 @@ func TestRemoveWaypoint(t *testing.T) {
 
 	// Run the appender...
 
-	a := AmbientAppender{ShowWaypoints: false}
+	a := AmbientAppender{
+		AccessibleNamespaces: map[string]*graph.AccessibleNamespace{
+			fmt.Sprintf("%s:%s", defaultCluster, appNamespace): {
+				Cluster: defaultCluster,
+				Name:    appNamespace,
+			},
+		},
+		ShowWaypoints: false}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(4, len(trafficMap))
@@ -198,7 +206,14 @@ func TestIsWaypoint(t *testing.T) {
 
 	// Run the appender...
 
-	a := AmbientAppender{ShowWaypoints: true}
+	a := AmbientAppender{
+		AccessibleNamespaces: map[string]*graph.AccessibleNamespace{
+			fmt.Sprintf("%s:%s", defaultCluster, appNamespace): {
+				Cluster: defaultCluster,
+				Name:    appNamespace,
+			},
+		},
+		ShowWaypoints: true}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(5, len(trafficMap))
@@ -228,7 +243,14 @@ func TestIsWaypointExcludedNs(t *testing.T) {
 
 	// Run the appender...
 
-	a := AmbientAppender{ShowWaypoints: true}
+	a := AmbientAppender{
+		AccessibleNamespaces: map[string]*graph.AccessibleNamespace{
+			fmt.Sprintf("%s:%s", defaultCluster, appNamespace): {
+				Cluster: defaultCluster,
+				Name:    appNamespace,
+			},
+		},
+		ShowWaypoints: true}
 
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
 

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -211,7 +211,8 @@ func ParseAppenders(o graph.TelemetryOptions) (appenders []graph.Appender, final
 			}
 		}
 		a := AmbientAppender{
-			ShowWaypoints: waypoints,
+			AccessibleNamespaces: o.AccessibleNamespaces,
+			ShowWaypoints:        waypoints,
 		}
 		appenders = append(appenders, a)
 	}


### PR DESCRIPTION
Related to #7448 

A follow-up for https://github.com/kiali/kiali/issues/7448.  The original PR may be sufficient but I think could be improved by using some of the existing conventions and/or flags available.
- In Ambient appender, use AccessibleNamespaces to check whether it is safe to call the back-end.
- For the cytoscape context menu, use the `isInaccessible` flag to block the user (and the code) from requesting unavailable information.
- Also block context menu options in PFT graph for inaccessible nodes.
