### PR TITLE
[v1.73] Fix missing sidecars in some demo applications

### DIFF
--- a/hack/istio/functions.sh
+++ b/hack/istio/functions.sh
@@ -32,6 +32,7 @@ EOM
   fi
 
   if [ "${ENABLE_INJECTION}" == "true" ] || [ "${AUTO_INJECTION}" == "true" ]; then
+    ${CLIENT_EXE} wait pods -n ${ns} --for condition=Ready --timeout=60s --all
     for d in $(${CLIENT_EXE} get deployments -n ${ns} -o name)
     do
       echo "Enabling sidecar injection for deployment: ${d}"

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -179,9 +179,10 @@ EOF
     ${CLIENT_EXE} patch VirtualService bookinfo -n bookinfo --type json -p "[{\"op\": \"replace\", \"path\": \"/spec/hosts/0\", \"value\": \"${ISTIO_INGRESS_HOST}\"}]"
   fi
 
-  for namespace in bookinfo alpha beta gamma
+  for namespace in bookinfo alpha beta gamma sleep
   do
     wait_for_workloads "${namespace}"
+    ${CLIENT_EXE} get pods -n "${namespace}"
   done
 
 else


### PR DESCRIPTION
### Describe the change

Sometimes (on some platforms), not every demo application has a sidecar which causes test failures. 
I suspect that the install script starts patching deployment CRs with sidecar annotation, however, the deployments are not ready yet, or, starts restarting the pods before the annotation is there ( so no sidecar after the restart ).

- So the script must wait until all pods are ready in the namespace (without sidecars) before enabling sidecar infections.
- Added also get all pods after the script is done to identify this type of issue in the future from the log.

Backport is not needed since this is only maistra-related (which is removed in the next branches).