### PR TITLE
[OSSM-6833] Update IBM images

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -330,15 +330,15 @@ if [ "${MYSQL_ENABLED}" == "true" ]; then
   MYSQL_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml"
 
   if [ "${ARCH}" == "ppc64le" ]; then
-    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mysqldb:2.0.0-ibm-p;g" ${MYSQL_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-ppc64le.yaml
+    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mysqldb:2.5.0-ibm-p;g" ${MYSQL_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-ppc64le.yaml
     MYSQL_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-ppc64le.yaml"
-    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-ratings-v2:2.0.0-ibm-p;g" ${MYSQL_SERVICE_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-ppc64le.yaml
+    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-ratings-v2:2.5.0-ibm-p;g" ${MYSQL_SERVICE_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-ppc64le.yaml
     MYSQL_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-ppc64le.yaml"
   fi
   if [ "${ARCH}" == "s390x" ]; then
-    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mysqldb:2.0.0-ibm-z;g" ${MYSQL_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-s390x.yaml
+    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mysqldb:2.5.0-ibm-z;g" ${MYSQL_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-s390x.yaml
     MYSQL_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-s390x.yaml"
-    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-ratings-v2:2.0.0-ibm-z;g" ${MYSQL_SERVICE_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-s390x.yaml
+    sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-ratings-v2:2.5.0-ibm-z;g" ${MYSQL_SERVICE_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-s390x.yaml
     MYSQL_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-s390x.yaml"
   fi
 

--- a/hack/istio/kustomization/bookinfo-ppc64le.yaml
+++ b/hack/istio/kustomization/bookinfo-ppc64le.yaml
@@ -4,19 +4,19 @@ images:
 # bookinfo.yaml
 - name: docker.io/istio/examples-bookinfo-details-v1
   newName: quay.io/maistra/examples-bookinfo-details-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-ratings-v1
   newName: quay.io/maistra/examples-bookinfo-ratings-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v1
   newName: quay.io/maistra/examples-bookinfo-reviews-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v2
   newName: quay.io/maistra/examples-bookinfo-reviews-v2
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v3
   newName: quay.io/maistra/examples-bookinfo-reviews-v3
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-productpage-v1
   newName: quay.io/maistra/examples-bookinfo-productpage-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.5.0-ibm-p

--- a/hack/istio/kustomization/bookinfo-s390x.yaml
+++ b/hack/istio/kustomization/bookinfo-s390x.yaml
@@ -3,19 +3,19 @@ resources:
 images:
 - name: docker.io/istio/examples-bookinfo-details-v1
   newName: quay.io/maistra/examples-bookinfo-details-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-ratings-v1
   newName: quay.io/maistra/examples-bookinfo-ratings-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v1
   newName: quay.io/maistra/examples-bookinfo-reviews-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v2
   newName: quay.io/maistra/examples-bookinfo-reviews-v2
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v3
   newName: quay.io/maistra/examples-bookinfo-reviews-v3
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-productpage-v1
   newName: quay.io/maistra/examples-bookinfo-productpage-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.5.0-ibm-z


### PR DESCRIPTION
IBM images in the Kiali scripts are pretty old (2.0.0)
https://github.com/kiali/kiali/tree/v1.73/hack/istio/kustomization
so they needs to be updated to be aligned with MTT images here https://github.com/maistra/maistra-test-tool/blob/main/images.yaml
