### PR TITLE
[hack-scripts] Add waiting for bookinfo app before the traffic genera…

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -430,6 +430,14 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
       fi
     fi
   fi
+  # # Do not create traffic generator until all pods are ready
+  echo "Waiting till all pods are ready before installing the traffic generator"
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/details-v1 --timeout=5m
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/productpage-v1 --timeout=5m
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/ratings-v1 --timeout=5m
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/reviews-v1 --timeout=5m
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/reviews-v2 --timeout=5m
+  $CLIENT_EXE -n ${NAMESPACE} wait --for condition=Available deployment/reviews-v3 --timeout=5m
 
   if [ "${INGRESS_ROUTE}" != "" ] ; then
     if [ "${IS_OPENSHIFT}" == "true" ]; then


### PR DESCRIPTION
### Describe the change

The traffic generator is installed right after bookinfo app, however, it doesn't wait till bookinfo app is ready. So, if it takes longer (e.g. cluster is still pulling the images), the traffic generator starts sending requests to the app that is not ready. So results in the traffic generator contain 503 errors 

