### PR TITLE
Fix url matching for openshift login negative test

### DIFF
--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -134,7 +134,7 @@ Then('user sees the Overview page', () => {
 });
 
 Then('the server will return a login error', () => {
-  cy.intercept({ url: `${Cypress.config('baseUrl')}/*`, query: { code: '*' } }, req => {
+  cy.intercept({ url: `${Cypress.config('baseUrl')}/api/auth/callback*`, query: { code: '*' } }, req => {
     req.query['code'] = 'invalidcode';
   });
 });


### PR DESCRIPTION
### Describe the change

Fix url matching for openshift login negative test. Uses new auth callback url.

### Steps to test the PR

Run `kiali_login` test on openshift with the changes.

### Automation testing

Fixes e2e test.