### PR TITLE
Mesh page throws error when one of the clusters is inaccessible

### DIFF
--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -98,7 +98,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 	for _, cp := range meshDef.ControlPlanes {
 		// Check if istio namespace is accessible for that cluster
 		cpKey := mesh.GetClusterSensitiveKey(cp.Cluster.Name, cp.IstiodNamespace)
-		if o.AccessibleNamespaces[cpKey] == nil {
+		if _, ok := o.AccessibleNamespaces[cpKey]; !ok {
 			log.Tracef("No access for control plane %s in %s cluster", cp.IstiodNamespace, cp.Cluster.Name)
 			continue
 		}

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -97,7 +97,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 	clusterMap := make(map[string]bool)
 	for _, cp := range meshDef.ControlPlanes {
 		// Check if istio namespace is accessible for that cluster
-		cpKey := fmt.Sprintf("%s:%s", cp.Cluster.Name, cp.IstiodNamespace)
+		cpKey := mesh.GetClusterSensitiveKey(cp.Cluster.Name, cp.IstiodNamespace)
 		if o.AccessibleNamespaces[cpKey] == nil {
 			log.Tracef("No access for control plane %s in %s cluster", cp.IstiodNamespace, cp.Cluster.Name)
 			continue

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/mesh"
 	"github.com/kiali/kiali/mesh/appender"
 	"github.com/kiali/kiali/models"
@@ -95,6 +96,12 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 
 	clusterMap := make(map[string]bool)
 	for _, cp := range meshDef.ControlPlanes {
+		// Check if istio namespace is accessible for that cluster
+		cpKey := fmt.Sprintf("%s:%s", cp.Cluster.Name, cp.IstiodNamespace)
+		if o.AccessibleNamespaces[cpKey] == nil {
+			log.Tracef("No access for control plane %s in %s cluster", cp.IstiodNamespace, cp.Cluster.Name)
+			continue
+		}
 		// add control plane cluster if not already added
 		if _, ok := clusterMap[cp.Cluster.Name]; !ok {
 			k8sVersion := esVersions[fmt.Sprintf("%s-%s", "Kubernetes", cp.Cluster.Name)]


### PR DESCRIPTION
### Describe the change

Check the permissions for the control plane component. The cluster won't be shown if there are no permissions. 

No permissions in west cluster: 

![image](https://github.com/kiali/kiali/assets/49480155/bd0b5709-3711-434a-b946-478774aca2cd)

User with permissions in both clusters: 

![image](https://github.com/kiali/kiali/assets/49480155/d75d5e78-c424-4c73-805d-bb30ce49ae5a)


### Steps to test the PR


1. Deploy multi-cluster environment with RBAC enabled:

    `hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`

2. Disable access for the logged in user to the west cluster

    `kubectl delete clusterrolebindings --context kind-west kiali-testing-user`

3. Visit mesh page


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/7455 
