### PR TITLE
Add CSRF token to OSSMC non-GET request header

### DIFF
--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -3,7 +3,7 @@ import { config } from '../config';
 import { LoginSession } from '../store/Store';
 import { App, AppQuery } from '../types/App';
 import { AppList, AppListQuery } from '../types/AppList';
-import { AuthInfo } from '../types/Auth';
+import { AuthInfo, getCSRFToken } from '../types/Auth';
 import { DurationInSeconds, HTTP_VERBS, Password, TimeInSeconds, UserName } from '../types/Common';
 import { DashboardModel } from 'types/Dashboards';
 import { GrafanaInfo } from '../types/GrafanaInfo';
@@ -65,6 +65,7 @@ import {
 } from '../types/Workload';
 import { CertsInfo } from 'types/CertsInfo';
 import { ApiError, ApiResponse } from 'types/Api';
+
 export const ANONYMOUS_USER = 'anonymous';
 
 interface ClusterParam {
@@ -104,10 +105,17 @@ const loginHeaders = config.login.headers;
 
 /**  Helpers to Requests */
 
-const getHeaders = (urlEncoded?: boolean): Partial<AxiosHeaders> => {
+const getHeaders = (method: HTTP_VERBS, urlEncoded: boolean): Partial<AxiosHeaders> => {
   if (apiProxy) {
     // apiProxy is used by OSSMC, which doesn't need Kiali login headers (and can cause CORS issues)
-    return { 'Content-Type': 'application/x-www-form-urlencoded' };
+    const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+
+    // X-CSRFToken is used only for non-GET requests
+    if (method !== HTTP_VERBS.GET) {
+      headers['X-CSRFToken'] = getCSRFToken();
+    }
+
+    return headers;
   } else if (urlEncoded) {
     return { 'Content-Type': 'application/x-www-form-urlencoded', ...loginHeaders };
   } else {
@@ -132,7 +140,7 @@ const newRequest = <P>(
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
     data: requestData,
-    headers: getHeaders() as AxiosHeaders,
+    headers: getHeaders(method, false) as AxiosHeaders,
     params: queryParams
   });
 };
@@ -148,10 +156,12 @@ export const login = async (
   const params = new URLSearchParams();
   params.append('token', request.token);
 
+  const method = HTTP_VERBS.POST;
+
   const axiosRequest = {
-    method: HTTP_VERBS.POST,
+    method: method,
     url: apiProxy ? `${apiProxy}/${urls.authenticate}` : urls.authenticate,
-    headers: getHeaders(true) as AxiosHeaders,
+    headers: getHeaders(method, true) as AxiosHeaders,
     data: params
   };
 

--- a/frontend/src/types/Auth.ts
+++ b/frontend/src/types/Auth.ts
@@ -39,3 +39,18 @@ export interface SessionInfo {
   expiresOn?: string;
   username?: string;
 }
+
+export const getCSRFToken = (): string | undefined => {
+  const cookiePrefix = 'csrf-token=';
+
+  return (
+    document &&
+    document.cookie &&
+    document.cookie
+      .split(';')
+      .map(c => c.trim())
+      .filter(c => c.startsWith(cookiePrefix))
+      .map(c => c.slice(cookiePrefix.length))
+      .pop()
+  );
+};


### PR DESCRIPTION
### Describe the change

The OpenShift console blocks any non-GET request that does not contain CSRF token in the request header. For this reason OSSMC has to add CSRF token in the non-GET request header to avoid a `403 Forbidden` response.

### Steps to test the PR

**Kiali**: This PR does not affect Kiali

**OSSMC**:
1. Execute `./hack/crc-openshift.sh start` to launch an OpenShift cluster
2. Install Istio via `./hack/istio/install-istio-via-istioctl.sh` and bookinfo demo `./hack/istio/install-bookinfo-demo.sh -tg -c oc`
3. cd to the kiali/kiali local repo and run this to prepare the image registry: `make cluster-status`
4. Look at the output of that make command to find the login command to the image registry and run that (it will be something like `podman login --tls-verify=false -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing`)
5. cd to OSSMC local repo (`main` branch), and execute `./hack/copy-frontend-src-to-ossmc.sh -pr 7568` to copy this PR into OSSMC code:
6. run `make cluster-push` to build and push the new plugin image to the cluster
7. cd back to kiali/kiali local repo and run this to install dev builds of everything (server, operator, and ossmc): `make build build-ui cluster-push operator-create kiali-create ossmconsole-create`
8. Go to the console via browser: `xdg-open https://console-openshift-console.apps-crc.testing/dashboards`
9. Go to the Service Mesh -> Overview page
10. Click on the options menu of any namespace and select `Enable injection` option, or perform any action that create/update any Istio object.
11. Verify that OSSMC is able to update the namespace/istio object.

### Automation testing

N/A

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/330
