### PR TITLE
Overview: Added missing cluster filter of results.

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -230,7 +230,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
             return nameFilters.length === 0 || nameFilters.some(f => ns.name.includes(f.value));
           })
           .map(ns => {
-            const previous = this.state.namespaces.find(prev => prev.name === ns.name);
+            const previous = this.state.namespaces.find(prev => prev.name === ns.name && prev.cluster === ns.cluster);
 
             return {
               name: ns.name,


### PR DESCRIPTION
### Describe the change

In MC mode, Overview page, refresh button click was causing mixing results from one cluster to another before the refresh is done.

There was missing filter of results by cluster of namespace.
Added now.

### Steps to test the PR

Setup Multicluster either primary-remote or multi-primary.
Open Overview page.
Click the 'refresh' button several times.
You will notice that 'bookinfo' card content from 'east' cluster is shown for the card from 'west' cluster, then in a second or less the card is shown correctly when refresh response is ready.

### Automation testing

n/a

### Issue reference
https://github.com/kiali/kiali/issues/7063
