### PR TITLE
Added WithTransform for Pods and Services.

### DIFF
--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -446,7 +446,7 @@ func (c *kubeCache) createKubernetesInformers(namespace string) informers.Shared
 	opts = append(
 		opts,
 		informers.WithTransform(func(obj interface{}) (interface{}, error) {
-			StripUnusedFields(obj)
+			obj, _ = StripUnusedFields(obj)
 
 			switch obj := obj.(type) {
 			case *core_v1.Pod:


### PR DESCRIPTION
### Describe the change

Retrieving Pods and Services comes with a lot of additional info which is not used in Kiali.
Added WithTransform to trim those objects and return only used fields.
Removed deprecated 'fetchWorkloads' method and replaced by 'fetchWorkloadsFromCluster'.

### Steps to test the PR

Full Regression test, including health checks of Workloads, Services.

### Automation testing

n/a, existing tests should pass.

Running Kiali perf tests does show only slightly improvements.

### Issue reference

https://github.com/kiali/kiali/issues/7017
