### PR TITLE
Gateway Namespace divided into Ingress and Egress.

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -260,7 +260,10 @@ func (iss *IstioStatusService) getStatusOf(workloads []*models.Workload, cluster
 	componentNotFound := 0
 	for comp, stat := range statusComponents {
 		if _, found := cf[comp]; !found {
-			if number, mfound := mcf[comp]; !mfound || number < len(iss.userClients) { // multicluster components should exist on all clusters
+			// @TODO for remote cluster
+			// multicluster components should exist on all clusters
+			// !mfound || number < len(iss.userClients)
+			if _, mfound := mcf[comp]; !mfound {
 				componentNotFound += 1
 				isc = append(isc, kubernetes.ComponentStatus{
 					Cluster: cluster,

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -106,13 +106,12 @@ func (iss *IstioStatusService) getIstioComponentStatus(ctx context.Context, clus
 }
 
 func (iss *IstioStatusService) getGatewaysStatus(ctx context.Context, cluster string) kubernetes.IstioComponentStatus {
-	// Fetching gateway workloads from gateway namespace
-	namespace := iss.conf.ExternalServices.Istio.GatewayNamespace
-	if namespace == "" {
-		namespace = iss.conf.IstioNamespace
-	}
 	var gatewaysStatus kubernetes.IstioComponentStatus
-	updateGatewayStatus := func(label string, isCore bool) {
+	updateGatewayStatus := func(label string, isCore bool, namespace string) {
+		// Fetching gateway workloads from gateway namespace
+		if namespace == "" {
+			namespace = iss.conf.IstioNamespace
+		}
 		// keep the label in status name, to align with ComponentStatuses
 		wls, err := iss.workloads.fetchWorkloadsFromCluster(ctx, cluster, namespace, label)
 		if err == nil && len(wls) != 0 {
@@ -136,8 +135,8 @@ func (iss *IstioStatusService) getGatewaysStatus(ctx context.Context, cluster st
 			})
 		}
 	}
-	updateGatewayStatus(iss.conf.IstioLabels.IngressGatewayLabel, true)
-	updateGatewayStatus(iss.conf.IstioLabels.EgressGatewayLabel, false)
+	updateGatewayStatus(iss.conf.IstioLabels.IngressGatewayLabel, true, iss.conf.ExternalServices.Istio.IngressGatewayNamespace)
+	updateGatewayStatus(iss.conf.IstioLabels.EgressGatewayLabel, false, iss.conf.ExternalServices.Istio.EgressGatewayNamespace)
 
 	return gatewaysStatus
 }

--- a/config/config.go
+++ b/config/config.go
@@ -277,8 +277,8 @@ type RegistryConfig struct {
 type IstioConfig struct {
 	ComponentStatuses                 ComponentStatuses   `yaml:"component_status,omitempty"`
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
-	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
 	EgressGatewayNamespace            string              `yaml:"egress_gateway_namespace,omitempty"`
+	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
 	IngressGatewayNamespace           string              `yaml:"ingress_gateway_namespace,omitempty"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`

--- a/config/config.go
+++ b/config/config.go
@@ -278,8 +278,9 @@ type IstioConfig struct {
 	ComponentStatuses                 ComponentStatuses   `yaml:"component_status,omitempty"`
 	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
+	EgressGatewayNamespace            string              `yaml:"egress_gateway_namespace,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
-	GatewayNamespace                  string              `yaml:"gateway_namespace,omitempty"`
+	IngressGatewayNamespace           string              `yaml:"ingress_gateway_namespace,omitempty"`
 	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
 	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
 	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
@@ -695,7 +696,9 @@ func NewConfig() (c *Config) {
 					Components: []ComponentStatus{},
 				},
 				ConfigMapName:                     "",
+				EgressGatewayNamespace:            "",
 				EnvoyAdminLocalPort:               15000,
+				IngressGatewayNamespace:           "",
 				IstioAPIEnabled:                   true,
 				IstioIdentityDomain:               "svc.cluster.local",
 				IstioInjectionAnnotation:          "sidecar.istio.io/inject",
@@ -707,7 +710,6 @@ func NewConfig() (c *Config) {
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "",
 				GatewayAPIClasses:                 []GatewayAPIClass{},
-				GatewayNamespace:                  "",
 			},
 			Prometheus: PrometheusConfig{
 				Auth: Auth{

--- a/frontend/src/pages/Overview/ControlPlaneBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneBadge.tsx
@@ -44,11 +44,13 @@ export const ControlPlaneBadge: React.FC<Props> = (props: Props) => {
           {t('Control plane')}
         </Label>
       </Tooltip>
+
       {isRemoteCluster(props.annotations) && <RemoteClusterBadge />}
+
       {serverConfig.ambientEnabled && (
         <AmbientBadge tooltip={t('Istio Ambient ztunnel detected in the Control plane')}></AmbientBadge>
       )}
-      // @TODO for remote cluster
+
       {!isRemoteCluster(props.annotations) && (
         <IstioStatus
           icons={{

--- a/frontend/src/pages/Overview/ControlPlaneBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneBadge.tsx
@@ -44,13 +44,11 @@ export const ControlPlaneBadge: React.FC<Props> = (props: Props) => {
           {t('Control plane')}
         </Label>
       </Tooltip>
-
       {isRemoteCluster(props.annotations) && <RemoteClusterBadge />}
-
       {serverConfig.ambientEnabled && (
         <AmbientBadge tooltip={t('Istio Ambient ztunnel detected in the Control plane')}></AmbientBadge>
       )}
-
+      // @TODO for remote cluster
       {!isRemoteCluster(props.annotations) && (
         <IstioStatus
           icons={{

--- a/handlers/istio_status.go
+++ b/handlers/istio_status.go
@@ -26,7 +26,8 @@ func IstioStatus(w http.ResponseWriter, r *http.Request) {
 	cluster := clusterNameFromQuery(queryParams)
 
 	istioStatus = sliceutil.Filter(istioStatus, func(status kubernetes.ComponentStatus) bool {
-		return status.Cluster == cluster
+		// empty Cluster for addons
+		return status.Cluster == "" || status.Cluster == cluster
 	})
 
 	RespondWithJSON(w, http.StatusOK, istioStatus)

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -235,7 +235,8 @@
             "ConfigMapName": "",
             "EnvoyAdminLocalPort": 15000,
             "GatewayAPIClasses": [],
-            "GatewayNamespace": "",
+            "EgressGatewayNamespace": "",
+            "IngressGatewayNamespace": "",
             "IstioAPIEnabled": true,
             "IstioCanaryRevision": {
               "Current": "",


### PR DESCRIPTION
### Describe the change

There can be a potential issue in gateways discovery, as Ingress and Egress Gateways can be in a different namespaces.
Made 2 separate configurations for IngressGatewayNamespace and EgressGatewayNamespace.

### Steps to test the PR

Make sure that Istio Ingress Gateway is installed in 'istio-system' but the pod is not running.
Verify that Kiali component status ill display a warning.
Install Ingress gateway into different namespaces than 'istio-system' and make sure pod is running.
Set 'ingress_gateway_namespace' config value to the correct namespaces.
Verify that the Inress component is recognized and not showing any warning.
The same steps for Egress Gateway.

### Automation testing

Fixed automation tests.

### Issue reference

https://github.com/kiali/kiali/issues/7501
