### PR TITLE
Canary versions autodiscover

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
@@ -88,7 +89,7 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 
 	// Get migrated and pending namespaces
 	// TODO: Support multi-primary
-	migratedNss, err := in.homeClusterSAClient.GetNamespaces(fmt.Sprintf("istio.io/rev=%s", upgrade))
+	migratedNss, err := in.homeClusterSAClient.GetNamespaces(fmt.Sprintf("%s=%s", in.conf.IstioLabels.InjectionLabelRev, upgrade))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,9 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 		return nil, err
 	}
 	for _, ns := range pendingNss {
-		pendingNsList = append(pendingNsList, ns.Name)
+		if !slices.Contains(pendingNsList, ns.Name) {
+			pendingNsList = append(pendingNsList, ns.Name)
+		}
 	}
 
 	status := &models.CanaryUpgradeStatus{

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -59,7 +59,7 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 	upgrade := ""
 	current := ""
 
-	kubeCache, err := in.kialiCache.GetKubeCache(in.homeClusterSAClient.ClusterInfo().Name)
+	kubeCache, err := in.kialiCache.GetKubeCache(in.conf.KubernetesConfig.ClusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -3,13 +3,13 @@ package business
 import (
 	"fmt"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/models"
-
-	"golang.org/x/exp/maps"
 )
 
 const (

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/models"
+
 	"golang.org/x/exp/maps"
 )
 

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,114 +19,66 @@ import (
 func TestCanaryUpgradeNotConfigured(t *testing.T) {
 	check := assert.New(t)
 
-	k8s := new(kubetest.K8SClientMock)
 	conf := config.NewConfig()
-
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	kubernetes.SetConfig(t, *conf)
 	config.Set(conf)
 
-	k8s.On("IsOpenShift").Return(false)
-	k8s.On("IsGatewayAPI").Return(false)
-	k8s.On("ClusterInfo").Return(kubernetes.ClusterInfo{Name: conf.KubernetesConfig.ClusterName})
-	k8s.On("GetNamespaces", "istio-injection=enabled").Return([]core_v1.Namespace{}, nil)
-	k8s.On("GetNamespaces", "istio.io/rev=default").Return([]core_v1.Namespace{}, nil)
-	k8s.On("GetNamespaces", "istio.io/rev=canary").Return([]core_v1.Namespace{}, nil)
+	migratedNamespace := core_v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: "travel-agency", Labels: map[string]string{"istio.io/rev": "canary"}},
+	}
+
+	pendingNamespace := core_v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: "travel-portal", Labels: map[string]string{"istio-injection": "enabled"}},
+	}
 
 	// Create a MeshService and invoke IsMeshConfigured
-	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	layer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
-	meshSvc := layer.Mesh
+	k8sclients := map[string]kubernetes.ClientInterface{
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
+			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: conf.IstioNamespace}},
+			runningIstiodPod(),
+			&migratedNamespace,
+			&pendingNamespace,
+		),
+	}
+
+	cf := kubetest.NewFakeClientFactory(conf, k8sclients)
+	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
+	nsService := business.NewNamespaceService(k8sclients, k8sclients, cache, conf, discovery)
+	business.SetupBusinessLayer(t, k8sclients[conf.KubernetesConfig.ClusterName], *conf)
+	business.WithKialiCache(cache)
+	business.WithDiscovery(discovery)
+	meshSvc := business.NewMeshService(k8sclients, cache, nsService, conf, discovery)
 
 	canaryUpgradeStatus, err := meshSvc.CanaryUpgradeStatus()
 
 	check.Nil(err, "IstiodCanariesStatus failed: %s", err)
 	check.NotNil(canaryUpgradeStatus)
+	check.Equal(0, len(canaryUpgradeStatus.MigratedNamespaces))
+	check.Equal(0, len(canaryUpgradeStatus.PendingNamespaces))
 }
 
 // TestCanaryUpgradeConfigured verifies that when there is a canary upgrade in place, the migrated and pending namespaces should have namespaces
 func TestCanaryUpgradeConfigured(t *testing.T) {
 	check := assert.New(t)
 
-	k8s := new(kubetest.K8SClientMock)
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	kubernetes.SetConfig(t, *conf)
 	config.Set(conf)
 
-	k8s.On("IsOpenShift").Return(false)
-	k8s.On("IsGatewayAPI").Return(false)
-	k8s.On("IsIstioAPI").Return(true)
-	k8s.On("ClusterInfo").Return(kubernetes.ClusterInfo{Name: conf.KubernetesConfig.ClusterName})
-
 	migratedNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-agency"},
+		ObjectMeta: v1.ObjectMeta{Name: "travel-agency", Labels: map[string]string{"istio.io/rev": "canary"}},
 	}
-	migratedNamespaces := []core_v1.Namespace{migratedNamespace}
 
 	pendingNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-portal"},
+		ObjectMeta: v1.ObjectMeta{Name: "travel-portal", Labels: map[string]string{"istio-injection": "enabled"}},
 	}
-	pendingNamespaces := []core_v1.Namespace{pendingNamespace}
-
-	k8s.On("GetNamespaces", "istio-injection=enabled").Return(pendingNamespaces, nil)
-	k8s.On("GetNamespaces", "istio.io/rev=default").Return([]core_v1.Namespace{}, nil)
-	k8s.On("GetNamespaces", "istio.io/rev=canary").Return(migratedNamespaces, nil)
 
 	k8sclients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: conf.IstioNamespace}},
-			// Ideally we wouldn't need to set all this stuff up here but there's not a good way
-			// mock out the business.IstioStatus service since it's a struct.
-			&appsv1.Deployment{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "istiod",
-					Namespace: conf.IstioNamespace,
-					Labels: map[string]string{
-						"app":          "istiod",
-						"istio.io/rev": "default",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: core_v1.PodTemplateSpec{
-						ObjectMeta: v1.ObjectMeta{
-							Labels: map[string]string{"app": "istiod", "istio.io/rev": "default"},
-						},
-					},
-				},
-			},
-			&core_v1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "istio",
-					Namespace: conf.IstioNamespace,
-					Labels:    map[string]string{"istio.io/rev": "default"},
-				},
-				Data: map[string]string{"mesh": ""},
-			},
-			&appsv1.Deployment{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "istiod-canary",
-					Namespace: conf.IstioNamespace,
-					Labels: map[string]string{
-						"app":          "istiod",
-						"istio.io/rev": "canary",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: core_v1.PodTemplateSpec{
-						ObjectMeta: v1.ObjectMeta{
-							Labels: map[string]string{"app": "istiod", "istio.io/rev": "canary"},
-						},
-					},
-				},
-			},
-			&core_v1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "istio-canary",
-					Namespace: conf.IstioNamespace,
-					Labels:    map[string]string{"istio.io/rev": "canary"},
-				},
-				Data: map[string]string{"mesh": ""},
-			},
 			runningIstiodPod(),
 			runningIstiodCanaryPod(),
 			&migratedNamespace,
@@ -135,7 +86,6 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 		),
 	}
 
-	//k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	cf := kubetest.NewFakeClientFactory(conf, k8sclients)
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(k8sclients, cache, conf)

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -19,13 +22,12 @@ func TestCanaryUpgradeNotConfigured(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	conf := config.NewConfig()
-	conf.ExternalServices.Istio.IstioCanaryRevision.Current = "default"
-	conf.ExternalServices.Istio.IstioCanaryRevision.Upgrade = "canary"
 
 	config.Set(conf)
 
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("IsGatewayAPI").Return(false)
+	k8s.On("ClusterInfo").Return(kubernetes.ClusterInfo{Name: conf.KubernetesConfig.ClusterName})
 	k8s.On("GetNamespaces", "istio-injection=enabled").Return([]core_v1.Namespace{}, nil)
 	k8s.On("GetNamespaces", "istio.io/rev=default").Return([]core_v1.Namespace{}, nil)
 	k8s.On("GetNamespaces", "istio.io/rev=canary").Return([]core_v1.Namespace{}, nil)
@@ -48,13 +50,14 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 
 	k8s := new(kubetest.K8SClientMock)
 	conf := config.NewConfig()
-	conf.ExternalServices.Istio.IstioCanaryRevision.Current = "default"
-	conf.ExternalServices.Istio.IstioCanaryRevision.Upgrade = "canary"
-
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	kubernetes.SetConfig(t, *conf)
 	config.Set(conf)
 
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("IsGatewayAPI").Return(false)
+	k8s.On("IsIstioAPI").Return(true)
+	k8s.On("ClusterInfo").Return(kubernetes.ClusterInfo{Name: conf.KubernetesConfig.ClusterName})
 
 	migratedNamespace := core_v1.Namespace{
 		ObjectMeta: v1.ObjectMeta{Name: "travel-agency"},
@@ -70,11 +73,77 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	k8s.On("GetNamespaces", "istio.io/rev=default").Return([]core_v1.Namespace{}, nil)
 	k8s.On("GetNamespaces", "istio.io/rev=canary").Return(migratedNamespaces, nil)
 
-	// Create a MeshService and invoke IsMeshConfigured
-	k8sclients := make(map[string]kubernetes.ClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	layer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
-	meshSvc := layer.Mesh
+	k8sclients := map[string]kubernetes.ClientInterface{
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
+			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: conf.IstioNamespace}},
+			// Ideally we wouldn't need to set all this stuff up here but there's not a good way
+			// mock out the business.IstioStatus service since it's a struct.
+			&appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "istiod",
+					Namespace: conf.IstioNamespace,
+					Labels: map[string]string{
+						"app":          "istiod",
+						"istio.io/rev": "default",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: map[string]string{"app": "istiod", "istio.io/rev": "default"},
+						},
+					},
+				},
+			},
+			&core_v1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "istio",
+					Namespace: conf.IstioNamespace,
+					Labels:    map[string]string{"istio.io/rev": "default"},
+				},
+				Data: map[string]string{"mesh": ""},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "istiod-canary",
+					Namespace: conf.IstioNamespace,
+					Labels: map[string]string{
+						"app":          "istiod",
+						"istio.io/rev": "canary",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: map[string]string{"app": "istiod", "istio.io/rev": "canary"},
+						},
+					},
+				},
+			},
+			&core_v1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "istio-canary",
+					Namespace: conf.IstioNamespace,
+					Labels:    map[string]string{"istio.io/rev": "canary"},
+				},
+				Data: map[string]string{"mesh": ""},
+			},
+			runningIstiodPod(),
+			runningIstiodCanaryPod(),
+			&migratedNamespace,
+			&pendingNamespace,
+		),
+	}
+
+	//k8sclients[conf.KubernetesConfig.ClusterName] = k8s
+	cf := kubetest.NewFakeClientFactory(conf, k8sclients)
+	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := istio.NewDiscovery(k8sclients, cache, conf)
+	nsService := business.NewNamespaceService(k8sclients, k8sclients, cache, conf, discovery)
+	business.SetupBusinessLayer(t, k8sclients[conf.KubernetesConfig.ClusterName], *conf)
+	business.WithKialiCache(cache)
+	business.WithDiscovery(discovery)
+	meshSvc := business.NewMeshService(k8sclients, cache, nsService, conf, discovery)
 
 	canaryUpgradeStatus, err := meshSvc.CanaryUpgradeStatus()
 
@@ -83,4 +152,36 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	check.Equal(1, len(canaryUpgradeStatus.MigratedNamespaces))
 	check.Contains(canaryUpgradeStatus.PendingNamespaces, "travel-portal")
 	check.Equal(1, len(canaryUpgradeStatus.PendingNamespaces))
+}
+
+func runningIstiodPod() *core_v1.Pod {
+	return &core_v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod-123",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app":          "istiod",
+				"istio.io/rev": "default",
+			},
+		},
+		Status: core_v1.PodStatus{
+			Phase: core_v1.PodRunning,
+		},
+	}
+}
+
+func runningIstiodCanaryPod() *core_v1.Pod {
+	return &core_v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "istiod-456",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				"app":          "istiod",
+				"istio.io/rev": "canary",
+			},
+		},
+		Status: core_v1.PodStatus{
+			Phase: core_v1.PodRunning,
+		},
+	}
 }

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -55,8 +55,7 @@ func TestCanaryUpgradeNotConfigured(t *testing.T) {
 
 	check.Nil(err, "IstiodCanariesStatus failed: %s", err)
 	check.NotNil(canaryUpgradeStatus)
-	check.Equal(0, len(canaryUpgradeStatus.MigratedNamespaces))
-	check.Equal(0, len(canaryUpgradeStatus.PendingNamespaces))
+	check.Equal(0, len(canaryUpgradeStatus.NamespacesPerRevision))
 }
 
 // TestCanaryUpgradeConfigured verifies that when there is a canary upgrade in place, the migrated and pending namespaces should have namespaces
@@ -98,10 +97,10 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	canaryUpgradeStatus, err := meshSvc.CanaryUpgradeStatus()
 
 	check.Nil(err, "IstiodCanariesStatus failed: %s", err)
-	check.Contains(canaryUpgradeStatus.MigratedNamespaces, "travel-agency")
-	check.Equal(1, len(canaryUpgradeStatus.MigratedNamespaces))
-	check.Contains(canaryUpgradeStatus.PendingNamespaces, "travel-portal")
-	check.Equal(1, len(canaryUpgradeStatus.PendingNamespaces))
+	check.Contains(canaryUpgradeStatus.NamespacesPerRevision["canary"], "travel-agency")
+	check.Equal(1, len(canaryUpgradeStatus.NamespacesPerRevision["canary"]))
+	check.Contains(canaryUpgradeStatus.NamespacesPerRevision["default"], "travel-portal")
+	check.Equal(1, len(canaryUpgradeStatus.NamespacesPerRevision["default"]))
 }
 
 func runningIstiodPod() *core_v1.Pod {

--- a/config/config.go
+++ b/config/config.go
@@ -275,31 +275,25 @@ type RegistryConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	ComponentStatuses                 ComponentStatuses   `yaml:"component_status,omitempty"`
-	ConfigMapName                     string              `yaml:"config_map_name,omitempty"`
-	EgressGatewayNamespace            string              `yaml:"egress_gateway_namespace,omitempty"`
-	EnvoyAdminLocalPort               int                 `yaml:"envoy_admin_local_port,omitempty"`
-	GatewayAPIClasses                 []GatewayAPIClass   `yaml:"gateway_api_classes,omitempty"`
-	IngressGatewayNamespace           string              `yaml:"ingress_gateway_namespace,omitempty"`
-	IstioAPIEnabled                   bool                `yaml:"istio_api_enabled"`
-	IstioCanaryRevision               IstioCanaryRevision `yaml:"istio_canary_revision,omitempty"`
-	IstioIdentityDomain               string              `yaml:"istio_identity_domain,omitempty"`
-	IstioInjectionAnnotation          string              `yaml:"istio_injection_annotation,omitempty"`
-	IstioSidecarInjectorConfigMapName string              `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
-	IstioSidecarAnnotation            string              `yaml:"istio_sidecar_annotation,omitempty"`
-	IstiodDeploymentName              string              `yaml:"istiod_deployment_name,omitempty"`
-	IstiodPodMonitoringPort           int                 `yaml:"istiod_pod_monitoring_port,omitempty"`
+	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty"`
+	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
+	EgressGatewayNamespace            string            `yaml:"egress_gateway_namespace,omitempty"`
+	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
+	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
+	IngressGatewayNamespace           string            `yaml:"ingress_gateway_namespace,omitempty"`
+	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
+	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
+	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`
+	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
+	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty"`
+	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty"`
+	IstiodPodMonitoringPort           int               `yaml:"istiod_pod_monitoring_port,omitempty"`
 	// IstiodPollingIntervalSeconds is how often in seconds Kiali will poll istiod(s) for
 	// proxy status and registry services. Polling is not performed if IstioAPIEnabled is false.
 	IstiodPollingIntervalSeconds int             `yaml:"istiod_polling_interval_seconds,omitempty"`
 	Registry                     *RegistryConfig `yaml:"registry,omitempty"`
 	RootNamespace                string          `yaml:"root_namespace,omitempty"`
 	UrlServiceVersion            string          `yaml:"url_service_version"`
-}
-
-type IstioCanaryRevision struct {
-	Current string `yaml:"current,omitempty"`
-	Upgrade string `yaml:"upgrade,omitempty"`
 }
 
 type ComponentStatuses struct {

--- a/frontend/src/components/DebugInformation/DebugInformation.tsx
+++ b/frontend/src/components/DebugInformation/DebugInformation.tsx
@@ -63,7 +63,6 @@ const propsToShow = [
   'gatewayAPIClasses',
   'gatewayAPIEnabled',
   'istioAnnotationsAction',
-  'istioCanaryRevision',
   'istioConfigMap',
   'istioIdentityDomain',
   'istioInjectionAction',

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -75,10 +75,6 @@ const defaultServerConfig: ComputedServerConfig = {
     ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: 'sidecar.istio.io/inject'
   },
-  istioCanaryRevision: {
-    current: '',
-    upgrade: ''
-  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
@@ -203,10 +203,7 @@ export class TargetPanelControlPlane extends React.Component<
 
   private hasCanaryUpgradeConfigured = (): boolean => {
     if (this.state.canaryUpgradeStatus) {
-      if (
-        this.state.canaryUpgradeStatus.pendingNamespaces.length > 0 ||
-        this.state.canaryUpgradeStatus.migratedNamespaces.length > 0
-      ) {
+      if (Object.keys(this.state.canaryUpgradeStatus.namespacesPerRevision).length > 1) {
         return true;
       }
     }
@@ -272,10 +269,7 @@ export class TargetPanelControlPlane extends React.Component<
       .then(response => {
         this.setState({
           canaryUpgradeStatus: {
-            currentVersion: response.data.currentVersion,
-            upgradeVersion: response.data.upgradeVersion,
-            migratedNamespaces: response.data.migratedNamespaces,
-            pendingNamespaces: response.data.pendingNamespaces
+            namespacesPerRevision: response.data.namespacesPerRevision
           }
         });
       })

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
@@ -17,7 +17,6 @@ import { DirectionType } from 'pages/Overview/OverviewToolbar';
 import { ControlPlaneNamespaceStatus } from 'pages/Overview/ControlPlaneNamespaceStatus';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import { TLSInfo } from 'components/Overview/TLSInfo';
-import { CanaryUpgradeProgress } from 'pages/Overview/CanaryUpgradeProgress';
 import { OverviewCardControlPlaneNamespace } from 'pages/Overview/OverviewCardControlPlaneNamespace';
 import * as API from '../../../services/Api';
 import { IstioMetricsOptions } from 'types/MetricsOptions';
@@ -164,13 +163,6 @@ export class TargetPanelControlPlane extends React.Component<
 
           {!isRemoteCluster(nsInfo.annotations) && (
             <>
-              {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
-                <>
-                  {targetPanelHR}
-                  <CanaryUpgradeProgress canaryUpgradeStatus={this.state.canaryUpgradeStatus} />
-                </>
-              )}
-
               {this.props.istioAPIEnabled && (
                 <>
                   {targetPanelHR}
@@ -199,16 +191,6 @@ export class TargetPanelControlPlane extends React.Component<
         </div>
       </div>
     );
-  };
-
-  private hasCanaryUpgradeConfigured = (): boolean => {
-    if (this.state.canaryUpgradeStatus) {
-      if (Object.keys(this.state.canaryUpgradeStatus.namespacesPerRevision).length > 1) {
-        return true;
-      }
-    }
-
-    return false;
   };
 
   private load = (): void => {

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -431,8 +431,8 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
       if (
         serverConfig.kialiFeatureFlags.istioUpgradeAction &&
-        serverConfig.istioCanaryRevision.upgrade &&
-        serverConfig.istioCanaryRevision.current
+        this.state.canaryUpgradeStatus?.upgradeVersion &&
+        this.state.canaryUpgradeStatus.currentVersion
       ) {
         namespaceActions.push({
           isGroup: false,
@@ -442,7 +442,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
         const upgradeAction = {
           isGroup: false,
           isSeparator: false,
-          title: `Upgrade to ${serverConfig.istioCanaryRevision.upgrade} revision`,
+          title: `Upgrade to ${this.state.canaryUpgradeStatus.upgradeVersion} revision`,
           action: (ns: string) => console.log(`TODO: Upgrade revision [${ns}]`)
           /*
             this.setState({
@@ -458,7 +458,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
         const downgradeAction = {
           isGroup: false,
           isSeparator: false,
-          title: `Downgrade to ${serverConfig.istioCanaryRevision.current} revision`,
+          title: `Downgrade to ${this.state.canaryUpgradeStatus.currentVersion} revision`,
           action: (ns: string) => console.log(`TODO: Downgrade revision [${ns}]`)
           /*
             this.setState({
@@ -474,7 +474,8 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
         if (
           nsInfo.labels &&
           ((nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] &&
-            nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] === serverConfig.istioCanaryRevision.current) ||
+            nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] ===
+              this.state.canaryUpgradeStatus?.currentVersion) ||
             (nsInfo.labels[serverConfig.istioLabels.injectionLabelName] &&
               nsInfo.labels[serverConfig.istioLabels.injectionLabelName] === 'enabled'))
         ) {
@@ -482,7 +483,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
         } else if (
           nsInfo.labels &&
           nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] &&
-          nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] === serverConfig.istioCanaryRevision.upgrade
+          nsInfo.labels[serverConfig.istioLabels.injectionLabelRev] === this.state.canaryUpgradeStatus?.upgradeVersion
         ) {
           namespaceActions.push(downgradeAction);
         }

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -293,7 +293,6 @@ export class OverviewTrafficPolicies extends React.Component<OverviewTrafficPoli
   };
 
   render(): React.ReactNode {
-    console.log(this.props.opTarget);
     const canaryVersion = this.props.kind === 'canary' ? this.getCanaryUpgradeVersion(this.props.opTarget) : '';
 
     const modalAction =

--- a/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
+++ b/frontend/src/pages/Overview/OverviewTrafficPolicies.tsx
@@ -293,10 +293,13 @@ export class OverviewTrafficPolicies extends React.Component<OverviewTrafficPoli
   };
 
   render(): React.ReactNode {
+    console.log(this.props.opTarget);
     const canaryVersion = this.props.kind === 'canary' ? this.getCanaryUpgradeVersion(this.props.opTarget) : '';
 
     const modalAction =
-      this.props.opTarget.length > 0
+      this.props.kind === 'canary'
+        ? 'Switch'
+        : this.props.opTarget.length > 0
         ? `${this.props.opTarget.charAt(0).toLocaleUpperCase()}${this.props.opTarget.slice(1)}`
         : '';
 
@@ -360,8 +363,8 @@ export class OverviewTrafficPolicies extends React.Component<OverviewTrafficPoli
             </>
           ) : this.props.kind === 'canary' ? (
             <>
-              You're going to {this.state.selectedRevision} revision in the namespace {this.props.nsTarget}. Are you
-              sure?
+              You're going to switch to {this.state.selectedRevision} revision in the namespace {this.props.nsTarget}.
+              Are you sure?
             </>
           ) : (
             <>

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -165,10 +165,6 @@ export const serverRateConfig = {
     ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: ''
   },
-  istioCanaryRevision: {
-    current: '',
-    upgrade: ''
-  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1418,10 +1418,7 @@ export interface APIKey {
 }
 
 export interface CanaryUpgradeStatus {
-  currentVersion: string;
-  migratedNamespaces: string[];
-  pendingNamespaces: string[];
-  upgradeVersion: string;
+  namespacesPerRevision: { [key: string]: string[] };
 }
 
 export const MAX_PORT = 65535;

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -110,11 +110,6 @@ export interface KialiCrippledFeatures {
   responseTimePercentiles: boolean;
 }
 
-interface IstioCanaryRevision {
-  current: string;
-  upgrade: string;
-}
-
 /*
  Health Config
 */
@@ -155,7 +150,6 @@ export interface ServerConfig {
   healthConfig: HealthConfig;
   installationTag?: string;
   istioAnnotations: IstioAnnotations;
-  istioCanaryRevision: IstioCanaryRevision;
   istioIdentityDomain: string;
   istioLabels: { [key in IstioLabelKey]: string };
   istioNamespace: string;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -85,10 +85,6 @@ export const healthConfig = {
     ambientAnnotationEnabled: 'enabled',
     istioInjectionAnnotation: ''
   },
-  istioCanaryRevision: {
-    current: '',
-    upgrade: ''
-  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -27,11 +27,6 @@ type IstioAnnotations struct {
 	IstioInjectionAnnotation string `json:"istioInjectionAnnotation,omitempty"`
 }
 
-type IstioCanaryRevision struct {
-	Current string `json:"current,omitempty"`
-	Upgrade string `json:"upgrade,omitempty"`
-}
-
 // PrometheusConfig holds actual Prometheus configuration that is useful to Kiali.
 // All durations are in seconds.
 type PrometheusConfig struct {
@@ -56,7 +51,6 @@ type PublicConfig struct {
 	HealthConfig         config.HealthConfig           `json:"healthConfig,omitempty"`
 	InstallationTag      string                        `json:"installationTag,omitempty"`
 	IstioAnnotations     IstioAnnotations              `json:"istioAnnotations,omitempty"`
-	IstioCanaryRevision  IstioCanaryRevision           `json:"istioCanaryRevision,omitempty"`
 	IstioConfigMap       string                        `json:"istioConfigMap"`
 	IstioIdentityDomain  string                        `json:"istioIdentityDomain,omitempty"`
 	IstioLabels          config.IstioLabels            `json:"istioLabels,omitempty"`
@@ -95,12 +89,8 @@ func Config(conf *config.Config, discovery *istio.Discovery) http.HandlerFunc {
 			IstioNamespace:      conf.IstioNamespace,
 			IstioLabels:         conf.IstioLabels,
 			IstioConfigMap:      conf.ExternalServices.Istio.ConfigMapName,
-			IstioCanaryRevision: IstioCanaryRevision{
-				Current: conf.ExternalServices.Istio.IstioCanaryRevision.Current,
-				Upgrade: conf.ExternalServices.Istio.IstioCanaryRevision.Upgrade,
-			},
-			KialiFeatureFlags: conf.KialiFeatureFlags,
-			LogLevel:          log.GetLogLevel(),
+			KialiFeatureFlags:   conf.KialiFeatureFlags,
+			LogLevel:            log.GetLogLevel(),
 			Prometheus: PrometheusConfig{
 				GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 				StorageTsdbRetention: promConfig.StorageTsdbRetention,

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -36,8 +36,6 @@ const (
 const (
 	// DefaultRevisionLabel is the value for the default revision.
 	DefaultRevisionLabel = "default"
-	// CanaryRevisionLabel is the value for the canary revision.
-	CanaryRevisionLabel = "canary"
 	// IstioInjectionLabel is the value for the istio injection label on a namespace.
 	IstioInjectionLabel = "istio-injection"
 )

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -36,6 +36,8 @@ const (
 const (
 	// DefaultRevisionLabel is the value for the default revision.
 	DefaultRevisionLabel = "default"
+	// CanaryRevisionLabel is the value for the canary revision.
+	CanaryRevisionLabel = "canary"
 	// IstioInjectionLabel is the value for the istio injection label on a namespace.
 	IstioInjectionLabel = "istio-injection"
 )

--- a/istio/kubernetes.go
+++ b/istio/kubernetes.go
@@ -6,12 +6,12 @@ package istio
 // level kubernetes package.
 
 import (
+	"golang.org/x/exp/maps"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes/cache"
-
-	"golang.org/x/exp/maps"
 )
 
 func GetHealthyIstiodPods(kubeCache cache.KubeCache, revision string, namespace string) ([]*corev1.Pod, error) {

--- a/istio/kubernetes.go
+++ b/istio/kubernetes.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/kubernetes/cache"
+
 	"golang.org/x/exp/maps"
 )
 

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -238,10 +238,6 @@
             "EgressGatewayNamespace": "",
             "IngressGatewayNamespace": "",
             "IstioAPIEnabled": true,
-            "IstioCanaryRevision": {
-              "Current": "",
-              "Upgrade": ""
-            },
             "IstioIdentityDomain": "svc.cluster.local",
             "IstioInjectionAnnotation": "sidecar.istio.io/inject",
             "IstioSidecarInjectorConfigMapName": "",

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -143,6 +143,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 		dataplaneMap := make(map[clusterRevisionKey][]models.Namespace)
 		cpNamespaces := namespaces
 		if isCanary && canaryStatus.NamespacesPerRevision[cp.Revision] != nil {
+			cpNamespaces = []models.Namespace{}
 			for _, ns := range canaryStatus.NamespacesPerRevision[cp.Revision] {
 				cpNamespaces = append(cpNamespaces, getNamespacesByName(ns, namespaces)...)
 			}
@@ -163,7 +164,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 				dataplaneMap[key] = append(clusterNamespaces, ns)
 			}
 		}
-		for clusterrev, namespaces := range dataplaneMap {
+		for clusterrev, dPNss := range dataplaneMap {
 			// sort namespaces by cluster,name. This is more for test data consistency than anything else, but it doesn't hurt
 			slices.SortFunc(namespaces, func(a, b models.Namespace) int {
 				clusterComp := cmp.Compare(a.Cluster, b.Cluster)
@@ -176,7 +177,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 			isDataPlaneCanary := isCanary && canaryStatus.NamespacesPerRevision[cp.Revision] != nil
 
 			// Note that version here is not the actual istio version, but the revision of the control plane that is managing this dataplane.
-			dp, _, err := addInfra(meshMap, mesh.InfraTypeDataPlane, clusterrev.Cluster, "", "Data Plane", namespaces, cp.Revision, false, "", isDataPlaneCanary)
+			dp, _, err := addInfra(meshMap, mesh.InfraTypeDataPlane, clusterrev.Cluster, "", "Data Plane", dPNss, cp.Revision, false, "", isDataPlaneCanary)
 			graph.CheckError(err)
 
 			istiod.AddEdge(dp)

--- a/models/istio_canaries.go
+++ b/models/istio_canaries.go
@@ -2,8 +2,5 @@ package models
 
 // CanaryUpgradeStatus contains the namespaces that are part of the canary and the namespaces that are still using the current revision
 type CanaryUpgradeStatus struct {
-	CurrentVersion     string   `json:"currentVersion"`
-	UpgradeVersion     string   `json:"upgradeVersion"`
-	MigratedNamespaces []string `json:"migratedNamespaces"`
-	PendingNamespaces  []string `json:"pendingNamespaces"`
+	NamespacesPerRevision map[string][]string `json:"namespacesPerRevision"`
 }


### PR DESCRIPTION
### Describe the change

Removed `ExternalServices.Istio.IstioCanaryRevision` configuration usage, now Kiali checks if there are Istiod pods with  `istio.io/rev=canary` and `istio.io/rev=default` labels.

### Steps to test the PR

Install Istio default.
Install Istio 1.22.2.
Install bookinfo.
Install Istio 1.22.3.
In Kiali UI you should be able to canary upgrade downgrade your data plane namespaces.
In Mesh page, the piechart is removed for dataplane.
In Mesh page, the piechart is changed to support multiple revisions.

![Screenshot from 2024-08-08 11-39-12](https://github.com/user-attachments/assets/05e86ac2-75e2-4263-859a-6d07a8fa1a2e)
![Screenshot from 2024-08-08 11-39-25](https://github.com/user-attachments/assets/6d0f8b45-27c5-45da-ae7e-e32e2d6b26b4)
![Screenshot from 2024-08-08 11-41-00](https://github.com/user-attachments/assets/d30ec06e-d370-409e-8482-8c36e8b8aa99)
![Screenshot from 2024-08-13 12-43-36](https://github.com/user-attachments/assets/644eb3ed-edce-4e8f-beb7-a1cf6c637015)
![Screenshot from 2024-08-13 12-43-17](https://github.com/user-attachments/assets/ee27a1fb-e2aa-4880-841f-ea58a156e980)



### Automation testing

Unit tests are modified to support listing istiod pods.

### Issue reference

https://github.com/kiali/kiali/issues/7515
