### PR TITLE
Fix issue with yaml debug-info generation

### DIFF
--- a/frontend/src/components/DebugInformation/DebugInformation.tsx
+++ b/frontend/src/components/DebugInformation/DebugInformation.tsx
@@ -157,7 +157,7 @@ const DebugInformationComponent: React.FC<DebugInformationProps> = (props: Debug
     setCopyStatus(CopyStatus.NOT_COPIED);
   };
 
-  const parseConfig = (key: string, value: any): any | null => {
+  const parseConfig = (key: string, value: unkown): unkown | null => {
     // We have to patch some runtime properties  we don't want to serialize
     if (propsToPatch.includes(key)) {
       return null;

--- a/frontend/src/components/DebugInformation/DebugInformation.tsx
+++ b/frontend/src/components/DebugInformation/DebugInformation.tsx
@@ -157,7 +157,7 @@ const DebugInformationComponent: React.FC<DebugInformationProps> = (props: Debug
     setCopyStatus(CopyStatus.NOT_COPIED);
   };
 
-  const parseConfig = (key: string, value: unkown): unkown | null => {
+  const parseConfig = (key: string, value: unknown): unknown | null => {
     // We have to patch some runtime properties  we don't want to serialize
     if (propsToPatch.includes(key)) {
       return null;

--- a/frontend/src/components/DebugInformation/DebugInformation.tsx
+++ b/frontend/src/components/DebugInformation/DebugInformation.tsx
@@ -157,7 +157,7 @@ const DebugInformationComponent: React.FC<DebugInformationProps> = (props: Debug
     setCopyStatus(CopyStatus.NOT_COPIED);
   };
 
-  const parseConfig = (key: string, value: string): string | null => {
+  const parseConfig = (key: string, value: any): any | null => {
     // We have to patch some runtime properties  we don't want to serialize
     if (propsToPatch.includes(key)) {
       return null;
@@ -197,6 +197,7 @@ const DebugInformationComponent: React.FC<DebugInformationProps> = (props: Debug
 
   // skip invalid regex not allowed by js-yaml dump
   const debugInformationText = dump(debugInformation, {
+    noRefs: true,
     replacer: parseConfig,
     skipInvalid: true,
     ...yamlDumpOptions


### PR DESCRIPTION
Fix issue with yaml debug-info generation when we try to dump cytoscape graph info.  Make sure to protect against cy's duplicate refs, and also stringification of any cy structures. 

Fixes https://github.com/kiali/kiali/issues/7504

See issue for more detail about the problem.

To test:
Before the PR visiting a Cy graph and then asking for debug info would hang the browser tab.  After the fix it should work as expected.