### PR TITLE
Removed 'external_services.istio.component_status.components' duplicate labels.

### DIFF
--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -414,8 +414,9 @@ func TestNoIstioComponentFoundError(t *testing.T) {
 	clients[conf.KubernetesConfig.ClusterName] = k8s
 
 	iss := NewWithBackends(clients, clients, nil, mockJaeger()).IstioStatus
-	_, error := iss.GetStatus(context.TODO())
-	assert.Error(error)
+	icsl, error := iss.GetStatus(context.TODO())
+	assert.NoError(error)
+	assertComponent(assert, icsl, "istiod", kubernetes.ComponentNotFound, true)
 }
 
 func TestDefaults(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -279,6 +279,7 @@ type IstioConfig struct {
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
+	GatewayNamespace                  string              `yaml:"gateway_namespace,omitempty"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
@@ -688,23 +689,6 @@ func NewConfig() (c *Config) {
 			Istio: IstioConfig{
 				ComponentStatuses: ComponentStatuses{
 					Enabled: true,
-					Components: []ComponentStatus{
-						{
-							AppLabel: "istio-egressgateway",
-							IsCore:   false,
-							IsProxy:  true,
-						},
-						{
-							AppLabel: "istio-ingressgateway",
-							IsCore:   true,
-							IsProxy:  true,
-						},
-						{
-							AppLabel: "istiod",
-							IsCore:   true,
-							IsProxy:  false,
-						},
-					},
 				},
 				ConfigMapName:                     "",
 				EnvoyAdminLocalPort:               15000,
@@ -719,6 +703,7 @@ func NewConfig() (c *Config) {
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "",
 				GatewayAPIClasses:                 []GatewayAPIClass{},
+				GatewayNamespace:                  "",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/config/config.go
+++ b/config/config.go
@@ -689,6 +689,10 @@ func NewConfig() (c *Config) {
 			Istio: IstioConfig{
 				ComponentStatuses: ComponentStatuses{
 					Enabled: true,
+					// Leaving default Components values empty
+					// Istio components are auto discovered and status is checked
+					// Components config is left for custom components status check
+					Components: []ComponentStatus{},
 				},
 				ConfigMapName:                     "",
 				EnvoyAdminLocalPort:               15000,

--- a/handlers/istio_status.go
+++ b/handlers/istio_status.go
@@ -22,11 +22,12 @@ func IstioStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cluster := r.URL.Query().Get("clusterName"); cluster != "" {
-		istioStatus = sliceutil.Filter(istioStatus, func(status kubernetes.ComponentStatus) bool {
-			return status.Cluster == cluster
-		})
-	}
+	queryParams := r.URL.Query()
+	cluster := clusterNameFromQuery(queryParams)
+
+	istioStatus = sliceutil.Filter(istioStatus, func(status kubernetes.ComponentStatus) bool {
+		return status.Cluster == cluster
+	})
 
 	RespondWithJSON(w, http.StatusOK, istioStatus)
 }

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -1526,8 +1526,8 @@ func TestUpdateStatusMultipleRevsWithoutHealthyPods(t *testing.T) {
 	require.NoError(err)
 	require.Len(mesh.ControlPlanes, 2)
 
-	require.Equal("", mesh.ControlPlanes[0].Status)
-	require.Equal("", mesh.ControlPlanes[1].Status)
+	require.Equal(kubernetes.ComponentNotReady, mesh.ControlPlanes[0].Status)
+	require.Equal(kubernetes.ComponentNotReady, mesh.ControlPlanes[1].Status)
 }
 
 func TestUpdateStatusMultipleHealthyRevs(t *testing.T) {

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -230,33 +230,12 @@
           "infraData": {
             "ComponentStatuses": {
               "Enabled": true,
-              "Components": [
-                {
-                  "AppLabel": "istio-egressgateway",
-                  "IsCore": false,
-                  "IsProxy": true,
-                  "IsMultiCluster": false,
-                  "Namespace": ""
-                },
-                {
-                  "AppLabel": "istio-ingressgateway",
-                  "IsCore": true,
-                  "IsProxy": true,
-                  "IsMultiCluster": false,
-                  "Namespace": ""
-                },
-                {
-                  "AppLabel": "istiod",
-                  "IsCore": true,
-                  "IsProxy": false,
-                  "IsMultiCluster": false,
-                  "Namespace": ""
-                }
-              ]
+              "Components": null
             },
             "ConfigMapName": "",
             "EnvoyAdminLocalPort": 15000,
             "GatewayAPIClasses": [],
+            "GatewayNamespace": "",
             "IstioAPIEnabled": true,
             "IstioCanaryRevision": {
               "Current": "",

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -230,7 +230,7 @@
           "infraData": {
             "ComponentStatuses": {
               "Enabled": true,
-              "Components": null
+              "Components": []
             },
             "ConfigMapName": "",
             "EnvoyAdminLocalPort": 15000,


### PR DESCRIPTION
### Describe the change

`external_services.istio.component_status.components` was expecting to have values for `istiod` and `ingress/egressgateway`, which was causing duplication for Istio component statuses, also duplication of labels in configuration and in code.
Now `external_services.istio.component_status.components` by default made empty, and `istiod` and `ingress/egressgateway` component statuses are read in code.
Functionality of  `external_services.istio.component_status.components` is left as deprecated for now, until will be removed, or will left as empty for possible custom components such as `eastwestgateway`.

### Steps to test the PR
Make sure you have 'istiod' without pods sunning.
Before:
![Screenshot from 2024-07-15 14-08-00](https://github.com/user-attachments/assets/b4f26d97-2ec6-4dea-beb4-4074fe5e5f0d)

After:
![Screenshot from 2024-07-15 13-34-34](https://github.com/user-attachments/assets/f64d81de-90b9-4ebc-9cb6-5bfe9e7188cb)

### Automation testing
Tests modified.

### Issue reference
https://github.com/kiali/kiali/issues/7501
https://github.com/kiali/kiali/issues/7524
Operator PR https://github.com/kiali/kiali-operator/pull/795
