### PR TITLE
Added cross-namespace validations into K8s Routes.

### DIFF
--- a/business/checkers/k8sgrpcroute_checker.go
+++ b/business/checkers/k8sgrpcroute_checker.go
@@ -42,13 +42,15 @@ func (in K8sGRPCRouteChecker) runIndividualChecks() models.IstioValidations {
 	return validations
 }
 
-func (in K8sGRPCRouteChecker) runChecks(rt *k8s_networking_v1.GRPCRoute, gatewayNames map[string]struct{}) models.IstioValidations {
+func (in K8sGRPCRouteChecker) runChecks(rt *k8s_networking_v1.GRPCRoute, gatewayNames map[string]k8s_networking_v1.Gateway) models.IstioValidations {
 	key, validations := EmptyValidValidation(rt.Name, rt.Namespace, K8sGRPCRouteCheckerType, in.Cluster)
 
 	enabledCheckers := []Checker{
 		k8sgrpcroutes.NoK8sGatewayChecker{
+			Cluster:      in.Cluster,
 			K8sGRPCRoute: rt,
 			GatewayNames: gatewayNames,
+			Namespaces:   in.Namespaces,
 		},
 		k8sgrpcroutes.NoHostChecker{
 			Namespaces:         in.Namespaces,

--- a/business/checkers/k8sgrpcroutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8sgrpcroutes/no_k8sgateway_checker.go
@@ -2,6 +2,7 @@ package k8sgrpcroutes
 
 import (
 	"fmt"
+
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/business/checkers/k8shttproutes"

--- a/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
@@ -108,6 +108,26 @@ func TestFoundSharedK8sGateway(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestFoundSharedToAllK8sGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedToAllListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}),
+		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo"}},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestWrongNSSharedK8sGatewayError(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
@@ -20,7 +20,7 @@ func TestMissingK8sGateway(t *testing.T) {
 
 	checker := NoK8sGatewayChecker{
 		K8sGRPCRoute: data.CreateGRPCRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"}),
-		GatewayNames: make(map[string]struct{}),
+		GatewayNames: make(map[string]k8s_networking_v1.Gateway),
 	}
 
 	vals, valid := checker.Check()
@@ -38,7 +38,7 @@ func TestMissingK8sGateways(t *testing.T) {
 	checker := NoK8sGatewayChecker{
 		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("gateway2", "bookinfo2",
 			data.CreateGRPCRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
-		GatewayNames: make(map[string]struct{}),
+		GatewayNames: make(map[string]k8s_networking_v1.Gateway),
 	}
 
 	vals, valid := checker.Check()
@@ -56,12 +56,12 @@ func TestValidAndMissingK8sGateway(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	var empty struct{}
-
 	checker := NoK8sGatewayChecker{
 		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("correctgw", "bookinfo2",
 			data.CreateGRPCRoute("route", "bookinfo", "gatewayapi", []string{"bookinfo"})),
-		GatewayNames: map[string]struct{}{"correctgw": empty},
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.CreateEmptyK8sGateway("correctgw", "bookinfo"),
+		}),
 	}
 
 	vals, valid := checker.Check()
@@ -86,4 +86,90 @@ func TestFoundK8sGateway(t *testing.T) {
 	vals, valid := checker.Check()
 	assert.True(valid)
 	assert.Empty(vals)
+}
+
+func TestFoundSharedK8sGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}),
+		Namespaces: models.Namespaces{data.CreateSharedNamespace("bookinfo")},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestWrongNSSharedK8sGatewayError(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwnswrong",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}),
+		Namespaces: models.Namespaces{data.CreateSharedNamespace("bookinfo")},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
+}
+
+func TestSharedK8sGatewayWrongNSError(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwnswrong")),
+		}),
+		Namespaces: models.Namespaces{data.CreateSharedNamespace("bookinfo")},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
+}
+
+func TestNotSharedNSK8sGatewayError(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}),
+		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo"}},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
 }

--- a/business/checkers/k8shttproute_checker.go
+++ b/business/checkers/k8shttproute_checker.go
@@ -42,13 +42,15 @@ func (in K8sHTTPRouteChecker) runIndividualChecks() models.IstioValidations {
 	return validations
 }
 
-func (in K8sHTTPRouteChecker) runChecks(rt *k8s_networking_v1.HTTPRoute, gatewayNames map[string]struct{}) models.IstioValidations {
+func (in K8sHTTPRouteChecker) runChecks(rt *k8s_networking_v1.HTTPRoute, gatewayNames map[string]k8s_networking_v1.Gateway) models.IstioValidations {
 	key, validations := EmptyValidValidation(rt.Name, rt.Namespace, K8sHTTPRouteCheckerType, in.Cluster)
 
 	enabledCheckers := []Checker{
 		k8shttproutes.NoK8sGatewayChecker{
+			Cluster:      in.Cluster,
 			K8sHTTPRoute: rt,
 			GatewayNames: gatewayNames,
+			Namespaces:   in.Namespaces,
 		},
 		k8shttproutes.NoHostChecker{
 			Namespaces:         in.Namespaces,

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker.go
@@ -3,6 +3,7 @@ package k8shttproutes
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/labels"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/kubernetes"
@@ -10,8 +11,10 @@ import (
 )
 
 type NoK8sGatewayChecker struct {
+	Cluster      string
+	GatewayNames map[string]k8s_networking_v1.Gateway
 	K8sHTTPRoute *k8s_networking_v1.HTTPRoute
-	GatewayNames map[string]struct{}
+	Namespaces   models.Namespaces
 }
 
 // Check validates that the HTTPRoute is pointing to an existing Gateway
@@ -30,26 +33,46 @@ func (s NoK8sGatewayChecker) ValidateHTTPRouteGateways(validations *[]*models.Is
 	if len(s.K8sHTTPRoute.Spec.ParentRefs) > 0 {
 		for index, parentRef := range s.K8sHTTPRoute.Spec.ParentRefs {
 			if string(parentRef.Name) != "" && string(*parentRef.Kind) == kubernetes.K8sActualGatewayType && string(*parentRef.Group) == kubernetes.K8sNetworkingGroupVersionV1.Group {
-				namespace := s.K8sHTTPRoute.Namespace
+				gwNs := s.K8sHTTPRoute.Namespace
 				if parentRef.Namespace != nil && string(*parentRef.Namespace) != "" {
-					namespace = string(*parentRef.Namespace)
+					gwNs = string(*parentRef.Namespace)
 				}
-				valid = s.checkGateway(string(parentRef.Name), namespace, validations, fmt.Sprintf("spec/parentRefs[%d]/name/%s", index, string(parentRef.Name))) && valid
+				valid = CheckGateway(string(parentRef.Name), gwNs, s.K8sHTTPRoute.Namespace, s.Cluster, s.GatewayNames, s.Namespaces, validations, fmt.Sprintf("spec/parentRefs[%d]/name/%s", index, string(parentRef.Name))) && valid
 			}
 		}
 	}
 	return valid
 }
 
-func (s NoK8sGatewayChecker) checkGateway(name, namespace string, validations *[]*models.IstioCheck, location string) bool {
-	hostname := kubernetes.ParseGatewayAsHost(name, namespace)
-	for gw := range s.GatewayNames {
-		gwHostname := kubernetes.ParseHost(gw, namespace)
+func CheckGateway(gwName, gwNs, routeNs, cluster string, gatewayNames map[string]k8s_networking_v1.Gateway, nss models.Namespaces, validations *[]*models.IstioCheck, location string) bool {
+	hostname := kubernetes.ParseGatewayAsHost(gwName, gwNs)
+	for gw := range gatewayNames {
+		gwHostname := kubernetes.ParseHost(gw, gwNs)
 		if found := kubernetes.FilterByHost(hostname.String(), hostname.Namespace, gw, gwHostname.Namespace); found {
-			return true
+			if gwHostname.Namespace == routeNs {
+				return true
+			} else if IsGatewaySharedWithNS(routeNs, cluster, gatewayNames[gw], nss) {
+				return true
+			}
 		}
 	}
 	validation := models.Build("k8sroutes.nok8sgateway", location)
 	*validations = append(*validations, &validation)
+	return false
+}
+
+// If K8sGateway's allowedRoutes selector matches the labels of given namespace
+func IsGatewaySharedWithNS(namespace string, cluster string, gw k8s_networking_v1.Gateway, nss models.Namespaces) bool {
+	ns := nss.GetNamespace(namespace, cluster)
+	if ns == nil {
+		return false
+	}
+	for _, l := range gw.Spec.Listeners {
+		if *l.AllowedRoutes.Namespaces.From == "Selector" &&
+			l.AllowedRoutes.Namespaces.Selector != nil &&
+			labels.SelectorFromSet(labels.Set(l.AllowedRoutes.Namespaces.Selector.MatchLabels)).Matches(labels.Set(ns.Labels)) {
+			return true
+		}
+	}
 	return false
 }

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker.go
@@ -68,9 +68,10 @@ func IsGatewaySharedWithNS(namespace string, cluster string, gw k8s_networking_v
 		return false
 	}
 	for _, l := range gw.Spec.Listeners {
-		if *l.AllowedRoutes.Namespaces.From == "Selector" &&
-			l.AllowedRoutes.Namespaces.Selector != nil &&
-			labels.SelectorFromSet(labels.Set(l.AllowedRoutes.Namespaces.Selector.MatchLabels)).Matches(labels.Set(ns.Labels)) {
+		if *l.AllowedRoutes.Namespaces.From == "All" ||
+			(*l.AllowedRoutes.Namespaces.From == "Selector" &&
+				l.AllowedRoutes.Namespaces.Selector != nil &&
+				labels.SelectorFromSet(labels.Set(l.AllowedRoutes.Namespaces.Selector.MatchLabels)).Matches(labels.Set(ns.Labels))) {
 			return true
 		}
 	}

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
@@ -108,6 +108,26 @@ func TestFoundSharedK8sGateway(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestFoundSharedToAllK8sGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("sharedgw", "gwns",
+			data.CreateEmptyHTTPRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(data.CreateSharedToAllListener("test", "host.com", 80, "http"),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}),
+		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo"}},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
 func TestWrongNSSharedK8sGatewayError(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -264,7 +264,7 @@ func (in *IstioConfigService) getIstioConfigList(ctx context.Context, cluster st
 		}
 	}
 
-	if userClient.IsExpGatewayAPI() && criteria.Include(kubernetes.K8sGRPCRoutes) {
+	if userClient.IsGatewayAPI() && criteria.Include(kubernetes.K8sGRPCRoutes) {
 		istioConfigList.K8sGRPCRoutes, err = kubeCache.GetK8sGRPCRoutes(namespace, criteria.LabelSelector)
 		if err != nil {
 			return nil, err

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -416,14 +416,14 @@ func (c *kubeCache) createGatewayInformers(namespace string) gateway.SharedInfor
 		lister.k8shttprouteLister = sharedInformers.Gateway().V1().HTTPRoutes().Lister()
 		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1().HTTPRoutes().Informer().HasSynced)
 
+		lister.k8sgrpcrouteLister = sharedInformers.Gateway().V1().GRPCRoutes().Lister()
+		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1().GRPCRoutes().Informer().HasSynced)
+
 		lister.k8sreferencegrantLister = sharedInformers.Gateway().V1beta1().ReferenceGrants().Lister()
 		lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1beta1().ReferenceGrants().Informer().HasSynced)
 		c.hasGatewayAPIStarted = true
 
 		if c.client.IsExpGatewayAPI() {
-			lister.k8sgrpcrouteLister = sharedInformers.Gateway().V1().GRPCRoutes().Lister()
-			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1().GRPCRoutes().Informer().HasSynced)
-
 			lister.k8stcprouteLister = sharedInformers.Gateway().V1alpha2().TCPRoutes().Lister()
 			lister.cachesSynced = append(lister.cachesSynced, sharedInformers.Gateway().V1alpha2().TCPRoutes().Informer().HasSynced)
 
@@ -1726,7 +1726,7 @@ func (c *kubeCache) GetK8sGRPCRoutes(namespace, labelSelector string) ([]*gatewa
 	// but it won't prevent other routines from reading from the lister.
 	defer c.cacheLock.RUnlock()
 	c.cacheLock.RLock()
-	if !c.isK8sExpGatewayListerInit(namespace) {
+	if !c.isK8sGatewayListerInit(namespace) {
 		return k8sGRPCRoutes, nil
 	}
 	if namespace == metav1.NamespaceAll {

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -254,11 +254,10 @@ func GatewayNames(gateways []*networking_v1.Gateway) map[string]struct{} {
 }
 
 // K8sGatewayNames extracts the gateway names for easier matching
-func K8sGatewayNames(gateways []*k8s_networking_v1.Gateway) map[string]struct{} {
-	var empty struct{}
-	names := make(map[string]struct{})
+func K8sGatewayNames(gateways []*k8s_networking_v1.Gateway) map[string]k8s_networking_v1.Gateway {
+	names := make(map[string]k8s_networking_v1.Gateway)
 	for _, gw := range gateways {
-		names[ParseHost(gw.Name, gw.Namespace).String()] = empty
+		names[ParseHost(gw.Name, gw.Namespace).String()] = *gw
 	}
 	return names
 }

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -280,7 +280,7 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"k8sroutes.nok8sgateway": {
 		Code:     "KIA1401",
-		Message:  "Route is pointing to a non-existent K8s gateway",
+		Message:  "Route is pointing to a non-existent or inaccessible K8s gateway",
 		Severity: ErrorSeverity,
 	},
 	"peerauthentication.mtls.destinationrulemissing": {

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -116,6 +116,15 @@ func (nss Namespaces) IsNamespaceAmbient(namespace, cluster string) bool {
 	return false
 }
 
+func (nss Namespaces) GetNamespace(namespace, cluster string) *Namespace {
+	for _, ns := range nss {
+		if ns.Name == namespace && ns.Cluster == cluster {
+			return &ns
+		}
+	}
+	return nil
+}
+
 func (nss Namespaces) GetNames() []string {
 	names := make([]string, len(nss))
 	for _, ns := range nss {

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -179,6 +179,23 @@ func CreateSharedListener(name string, hostname string, port int, protocol strin
 	return listener
 }
 
+func CreateSharedToAllListener(name string, hostname string, port int, protocol string) k8s_networking_v1.Listener {
+	hn := k8s_networking_v1.Hostname(hostname)
+	namespaceFromSelector := k8s_networking_v1.NamespacesFromAll
+	listener := k8s_networking_v1.Listener{
+		Name:     k8s_networking_v1.SectionName(name),
+		Hostname: &hn,
+		Port:     k8s_networking_v1.PortNumber(port),
+		Protocol: k8s_networking_v1.ProtocolType(protocol),
+		AllowedRoutes: &k8s_networking_v1.AllowedRoutes{
+			Namespaces: &k8s_networking_v1.RouteNamespaces{
+				From: &namespaceFromSelector,
+			},
+		},
+	}
+	return listener
+}
+
 func CreateGWAddress(addrType k8s_networking_v1.AddressType, value string) k8s_networking_v1.GatewayAddress {
 	address := k8s_networking_v1.GatewayAddress{
 		Type:  &addrType,

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -1,12 +1,12 @@
 package data
 
 import (
-	"github.com/kiali/kiali/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
 )
 
 func CreateEmptyHTTPRoute(name string, namespace string, hosts []string) *k8s_networking_v1.HTTPRoute {

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"github.com/kiali/kiali/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -158,6 +159,26 @@ func CreateListener(name string, hostname string, port int, protocol string) k8s
 	return listener
 }
 
+func CreateSharedListener(name string, hostname string, port int, protocol string) k8s_networking_v1.Listener {
+	hn := k8s_networking_v1.Hostname(hostname)
+	namespaceFromSelector := k8s_networking_v1.NamespacesFromSelector
+	listener := k8s_networking_v1.Listener{
+		Name:     k8s_networking_v1.SectionName(name),
+		Hostname: &hn,
+		Port:     k8s_networking_v1.PortNumber(port),
+		Protocol: k8s_networking_v1.ProtocolType(protocol),
+		AllowedRoutes: &k8s_networking_v1.AllowedRoutes{
+			Namespaces: &k8s_networking_v1.RouteNamespaces{
+				From: &namespaceFromSelector,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"shared-gateway-access": "true"},
+				},
+			},
+		},
+	}
+	return listener
+}
+
 func CreateGWAddress(addrType k8s_networking_v1.AddressType, value string) k8s_networking_v1.GatewayAddress {
 	address := k8s_networking_v1.GatewayAddress{
 		Type:  &addrType,
@@ -184,4 +205,8 @@ func CreateReferenceGrantByKind(name string, namespace string, fromNamespace str
 	rg.Spec.From = append(rg.Spec.From, k8s_networking_v1beta1.ReferenceGrantFrom{Kind: kind, Group: k8s_networking_v1beta1.GroupName, Namespace: k8s_networking_v1.Namespace(fromNamespace)})
 	rg.Spec.To = append(rg.Spec.To, k8s_networking_v1beta1.ReferenceGrantTo{Kind: kubernetes.ServiceType})
 	return &rg
+}
+
+func CreateSharedNamespace(name string) models.Namespace {
+	return models.Namespace{Name: name, Labels: map[string]string{"shared-gateway-access": "true"}}
 }

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -163,7 +163,7 @@ func TestK8sHTTPRoutesGatewaysError(t *testing.T) {
 	require.Equal("k8shttproute", config.IstioValidation.ObjectType)
 	require.NotEmpty(config.IstioValidation.Checks)
 	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	require.Equal("Route is pointing to a non-existent K8s gateway", config.IstioValidation.Checks[0].Message)
+	require.Equal("Route is pointing to a non-existent or inaccessible K8s gateway", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sHTTPRoutesServicesError(t *testing.T) {
@@ -218,7 +218,7 @@ func TestK8sGRPCRoutesGatewaysError(t *testing.T) {
 	require.Equal("k8sgrpcroute", config.IstioValidation.ObjectType)
 	require.NotEmpty(config.IstioValidation.Checks)
 	require.Equal(models.ErrorSeverity, config.IstioValidation.Checks[0].Severity)
-	require.Equal("Route is pointing to a non-existent K8s gateway", config.IstioValidation.Checks[0].Message)
+	require.Equal("Route is pointing to a non-existent or inaccessible K8s gateway", config.IstioValidation.Checks[0].Message)
 }
 
 func TestK8sGRPCRoutesServicesError(t *testing.T) {


### PR DESCRIPTION
K8s HTTPRoutes and GRPCRoutes can be created in a different namespace than K8sGateway exists and is referred in a parentRef.
For having access to K8sGateway from different namespace:
1. Gateway should be marked by label `shared-gateway-access: "true"`.
2. Namespace where HTTPRoute is created should also be labeled `shared-gateway-access: "true"`.
Then the HTTPRoute with a 'parentRefs' to a K8sGateways from different namespace will be recognized. Otherwise Error `KIA1401 Route is pointing to a non-existent K8s gateway` will be shown.

Fixed GRPCRoutes showing. Added tests.

More info at https://gateway-api.sigs.k8s.io/guides/multiple-ns/

### Describe the change

Added cross namespace validation for GRPCRoute and HTTPRoute objects which point to K8sGateways from different namespace.
GRPCRoute is GA, not experimental.

### Steps to test the PR
Make sure K8s CRDs are installed:
`kubectl get crd gateways.gateway.networking.k8s.io || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.1.0" | kubectl apply -f -; }
`
Create the following objects.

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: shared-gateway
  namespace: infra-ns
spec:
  gatewayClassName: istio
  listeners:
  - name: https
    hostname: "foo.example.com"
    protocol: HTTPS
    port: 443
    allowedRoutes:
      namespaces:
        from: Selector
        selector:
          matchLabels:
            shared-gateway-access: "true"
---
apiVersion: v1
kind: Namespace
metadata:
  name: infra-ns
  labels:
    shared-gateway-access: "true"
---
apiVersion: v1
kind: Namespace
metadata:
  name: site-ns
  labels:
    shared-gateway-access: "true"
---
apiVersion: v1
kind: Namespace
metadata:
  name: store-ns
  labels:
    shared-gateway-access: "true"
---
apiVersion: v1
kind: Namespace
metadata:
  name: no-external-access
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: store
  namespace: store-ns
spec:
  parentRefs:
  - name: shared-gateway
    namespace: infra-ns
  rules:
  - matches:
    - path:
        value: /store
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: home
  namespace: site-ns
spec:
  parentRefs:
  - name: shared-gateway
    namespace: infra-ns
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: login
  namespace: site-ns
spec:
  parentRefs:
  - name: shared-gateway
    namespace: infra-ns
  rules:
  - matches:
    - path:
        value: /login
---
apiVersion: gateway.networking.k8s.io/v1
kind: GRPCRoute
metadata:
  name: example-route
  namespace: store-ns
spec:
  parentRefs:
  - name: shared-gateway
    namespace: infra-ns
  hostnames:
  - "example.com"

```
HTTPRoutes and GRPCRoutes should not display errors on 'parentRefs:'.
Change and spoil the Gateway's `shared-gateway-access: "true"`.
Now errors are displayed on all routes.

### Automation testing

Unit tests are created.

### Issue reference

https://github.com/kiali/kiali/issues/7413
