### PR TITLE
Made istio=ingressgateway and istio=egressgateway selector labels configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,9 @@ type IstioLabels struct {
 	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
 	AmbientWaypointUseLabel    string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName         string `yaml:"injection_label,omitempty" json:"injectionLabelName"`
+	EgressGatewayLabel         string `yaml:"egress_gateway_label,omitempty" json:"egressGatewayLabel"`
+	IngressGatewayLabel        string `yaml:"ingress_gateway_label,omitempty" json:"ingressGatewayLabel"`
+	InjectionLabelName         string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
 	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
@@ -762,6 +764,8 @@ func NewConfig() (c *Config) {
 			AmbientWaypointLabelValue:  WaypointLabelValue,
 			AmbientWaypointUseLabel:    WaypointUseLabel,
 			AppLabelName:               "app",
+			EgressGatewayLabel:         "istio=egressgateway",
+			IngressGatewayLabel:        "istio=ingressgateway",
 			InjectionLabelName:         "istio-injection",
 			InjectionLabelRev:          "istio.io/rev",
 			VersionLabelName:           "version",
@@ -965,6 +969,14 @@ func (conf *Config) IsServerHTTPS() bool {
 	return conf.Identity.CertFile != "" && conf.Identity.PrivateKeyFile != ""
 }
 
+func (conf *Config) GatewayLabel(labelConfig string) []string {
+	label := strings.Split(labelConfig, "=")
+	if len(label) == 2 {
+		return label
+	}
+	return []string{"", ""}
+}
+
 // Get the global Config
 func Get() (conf *Config) {
 	rwMutex.RLock()
@@ -1000,7 +1012,7 @@ func (conf Config) String() (str string) {
 	obf := conf.Obfuscate()
 	str, err := Marshal(&obf)
 	if err != nil {
-		str = fmt.Sprintf("Failed to marshal config to string. err=%v", err)
+		str = fmt.Sprintf("Failed to marsx`hal config to string. err=%v", err)
 		log.Debugf(str)
 	}
 

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -66,6 +66,7 @@ import { QUERY_PARAMS, PATH, HEADERS, METHOD } from './K8sRequestRouting/K8sMatc
 import { ServiceOverview } from '../../types/ServiceList';
 import { ADD, SET, REQ_MOD, RESP_MOD, REQ_RED, REQ_MIR } from './K8sRequestRouting/K8sFilterBuilder';
 import { ANYTHING, PRESENCE } from './RequestRouting/MatchBuilder';
+import { getGatewayLabels } from '../../helpers/LabelFilterHelper';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -689,6 +690,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
     };
 
     // Wizard is optional, only when user has explicitly selected "Create a Gateway or K8s API Gateway"
+    const ingressLabels = getGatewayLabels(serverConfig.istioLabels.ingressGatewayLabel);
     wizardGW =
       wState.gateway && wState.gateway.addGateway && wState.gateway.newGateway
         ? {
@@ -703,7 +705,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
             },
             spec: {
               selector: {
-                istio: 'ingressgateway'
+                [ingressLabels[0]]: ingressLabels[1]
               },
               servers: [
                 {

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -87,6 +87,8 @@ const defaultServerConfig: ComputedServerConfig = {
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
+    egressGatewayLabel: 'istio=egressgateway',
+    ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'

--- a/frontend/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -4,6 +4,7 @@ import { ServerList } from './GatewayForm/ServerList';
 import { MAX_PORT, Server, ServerForm, ServerTLSSettings, MIN_PORT } from '../../types/IstioObjects';
 import { isValid } from 'utils/Common';
 import { areValidHosts } from './GatewayForm/ServerBuilder';
+import { serverConfig } from '../../config';
 
 export const GATEWAY = 'Gateway';
 export const GATEWAYS = 'gateways';
@@ -26,7 +27,7 @@ export const initGateway = (): GatewayState => ({
   addWorkloadSelector: false,
   gatewayServers: [],
   serversForm: [],
-  workloadSelectorLabels: 'istio=ingressgateway',
+  workloadSelectorLabels: serverConfig.istioLabels.ingressGatewayLabel,
   workloadSelectorValid: true
 });
 
@@ -71,7 +72,7 @@ export class GatewayForm extends React.Component<Props, GatewayState> {
     this.state = initGateway();
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.setState(this.props.gateway);
   }
 
@@ -126,7 +127,7 @@ export class GatewayForm extends React.Component<Props, GatewayState> {
     this.setState({ gatewayServers: servers, serversForm: serversForm }, () => this.props.onChange(this.state));
   };
 
-  render() {
+  render(): React.ReactNode {
     return (
       <>
         <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -176,6 +176,8 @@ export const serverRateConfig = {
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
+    egressGatewayLabel: 'istio=egressgateway',
+    ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -7,9 +7,11 @@ export type IstioLabelKey =
   | 'ambientWaypointLabel'
   | 'ambientWaypointLabelValue'
   | 'appLabelName'
-  | 'versionLabelName'
+  | 'egressGatewayLabel'
+  | 'ingressGatewayLabel'
   | 'injectionLabelName'
-  | 'injectionLabelRev';
+  | 'injectionLabelRev'
+  | 'versionLabelName';
 
 interface DeploymentConfig {
   viewOnlyMode: boolean;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -96,6 +96,8 @@ export const healthConfig = {
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
+    egressGatewayLabel: 'istio=egressgateway',
+    ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'

--- a/models/workload.go
+++ b/models/workload.go
@@ -461,11 +461,17 @@ func (workload *Workload) HasIstioSidecar() bool {
 
 // IsGateway return true if the workload is Ingress or Egress Gateway
 func (workload *Workload) IsGateway() bool {
+	conf := config.Get()
 	if workload.Type == "Deployment" {
 		if labelValue, ok := workload.Labels["operator.istio.io/component"]; ok && (labelValue == "IngressGateways" || labelValue == "EgressGateways") {
 			return true
 		}
-		if labelValue, ok := workload.Labels["istio"]; ok && (labelValue == "ingressgateway" || labelValue == "egressgateway") {
+		ingressLabel := conf.GatewayLabel(conf.IstioLabels.IngressGatewayLabel)
+		if labelValue, ok := workload.Labels[ingressLabel[0]]; ok && labelValue == ingressLabel[1] {
+			return true
+		}
+		egressLabel := conf.GatewayLabel(conf.IstioLabels.EgressGatewayLabel)
+		if labelValue, ok := workload.Labels[egressLabel[0]]; ok && labelValue == egressLabel[1] {
 			return true
 		}
 	}


### PR DESCRIPTION
### Describe the change

There were hardcoded `istio=ingressgateway` and `istio=egressgateway` label selectors in the code, moved them into "istio_labels" configuration with default values.

### Steps to test the PR

Make sure that config values `ingress_gateway_label` and `egress_gateway_label` are read correctly.
Regression testing of workloads lists and details pages for gateway workloads.
![Screenshot from 2024-06-28 16-52-07](https://github.com/kiali/kiali/assets/604313/c60bf02d-bff9-46ef-87b4-cfb9f14ac81e)

Istio config wizard -> creation of Gateway:
![Screenshot from 2024-06-28 16-32-27](https://github.com/kiali/kiali/assets/604313/e01023a8-b722-4092-9983-5d231baa1976)


### Automation testing

n/a

### Issue reference

https://github.com/kiali/kiali/issues/7232
