### PR TITLE
Tracing is disabled by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -741,7 +741,7 @@ func NewConfig() (c *Config) {
 					Type: AuthTypeNone,
 				},
 				CustomHeaders:        map[string]string{},
-				Enabled:              true,
+				Enabled:              false,
 				GrpcPort:             9095,
 				InClusterURL:         "http://tracing.istio-system:16685/jaeger",
 				IsCore:               false,

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -32,6 +32,9 @@ fi
 
 deploy_kiali() {
   local helm_args=()
+  #Enable tracing
+  helm_args+=("--set external_services.tracing.enabled=true")
+
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     helm_args+=("--disable-openapi-validation")
     if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -178,6 +178,7 @@ setup_kind_singlecluster() {
     --set deployment.service_type="LoadBalancer" \
     --set external_services.grafana.url="http://grafana.istio-system:3000" \
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard" \
+    --set external_services.tracing.enabled="true" \
     --set external_services.tracing.url="http://tracing.istio-system:16685/jaeger" \
     --set health_config.rate[0].kind="service" \
     --set health_config.rate[0].name="y-server" \

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -235,6 +235,7 @@ setup_kind_tempo() {
     --set deployment.service_type="LoadBalancer" \
     --set external_services.grafana.url="http://grafana.istio-system:3000" \
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard" \
+    --set external_services.tracing.enabled="true" \
     --set external_services.tracing.provider="tempo" \
     --set external_services.tracing.url="http://tempo-cr-query-frontend.tempo:3200" \
     --set external_services.tracing.in_cluster_url="http://tempo-cr-query-frontend.tempo:3200" \

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -39,6 +39,7 @@ func setupMocks(t *testing.T) *mesh.AppenderGlobalInfo {
 	require := require.New(t)
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "cluster-primary"
+	conf.ExternalServices.Tracing.Enabled = true
 	config.Set(conf)
 
 	istiodDeployment := apps_v1.Deployment{

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -120,6 +120,7 @@ func (in *Instance) GetConfig(ctx context.Context) (*config.Config, error) {
 	}
 
 	currentConfig, err := config.Unmarshal(cm.Data["config.yaml"])
+	currentConfig.ExternalServices.Tracing.Enabled = true
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Describe the change

Tracing is disabled by default now

### Steps to test the PR

Run Kiali without any additional config (And without the operator).
Tracing should be disabled. 

### Automation testing
Update setup for tests

### Issue reference
#7332 

