### PR TITLE
Update kiali token assertion in cypress tests

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -191,7 +191,12 @@ Cypress.Commands.add('login', (username: string, password: string) => {
       validate: () => {
         // For some reason validate is needed to preserve the kiali-token-aes cookie.
         if (auth_strategy === 'openshift') {
-          cy.getCookie('kiali-token-aes').should('exist');
+          cy.getCookies()
+            .should('exist')
+            .and('have.length', 1)
+            .then((cookies: any) => {
+              expect(cookies[0].name).to.match(/^kiali-token/);
+            });
         }
       }
     }

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -193,9 +193,10 @@ Cypress.Commands.add('login', (username: string, password: string) => {
         if (auth_strategy === 'openshift') {
           cy.getCookies()
             .should('exist')
-            .and('have.length', 1)
+            .and('have.length.at.least', 1)
             .then((cookies: any) => {
-              expect(cookies[0].name).to.match(/^kiali-token/);
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              expect(cookies.some(cookie => cookie.name.startsWith('kiali-token'))).to.be.true;
             });
         }
       }


### PR DESCRIPTION
### Describe the change

Since https://github.com/kiali/kiali/pull/7366 was merged the kiali token cookie has changed and needs to be updated in the cypress tests.

### Steps to test the PR

Run the cypress tests on openshift and ensure they are passing.