### PR TITLE
Always return service account clients when rbac disabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -968,6 +968,11 @@ func (conf *Config) GatewayLabel(labelConfig string) []string {
 	return []string{}
 }
 
+func (conf *Config) RBACDisabled() bool {
+	return conf.Auth.Strategy == AuthStrategyAnonymous ||
+		(conf.Auth.Strategy == AuthStrategyOpenId && conf.Auth.OpenId.DisableRBAC)
+}
+
 // Get the global Config
 func Get() (conf *Config) {
 	rwMutex.RLock()

--- a/config/config.go
+++ b/config/config.go
@@ -968,7 +968,7 @@ func (conf *Config) GatewayLabel(labelConfig string) []string {
 	return []string{}
 }
 
-func (conf *Config) RBACDisabled() bool {
+func (conf *Config) IsRBACDisabled() bool {
 	return conf.Auth.Strategy == AuthStrategyAnonymous ||
 		(conf.Auth.Strategy == AuthStrategyOpenId && conf.Auth.OpenId.DisableRBAC)
 }

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -26,8 +26,10 @@ const (
 	waypointExpirationTime     = 1 * time.Minute
 )
 
-const kialiCacheMeshKey = "mesh"
-const ztunnelApp = "ztunnel"
+const (
+	kialiCacheMeshKey = "mesh"
+	ztunnelApp        = "ztunnel"
+)
 
 // KialiCache stores both kube objects and non-kube related data such as pods' proxy status.
 // It is exclusively used by the business layer where it's expected to be a singleton.
@@ -305,6 +307,10 @@ func (c *kialiCacheImpl) IsWaypointListExpired() bool {
 type namespacesKey struct {
 	cluster string
 	token   string
+}
+
+func (n namespacesKey) String() string {
+	return fmt.Sprintf("cluster: %s\ttoken: xxx", n.cluster)
 }
 
 func (c *kialiCacheImpl) GetNamespace(cluster string, token string, namespace string) (models.Namespace, bool) {

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -276,7 +276,7 @@ func (cf *clientFactory) GetSAClients() map[string]ClientInterface {
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClient(authInfo *api.AuthInfo, cluster string) (ClientInterface, error) {
-	if cf.kialiConfig.RBACDisabled() {
+	if cf.kialiConfig.IsRBACDisabled() {
 		return cf.GetSAClient(cluster), nil
 	}
 
@@ -285,7 +285,7 @@ func (cf *clientFactory) GetClient(authInfo *api.AuthInfo, cluster string) (Clie
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClients(authInfos map[string]*api.AuthInfo) (map[string]ClientInterface, error) {
-	if cf.kialiConfig.RBACDisabled() {
+	if cf.kialiConfig.IsRBACDisabled() {
 		return cf.GetSAClients(), nil
 	}
 

--- a/kubernetes/testing.go
+++ b/kubernetes/testing.go
@@ -56,7 +56,7 @@ func NewTestingClientFactory(t *testing.T) *clientFactory {
 	}
 
 	clientConfig := rest.Config{}
-	client, err := newClientFactory(&clientConfig)
+	client, err := newClientFactory(config.Get(), &clientConfig)
 	if err != nil {
 		t.Fatalf("Error creating client factory: %v", err)
 	}

--- a/store/expiration_store.go
+++ b/store/expiration_store.go
@@ -90,7 +90,7 @@ func (s *ExpirationStore[K, V]) checkAndRemoveExpiredKeys(ctx context.Context) <
 					}
 
 					if time.Now().After(expiration) {
-						log.Tracef("Key %v expired. Removing from store", key)
+						log.Tracef("Key '%v' expired. Removing from store", key)
 						s.Remove(key)
 					}
 				}


### PR DESCRIPTION
### Describe the change

When the auth strategy is `anonymous` or `openid` with rbac disabled, Kiali uses its own service account client to talk to the kube API. This commit ensures for these auth strategies that the client factory will always use the service account client rather than creating a new client with the kiali service account token.

### Steps to test the PR

### Automation testing

Unit tests created.

### Issue reference

Fixes #7542 