### PR TITLE
Stringify the query data only if it is not already stringified

### DIFF
--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -128,7 +128,7 @@ const newRequest = <P>(
   return axios.request<P>({
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
-    data: apiProxy ? JSON.stringify(data) : data,
+    data: data,
     headers: getHeaders() as AxiosHeaders,
     params: queryParams
   });
@@ -1183,7 +1183,7 @@ export const getIstioPermissions = (namespaces: string[], cluster?: string): Pro
 };
 
 export const getMetricsStats = (queries: MetricsStatsQuery[]): Promise<ApiResponse<MetricsStatsResult>> => {
-  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, { queries: queries });
+  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, JSON.stringify({ queries: queries }));
 };
 
 export function deleteServiceTrafficRouting(

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -125,10 +125,13 @@ const newRequest = <P>(
   queryParams: unknown,
   data: unknown
 ): Promise<ApiResponse<P>> => {
+  // stringify request data that is not already stringified
+  const requestData = typeof data !== 'string' ? JSON.stringify(data) : data;
+
   return axios.request<P>({
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
-    data: data,
+    data: requestData,
     headers: getHeaders() as AxiosHeaders,
     params: queryParams
   });
@@ -1183,7 +1186,7 @@ export const getIstioPermissions = (namespaces: string[], cluster?: string): Pro
 };
 
 export const getMetricsStats = (queries: MetricsStatsQuery[]): Promise<ApiResponse<MetricsStatsResult>> => {
-  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, JSON.stringify({ queries: queries }));
+  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, { queries: queries });
 };
 
 export function deleteServiceTrafficRouting(


### PR DESCRIPTION
### Describe the change

Currently, Kiali can send body data in requests as JSON or string since its `Content-Type` header has the value `application/json`. However, OSSMC only supports string data because its `Content-Type` header is `application/x-www-form-urlencoded` to avoid CORS issues. 

Previously, all request data for OSSMC was stringified, but the problem is that some request data is already stringified in the business logic, which causes failures (e.g., updateNamespace). Now the application only stringifies data that is not already stringified.

### Steps to test the PR

This PR fixes an OSSMC issue. From Kiali perspective, just check that everything works as expected.

### Automation testing

N/A

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/330
