### PR TITLE
[1.73] Update the way the Kiali CR is updated for no istiod tests 

### DIFF
--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -48,6 +48,12 @@ func TestNoIstiod(t *testing.T) {
 
 func servicesListNoRegistryServices(t *testing.T) {
 	require := require.New(t)
+
+	defer func() {
+    	deleteSe := utils.DeleteFile("../assets/bookinfo-service-entry-external.yaml", "bookinfo")
+		require.True(deleteSe)
+	}()
+
 	serviceList, err := kiali.ServicesList(kiali.BOOKINFO)
 
 	require.NoError(err)
@@ -67,10 +73,7 @@ func servicesListNoRegistryServices(t *testing.T) {
 	// Now, create a Service Entry (Part of th
 	require.NotNil(serviceList.Validations)
 	require.Equal(kiali.BOOKINFO, serviceList.Namespace.Name)
-
-	// Cleanup
-	deleteSe := utils.DeleteFile("../assets/bookinfo-service-entry-external.yaml", "bookinfo")
-	require.True(deleteSe)
+	
 }
 
 func noProxyStatus(t *testing.T) {

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -51,7 +51,7 @@ func servicesListNoRegistryServices(t *testing.T) {
 	require := require.New(t)
 
 	defer func() {
-    	deleteSe := utils.DeleteFile("../assets/bookinfo-service-entry-external.yaml", "bookinfo")
+		deleteSe := utils.DeleteFile("../assets/bookinfo-service-entry-external.yaml", "bookinfo")
 		require.True(deleteSe)
 	}()
 

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	k8s "github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tests/integration/utils/kiali"
 	"github.com/kiali/kiali/tests/integration/utils/kube"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNoIstiod(t *testing.T) {
@@ -73,7 +74,7 @@ func servicesListNoRegistryServices(t *testing.T) {
 	// Now, create a Service Entry (Part of th
 	require.NotNil(serviceList.Validations)
 	require.Equal(kiali.BOOKINFO, serviceList.Namespace.Name)
-	
+
 }
 
 func noProxyStatus(t *testing.T) {

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -1,0 +1,238 @@
+package kiali
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/tests/integration/utils/kube"
+)
+
+var kialiGroupVersionResource = schema.GroupVersionResource{Group: "kiali.io", Version: "v1alpha1", Resource: "kialis"}
+
+// NewInstance finds the kiali instance deployed in the cluster and creates an Instance out of it.
+// Assumes there's only a single Kiali deployed to the cluster.
+func NewInstance(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) (*Instance, error) {
+	log.Debug("Finding Kiali Instance")
+
+	var kialiCRDExists bool
+	if _, err := kubeClient.Discovery().RESTClient().Get().AbsPath("/apis/kiali.io").DoRaw(ctx); err != nil {
+		// If it's an error other than NotFound then we should return it since we can't determine if the CRD exists.
+		if !kubeerrors.IsNotFound(err) {
+			return nil, err
+		}
+		// Otherwise we know the CRD doesn't exist because it's a not found error so keep the default of false.
+		log.Debug("Kiali CRD does not exist. Kiali must be deployed with helm.")
+	} else {
+		log.Debug("Kiali CRD exists. Kiali must be deployed with the operator.")
+		kialiCRDExists = true
+	}
+
+	instance := &Instance{
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+		useKialiCR:    kialiCRDExists,
+	}
+
+	if kialiCRDExists {
+		kialiCRs, err := dynamicClient.Resource(kialiGroupVersionResource).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(kialiCRs.Items) > 1 {
+			return nil, fmt.Errorf("Expecting only one Kiali CR but found %d", len(kialiCRs.Items))
+		}
+
+		kialiCR := kialiCRs.Items[0]
+		instance.Name = kialiCR.GetName()
+		instance.Namespace = kialiCR.GetNamespace()
+		instance.ResourceNamespace = instance.Namespace
+
+		// If the CR has a spec.deployment.namespace then all the kiali resources will be deployed
+		// in that namespace rather than the namespace of the CR.
+		if spec, ok := kialiCR.Object["spec"].(map[string]interface{}); ok {
+			if deployment, ok := spec["deployment"].(map[string]interface{}); ok {
+				if namespace, ok := deployment["namespace"].(string); ok {
+					instance.ResourceNamespace = namespace
+				}
+			}
+		}
+		log.Debugf("Found Kiali CR: [%s] in namespace: [%s]. All Kiali CR resources are in namespace: [%s].", instance.Name, instance.Namespace, instance.ResourceNamespace)
+	} else {
+		kialiDeployments, err := kubeClient.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: "app=kiali"})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(kialiDeployments.Items) > 1 {
+			return nil, fmt.Errorf("Expecting only one Kiali deployment but found %d", len(kialiDeployments.Items))
+		}
+
+		kialiDeployment := kialiDeployments.Items[0]
+		instance.Name = kialiDeployment.Name
+		instance.Namespace = kialiDeployment.Namespace
+		instance.ResourceNamespace = instance.Namespace
+
+		log.Debugf("Found Kiali deployment: [%s] in namespace: [%s]. All Kiali resources are in namespace: [%s].", instance.Name, instance.Namespace, instance.ResourceNamespace)
+	}
+
+	return instance, nil
+}
+
+// Instance is a single deployment of Kiali. It abstracts away the differences between
+// Kiali deployed with the operator and Kiali deployed with helm and provides an interface
+// for interacting with the Kiali instance for actions like updating the Kiali config.
+type Instance struct {
+	dynamicClient dynamic.Interface
+	kubeClient    kubernetes.Interface
+
+	// Name of the kiali instance. Either the name of the CR or the name of the deployment.
+	Name string
+
+	// Namespace of the kiali instance. Either the namespace of the CR or the namespace of the deployment.
+	Namespace string
+
+	// ResourceNamespace is the namespace where the Kiali resources are deployed aka spec.deployment.namespace.
+	ResourceNamespace string
+
+	useKialiCR bool
+}
+
+// GetConfig fetches the kiali configuration from the kiali configmap.
+func (in *Instance) GetConfig(ctx context.Context) (*config.Config, error) {
+	cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentConfig, err := config.Unmarshal(cm.Data["config.yaml"])
+	currentConfig.ExternalServices.Tracing.Enabled = true
+	if err != nil {
+		return nil, err
+	}
+
+	return currentConfig, nil
+}
+
+// UpdateConfig will update the Kiali instance with the new config. It will ensure
+// that the underlying configmap is actually updated before returning.
+func (in *Instance) UpdateConfig(ctx context.Context, conf *config.Config) error {
+	log.Debug("Updating Kiali config")
+	// Update the configmap directly by getting the configmap and patching it.
+	if in.useKialiCR {
+		// Before we patch the Kiali CR, get the current configmap so that later we can ensure the configmap is updated.
+		cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Fetch the Kiali CR and update the config on it.
+		// Update the Kiali CR
+		newConfig, err := config.Marshal(conf)
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("Diff between old config and new config: %s\n", cmp.Diff(cm.Data["config.yaml"], newConfig))
+
+		jsonConfig, err := yaml.ToJSON([]byte(newConfig))
+		if err != nil {
+			return err
+		}
+
+		mergePatch := []byte(fmt.Sprintf(`{"spec": %s}`, string(jsonConfig)))
+		_, err = in.dynamicClient.Resource(kialiGroupVersionResource).Namespace(in.Namespace).Patch(ctx, in.Name, types.MergePatchType, mergePatch, metav1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Need to know when the kiali operator has seen the CR change and finished updating
+		// the configmap. There's no ObservedGeneration on the Kiali CR so just checking the configmap itself.
+		timeout := 5 * time.Minute
+		pollInterval := 10 * time.Second
+
+		return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+			log.Debug("Waiting for kiali configmap to update")
+			currentConfigMap, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			return currentConfigMap.ResourceVersion != cm.ResourceVersion, nil
+		})
+	} else {
+		// Update the configmap directly. It's important to use yaml.Marshal because the config struct
+		// doesn't have json tags.
+		newConfig, err := config.Marshal(conf)
+		if err != nil {
+			return err
+		}
+
+		cm, err := in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Get(ctx, in.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("Diff between old config and new config: %s\n", cmp.Diff(cm.Data["config.yaml"], newConfig))
+
+		cm.Data["config.yaml"] = newConfig
+
+		_, err = in.kubeClient.CoreV1().ConfigMaps(in.ResourceNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func restartDeployment(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Update the pod template annotation to trigger a rolling restart
+		if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+			deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+		_, err = clientset.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+		return err
+	})
+
+	return retryErr
+}
+
+// Restart will recreate the Kiali pod and wait for it to be ready.
+func (in *Instance) Restart(ctx context.Context) error {
+	log.Debug("Restarting Kiali deployment")
+	if err := restartDeployment(ctx, in.kubeClient, in.ResourceNamespace, in.Name); err != nil {
+		return err
+	}
+
+	log.Debug("Waiting for Kiali deployment to be ready")
+	if err := kube.WaitForDeploymentReady(ctx, in.kubeClient, in.ResourceNamespace, in.Name); err != nil {
+		return err
+	}
+
+	log.Debug("Kiali is ready")
+
+	return nil
+}

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -303,6 +303,7 @@ func ServicesList(namespace string) (*ServiceListJson, error) {
 			return nil, err
 		}
 	} else {
+		log.Debugf("Error getting the services list: %s", err.Error())
 		return nil, err
 	}
 }

--- a/tests/integration/utils/kube/util.go
+++ b/tests/integration/utils/kube/util.go
@@ -1,0 +1,47 @@
+package kube
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiali/kiali/log"
+)
+
+// WaitForDeploymentReady waits for a deployment to be fully rolled out and ready.
+func WaitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) error {
+	timeout := 5 * time.Minute
+	pollInterval := 10 * time.Second
+
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			log.Debug("The deployment has not observed the latest spec update yet.")
+			return false, nil
+		}
+
+		if deployment.Status.Replicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be fully rolled out (%d/%d replicas)", deployment.Status.Replicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		if deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be updated (%d/%d replicas)", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+			log.Debugf("Waiting for deployment to be ready (%d/%d replicas)", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
+			return false, nil
+		}
+
+		return true, nil
+	})
+}


### PR DESCRIPTION
### Describe the change
- Update the way the Kiali CR is updated (Not working on IBM clusters) for no istiod tests
- Do proper cleanup 

### Steps to test the PR

`make test-integration -e URL=https://kiali-istio-system.apps.ppc64le-qe54c.psi.redhat.com -e TOKEN=sha256~2ULKI2rGCIaEg6P0_PD89VWzDaBx8TEUFiKUHsw0xrk -e 'GO_TEST_FLAGS=-run="TestNoIstiod"'`

### Automation testing

N/A

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
