### PR TITLE
accessible namespaces to discovery selectors refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ OPERATOR_INSTALL_KIALI_CR_NAMESPACE ?= ${OPERATOR_WATCH_NAMESPACE}
 endif
 
 # When installing Kiali to a remote cluster via make, here are some configuration settings for it.
-ACCESSIBLE_NAMESPACES ?= **
+CLUSTER_WIDE_ACCESS ?= true
 ifneq ($(CLUSTER_TYPE),openshift)
 AUTH_STRATEGY ?= anonymous
 else

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -7,7 +7,6 @@ import (
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	core_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -31,7 +30,7 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	config.Set(conf)
 	// Auxiliar fake* tests defined in workload_test.go
 	objects := []runtime.Object{
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
+		kubetest.FakeNamespace("Namespace"),
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
 	for _, obj := range FakeDeployments(*conf) {

--- a/business/controlplane_monitor_test.go
+++ b/business/controlplane_monitor_test.go
@@ -165,7 +165,7 @@ func TestRefreshIstioCache(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(
 		runningIstiodPod(),
 		fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true),
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istioConfigMap,
 	)
 	// RefreshIstioCache relies on this being set.
@@ -238,7 +238,7 @@ func TestPollingPopulatesCache(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(
 		runningIstiodPod(),
 		fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true),
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istioConfigMap,
 	)
 	// RefreshIstioCache relies on this being set.

--- a/business/discovery_selectors.go
+++ b/business/discovery_selectors.go
@@ -1,0 +1,97 @@
+package business
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/models"
+)
+
+// getDiscoverySelectorsForCluster will return the discovery selectors applicable for the named cluster.
+// If the cluster has overrides defined in the Kiali config, those overrides will be returned.
+// If there are no overrides, but default discovery selectors are defined in the Kiali config, those will be returned.
+// If there are no selectors defined in the Kiali config, nil is returned (Istio's own discovery selectors will be ignored).
+// kialiConfig argument may be nil - if so, they are ignored and nil is returned.
+func getDiscoverySelectorsForCluster(cluster string, kialiConfig *config.Config) config.DiscoverySelectorsType {
+	ds := getKialiDiscoverySelectors(cluster, kialiConfig)
+	return ds
+}
+
+// getKialiDiscoverySelectors will return the discovery selectors applicable for the named cluster as configured
+// in the Kiali config (this func does nothing with Istio discovery selectors - it is only concerned with the Kiali config).
+// If the cluster has overrides defined in the Kiali config, those overrides will be returned.
+// If there are no overrides, but default discovery selectors are defined in the Kiali config, those will be returned.
+// If there are no selectors defined in the Kiali config, nil is returned.
+// If selectors are defined, this function will always return one more than what was configured - this extra selector
+// will select the control plane namespace as defined in the Kiali config in order to assure Kiali will always match
+// the control plane namespace (Kiali should always see that namespace).
+// NOTE: You probably don't want to use this func; instead, see getDiscoverySelectorsForCluster()
+func getKialiDiscoverySelectors(cluster string, cfg *config.Config) config.DiscoverySelectorsType {
+
+	if cfg == nil {
+		return nil
+	}
+
+	cpNamespaceSelector := config.DiscoverySelectorsType{
+		&config.DiscoverySelectorType{
+			MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": cfg.IstioNamespace,
+			},
+		},
+	}
+
+	dsConfig := cfg.Deployment.DiscoverySelectors
+
+	// if the cluster has its own overrides, we use those
+	dsOverrides := dsConfig.Overrides
+	if dsOverrides != nil {
+		if dsCluster, ok := dsOverrides[cluster]; ok {
+			return append(cpNamespaceSelector, dsCluster...)
+		}
+	}
+
+	// there are no overrides for the given cluster, see if we have defaults that we can fallback to
+	dsDefault := dsConfig.Default
+	if dsDefault != nil {
+		return append(cpNamespaceSelector, dsDefault...)
+	}
+
+	// there are no discovery selectors configured within the Kiali config; return nil to indicate this
+	return nil
+}
+
+// filterNamespacesWithDiscoverySelectors will look at the given list of namespaces and return a list
+// containing only those namespaces that match the given discovery selectors. If there are no discoverySelectors,
+// then the full list of namespaces is returned as-is.
+func filterNamespacesWithDiscoverySelectors(namespaces []models.Namespace, discoverySelectors config.DiscoverySelectorsType) []models.Namespace {
+
+	if len(namespaces) == 0 || len(discoverySelectors) == 0 {
+		return namespaces
+	}
+
+	// convert LabelSelectors to Selectors
+	selectors := make([]labels.Selector, 0)
+	for _, selector := range discoverySelectors {
+		ls, err := meta_v1.LabelSelectorAsSelector((*meta_v1.LabelSelector)(selector))
+		if err != nil {
+			log.Errorf("skipping invalid discovery selector: %v", err)
+		} else {
+			selectors = append(selectors, ls)
+		}
+	}
+
+	// range over all namespaces and keep only those that match; notice each selector result is ORed (as per Istio convention)
+	matchedNamespaces := make([]models.Namespace, 0)
+	for _, ns := range namespaces {
+		for _, selector := range selectors {
+			if selector.Matches(labels.Set(ns.Labels)) {
+				matchedNamespaces = append(matchedNamespaces, ns)
+				break
+			}
+		}
+	}
+
+	return matchedNamespaces
+}

--- a/business/discovery_selectors_test.go
+++ b/business/discovery_selectors_test.go
@@ -1,0 +1,319 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+)
+
+func TestGetKialiDiscoverySelectors(t *testing.T) {
+	assert.Nil(t, getKialiDiscoverySelectors("a", nil))
+
+	// config with no selectors defined
+	cfgNoSelectors := config.Config{
+		Deployment: config.DeploymentConfig{
+			DiscoverySelectors: config.DiscoverySelectorsConfig{
+				Default:   nil,
+				Overrides: nil,
+			},
+		},
+	}
+	// config with only default selectors that match things with either (a) label1 and label1a or (b) label2
+	cfgDefaultSelectors := config.Config{
+		Deployment: config.DeploymentConfig{
+			DiscoverySelectors: config.DiscoverySelectorsConfig{
+				Default: config.DiscoverySelectorsType{
+					&config.DiscoverySelectorType{
+						MatchLabels: map[string]string{"label1": "labelValue1"},
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "label1a",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"labelValue1a"},
+							},
+						},
+					},
+					&config.DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "label2",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"labelValue2"},
+							},
+						},
+					},
+				},
+				Overrides: nil,
+			},
+		},
+	}
+	// config with only "cluster1" override selectors that match things with either (a) label3 or (b) label4
+	cfgOverrideSelectors := config.Config{
+		Deployment: config.DeploymentConfig{
+			DiscoverySelectors: config.DiscoverySelectorsConfig{
+				Default: nil,
+				Overrides: map[string]config.DiscoverySelectorsType{
+					"cluster1": {
+						&config.DiscoverySelectorType{
+							MatchLabels: map[string]string{"label3": "labelValue3"},
+						},
+						&config.DiscoverySelectorType{
+							MatchExpressions: []meta_v1.LabelSelectorRequirement{
+								{
+									Key:      "label4",
+									Operator: meta_v1.LabelSelectorOpIn,
+									Values:   []string{"labelValue4"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// config with default selectors that match things with either (a) label1 and label1a or (b) label2
+	// and with "cluster1" override selectors that match things with either (a) label3 or (b) label4
+	cfgDefaultAndOverrideSelectors := config.Config{
+		Deployment: config.DeploymentConfig{
+			DiscoverySelectors: config.DiscoverySelectorsConfig{
+				Default: config.DiscoverySelectorsType{
+					&config.DiscoverySelectorType{
+						MatchLabels: map[string]string{"label1": "labelValue1"},
+					},
+					&config.DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "label2",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"labelValue2"},
+							},
+						},
+					},
+				},
+				Overrides: map[string]config.DiscoverySelectorsType{
+					"cluster1": {
+						&config.DiscoverySelectorType{
+							MatchLabels: map[string]string{"label3": "labelValue3"},
+						},
+						&config.DiscoverySelectorType{
+							MatchExpressions: []meta_v1.LabelSelectorRequirement{
+								{
+									Key:      "label4",
+									Operator: meta_v1.LabelSelectorOpIn,
+									Values:   []string{"labelValue4"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// namespaces we are going to test with
+	fooNamespace := models.Namespace{
+		Name: "foo",
+	}
+	oneNamespace := models.Namespace{
+		Name:   "one",
+		Labels: map[string]string{"label1": "labelValue1", "label1a": "labelValue1a"},
+	}
+	twoNamespace := models.Namespace{
+		Name:   "two",
+		Labels: map[string]string{"label2": "labelValue2"},
+	}
+	threeNamespace := models.Namespace{
+		Name:   "three",
+		Labels: map[string]string{"label3": "labelValue3"},
+	}
+	fourNamespace := models.Namespace{
+		Name:   "four",
+		Labels: map[string]string{"label4": "labelValue4"},
+	}
+
+	cases := map[string]struct {
+		config            config.Config
+		clusterName       string
+		allNamespaces     []models.Namespace
+		matchedNamespaces []models.Namespace
+	}{
+		"no selectors - no namespaces": {
+			config:            cfgNoSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     nil,
+			matchedNamespaces: nil,
+		},
+		"default selectors - no namespaces": {
+			config:            cfgDefaultSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     nil,
+			matchedNamespaces: nil,
+		},
+		"override selectors - no namespaces": {
+			config:            cfgOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     nil,
+			matchedNamespaces: nil,
+		},
+		"default/override selectors - no namespaces": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     nil,
+			matchedNamespaces: nil,
+		},
+		"no selectors - all namespaces": {
+			config:            cfgNoSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+			matchedNamespaces: []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+		},
+		"default selectors - all namespaces": {
+			config:            cfgDefaultSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+			matchedNamespaces: []models.Namespace{oneNamespace, twoNamespace},
+		},
+		"override selectors - all namespaces - unknown cluster (there are no default selectors, so everything is getting selected)": {
+			config:            cfgOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+			matchedNamespaces: []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+		},
+		"default/override selectors - all namespaces - unknown cluster (so defaults take effect)": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+			matchedNamespaces: []models.Namespace{oneNamespace, twoNamespace},
+		},
+		"default/override selectors - all namespaces - cluster1 cluster (so overrides take effect)": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "cluster1",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace, twoNamespace, threeNamespace, fourNamespace},
+			matchedNamespaces: []models.Namespace{threeNamespace, fourNamespace},
+		},
+		"default/override selectors - only foo namespace - unknown cluster (foo doesn't match anything)": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace},
+			matchedNamespaces: []models.Namespace{},
+		},
+		"default/override selectors - only foo namespace - cluster1 cluster (foo doesn't match anything)": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "cluster1",
+			allNamespaces:     []models.Namespace{fooNamespace},
+			matchedNamespaces: []models.Namespace{},
+		},
+		"default selectors - foo and one namespaces": {
+			config:            cfgDefaultSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace},
+			matchedNamespaces: []models.Namespace{oneNamespace},
+		},
+		"override selectors - foo and one namespaces (there are no defaults and since unknown doesn't have overrides, no selectors means match everything)": {
+			config:            cfgOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, oneNamespace},
+			matchedNamespaces: []models.Namespace{fooNamespace, oneNamespace},
+		},
+		"override selectors - foo and three namespaces": {
+			config:            cfgOverrideSelectors,
+			clusterName:       "cluster1",
+			allNamespaces:     []models.Namespace{fooNamespace, threeNamespace},
+			matchedNamespaces: []models.Namespace{threeNamespace},
+		},
+		"default/override selectors - foo and three namespaces - unknown cluster (neither matches)": {
+			config:            cfgDefaultAndOverrideSelectors,
+			clusterName:       "unknown",
+			allNamespaces:     []models.Namespace{fooNamespace, threeNamespace},
+			matchedNamespaces: []models.Namespace{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// make sure our config can marshal and unmarshal the config
+			yaml, err := config.Marshal(&tc.config)
+			assert.Nil(err)
+			config, err := config.Unmarshal(yaml)
+			assert.Nil(err)
+
+			selectors := getKialiDiscoverySelectors(tc.clusterName, config)
+			filteredNamespaces := filterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
+			assert.Equal(tc.matchedNamespaces, filteredNamespaces)
+		})
+	}
+}
+
+func TestGetDiscoverySelectorsForCluster(t *testing.T) {
+	assert.Nil(t, getDiscoverySelectorsForCluster("cluster1", nil))
+
+	// config with only "cluster1" override selectors
+	overrideSelectors := config.Config{
+		IstioNamespace: "istio-system",
+		Deployment: config.DeploymentConfig{
+			DiscoverySelectors: config.DiscoverySelectorsConfig{
+				Default: nil,
+				Overrides: map[string]config.DiscoverySelectorsType{
+					"cluster1": {
+						&config.DiscoverySelectorType{
+							MatchLabels: map[string]string{"label2": "labelValue2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// namespaces we are going to test with
+	fooNamespace := models.Namespace{
+		Name: "foo",
+	}
+	istioNamespace := models.Namespace{
+		Name:   "istio-system",
+		Labels: map[string]string{"kubernetes.io/metadata.name": "istio-system"},
+	}
+	oneNamespace := models.Namespace{
+		Name:   "one",
+		Labels: map[string]string{"label1": "labelValue1"},
+	}
+	twoNamespace := models.Namespace{
+		Name:   "two",
+		Labels: map[string]string{"label2": "labelValue2"},
+	}
+
+	cases := map[string]struct {
+		clusterName       string
+		config            config.Config
+		allNamespaces     []models.Namespace
+		matchedNamespaces []models.Namespace
+	}{
+		"override discovery selectors - cluster has overrides so use the overrides": {
+			clusterName:       "cluster1",
+			config:            overrideSelectors,
+			allNamespaces:     []models.Namespace{fooNamespace, istioNamespace, oneNamespace, twoNamespace},
+			matchedNamespaces: []models.Namespace{istioNamespace, twoNamespace},
+		},
+		"override discovery selectors - cluster does NOT have overrides": {
+			clusterName:       "unknown-cluster",
+			config:            overrideSelectors,
+			allNamespaces:     []models.Namespace{fooNamespace, istioNamespace, oneNamespace, twoNamespace},
+			matchedNamespaces: []models.Namespace{fooNamespace, istioNamespace, oneNamespace, twoNamespace},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			selectors := getDiscoverySelectorsForCluster(tc.clusterName, &tc.config)
+			filteredNamespaces := filterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
+			assert.Equal(tc.matchedNamespaces, filteredNamespaces)
+		})
+	}
+}

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -334,11 +334,11 @@ func TestGetNamespaceServicesHealthMultiCluster(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial"}},
 		),
 	}
@@ -372,12 +372,12 @@ func TestGetNamespaceApplicationsHealthMultiCluster(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial"}},
 			&core_v1.Pod{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial", Labels: map[string]string{"app": "httpbin", "version": "v1"}, Annotations: kubetest.FakeIstioAnnotations()}, Status: core_v1.PodStatus{Phase: core_v1.PodRunning}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial"}},
 			&core_v1.Pod{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial", Labels: map[string]string{"app": "httpbin", "version": "v1"}, Annotations: kubetest.FakeIstioAnnotations()}, Status: core_v1.PodStatus{Phase: core_v1.PodRunning}},
 		),
@@ -413,11 +413,11 @@ func TestGetNamespaceWorkloadsHealthMultiCluster(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Pod{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial", Labels: map[string]string{"app": "httpbin", "version": "v1"}, Annotations: kubetest.FakeIstioAnnotations()}, Status: core_v1.PodStatus{Phase: core_v1.PodRunning}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+			kubetest.FakeNamespace("tutorial"),
 			&core_v1.Pod{ObjectMeta: meta_v1.ObjectMeta{Name: "httpbin", Namespace: "tutorial", Labels: map[string]string{"app": "httpbin", "version": "v1"}, Annotations: kubetest.FakeIstioAnnotations()}, Status: core_v1.PodStatus{Phase: core_v1.PodRunning}},
 		),
 	}

--- a/business/istio_certs_test.go
+++ b/business/istio_certs_test.go
@@ -68,7 +68,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 		},
 	}
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		secret,
 	)
 
@@ -128,7 +128,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 		},
 	}
 	k8s := &forbiddenSecretClient{kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		secret,
 	)}
 
@@ -185,7 +185,7 @@ cdLzuNyDoeWOHU7mx52TuTwj3eObtQM+hlI=
 	}
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		secret,
 	)
 
@@ -326,7 +326,7 @@ iMXzPzS/OeYyKQ==
 	}
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&example1secret,
 		&example2secret,
 	)
@@ -414,7 +414,7 @@ iMXzPzS/OeYyKQ==
 	}
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&example1secret,
 	)
 

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -102,7 +102,7 @@ func TestGatewayValidationScopesToNamespaceWhenGatewayToNamespaceSet(t *testing.
 		Data: map[string]string{"mesh": ""},
 	}
 	injectorConfigMap := &core_v1.ConfigMap{ObjectMeta: meta_v1.ObjectMeta{Name: istioSidecarInjectorConfigMapName, Namespace: "istio-system"}}
-	istioSystemNamespace := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}}
+	istioSystemNamespace := kubetest.FakeNamespace("istio-system")
 
 	istiod_1_19_0 := &apps_v1.Deployment{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -466,7 +466,7 @@ func mockMultiNamespaceGatewaysValidationService(t *testing.T, cfg config.Config
 func mockCombinedValidationService(t *testing.T, istioConfigList *models.IstioConfigList, services []string) IstioValidationsService {
 	fakeIstioObjects := []runtime.Object{
 		&core_v1.ConfigMap{ObjectMeta: meta_v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "wrong"}},
+		kubetest.FakeNamespace("wrong"),
 	}
 	for _, p := range fakeMeshPolicies() {
 		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
@@ -610,16 +610,8 @@ func fakePolicies() []*security_v1.PeerAuthentication {
 
 func fakeNamespaces() []core_v1.Namespace {
 	return []core_v1.Namespace{
-		{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "test",
-			},
-		},
-		{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "test2",
-			},
-		},
+		*kubetest.FakeNamespace("test"),
+		*kubetest.FakeNamespace("test2"),
 	}
 }
 

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -24,13 +24,8 @@ func TestCanaryUpgradeNotConfigured(t *testing.T) {
 	kubernetes.SetConfig(t, *conf)
 	config.Set(conf)
 
-	migratedNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-agency", Labels: map[string]string{"istio.io/rev": "canary"}},
-	}
-
-	pendingNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-portal", Labels: map[string]string{"istio-injection": "enabled"}},
-	}
+	migratedNamespace := *kubetest.FakeNamespaceWithLabels("travel-agency", map[string]string{"istio.io/rev": "canary"})
+	pendingNamespace := *kubetest.FakeNamespaceWithLabels("travel-portal", map[string]string{"istio-injection": "enabled"})
 
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := map[string]kubernetes.ClientInterface{
@@ -67,17 +62,12 @@ func TestCanaryUpgradeConfigured(t *testing.T) {
 	kubernetes.SetConfig(t, *conf)
 	config.Set(conf)
 
-	migratedNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-agency", Labels: map[string]string{"istio.io/rev": "canary"}},
-	}
-
-	pendingNamespace := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "travel-portal", Labels: map[string]string{"istio-injection": "enabled"}},
-	}
+	migratedNamespace := *kubetest.FakeNamespaceWithLabels("travel-agency", map[string]string{"istio.io/rev": "canary"})
+	pendingNamespace := *kubetest.FakeNamespaceWithLabels("travel-portal", map[string]string{"istio-injection": "enabled"})
 
 	k8sclients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: conf.IstioNamespace}},
+			kubetest.FakeNamespace(conf.IstioNamespace),
 			runningIstiodPod(),
 			runningIstiodCanaryPod(),
 			&migratedNamespace,

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -3,15 +3,10 @@ package business
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 	"sync"
 
-	osproject_v1 "github.com/openshift/api/project/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -23,14 +18,13 @@ import (
 
 // NamespaceService deals with fetching k8sClients namespaces / OpenShift projects and convert to kiali model
 type NamespaceService struct {
-	conf                   *config.Config
-	discovery              meshDiscovery
-	hasProjects            bool
-	homeClusterUserClient  kubernetes.ClientInterface
-	isAccessibleNamespaces map[string]bool
-	kialiCache             cache.KialiCache
-	kialiSAClients         map[string]kubernetes.ClientInterface
-	userClients            map[string]kubernetes.ClientInterface
+	conf                  *config.Config
+	discovery             meshDiscovery
+	hasProjects           bool
+	homeClusterUserClient kubernetes.ClientInterface
+	kialiCache            cache.KialiCache
+	kialiSAClients        map[string]kubernetes.ClientInterface
+	userClients           map[string]kubernetes.ClientInterface
 }
 
 type AccessibleNamespaceError struct {
@@ -62,21 +56,14 @@ func NewNamespaceService(
 		hasProjects = false
 	}
 
-	ans := conf.Deployment.AccessibleNamespaces
-	isAccessibleNamespaces := make(map[string]bool, len(ans))
-	for _, ns := range ans {
-		isAccessibleNamespaces[ns] = true
-	}
-
 	return NamespaceService{
-		conf:                   conf,
-		discovery:              discovery,
-		hasProjects:            hasProjects,
-		homeClusterUserClient:  userClients[homeClusterName],
-		isAccessibleNamespaces: isAccessibleNamespaces,
-		kialiCache:             cache,
-		kialiSAClients:         kialiSAClients,
-		userClients:            userClients,
+		conf:                  conf,
+		discovery:             discovery,
+		hasProjects:           hasProjects,
+		homeClusterUserClient: userClients[homeClusterName],
+		kialiCache:            cache,
+		kialiSAClients:        kialiSAClients,
+		userClients:           userClients,
 	}
 }
 
@@ -87,29 +74,6 @@ func (in *NamespaceService) GetClusterList() []string {
 		clusterList = append(clusterList, cluster)
 	}
 	return clusterList
-}
-
-// Swallows all errors.
-func (in *NamespaceService) getDiscoverySelectors(ctx context.Context) []*meta_v1.LabelSelector {
-	mesh, err := in.discovery.Mesh(ctx)
-	if err != nil {
-		log.Errorf("Will not process discoverySelectors due to a failure to get mesh controlplane information: %v", err)
-		return nil
-	}
-
-	// Add all the discovery selectors together for all control planes.
-	var discoverySelectors []*meta_v1.LabelSelector
-	for _, controlPlane := range mesh.ControlPlanes {
-		discoverySelectors = append(discoverySelectors, controlPlane.Config.DiscoverySelectors...)
-	}
-
-	if len(discoverySelectors) > 0 {
-		log.Tracef("Istio discovery selectors: %+v", discoverySelectors)
-	} else {
-		log.Tracef("No Istio discovery selectors defined.")
-	}
-
-	return discoverySelectors
 }
 
 // Returns a list of the given namespaces / projects
@@ -129,6 +93,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 		if !found {
 			clustersToCheck[cluster] = client
 		} else {
+			// namespaces should already be filtered by discovery selectors, no need to do it here
 			namespaces = append(namespaces, cachedNamespaces...)
 		}
 	}
@@ -136,60 +101,6 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	// Cache hit for all namespaces.
 	if len(clustersToCheck) == 0 {
 		return namespaces, nil
-	}
-
-	discoverySelectors := in.getDiscoverySelectors(ctx)
-	// Need to do per revision discovery selectors.
-
-	// Let's explain the four different filters along with accessible namespaces (aka AN).
-	//
-	// First, we look at AN. AN is either ["**"] or it is not.
-	//
-	// If AN is ["**"], then the entire cluster of namespaces is accessible to Kiali.
-	// In this case, the user can further filter what namespaces this function should return using both includes and excludes.
-	// 1. LabelSelectorInclude is used to obtain an initial set of namespaces, if specified.
-	// 2. Added to that initial list will be the namespaces named in the Include list, if those namespaces actually exist.
-	// 3. If no LabelSelectorInclude or Include list is specified, then all namespaces are in the list.
-	// 4. Remove from that list those namespaces that match LabelSelectorExclude, as well as those namespaces found in the Exclude list.
-	// (Side note: You might ask: Why have an Include list when we already have the AN list?
-	// The difference is if you specify AN (not ["**"]), only those namespaces that exist __at install time__ will get a Role
-	// and hence are accessible to Kiali. The Include list is evaluated at the time this function is called, thus it
-	// allows Kiali to see those namespaces even if they are created after Kiali is installed).
-	//
-	// If AN is not ["**"], then only a subset of namespaces in the cluster is accessible to Kiali.
-	// When installed by the operator, Kiali will be given access to a set of namespaces (as defined in AN) via Roles that
-	// are created by the operator. Those namespaces that Kiali has access to (as defined in AN) will be labeled with the label
-	// selector defined in LabelSelectorInclude (Kiali CR "spec.api.namespaces.label_selector_include").
-	// 1. All of those namespaces are retrieved with the LabelSelectorInclude to obtain a set of namespaces.
-	// 2. Remove from that list those namespaces that match LabelSelectorExclude, as well as those namespaces found in the Exclude list.
-	// The Include option is ignored in this case - you cannot Include more namespaces over and above what AN specifies.
-	// (Side note 1: It probably doesn't make sense to set LabelSelectorExclude and Excludes when AN is not ["**"]. This is because
-	// you already have defined what namespaces you want to give Kiali access to (the AN list itself). However, for consistency,
-	// this function will still use those additional filters to filter out namespaces. So it is possible this function returns
-	// a subset of namespaces that are listed in AN.)
-	// (Side note 2: Notice the difference here between when AN is set to ["**"] and when it is not. When AN is not set to ["**"],
-	// LabelSelectorInclude does not tell the operator which namespaces are included - AN does that. Instead, the operator will
-	// create that label as defined by LabelSelectorInclude on each namespace defined in AN. Thus, after the operator installs
-	// Kiali, the Kiali Server can then use LabelSelectorInclude in this function in order to select all namespaces as defined in AN.
-	// If installed via the server helm chart, none of that is done, and it is up to the user to ensure
-	// LabelSelectorInclude (if defined) selects all namespaces in AN. It is a user-error if they do not configure that correctly.
-	// The server helm chart will not assume they did it correctly. The user therefore normally should not set LabelSelectorInclude
-	// if they also set AN to something not ["**"]. This is one reason why we recommend using the Kiali operator, and why we say
-	// the server helm chart is only provided as a convenience.)
-	// (Side note 3: The control plane namespace is always included via api.namespaces.include and
-	// never excluded via api.namespaces.exclude or api.namespaces.label_selector_exclude.)
-
-	// determine if we are to exclude namespaces by label - if so, set the label name and value for use later
-	labelSelectorExclude := in.conf.API.Namespaces.LabelSelectorExclude
-	var labelSelectorExcludeName string
-	var labelSelectorExcludeValue string
-	if labelSelectorExclude != "" {
-		excludeLabelList := strings.Split(labelSelectorExclude, "=")
-		if len(excludeLabelList) != 2 {
-			return nil, fmt.Errorf("api.namespaces.label_selector_exclude is invalid: %v", labelSelectorExclude)
-		}
-		labelSelectorExcludeName = excludeLabelList[0]
-		labelSelectorExcludeValue = excludeLabelList[1]
 	}
 
 	wg := &sync.WaitGroup{}
@@ -210,6 +121,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 				if error != nil {
 					resultsCh <- result{cluster: c, ns: nil, err: error}
 				} else {
+					// getNamespacesByCluster filters namespaces using discovery selectors; we don't have to do it here
 					resultsCh <- result{cluster: c, ns: list, err: nil}
 				}
 			}(cluster)
@@ -232,140 +144,40 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 		namespaces = append(namespaces, resultCh.ns...)
 	}
 
-	resultns := namespaces
-
-	// Filter out those namespaces that do not match discoverySelectors.
-	// Follow the semantics that Istio follows, which is:
-	//   If there is no discoverySelectors section in the config, skip this entirely.
-	//   If there is an empty discoverySelectors section, that means all namespaces are to be used.
-	//   If there are one or more discoverySelectors specified, the filter namespaces based on what they select.
-	if len(discoverySelectors) > 0 {
-		// 1. convert LabelSelectors to Selectors
-		selectors := make([]labels.Selector, 0)
-		for _, selector := range discoverySelectors {
-			ls, err := meta_v1.LabelSelectorAsSelector(selector)
-			if err != nil {
-				return nil, fmt.Errorf("error initializing discovery selectors filter, invalid discovery selector: %v", err)
-			}
-			selectors = append(selectors, ls)
-		}
-
-		// 2. range over all namespaces to get discovery namespaces, notice each selector result is ORed (as per Istio convention)
-		selectedNamespaces := make([]models.Namespace, 0)
-		for _, ns := range resultns {
-			if ns.Name == in.conf.IstioNamespace {
-				selectedNamespaces = append(selectedNamespaces, ns) // we always want to return the control plane namespace
-			} else {
-				for _, selector := range selectors {
-					if selector.Matches(labels.Set(ns.Labels)) {
-						selectedNamespaces = append(selectedNamespaces, ns)
-						break
-					}
-				}
-			}
-		}
-		namespaces = selectedNamespaces
-		resultns = namespaces
-	}
-
-	// exclude namespaces that are:
-	// 1. to be filtered out via the exclude list
-	// 2. to be filtered out via the label selector
-	// Note that the control plane namespace is never excluded
-	excludes := in.conf.API.Namespaces.Exclude
-	if len(excludes) > 0 || labelSelectorExclude != "" {
-		resultns = []models.Namespace{}
-	NAMESPACES:
-		for _, namespace := range namespaces {
-			if namespace.Name != in.conf.IstioNamespace {
-				if len(excludes) > 0 {
-					for _, excludePattern := range excludes {
-						if match, _ := regexp.MatchString(excludePattern, namespace.Name); match {
-							continue NAMESPACES
-						}
-					}
-				}
-				if labelSelectorExclude != "" {
-					if namespace.Labels[labelSelectorExcludeName] == labelSelectorExcludeValue {
-						continue NAMESPACES
-					}
-				}
-			}
-			resultns = append(resultns, namespace)
-		}
-	}
-
 	// store only the filtered set of namespaces in cache for the token
 	namespacesPerCluster := make(map[string][]models.Namespace)
-	for _, ns := range resultns {
+	for _, ns := range namespaces {
 		namespacesPerCluster[ns.Cluster] = append(namespacesPerCluster[ns.Cluster], ns)
 	}
 	for cluster, ns := range namespacesPerCluster {
 		in.kialiCache.SetNamespaces(in.userClients[cluster].GetToken(), ns)
 	}
 
-	return resultns, nil
+	return namespaces, nil
 }
 
+// getNamespacesByCluster returns the namespaces for the given cluster. The namespaces are filtered such
+// that only those namespaces that match discovery selectors are returned.
 func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster string) ([]models.Namespace, error) {
-	configObject := in.conf
-
-	labelSelectorInclude := configObject.API.Namespaces.LabelSelectorInclude
 
 	var namespaces []models.Namespace
-	_, queryAllNamespaces := in.isAccessibleNamespaces["**"]
+
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
 	if in.hasProjects {
-		projects, err := in.userClients[cluster].GetProjects(ctx, labelSelectorInclude)
+		projects, err := in.userClients[cluster].GetProjects(ctx, "")
 		if err != nil {
 			return nil, err
 		}
-		if queryAllNamespaces {
-			namespaces = models.CastProjectCollection(projects, cluster)
-			// add the namespaces explicitly included in the include list.
-			includes := configObject.API.Namespaces.Include
-			if len(includes) > 0 {
-				var allNamespaces []models.Namespace
-				var seedNamespaces []models.Namespace
-
-				if labelSelectorInclude == "" {
-					// we have already retrieved all the namespaces, but we want only those in the Include list
-					allNamespaces = namespaces
-					seedNamespaces = make([]models.Namespace, 0)
-				} else {
-					// we have already got those namespaces that match the LabelSelectorInclude - that is our seed list.
-					// but we need ALL namespaces so we can look for more that match the Include list.
-					allProjectList, err := in.userClients[cluster].GetProjects(ctx, "")
-					if err != nil {
-						return nil, err
-					}
-
-					allNamespaces = models.CastProjectCollection(allProjectList, cluster)
-					seedNamespaces = namespaces
-				}
-				namespaces = in.addIncludedNamespaces(allNamespaces, seedNamespaces)
-			}
-		} else {
-			filteredProjects := make([]osproject_v1.Project, 0)
-			for _, project := range projects {
-				if _, isAccessible := in.isAccessibleNamespaces[project.Name]; isAccessible {
-					filteredProjects = append(filteredProjects, project)
-				}
-			}
-			namespaces = models.CastProjectCollection(filteredProjects, cluster)
-		}
+		namespaces = models.CastProjectCollection(projects, cluster)
 	} else {
-		// if the accessible namespaces define a distinct list of namespaces, use only those.
-		// If accessible namespaces include the special "**" (meaning all namespaces) ask k8sClients for them.
-		// Note that "**" requires cluster role permission to list all namespaces.
-		accessibleNamespaces := configObject.Deployment.AccessibleNamespaces
-		if queryAllNamespaces {
+		// Note that cluster-wide-access mode requires cluster role permission to list all namespaces.
+		if in.conf.Deployment.ClusterWideAccess {
 
-			nss, err := in.userClients[cluster].GetNamespaces(labelSelectorInclude)
+			nss, err := in.userClients[cluster].GetNamespaces("")
 			if err != nil {
 				// Fallback to using the Kiali service account, if needed
 				if errors.IsForbidden(err) {
-					if nss, err = in.getNamespacesUsingKialiSA(cluster, labelSelectorInclude, err); err != nil {
+					if nss, err = in.getNamespacesUsingKialiSA(cluster, "", err); err != nil {
 						return nil, err
 					}
 				} else {
@@ -374,37 +186,13 @@ func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster 
 			}
 
 			namespaces = models.CastNamespaceCollection(nss, cluster)
-
-			// add the namespaces explicitly included in the includes list.
-			includes := configObject.API.Namespaces.Include
-			if len(includes) > 0 {
-				var allNamespaces []models.Namespace
-				var seedNamespaces []models.Namespace
-
-				if labelSelectorInclude == "" {
-					// we have already retrieved all the namespaces, but we want only those in the Include list
-					allNamespaces = namespaces
-					seedNamespaces = make([]models.Namespace, 0)
-				} else {
-					// we have already got those namespaces that match the LabelSelectorInclude - that is our seed list.
-					// but we need ALL namespaces so we can look for more that match the Include list.
-					allK8sNamespaces, errGetNs := in.userClients[cluster].GetNamespaces("")
-					if errGetNs != nil {
-						// Fallback to using the Kiali service account, if needed
-						if errors.IsForbidden(errGetNs) {
-							if allK8sNamespaces, errGetNs = in.getNamespacesUsingKialiSA(cluster, "", errGetNs); errGetNs != nil {
-								return nil, errGetNs
-							}
-						} else {
-							return nil, errGetNs
-						}
-					}
-					allNamespaces = models.CastNamespaceCollection(allK8sNamespaces, cluster)
-					seedNamespaces = namespaces
-				}
-				namespaces = in.addIncludedNamespaces(allNamespaces, seedNamespaces)
-			}
 		} else {
+			// We do not have cluster wide access, so we do not have permission to list namespaces.
+			// Therefore, we assume we can extract the list of accessible namespaces from the discovery selectors configuration.
+			// That list of accessible namespaces will be used as our base list which we then filter with discovery selectors down below.
+			// Note if this is a remote cluster, that remote cluster must have the same namespaces as those in our own local
+			// cluster's accessible namespaces. This is one reason why we suggest enabling CWA for multi-cluster environments.
+			accessibleNamespaces := in.conf.Deployment.AccessibleNamespaces
 			k8sNamespaces := make([]core_v1.Namespace, 0)
 			for _, ans := range accessibleNamespaces {
 				k8sNs, err := in.userClients[cluster].GetNamespace(ans)
@@ -427,6 +215,8 @@ func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster 
 		}
 	}
 
+	namespaces = filterNamespacesWithDiscoverySelectors(namespaces, getDiscoverySelectorsForCluster(cluster, in.conf))
+
 	return namespaces, nil
 }
 
@@ -445,103 +235,6 @@ func (in *NamespaceService) GetClusterNamespaces(ctx context.Context, cluster st
 	}
 
 	return clusterNamespaces, nil
-}
-
-// addIncludedNamespaces will look at all the namespaces and return all of them that match the Include list.
-// The returned results will be guaranteed to include the namespaces found in the given seed list.
-// There will be no duplicate namespaces in the returned list.
-func (in *NamespaceService) addIncludedNamespaces(all []models.Namespace, seed []models.Namespace) []models.Namespace {
-	var controlPlaneNamespace models.Namespace
-	hasNamespace := make(map[string]bool, len(seed))
-	results := make([]models.Namespace, 0, len(seed))
-	configObject := in.conf
-
-	// seed with the initial set of namespaces - this ensures there are no duplicates in the seed list
-	for _, ns := range seed {
-		if _, exists := hasNamespace[ns.Name]; !exists {
-			hasNamespace[ns.Name] = true
-			results = append(results, ns)
-		}
-	}
-
-	// go through the list of all namespaces and add to the results list those that match a regex found in the Include list
-	includes := configObject.API.Namespaces.Include
-NAMESPACES:
-	for _, ns := range all {
-		if _, exists := hasNamespace[ns.Name]; exists {
-			continue
-		}
-		for _, includePattern := range includes {
-			if match, _ := regexp.MatchString(includePattern, ns.Name); match {
-				hasNamespace[ns.Name] = true
-				results = append(results, ns)
-				continue NAMESPACES
-			}
-		}
-		if ns.Name == configObject.IstioNamespace {
-			controlPlaneNamespace = ns // squirrel away the control plane namepace in case we need to add it
-		}
-	}
-
-	// Kiali needs the control plane namespace, so it should always be included.
-	// If the user did not configure the include list to explicitly include the control plane namespace, then we need to include it now.
-	if _, exists := hasNamespace[configObject.IstioNamespace]; !exists {
-		if controlPlaneNamespace.Name != "" {
-			results = append(results, controlPlaneNamespace)
-		} else {
-			log.Errorf("Kiali needs to include the control plane namespace. Make sure you configured Kiali so it can access and include the namespace [%s].", configObject.IstioNamespace)
-		}
-	}
-	return results
-}
-
-func (in *NamespaceService) isAccessibleNamespace(namespace string) bool {
-	_, queryAllNamespaces := in.isAccessibleNamespaces["**"]
-	if queryAllNamespaces {
-		return true
-	}
-	_, isAccessible := in.isAccessibleNamespaces[namespace]
-	return isAccessible
-}
-
-func (in *NamespaceService) isExcludedNamespace(namespace string) bool {
-	configObject := in.conf
-	excludes := configObject.API.Namespaces.Exclude
-	if len(excludes) == 0 {
-		return false
-	}
-	if namespace == configObject.IstioNamespace {
-		return false // the control plane namespace is never excluded
-	}
-	for _, excludePattern := range excludes {
-		if match, _ := regexp.MatchString(excludePattern, namespace); match {
-			return true
-		}
-	}
-	return false
-}
-
-func (in *NamespaceService) isIncludedNamespace(namespace string) bool {
-	_, queryAllNamespaces := in.isAccessibleNamespaces["**"]
-	if !queryAllNamespaces {
-		return true // Include list is ignored if accessible namespaces is not **; for our purposes, when ignored we assume the Include list includes all.
-	}
-
-	configObject := in.conf
-	if namespace == configObject.IstioNamespace {
-		return true // the control plane namespace is always included
-	}
-
-	includes := configObject.API.Namespaces.Include
-	if len(includes) == 0 {
-		return true // if no Include list is specified, all namespaces are included
-	}
-	for _, includePattern := range includes {
-		if match, _ := regexp.MatchString(includePattern, namespace); match {
-			return true
-		}
-	}
-	return false
 }
 
 // GetNamespaceClusters is a convenience routine that filters GetNamespaces for a particular namespace
@@ -576,21 +269,13 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 		return nil, fmt.Errorf("cluster [%s] is not found or is not accessible for Kiali", cluster)
 	}
 
-	// Cache already has included/excluded namespaces applied
+	// Cache already has discovery selectors applied
 	if ns, found := in.kialiCache.GetNamespace(cluster, client.GetToken(), namespace); found {
 		return &ns, nil
 	}
 
-	if !in.isAccessibleNamespace(namespace) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] is not accessible for Kiali"}
-	}
-
-	if !in.isIncludedNamespace(namespace) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] is not included for Kiali"}
-	}
-
-	if in.isExcludedNamespace(namespace) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] is excluded for Kiali"}
+	if !in.isAccessibleNamespace(models.Namespace{Name: namespace, Cluster: cluster}) {
+		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
 	}
 
 	var result models.Namespace
@@ -684,4 +369,13 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 
 	// Return the list of namespaces where the user has the 'get namespace' read privilege.
 	return namespaces, nil
+}
+
+// isAccessibleNamespace will look at the discovery selectors and see if the namespace is allowed to be accessed.
+// This ignores cluster-wide-access mode since we can have discovery selectors even when given cluster wide access.
+// Also, this may be asking for the accessibility of a namespace in a remote cluster, in which case cluster-wide-access is moot.
+func (in *NamespaceService) isAccessibleNamespace(namespace models.Namespace) bool {
+	selectors := getDiscoverySelectorsForCluster(namespace.Cluster, in.conf)
+	// see if the discovery selectors match the one namespace we are checking
+	return len(filterNamespacesWithDiscoverySelectors([]models.Namespace{namespace}, selectors)) == 1
 }

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -34,9 +34,9 @@ func setupNamespaceService(t *testing.T, k8s kubernetes.ClientInterface, conf *c
 func setupNamespaceServiceWithNs() *kubetest.FakeK8sClient {
 	// config needs to be set by other services since those rely on the global.
 	objects := []runtime.Object{
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "alpha"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "beta"}},
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("alpha"),
+		kubetest.FakeNamespace("beta"),
 	}
 	for _, obj := range fakeNamespaces() {
 		o := obj
@@ -55,9 +55,9 @@ func setupAmbientNamespaceServiceWithNs() kubernetes.ClientInterface {
 	}
 	// config needs to be set by other services since those rely on the global.
 	objects := []runtime.Object{
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo", Labels: labels}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "alpha"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "beta"}},
+		kubetest.FakeNamespaceWithLabels("bookinfo", labels),
+		kubetest.FakeNamespace("alpha"),
+		kubetest.FakeNamespace("beta"),
 	}
 	for _, obj := range fakeNamespaces() {
 		o := obj
@@ -225,10 +225,10 @@ func TestMultiClusterGetNamespace(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		"east": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 		),
 	}
 	clientFactory.SetClients(clients)
@@ -258,10 +258,10 @@ func TestMultiClusterGetNamespaces(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		"east": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 		),
 	}
 	clientFactory.SetClients(clients)

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -33,7 +33,7 @@ func TestServiceListParsing(t *testing.T) {
 	s1 := kubetest.FakeService("Namespace", "reviews")
 	s2 := kubetest.FakeService("Namespace", "httpbin")
 	objects := []runtime.Object{
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Namespace"}},
+		kubetest.FakeNamespace("Namespace"),
 		&s1,
 		&s2,
 	}
@@ -74,7 +74,7 @@ func TestParseRegistryServices(t *testing.T) {
 	require.NoError(yaml.Unmarshal(configz, &serviceEntries))
 	require.Equal(2, len(serviceEntries))
 
-	objs := []runtime.Object{&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "electronic-shop"}}}
+	objs := []runtime.Object{kubetest.FakeNamespace("electronic-shop")}
 	objs = append(objs, kubernetes.ToRuntimeObjects(serviceEntries)...)
 	k8s := kubetest.NewFakeK8sClient(objs...)
 	k8sclients := make(map[string]kubernetes.ClientInterface)
@@ -133,11 +133,11 @@ func TestGetServiceListFromMultipleClusters(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-west-cluster", Namespace: "bookinfo"}},
 		),
 	}
@@ -168,11 +168,11 @@ func TestMultiClusterGetService(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-west-cluster", Namespace: "bookinfo"}},
 		),
 	}
@@ -203,11 +203,11 @@ func TestMultiClusterServiceUpdate(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-west-cluster", Namespace: "bookinfo"}},
 		),
 	}
@@ -245,11 +245,11 @@ func TestMultiClusterGetServiceDetails(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-west-cluster", Namespace: "bookinfo"}},
 		),
 	}
@@ -280,11 +280,11 @@ func TestMultiClusterGetServiceAppName(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo"}},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&core_v1.Service{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "ratings-west-cluster",

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -1058,7 +1058,7 @@ func TestGetWorkloadMultiCluster(t *testing.T) {
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clients := map[string]kubernetes.ClientInterface{
 		"east": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&apps_v1.Deployment{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "ratings-v1",
@@ -1070,7 +1070,7 @@ func TestGetWorkloadMultiCluster(t *testing.T) {
 			},
 		),
 		"west": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+			kubetest.FakeNamespace("bookinfo"),
 			&apps_v1.Deployment{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "ratings-v1",

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config/dashboards"
 	"github.com/kiali/kiali/config/security"
@@ -376,19 +377,6 @@ type KubernetesConfig struct {
 	QPS              float32  `yaml:"qps,omitempty"`
 }
 
-// ApiConfig contains API specific configuration.
-type ApiConfig struct {
-	Namespaces ApiNamespacesConfig
-}
-
-// ApiNamespacesConfig provides a list of regex strings defining namespaces to include or exclude.
-type ApiNamespacesConfig struct {
-	Exclude              []string `yaml:"exclude,omitempty" json:"exclude"`
-	Include              []string `yaml:"include,omitempty" json:"include"`
-	LabelSelectorExclude string   `yaml:"label_selector_exclude,omitempty" json:"labelSelectorExclude"`
-	LabelSelectorInclude string   `yaml:"label_selector_include,omitempty" json:"labelSelectorInclude"`
-}
-
 // AuthConfig provides details on how users are to authenticate
 type AuthConfig struct {
 	OpenId    OpenIdConfig    `yaml:"openid,omitempty"`
@@ -423,15 +411,56 @@ type OpenIdConfig struct {
 
 // DeploymentConfig provides details on how Kiali was deployed.
 type DeploymentConfig struct {
-	AccessibleNamespaces []string `yaml:"accessible_namespaces"`
-	ClusterWideAccess    bool     `yaml:"cluster_wide_access,omitempty"`
-	InstanceName         string   `yaml:"instance_name"`
-	Namespace            string   `yaml:"namespace,omitempty"` // Kiali deployment namespace
-	ViewOnlyMode         bool     `yaml:"view_only_mode,omitempty"`
+	AccessibleNamespaces []string                 // this is no longer part of the actual config - we will generate this in Unmarshal()
+	ClusterWideAccess    bool                     `yaml:"cluster_wide_access,omitempty"`
+	DiscoverySelectors   DiscoverySelectorsConfig `yaml:"discovery_selectors,omitempty"`
+	InstanceName         string                   `yaml:"instance_name"`
+	Namespace            string                   `yaml:"namespace,omitempty"` // Kiali deployment namespace
+	ViewOnlyMode         bool                     `yaml:"view_only_mode,omitempty"`
 	// RemoteSecretPath is used to identify the remote cluster Kiali will connect to as its "local cluster".
 	// This is to support installing Kiali in the control plane, but observing only the data plane in the remote cluster.
 	// Experimental feature. See: https://github.com/kiali/kiali/issues/3002
 	RemoteSecretPath string `yaml:"remote_secret_path,omitempty"`
+}
+
+// we need to play games with a custom unmarshaller/marshaller for metav1.LabelSelector because it has no yaml struct tags so
+// it is not processing it the way we want by default (it isn't using camelCase; the fields are lowercase - e.g. matchlabels/matchexpressions)
+type DiscoverySelectorType metav1.LabelSelector
+type DiscoverySelectorsType []*DiscoverySelectorType
+
+func (dst *DiscoverySelectorType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Define a temporary struct to map YAML fields to Go struct fields
+	type Alias metav1.LabelSelector
+	aux := &struct {
+		MatchLabels      map[string]string                 `yaml:"matchLabels"`
+		MatchExpressions []metav1.LabelSelectorRequirement `yaml:"matchExpressions"`
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	// Unmarshal into the temporary struct
+	if err := unmarshal(&aux); err != nil {
+		return err
+	}
+
+	// Map the fields from the temporary struct to the actual fields
+	dst.MatchLabels = aux.MatchLabels
+	dst.MatchExpressions = aux.MatchExpressions
+
+	return nil
+}
+
+func (dst DiscoverySelectorType) MarshalYAML() (interface{}, error) {
+	return map[string]interface{}{
+		"matchLabels":      dst.MatchLabels,
+		"matchExpressions": dst.MatchExpressions,
+	}, nil
+}
+
+type DiscoverySelectorsConfig struct {
+	Default   DiscoverySelectorsType            `yaml:"default,omitempty"`
+	Overrides map[string]DiscoverySelectorsType `yaml:"overrides,omitempty"`
 }
 
 // GraphFindOption defines a single Graph Find/Hide Option
@@ -596,7 +625,6 @@ type Profiler struct {
 // Config defines full YAML configuration.
 type Config struct {
 	AdditionalDisplayDetails []AdditionalDisplayItem             `yaml:"additional_display_details,omitempty"`
-	API                      ApiConfig                           `yaml:"api,omitempty"`
 	Auth                     AuthConfig                          `yaml:"auth,omitempty"`
 	Clustering               Clustering                          `yaml:"clustering,omitempty"`
 	CustomDashboards         dashboards.MonitoringDashboardsList `yaml:"custom_dashboards,omitempty"`
@@ -619,19 +647,6 @@ func NewConfig() (c *Config) {
 	c = &Config{
 		InCluster:      true,
 		IstioNamespace: "istio-system",
-		API: ApiConfig{
-			Namespaces: ApiNamespacesConfig{
-				Exclude: []string{
-					"^istio-operator",
-					"^kube-.*",
-					"^openshift.*",
-					"^ibm.*",
-					"^kial-operator",
-				},
-				Include:              []string{},
-				LabelSelectorExclude: "",
-			},
-		},
 		Auth: AuthConfig{
 			Strategy: "token",
 			OpenId: OpenIdConfig{
@@ -653,12 +668,12 @@ func NewConfig() (c *Config) {
 		},
 		CustomDashboards: dashboards.GetBuiltInMonitoringDashboards(),
 		Deployment: DeploymentConfig{
-			AccessibleNamespaces: []string{"**"},
-			ClusterWideAccess:    true,
-			InstanceName:         "kiali",
-			Namespace:            "istio-system",
-			RemoteSecretPath:     "/kiali-remote-secret/kiali",
-			ViewOnlyMode:         false,
+			ClusterWideAccess:  true,
+			DiscoverySelectors: DiscoverySelectorsConfig{Default: nil, Overrides: nil},
+			InstanceName:       "kiali",
+			Namespace:          "istio-system",
+			RemoteSecretPath:   "/kiali-remote-secret/kiali",
+			ViewOnlyMode:       false,
 		},
 		ExternalServices: ExternalServices{
 			CustomDashboards: CustomDashboardsConfig{
@@ -934,18 +949,7 @@ func (conf *Config) AddHealthDefault() {
 }
 
 // AllNamespacesAccessible determines if kiali has access to all namespaces.
-// When using the operator, the operator will grant the kiali service account
-// cluster role permissions when '**' is provided in the accessible_namespaces
-// or if cluster-wide-access was explicitly requested.
 func (conf *Config) AllNamespacesAccessible() bool {
-	// look for ** in accessible namespaces first, as we have done in the past. This backwards compatible
-	// behavior will help support users who installed the server via the server helm chart.
-	for _, ns := range conf.Deployment.AccessibleNamespaces {
-		if ns == "**" {
-			return true
-		}
-	}
-	// it is still possible we are in cluster wide access mode even if accessible namespaces has been restricted
 	return conf.Deployment.ClusterWideAccess
 }
 
@@ -1038,6 +1042,19 @@ func Unmarshal(yamlString string) (conf *Config, err error) {
 	err = yaml.Unmarshal([]byte(yamlString), &conf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse yaml data. error=%v", err)
+	}
+
+	// Determine what the accessible namespaces are. These are namespaces we must have permission to see
+	// when not in cluster-wide access mode. These are only necessary when we are not in cluster-wide access mode.
+	// We do not set this when in cluster-wide mode because in that case we have access to see everything.
+	// Note that in past versions "accessible_namespaces" came over in the yaml itself, but that is no longer the case.
+	// Accessible namespaces can now be derived from discovery selectors so long as they are specified in a specific way.
+	// See the comments found in extractAccessibleNamespaceList for more details.
+	if !conf.Deployment.ClusterWideAccess {
+		conf.Deployment.AccessibleNamespaces, err = conf.extractAccessibleNamespaceList()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	conf.prepareDashboards()
@@ -1274,4 +1291,58 @@ func validateSigningKey(signingKey string, authStrategy string) error {
 	}
 
 	return nil
+}
+
+// extractAccessibleNamespaceList will take the default set of discovery selectors from the config and build a
+// list of namespace names by using all discovery selectors that look for matches of the label "kubernetes.io/metadata.name".
+// This means if a matchLabels wants to match a value on the label "kubernetes.io/metadata.name" or a single matchExpressions
+// wants to match key="kubernetes.io/metadata.name" with operator="In" with a single value defined, the value is assumed
+// to be an accessible namespace that will be added to the list that is returned. For example:
+//
+//	default:
+//	- matchLabels:
+//	    kubernetes.io/metadata.name: an-accessible-namespace
+//	- matchExpressions:
+//	  - key: kubernetes.io/metadata.name
+//	    operator: In
+//	    values: ["another-accessible-namespace"]
+//
+// When the Kiali Server is not in Cluster Wide Access mode, it is assumed (required, in fact) that all the
+// default discovery selectors only use match criteria as explained above.
+// This function therefore is used to obtain a list of accessible namespaces from the discovery selectors when CWA=false.
+func (config *Config) extractAccessibleNamespaceList() ([]string, error) {
+	errs := make([]string, 0)
+	namespaceNames := make([]string, 0)
+	for _, selector := range config.Deployment.DiscoverySelectors.Default {
+		if len(selector.MatchLabels) > 0 && len(selector.MatchExpressions) > 0 {
+			errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selector: one label selector cannot have both an equality-based and a set-based selector: %v", selector))
+		} else if len(selector.MatchLabels) > 1 {
+			errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selector: matchLabel selector must match one and only one label named kubernetes.io/metadata.name: %v", selector))
+		} else if len(selector.MatchExpressions) > 1 {
+			errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selectors: matchExpressions selector must match one and only one label named kubernetes.io/metadata.name using the IN operator: %v", selector))
+		} else if len(selector.MatchLabels) == 1 {
+			if namespaceName, ok := selector.MatchLabels["kubernetes.io/metadata.name"]; ok {
+				namespaceNames = append(namespaceNames, namespaceName)
+			} else {
+				errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selector: matchLabel selector must match the label named kubernetes.io/metadata.name: %v", selector))
+			}
+		} else if len(selector.MatchExpressions) == 1 {
+			expr := selector.MatchExpressions[0]
+			if len(expr.Values) == 1 {
+				if expr.Key == "kubernetes.io/metadata.name" && expr.Operator == metav1.LabelSelectorOpIn {
+					namespaceNames = append(namespaceNames, expr.Values[0])
+				} else {
+					errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selectors: matchExpressions selector must match the label named kubernetes.io/metadata.name using the IN operator: %v", selector))
+				}
+			} else {
+				errs = append(errs, fmt.Sprintf("invalid accessible namespace discovery selectors: matchExpressions selector must match one and only one value for label named kubernetes.io/metadata.name using the IN operator: %v", selector))
+			}
+		}
+	}
+
+	if len(errs) == 0 {
+		return namespaceNames, nil
+	} else {
+		return namespaceNames, errors.New(strings.Join(errs, "\n"))
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/kiali/kiali/util"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/util"
 )
 
 func TestSecretFileOverrides(t *testing.T) {
@@ -129,33 +131,35 @@ func TestMarshalUnmarshalStaticContentRootDirectory(t *testing.T) {
 	}
 }
 
-func TestMarshalUnmarshalApiConfig(t *testing.T) {
-	testConf := Config{
-		API: ApiConfig{
-			Namespaces: ApiNamespacesConfig{
-				Exclude: []string{"istio-operator", "kube.*"},
-			},
-		},
-	}
-
-	yamlString, err := Marshal(&testConf)
-	if err != nil {
-		t.Errorf("Failed to marshal: %v", err)
-	}
-	if yamlString != "api:\n  namespaces:\n    exclude:\n    - istio-operator\n    - kube.*\n" {
-		t.Errorf("Failed to marshal Api:\n%q", yamlString)
-	}
-	conf, err := Unmarshal(yamlString)
-	if err != nil {
-		t.Errorf("Failed to unmarshal: %v", err)
-	}
-	if len(conf.API.Namespaces.Exclude) != 2 {
-		t.Errorf("Failed to unmarshal Api:\n%+v", conf.API)
-	}
-}
-
 func TestMarshalUnmarshal(t *testing.T) {
 	testConf := Config{
+		Deployment: DeploymentConfig{
+			DiscoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "foo",
+						},
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "thekey",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"a"},
+							},
+						},
+					},
+				},
+				Overrides: map[string]DiscoverySelectorsType{
+					"cluster1": {
+						{
+							MatchLabels: map[string]string{
+								"splat": "boing",
+							},
+						},
+					},
+				},
+			},
+		},
 		Server: Server{
 			Address: "foo-test",
 			Port:    321,
@@ -171,6 +175,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 	if yamlString == "" {
 		t.Errorf("Failed to marshal - empty yaml string")
 	}
+	if strings.Contains(yamlString, "matchlabels") {
+		t.Errorf("Failed to marshal - matchLabels is not camelCase; yaml parsing not correct")
+	}
+	if strings.Contains(yamlString, "matchexpressions") {
+		t.Errorf("Failed to marshal - matchExpressions is not camelCase; yaml parsing not correct")
+	}
 
 	conf, err := Unmarshal(yamlString)
 	if err != nil {
@@ -185,6 +195,18 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 	if conf.Server.StaticContentRootDirectory != "/tmp" {
 		t.Errorf("Failed to unmarshal static content root directory:\n%v", conf)
+	}
+	if conf.Deployment.DiscoverySelectors.Default[0].MatchLabels["kubernetes.io/metadata.name"] != "foo" {
+		t.Errorf("Failed to unmarshal default discovery selector:\n%v", conf)
+	}
+	if conf.Deployment.DiscoverySelectors.Default[0].MatchExpressions[0].Key != "thekey" {
+		t.Errorf("Failed to unmarshal default discovery selector expression key:\n%v", conf)
+	}
+	if conf.Deployment.DiscoverySelectors.Default[0].MatchExpressions[0].Operator != "In" {
+		t.Errorf("Failed to unmarshal default discovery selector expression key:\n%v", conf)
+	}
+	if conf.Deployment.DiscoverySelectors.Overrides["cluster1"][0].MatchLabels["splat"] != "boing" {
+		t.Errorf("Failed to unmarshal default discovery selector:\n%v", conf)
 	}
 }
 
@@ -255,25 +277,18 @@ func TestRaces(t *testing.T) {
 }
 
 func TestAllNamespacesAccessible(t *testing.T) {
+	// cluster wide access flag is the only one that matters
 	cases := map[string]struct {
-		expectedAccessible   bool
-		accessibleNamespaces []string
+		expectedAccessible bool
+		clusterWideAccess  bool
 	}{
-		"with **": {
-			expectedAccessible:   true,
-			accessibleNamespaces: []string{"**"},
+		"with CWA=true": {
+			expectedAccessible: true,
+			clusterWideAccess:  true,
 		},
-		"with ** and others": {
-			expectedAccessible:   true,
-			accessibleNamespaces: []string{"test1", "test2", "**"},
-		},
-		"without **": {
-			expectedAccessible:   false,
-			accessibleNamespaces: []string{"test1", "test2"},
-		},
-		"empty": {
-			expectedAccessible:   false,
-			accessibleNamespaces: []string{},
+		"with CWA=false": {
+			expectedAccessible: false,
+			clusterWideAccess:  false,
 		},
 	}
 
@@ -283,7 +298,7 @@ func TestAllNamespacesAccessible(t *testing.T) {
 
 			conf := &Config{
 				Deployment: DeploymentConfig{
-					AccessibleNamespaces: tc.accessibleNamespaces,
+					ClusterWideAccess: tc.clusterWideAccess,
 				},
 			}
 
@@ -424,6 +439,286 @@ func TestIsRBACDisabled(t *testing.T) {
 			conf.Auth = tc.authConfig
 
 			require.Equal(tc.expectRBACDisabled, conf.IsRBACDisabled())
+		})
+	}
+}
+
+func TestExtractAccessibleNamespaceList(t *testing.T) {
+	cases := map[string]struct {
+		discoverySelectors DiscoverySelectorsConfig
+		expectedNamespaces []string
+		expectedError      bool
+	}{
+		"nil selectors": {
+			expectedNamespaces: []string{},
+		},
+		"no matchLabels": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "label1",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"labelValue1"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      true,
+		},
+		"one matchLabels but not kubernetes.io": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"notWhatWeWant": "foo"}},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      true,
+		},
+		"one matchLabels": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "good"}},
+				},
+			},
+			expectedNamespaces: []string{"good"},
+			expectedError:      false,
+		},
+		"ignore overrides": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Overrides: map[string]DiscoverySelectorsType{
+					"cluster1": {
+						&DiscoverySelectorType{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ignored"},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      false,
+		},
+		"one matchLabels in default; ignore overrides": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "good"}},
+				},
+				Overrides: map[string]DiscoverySelectorsType{
+					"cluster1": {
+						&DiscoverySelectorType{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ignored"},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"good"},
+			expectedError:      false,
+		},
+		"multiple matchLabels": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "one"}},
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "two"}},
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "three"}},
+				},
+			},
+			expectedNamespaces: []string{"one", "two", "three"},
+			expectedError:      false,
+		},
+		"one matchLabels, ignore the others - selector with both matchLabel and matchExpression is ignored": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "good"}},
+					&DiscoverySelectorType{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ignore"},
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "ignoreThisToo",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"ignoreThisToo"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"good"},
+			expectedError:      true,
+		},
+		"two selectors - one matchExpression and one matchLabel": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "good"}},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"good2"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"good", "good2"},
+			expectedError:      false,
+		},
+		"matchExpression must be operator=In, all others are ignored": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpNotIn,
+								Values:   []string{"ignore"},
+							},
+						},
+					},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"good"},
+							},
+						},
+					},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpDoesNotExist,
+							},
+						},
+					},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"good"},
+			expectedError:      true,
+		},
+		"cannot have multiple matchExpressions in a single selectors": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "good"}},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"nogood"},
+							},
+							{
+								Key:      "foo",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"bar"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"good"},
+			expectedError:      true,
+		},
+		"matchExpression must not have multiple values": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"too-many", "values"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      true,
+		},
+		"matchLabels must not have multiple values": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ignored", "too-many": "values"},
+					},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      true,
+		},
+		"one big mess with nothing matching": {
+			discoverySelectors: DiscoverySelectorsConfig{
+				Default: DiscoverySelectorsType{
+					&DiscoverySelectorType{MatchLabels: map[string]string{"ignore-this": "one"}},
+					&DiscoverySelectorType{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "one", "ignore-this": "too"}},
+					&DiscoverySelectorType{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ignored"},
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"nogood"},
+							},
+						},
+					},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"nogood"},
+							},
+							{
+								Key:      "foo",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"bar"},
+							},
+						},
+					},
+					&DiscoverySelectorType{
+						MatchExpressions: []meta_v1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: meta_v1.LabelSelectorOpIn,
+								Values:   []string{"nope", "nogood-either"},
+							},
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{},
+			expectedError:      true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			cfg := &Config{
+				Deployment: DeploymentConfig{
+					DiscoverySelectors: tc.discoverySelectors,
+				},
+			}
+
+			actualNamespaces, err := cfg.extractAccessibleNamespaceList()
+			if tc.expectedError {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+			assert.Equal(tc.expectedNamespaces, actualNamespaces)
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -629,7 +629,7 @@ func TestExtractAccessibleNamespaceList(t *testing.T) {
 			expectedNamespaces: []string{"good"},
 			expectedError:      true,
 		},
-		"matchExpression must not have multiple values": {
+		"matchExpression with multiple values": {
 			discoverySelectors: DiscoverySelectorsConfig{
 				Default: DiscoverySelectorsType{
 					&DiscoverySelectorType{
@@ -637,14 +637,14 @@ func TestExtractAccessibleNamespaceList(t *testing.T) {
 							{
 								Key:      "kubernetes.io/metadata.name",
 								Operator: meta_v1.LabelSelectorOpIn,
-								Values:   []string{"too-many", "values"},
+								Values:   []string{"one-ns", "two-ns", "three-ns"},
 							},
 						},
 					},
 				},
 			},
-			expectedNamespaces: []string{},
-			expectedError:      true,
+			expectedNamespaces: []string{"one-ns", "two-ns", "three-ns"},
+			expectedError:      false,
 		},
 		"matchLabels must not have multiple values": {
 			discoverySelectors: DiscoverySelectorsConfig{
@@ -683,15 +683,6 @@ func TestExtractAccessibleNamespaceList(t *testing.T) {
 								Key:      "foo",
 								Operator: meta_v1.LabelSelectorOpIn,
 								Values:   []string{"bar"},
-							},
-						},
-					},
-					&DiscoverySelectorType{
-						MatchExpressions: []meta_v1.LabelSelectorRequirement{
-							{
-								Key:      "kubernetes.io/metadata.name",
-								Operator: meta_v1.LabelSelectorOpIn,
-								Values:   []string{"nope", "nogood-either"},
 							},
 						},
 					},

--- a/frontend/src/components/DebugInformation/DebugInformation.tsx
+++ b/frontend/src/components/DebugInformation/DebugInformation.tsx
@@ -57,9 +57,9 @@ type DebugInformationData = {
 
 // Will be shown in Kiali Config and hidden in Additional state
 const propsToShow = [
-  'accessibleNamespaces',
   'authStrategy',
   'clusters',
+  'clusterWideAccess',
   'gatewayAPIClasses',
   'gatewayAPIEnabled',
   'istioAnnotationsAction',

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -55,10 +55,10 @@ const computeValidDurations = (cfg: ComputedServerConfig): void => {
 // Set some reasonable defaults. Initial values should be valid for fields
 // than may not be providedby/set on the server.
 const defaultServerConfig: ComputedServerConfig = {
-  accessibleNamespaces: [],
   ambientEnabled: false,
   authStrategy: '',
   clusters: {},
+  clusterWideAccess: true,
   durations: {},
   gatewayAPIClasses: [],
   gatewayAPIEnabled: false,

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -68,10 +68,10 @@ export const generateRequestHealth = (
 };
 
 export const serverRateConfig = {
-  accessibleNamespaces: [],
   authStrategy: '',
   ambientEnabled: false,
   clusters: {},
+  clusterWideAccess: true,
   controlPlaneClusters: [],
   gatewayAPIClasses: [],
   gatewayAPIEnabled: false,

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -140,10 +140,10 @@ export interface ToleranceConfig {
 */
 
 export interface ServerConfig {
-  accessibleNamespaces: Array<string>;
   ambientEnabled: boolean;
   authStrategy: string;
   clusters: { [key: string]: MeshCluster };
+  clusterWideAccess: boolean;
   deployment: DeploymentConfig;
   gatewayAPIClasses: GatewayAPIClass[];
   gatewayAPIEnabled: boolean;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -2,10 +2,10 @@ import { ServerConfig } from 'types/ServerConfig';
 import { getExpr } from '../../config/HealthConfig';
 
 export const healthConfig = {
-  accessibleNamespaces: [],
   authStrategy: '',
   ambientEnabled: false,
   clusters: {},
+  clusterWideAccess: true,
   controlPlaneClusters: [],
   gatewayAPIClasses: [],
   gatewayAPIEnabled: false,

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
@@ -41,8 +39,8 @@ func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock,
 	config.Set(conf)
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("tutorial"),
 	)
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 
@@ -3449,22 +3447,22 @@ func TestComplexGraph(t *testing.T) {
 
 	clients := map[string]kubernetes.ClientInterface{
 		"cluster-tutorial": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-telemetry"}},
+			kubetest.FakeNamespace("bookinfo"),
+			kubetest.FakeNamespace("istio-system"),
+			kubetest.FakeNamespace("tutorial"),
+			kubetest.FakeNamespace("istio-telemetry"),
 		),
 		"cluster-cp": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-telemetry"}},
+			kubetest.FakeNamespace("bookinfo"),
+			kubetest.FakeNamespace("istio-system"),
+			kubetest.FakeNamespace("tutorial"),
+			kubetest.FakeNamespace("istio-telemetry"),
 		),
 		"cluster-bookinfo": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-telemetry"}},
+			kubetest.FakeNamespace("bookinfo"),
+			kubetest.FakeNamespace("istio-system"),
+			kubetest.FakeNamespace("tutorial"),
+			kubetest.FakeNamespace("istio-telemetry"),
 		),
 	}
 	client, xapi, err, biz := setupMockedWithIstioComponentNamespaces(t, "mesh1", clients)
@@ -3784,12 +3782,12 @@ func TestMultiClusterSourceGraph(t *testing.T) {
 
 	clients := map[string]kubernetes.ClientInterface{
 		"kukulcan": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+			kubetest.FakeNamespace("bookinfo"),
+			kubetest.FakeNamespace("istio-system"),
 		),
 		"tzotz": kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+			kubetest.FakeNamespace("bookinfo"),
+			kubetest.FakeNamespace("istio-system"),
 		),
 	}
 	client, xapi, err, biz := setupMockedWithIstioComponentNamespaces(t, "", clients)

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -80,7 +80,7 @@ func setupWorkloadEntries(t *testing.T) *business.Layer {
 			},
 		}}
 
-	ns := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}}
+	ns := kubetest.FakeNamespace(appNamespace)
 
 	k8s := kubetest.NewFakeK8sClient(k8spod1, k8spod2, k8spod3, k8spod4, k8spod5, ns)
 	conf := config.NewConfig()

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -22,7 +22,7 @@ func setupWorkloads(t *testing.T) *business.Layer {
 	config.Set(conf)
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+		kubetest.FakeNamespace("testNamespace"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "testPodsWithTraffic-v1",

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -483,7 +483,7 @@ func TestErrorCausesPanic(t *testing.T) {
 	trafficMap := buildAppTrafficMap()
 	objects := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+		kubetest.FakeNamespace("testNamespace"),
 	}
 	for _, obj := range buildFakeWorkloadDeploymentsHealth(rateDefinition) {
 		o := obj
@@ -533,7 +533,7 @@ func TestMultiClusterHealthConfig(t *testing.T) {
 	trafficMap[westNode.ID] = westNode
 	objects := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+		kubetest.FakeNamespace("testNamespace"),
 	}
 	westClient := kubetest.NewFakeK8sClient(objects...)
 	for _, obj := range buildFakeWorkloadDeploymentsHealth(rateDefinition) {
@@ -619,7 +619,7 @@ func buildFakePodsHealth(rate string) []core_v1.Pod {
 func setupHealthConfig(t *testing.T, services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) *business.Layer {
 	objects := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+		kubetest.FakeNamespace("testNamespace"),
 	}
 	for _, obj := range services {
 		o := obj

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -62,11 +62,11 @@ func TestCBAll(t *testing.T) {
 			},
 		},
 	}
-	k8s := kubetest.NewFakeK8sClient(dRule, &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}})
+	k8s := kubetest.NewFakeK8sClient(dRule, kubetest.FakeNamespace("testNamespace"))
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := map[string]kubernetes.ClientInterface{
 		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+			kubetest.FakeNamespace("testNamespace"),
 		),
 	}
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
@@ -129,11 +129,11 @@ func TestCBSubset(t *testing.T) {
 			},
 		},
 	}
-	k8s := kubetest.NewFakeK8sClient(dRule, &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}})
+	k8s := kubetest.NewFakeK8sClient(dRule, kubetest.FakeNamespace("testNamespace"))
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := map[string]kubernetes.ClientInterface{
 		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+			kubetest.FakeNamespace("testNamespace"),
 		),
 	}
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
@@ -307,11 +307,11 @@ func TestSEInAppBox(t *testing.T) {
 			},
 		},
 	}
-	k8s := kubetest.NewFakeK8sClient(svc, &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}})
+	k8s := kubetest.NewFakeK8sClient(svc, kubetest.FakeNamespace("testNamespace"))
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := map[string]kubernetes.ClientInterface{
 		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+			kubetest.FakeNamespace("testNamespace"),
 		),
 	}
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -43,7 +43,7 @@ func setupLabelerK8S(t *testing.T) *business.Layer {
 	config.Set(conf)
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+		kubetest.FakeNamespace("testNamespace"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "test-v1",
@@ -102,7 +102,7 @@ func setupLabelerK8S(t *testing.T) *business.Layer {
 	business.SetupBusinessLayer(t, k8s, *conf)
 	k8sclients := map[string]kubernetes.ClientInterface{
 		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}},
+			kubetest.FakeNamespace("testNamespace"),
 		),
 	}
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)

--- a/graph/telemetry/istio/appender/mesh_check_test.go
+++ b/graph/telemetry/istio/appender/mesh_check_test.go
@@ -310,7 +310,7 @@ func buildFakeWorkloadPodsAmbient() []core_v1.Pod {
 }
 
 func setupSidecarsCheckWorkloads(t *testing.T, deployments []apps_v1.Deployment, pods []core_v1.Pod) *business.Layer {
-	objects := []runtime.Object{&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "testNamespace"}}}
+	objects := []runtime.Object{kubetest.FakeNamespace("testNamespace")}
 	for _, obj := range deployments {
 		o := obj
 		objects = append(objects, &o)

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
-	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/business"
@@ -54,7 +52,7 @@ func setupWorkloadEntries(t *testing.T) *business.Layer {
 		"app":     appName,
 		"version": "v2",
 	}
-	ns := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}}
+	ns := kubetest.FakeNamespace(appNamespace)
 	return setupBusinessLayer(t, workloadV1, workloadV2, ns)
 }
 
@@ -180,7 +178,7 @@ func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
 		"version": "v2",
 	}
 
-	ns := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}}
+	ns := kubetest.FakeNamespace(appNamespace)
 	businessLayer := setupBusinessLayer(t, workloadV1, workloadV2, ns)
 	trafficMap := workloadEntriesTrafficMap()
 
@@ -267,7 +265,7 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 		"version": "v2",
 	}
 
-	ns := &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}}
+	ns := kubetest.FakeNamespace(appNamespace)
 	businessLayer := setupBusinessLayer(t, workloadV1A, workloadV1B, workloadV2, ns)
 	trafficMap := workloadEntriesTrafficMap()
 
@@ -337,7 +335,7 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 	assert := require.New(t)
 
-	businessLayer := setupBusinessLayer(t, &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}})
+	businessLayer := setupBusinessLayer(t, kubetest.FakeNamespace(appNamespace))
 	trafficMap := workloadEntriesTrafficMap()
 
 	assert.Equal(5, len(trafficMap))
@@ -400,7 +398,7 @@ func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 func TestWEKiali7305(t *testing.T) {
 	assert := require.New(t)
 
-	businessLayer := setupBusinessLayer(t, &core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: appNamespace}})
+	businessLayer := setupBusinessLayer(t, kubetest.FakeNamespace(appNamespace))
 
 	// VersionedApp graph
 	trafficMap := make(map[string]*graph.Node)

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -104,10 +104,11 @@ create_resources_in_remote_cluster() {
     local helm_version_arg="--version ${KIALI_VERSION}"
   fi
 
-  local helm_template_output="$(${HELM} template                  \
+  local helm_template_output="$(${HELM} template            \
       ${helm_version_arg:-}                                 \
       --namespace ${REMOTE_CLUSTER_NAMESPACE}               \
       --set deployment.instance_name=${KIALI_RESOURCE_NAME} \
+      --set deployment.cluster_wide_access=true             \
       --set deployment.view_only_mode=${VIEW_ONLY}          \
       --set auth.strategy=anonymous                         \
       --show-only templates/serviceaccount.yaml             \
@@ -499,9 +500,9 @@ Valid command line arguments:
   -vo|--view-only: if 'true' then the created service account/remote secret
                    will only provide a read-only view of the remote cluster.
                    Default: "${DEFAULT_VIEW_ONLY}"
-  -eaj|--exec-auth-json: If you want to use exec auth for authentication, 
+  -eaj|--exec-auth-json: If you want to use exec auth for authentication,
                          specify ExecConfig in clientcmd/v1 in json format
-                         To use this option, kiali's 'auth.strategy' must be 
+                         To use this option, kiali's 'auth.strategy' must be
                          changed to 'anonymous'. 'yq' command is required.
                          (e.g. helm upgrade -n istio-system \\
                          --set auth.strategy="anonymous" kiali-server kiali/kiali-server)

--- a/hack/run-kiali-config-template.yaml
+++ b/hack/run-kiali-config-template.yaml
@@ -19,7 +19,7 @@ auth:
   strategy: "anonymous"
 
 deployment:
-  accessible_namespaces: ["**"]
+  cluster_wide_access: true
   remote_secret_path: "${REMOTE_SECRET_PATH}"
 
 external_services:

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -176,7 +176,7 @@ func setupAppMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.Pr
 		t.Fatal(err)
 	}
 	prom.Inject(xapi)
-	k8s := &clientNoPrivileges{kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})}
+	k8s := &clientNoPrivileges{kubetest.NewFakeK8sClient(kubetest.FakeNamespace("ns"))}
 	mr := mux.NewRouter()
 
 	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}

--- a/handlers/authentication/openid_auth_controller_test.go
+++ b/handlers/authentication/openid_auth_controller_test.go
@@ -18,7 +18,6 @@ import (
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -393,7 +392,7 @@ func TestOpenIdAuthControllerAuthenticatesCorrectlyWithAuthorizationCodeFlow(t *
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *conf)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, conf)
@@ -478,7 +477,7 @@ func TestOpenIdCodeFlowShouldFailWithMissingIdTokenFromOpenIdServer(t *testing.T
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -551,7 +550,7 @@ func TestOpenIdCodeFlowShouldFailWithBadResponseFromTokenEndpoint(t *testing.T) 
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -624,7 +623,7 @@ func TestOpenIdCodeFlowShouldFailWithNonJsonResponse(t *testing.T) {
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -697,7 +696,7 @@ func TestOpenIdCodeFlowShouldFailWithNonJwtIdToken(t *testing.T) {
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -741,7 +740,7 @@ func TestOpenIdCodeFlowShouldRejectMissingAuthorizationCode(t *testing.T) {
 	cfg.LoginToken.ExpirationSeconds = 1
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -811,7 +810,7 @@ func TestOpenIdCodeFlowShouldFailWithIdTokenWithoutExpiration(t *testing.T) {
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -884,7 +883,7 @@ func TestOpenIdCodeFlowShouldFailWithIdTokenWithNonNumericExpClaim(t *testing.T)
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -937,7 +936,7 @@ func TestOpenIdCodeFlowShouldRejectInvalidState(t *testing.T) {
 		Value: "nonceString",
 	})
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -982,7 +981,7 @@ func TestOpenIdCodeFlowShouldRejectBadStateFormat(t *testing.T) {
 		Value: "nonceString",
 	})
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -1025,7 +1024,7 @@ func TestOpenIdCodeFlowShouldRejectMissingState(t *testing.T) {
 		Value: "nonceString",
 	})
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -1058,7 +1057,7 @@ func TestOpenIdCodeFlowShouldRejectMissingNonceCookie(t *testing.T) {
 	cfg.LoginToken.ExpirationSeconds = 1
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)
@@ -1124,7 +1123,7 @@ func TestOpenIdCodeFlowShouldRejectMissingNonceInToken(t *testing.T) {
 	cfg.Auth.OpenId.ClientId = "kiali-client"
 	config.Set(cfg)
 
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *cfg)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, cfg)

--- a/handlers/authentication/token_auth_controller_test.go
+++ b/handlers/authentication/token_auth_controller_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/config"
@@ -85,7 +84,7 @@ func TestTokenAuthControllerRejectsInvalidToken(t *testing.T) {
 
 	// Returning a forbidden error when a cluster API call is made should have the result of
 	// a rejected authentication.
-	k8s := kubetest.NewFakeK8sClient(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(forbiddenClient{k8s})
 	cache := cache.NewTestingCacheWithFactory(t, mockClientFactory, *conf)
 	discovery := istio.NewDiscovery(mockClientFactory.Clients, cache, conf)
@@ -222,7 +221,7 @@ func createValidSession(t *testing.T) (*httptest.ResponseRecorder, *UserSessionD
 
 	// Returning some namespace when a cluster API call is made should have the result of
 	// a successful authentication.
-	k8s := kubetest.NewFakeK8sClient(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Foo"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("Foo"))
 
 	requestBody := strings.NewReader("token=" + testToken)
 	request := httptest.NewRequest(http.MethodPost, "/api/authenticate", requestBody)

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -41,24 +41,24 @@ type DeploymentConfig struct {
 // PublicConfig is a subset of Kiali configuration that can be exposed to clients to
 // help them interact with the system.
 type PublicConfig struct {
-	AccessibleNamespaces []string                      `json:"accessibleNamespaces,omitempty"`
-	AuthStrategy         string                        `json:"authStrategy,omitempty"`
-	AmbientEnabled       bool                          `json:"ambientEnabled,omitempty"`
-	Clusters             map[string]models.KubeCluster `json:"clusters,omitempty"`
-	Deployment           DeploymentConfig              `json:"deployment,omitempty"`
-	GatewayAPIClasses    []config.GatewayAPIClass      `json:"gatewayAPIClasses,omitempty"`
-	GatewayAPIEnabled    bool                          `json:"gatewayAPIEnabled,omitempty"`
-	HealthConfig         config.HealthConfig           `json:"healthConfig,omitempty"`
-	InstallationTag      string                        `json:"installationTag,omitempty"`
-	IstioAnnotations     IstioAnnotations              `json:"istioAnnotations,omitempty"`
-	IstioConfigMap       string                        `json:"istioConfigMap"`
-	IstioIdentityDomain  string                        `json:"istioIdentityDomain,omitempty"`
-	IstioLabels          config.IstioLabels            `json:"istioLabels,omitempty"`
-	IstioNamespace       string                        `json:"istioNamespace,omitempty"`
-	IstioStatusEnabled   bool                          `json:"istioStatusEnabled,omitempty"`
-	KialiFeatureFlags    config.KialiFeatureFlags      `json:"kialiFeatureFlags,omitempty"`
-	LogLevel             string                        `json:"logLevel,omitempty"`
-	Prometheus           PrometheusConfig              `json:"prometheus,omitempty"`
+	AuthStrategy        string                        `json:"authStrategy,omitempty"`
+	AmbientEnabled      bool                          `json:"ambientEnabled,omitempty"`
+	Clusters            map[string]models.KubeCluster `json:"clusters,omitempty"`
+	ClusterWideAccess   bool                          `json:"clusterWideAccess,omitempty"`
+	Deployment          DeploymentConfig              `json:"deployment,omitempty"`
+	GatewayAPIClasses   []config.GatewayAPIClass      `json:"gatewayAPIClasses,omitempty"`
+	GatewayAPIEnabled   bool                          `json:"gatewayAPIEnabled,omitempty"`
+	HealthConfig        config.HealthConfig           `json:"healthConfig,omitempty"`
+	InstallationTag     string                        `json:"installationTag,omitempty"`
+	IstioAnnotations    IstioAnnotations              `json:"istioAnnotations,omitempty"`
+	IstioConfigMap      string                        `json:"istioConfigMap"`
+	IstioIdentityDomain string                        `json:"istioIdentityDomain,omitempty"`
+	IstioLabels         config.IstioLabels            `json:"istioLabels,omitempty"`
+	IstioNamespace      string                        `json:"istioNamespace,omitempty"`
+	IstioStatusEnabled  bool                          `json:"istioStatusEnabled,omitempty"`
+	KialiFeatureFlags   config.KialiFeatureFlags      `json:"kialiFeatureFlags,omitempty"`
+	LogLevel            string                        `json:"logLevel,omitempty"`
+	Prometheus          PrometheusConfig              `json:"prometheus,omitempty"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -71,9 +71,9 @@ func Config(conf *config.Config, discovery *istio.Discovery) http.HandlerFunc {
 		promConfig := getPrometheusConfig()
 		conf := config.Get()
 		publicConfig := PublicConfig{
-			AccessibleNamespaces: conf.Deployment.AccessibleNamespaces,
-			AuthStrategy:         conf.Auth.Strategy,
-			Clusters:             make(map[string]models.KubeCluster),
+			AuthStrategy:      conf.Auth.Strategy,
+			Clusters:          make(map[string]models.KubeCluster),
+			ClusterWideAccess: conf.Deployment.ClusterWideAccess,
 			Deployment: DeploymentConfig{
 				ViewOnlyMode: conf.Deployment.ViewOnlyMode,
 			},

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -46,7 +46,7 @@ func TestGetMeshGraph(t *testing.T) {
 
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: conf.IstioNamespace}},
+			kubetest.FakeNamespace(conf.IstioNamespace),
 			// Ideally we wouldn't need to set all this stuff up here but there's not a good way
 			// mock out the business.IstioStatus service since it's a struct.
 			&appsv1.Deployment{

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -15,7 +15,6 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -120,7 +119,7 @@ func TestNamespaceMetricsWithParams(t *testing.T) {
 
 func TestNamespaceMetricsInaccessibleNamespace(t *testing.T) {
 	ts, _ := setupNamespaceMetricsEndpoint(t)
-	k8s := kubetest.NewFakeK8sClient(&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "my_namespace"}})
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("my_namespace"))
 	business.SetupBusinessLayer(t, &noPrivClient{k8s}, *config.NewConfig())
 
 	url := ts.URL + "/api/namespaces/my_namespace/metrics"
@@ -189,9 +188,9 @@ func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock)
 	config.Set(conf)
 
 	k := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("tutorial"),
+		kubetest.FakeNamespace("ns"),
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
 		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -14,7 +14,6 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -329,8 +328,8 @@ func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustes
 	conf := config.NewConfig()
 	config.Set(conf)
 	k := kubetest.NewFakeK8sClient(&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "my_namespace"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}})
+		kubetest.FakeNamespace("my_namespace"),
+		kubetest.FakeNamespace("ns"))
 	k.OpenShift = true
 
 	xapi := new(prometheustest.PromAPIMock)

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -43,8 +42,8 @@ func utilSetupMocks(t *testing.T, additionalObjs ...runtime.Object) promClientSu
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	config.Set(conf)
 	objs := []runtime.Object{
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns1"}},
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns2"}},
+		kubetest.FakeNamespace("ns1"),
+		kubetest.FakeNamespace("ns2"),
 	}
 	objs = append(objs, additionalObjs...)
 	k := kubetest.NewFakeK8sClient(objs...)

--- a/istio/discovery_internal_test.go
+++ b/istio/discovery_internal_test.go
@@ -135,7 +135,7 @@ func TestIstioConfigMapName(t *testing.T) {
 			conf := config.NewConfig()
 			conf.ExternalServices.Istio.ConfigMapName = tc.configMapName
 			k8s := kubetest.NewFakeK8sClient(
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+				kubetest.FakeNamespace("istio-system"),
 				tc.configMap,
 			)
 

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/testutils"
 	"github.com/kiali/kiali/util/slicetest"
 )
 
@@ -112,9 +113,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 		},
 	}
 
-	kialiNs := core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: "foo"},
-	}
+	kialiNs := kubetest.FakeNamespace("foo")
 
 	kialiSvc := []core_v1.Service{
 		{
@@ -141,7 +140,7 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 	objects := []runtime.Object{
 		&istioDeploymentMock,
 		&sidecarConfigMapMock,
-		&kialiNs,
+		kialiNs,
 	}
 
 	for _, obj := range kialiSvc {
@@ -183,12 +182,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 	conf := config.NewConfig()
 	conf.InCluster = false
 
-	remoteNs := &core_v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"topology.istio.io/network": "TheRemoteNetwork"},
-			Name:   conf.IstioNamespace,
-		},
-	}
+	remoteNs := kubetest.FakeNamespaceWithLabels(conf.IstioNamespace, map[string]string{"topology.istio.io/network": "TheRemoteNetwork"})
 
 	kialiSvc := &core_v1.Service{
 		ObjectMeta: v1.ObjectMeta{
@@ -317,7 +311,7 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 
 	// Create a MeshService and invoke GetClusters. This should cache the result.
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "foo"}},
+		kubetest.FakeNamespace("foo"),
 		istioDeploymentMock,
 		kialiSvc,
 	)
@@ -376,7 +370,7 @@ trustDomain: cluster.local
 	require := require.New(t)
 	conf := config.NewConfig()
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiodDeployment,
 		istioConfigMap,
 		sideCarConfigMap,
@@ -514,7 +508,7 @@ func TestMeshResolvesNetwork(t *testing.T) {
 			}
 
 			k8s := kubetest.NewFakeK8sClient(
-				&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+				kubetest.FakeNamespace("istio-system"),
 				istiodDeployment,
 				istioConfigMap,
 				tc.sideCarInjectorConfigMap,
@@ -586,7 +580,7 @@ trustDomain: cluster.local
 	require := require.New(t)
 	conf := config.NewConfig()
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiod_1_18_Deployment,
 		istio_1_18_ConfigMap,
 		istiod_1_19_Deployment,
@@ -650,7 +644,7 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiodDeployment,
 		istioConfigMap,
 	)
@@ -658,8 +652,9 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
@@ -700,7 +695,7 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	eastClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiodDeployment,
 		istioConfigMap,
 	)
@@ -708,8 +703,9 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "*"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
@@ -750,7 +746,7 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	eastClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiodDeployment,
 		istioConfigMap,
 	)
@@ -758,8 +754,9 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{"east": eastClient, "remote": remoteClient}
@@ -792,14 +789,14 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	eastClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("bookinfo"),
 		fakeIstiodDeployment("east", false),
 		istioConfigMap,
 	)
 	westClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("bookinfo"),
 		fakeIstiodDeployment("west", false),
 		istioConfigMap,
 	)
@@ -845,8 +842,8 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	eastClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("bookinfo"),
 		fakeIstiodDeployment("east", true),
 		istioConfigMap,
 	)
@@ -854,12 +851,13 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "east"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 	westClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("bookinfo"),
 		fakeIstiodDeployment("west", true),
 		istioConfigMap,
 	)
@@ -867,8 +865,9 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "west"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{
@@ -938,8 +937,8 @@ trustDomain: cluster.local
 	externalControlPlane.Name = "istiod"
 
 	controlPlaneClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "external-istiod"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("external-istiod"),
 		fakeIstiodDeployment("controlplane", false),
 		externalControlPlane,
 		istioConfigMap,
@@ -947,16 +946,17 @@ trustDomain: cluster.local
 	)
 
 	dataPlaneClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "external-istiod"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("external-istiod"),
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	dataPlaneRemoteClient := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "external-istiod",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: "dataplane"},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "external-istiod"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{
@@ -1038,9 +1038,14 @@ func TestGetClustersShowsConfiguredKialiInstances(t *testing.T) {
 func TestGetClustersWorksWithNamespacedScope(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	conf := config.NewConfig()
-	conf.Deployment.ClusterWideAccess = false
-	conf.Deployment.AccessibleNamespaces = []string{"istio-system"}
+
+	conf := testutils.GetConfigFromYaml(t, `
+deployment:
+  cluster_wide_access: false
+  discovery_selectors:
+    default:
+    - matchLabels: {"kubernetes.io/metadata.name": "istio-system" }
+`)
 
 	kialiService := &core_v1.Service{
 		ObjectMeta: v1.ObjectMeta{
@@ -1050,7 +1055,7 @@ func TestGetClustersWorksWithNamespacedScope(t *testing.T) {
 		},
 	}
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		kialiService,
 	)
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s}
@@ -1109,7 +1114,7 @@ trustDomain: cluster.local
 		Data: map[string]string{"mesh": configMapData},
 	}
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		istiodDeployment,
 		istioConfigMap,
 	)
@@ -1117,8 +1122,9 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
+		kubetest.FakeNamespace("bookinfo"),
 	)
 
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: k8s, "remote": remoteClient}
@@ -1309,7 +1315,7 @@ func TestIstiodResourceThresholds(t *testing.T) {
 				},
 			}
 			k8s := kubetest.NewFakeK8sClient(
-				&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+				kubetest.FakeNamespace("istio-system"),
 				istiodDeployment,
 				&core_v1.ConfigMap{
 					ObjectMeta: v1.ObjectMeta{
@@ -1435,7 +1441,7 @@ func TestCanConnectToIstiod(t *testing.T) {
 			runningIstiodPod("default"),
 			fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 			fakeIstioConfigMap("default"),
-			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+			kubetest.FakeNamespace("istio-system"),
 		),
 		testURL: testServer.URL,
 	}
@@ -1470,7 +1476,7 @@ func TestCanConnectToUnreachableIstiod(t *testing.T) {
 			runningIstiodPod("default"),
 			fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 			fakeIstioConfigMap("default"),
-			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+			kubetest.FakeNamespace("istio-system"),
 		),
 	}
 
@@ -1502,7 +1508,7 @@ func TestUpdateStatusMultipleRevsWithoutHealthyPods(t *testing.T) {
 	istiod_1_19 := fakeIstiodWithRevision(conf.KubernetesConfig.ClusterName, "1-19-0", false)
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		defaultIstiod,
 		istiod_1_19,
 		fakeIstioConfigMap("default"),
@@ -1544,7 +1550,7 @@ func TestUpdateStatusMultipleHealthyRevs(t *testing.T) {
 	istiod_1_19_pod.Labels[models.IstioRevisionLabel] = "1-19-0"
 
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		defaultIstiod,
 		istiod_1_19,
 		fakeIstioConfigMap("default"),

--- a/istio/version_test.go
+++ b/istio/version_test.go
@@ -210,7 +210,7 @@ func TestGetVersionRemoteCluster(t *testing.T) {
 					},
 				},
 			},
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+			kubetest.FakeNamespace("istio-system"),
 		),
 	}
 

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -146,7 +147,7 @@ func NewKialiCache(clientFactory kubernetes.ClientFactory, cfg config.Config) (K
 	}
 
 	for cluster, client := range clientFactory.GetSAClients() {
-		cache, err := NewKubeCache(client, cfg)
+		cache, err := NewKubeCache(client, cfg, kialiCacheImpl.deleteNamespace)
 		if err != nil {
 			log.Errorf("[Kiali Cache] Error creating kube cache for cluster: [%s]. Err: %v", cluster, err)
 			return nil, err
@@ -380,6 +381,18 @@ func (c *kialiCacheImpl) SetNamespace(token string, namespace models.Namespace) 
 
 	ns[namespace.Name] = namespace
 	c.namespaceStore.Set(key, ns)
+}
+
+// deleteNamespace is an error handler that will clean up some internals related to the given namespace
+// if that namespace has been detected to have been deleted. This function is called by the kube cache
+// informers when they encounter an error.
+func (c *kialiCacheImpl) deleteNamespace(kc *kubeCache, namespace string, err error) {
+	if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+		cluster := kc.client.ClusterInfo().Name
+		log.Errorf("Namespace [%v] in cluster [%v] appears to have been deleted or Kiali is forbidden from seeing it [err=%v]. Shutting down namespace cache.", namespace, cluster, err)
+		c.RefreshTokenNamespaces(cluster)
+		kc.StopNamespace(namespace)
+	}
 }
 
 func (c *kialiCacheImpl) GetBuildInfo() models.BuildInfo {

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -147,7 +147,12 @@ func NewKialiCache(clientFactory kubernetes.ClientFactory, cfg config.Config) (K
 	}
 
 	for cluster, client := range clientFactory.GetSAClients() {
-		cache, err := NewKubeCache(client, cfg, kialiCacheImpl.deleteNamespace)
+		// we only need our deleteNamespace function called when an error occurs in a namespace-scoped cache
+		var errHandler ErrorHandler
+		if !cfg.Deployment.ClusterWideAccess {
+			errHandler = kialiCacheImpl.deleteNamespace
+		}
+		cache, err := NewKubeCache(client, cfg, errHandler)
 		if err != nil {
 			log.Errorf("[Kiali Cache] Error creating kube cache for cluster: [%s]. Err: %v", cluster, err)
 			return nil, err

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -37,6 +37,7 @@ const (
 // to so it uses the kiali service account token instead of a user token. Access to
 // the objects returned by the cache should be filtered/restricted to the user's
 // token access but the cache returns objects without any filtering or restrictions.
+// This object keeps one KubeCache per cluster.
 // TODO: Consider removing the interface altogether in favor of just exporting the struct.
 type KialiCache interface {
 	GetBuildInfo() models.BuildInfo

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
-	core_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
@@ -39,7 +38,7 @@ func TestKubeCacheCreatedPerClient(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
 
-	ns := &core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	ns := kubetest.FakeNamespace("test")
 	deploymentCluster1 := &apps_v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment1", Namespace: "test"}}
 	deploymentCluster2 := &apps_v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment2", Namespace: "test"}}
 	client := kubetest.NewFakeK8sClient(ns, deploymentCluster1)
@@ -89,7 +88,7 @@ func TestIsAmbientEnabled(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
 	client := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		ztunnelDaemonSet(),
 	)
 	cache := cache.NewTestingCache(t, client, *conf)
@@ -105,7 +104,7 @@ func TestIsAmbientEnabledOutsideIstioSystem(t *testing.T) {
 	ztunnel := ztunnelDaemonSet()
 	ztunnel.Namespace = "alternate-istio-namespace"
 	client := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "alternate-istio-namespace"}},
+		kubetest.FakeNamespace("alternate-istio-namespace"),
 		ztunnel,
 	)
 	cache := cache.NewTestingCache(t, client, *conf)
@@ -119,7 +118,7 @@ func TestIsAmbientDisabled(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
 	client := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 	)
 	cache := cache.NewTestingCache(t, client, *conf)
 
@@ -133,11 +132,11 @@ func TestIsAmbientMultiCluster(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "east"
 	east := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		ztunnelDaemonSet(),
 	)
 	west := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 	)
 	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
 	clientFactory.SetClients(map[string]kubernetes.ClientInterface{
@@ -154,7 +153,7 @@ func TestIsAmbientMultiCluster(t *testing.T) {
 func TestIsAmbientIsThreadSafe(t *testing.T) {
 	conf := config.NewConfig()
 	client := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		ztunnelDaemonSet(),
 	)
 	cache := cache.NewTestingCache(t, client, *conf)

--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -60,6 +60,9 @@ type KubeCache interface {
 	// Stop all caches
 	Stop()
 
+	// StopNamespace cleans up the namespace-scoped cache for the given namespace
+	StopNamespace(namespace string)
+
 	// Client returns the underlying client for the KubeCache.
 	// This is useful for when you want to talk directly to the kube API
 	// using the Kiali Service Account client.
@@ -162,10 +165,23 @@ type cacheLister struct {
 	workloadGroupLister     istionet_v1_listers.WorkloadGroupLister
 }
 
+// ErrorHandler is a function that will be called when the cache's informers encounter an error while watching resources.
+// This is used so we can clean up things when a namespace has been discovered to have been deleted.
+// This is ONLY used for namespace-scoped caches.
+// This will ONLY report errors when watching core k8s resources (e.g. not Istio resources)
+//
+// kc: the kube cache whose informer encountered an error
+// namespace: the namespace that the kube cache is watching
+// err: the error that occurred
+type ErrorHandler func(kc *kubeCache, namespace string, err error)
+
 // kubeCache is a local cache of kube objects. Manages informers and listers.
 type kubeCache struct {
-	cacheLock          sync.RWMutex
+	cacheLock sync.RWMutex
+	// refreshOnce enforces thread safety around the re-starting of informers
+	refreshOnce        *OnceWrapper
 	cfg                config.Config
+	errorHandler       ErrorHandler
 	client             kubernetes.ClientInterface
 	clusterCacheLister *cacheLister
 	clusterScoped      bool
@@ -183,17 +199,19 @@ type kubeCache struct {
 }
 
 // Starts all informers. These run until context is cancelled.
-func NewKubeCache(kialiClient kubernetes.ClientInterface, cfg config.Config) (*kubeCache, error) {
+func NewKubeCache(kialiClient kubernetes.ClientInterface, cfg config.Config, errorHandler ErrorHandler) (*kubeCache, error) {
 	refreshDuration := time.Duration(cfg.KubernetesConfig.CacheDuration) * time.Second
 
 	c := &kubeCache{
-		cfg:    cfg,
-		client: kialiClient,
+		cfg:          cfg,
+		errorHandler: errorHandler,
+		client:       kialiClient,
 		// Only when all namespaces are accessible should the cache be cluster scoped.
 		// Otherwise, kiali may not have access to all namespaces since
 		// the operator only grants clusterroles when all namespaces are accessible.
 		clusterScoped:   cfg.AllNamespacesAccessible(),
 		refreshDuration: refreshDuration,
+		refreshOnce:     &OnceWrapper{once: &sync.Once{}},
 	}
 
 	if c.clusterScoped {
@@ -275,6 +293,16 @@ func (c *kubeCache) Stop() {
 	}
 }
 
+func (c *kubeCache) StopNamespace(namespace string) {
+	log.Infof("Stopping Kiali Cache for namespace [%v]", namespace)
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
+
+	if !c.clusterScoped {
+		c.stop(namespace)
+	}
+}
+
 func (c *kubeCache) stop(namespace string) {
 	if c.clusterScoped {
 		close(c.stopClusterScopedChan)
@@ -303,8 +331,17 @@ func (c *kubeCache) refresh(namespace string) error {
 		namespace = ""
 	}
 
-	c.stop(namespace)
-	return c.startInformers(namespace)
+	// We need to be thread-safe here so refreshing doesn't deadlock after a deleted namespace is re-created.
+	// Locking here ensures concurrent calls to getCacheLister doesn't deadlock. There tends to be a flurry
+	// of concurrent calls to getCacheLister and if at that time the namespace cache needs to be refreshed, we
+	// only want to create informers once here. This might not always create informers one time, but it helps limit
+	// the number of times informers are created and then immediately thrown away and created again.
+	defer c.refreshOnce.Reset()
+	return c.refreshOnce.Do(func() error {
+		log.Debugf("Restarting cache informers for namespace [%v]", namespace)
+		c.stop(namespace)
+		return c.startInformers(namespace)
+	})
 }
 
 // starter is a small interface around the different informer factories that
@@ -507,6 +544,39 @@ func (c *kubeCache) createKubernetesInformers(namespace string) informers.Shared
 
 	sharedInformers := informers.NewSharedInformerFactoryWithOptions(c.client.Kube(), c.refreshDuration, opts...)
 
+	// If this is a namespace-scoped cache, set a watch error handler on all the things we are watching.
+	// If the error is due to the client being forbidden from seeing the resource, this likely means the namespace
+	// has been deleted. In this case, we want to disable this namespace-scoped cache since it will not work for any
+	// resource. We add a watch handler on all informers because we don't know which one will be used first after
+	// the namespace deletion and we want to shut the informers down as quickly as we can.
+	if namespace != "" {
+		informersToWatchList := []cache.SharedIndexInformer{
+			sharedInformers.Apps().V1().Deployments().Informer(),
+			sharedInformers.Apps().V1().StatefulSets().Informer(),
+			sharedInformers.Apps().V1().DaemonSets().Informer(),
+			sharedInformers.Core().V1().Services().Informer(),
+			sharedInformers.Core().V1().Endpoints().Informer(),
+			sharedInformers.Core().V1().Pods().Informer(),
+			sharedInformers.Apps().V1().ReplicaSets().Informer(),
+			sharedInformers.Core().V1().ConfigMaps().Informer(),
+		}
+
+		watchErrorHandler := func(r *cache.Reflector, err error) {
+			if c.errorHandler != nil {
+				c.errorHandler(c, namespace, err)
+			} else {
+				log.Errorf("Error detected when watching namespace [%v] in cluster [%v]. error: %v", namespace, c.client.ClusterInfo().Name, err)
+			}
+		}
+
+		for _, informerToWatch := range informersToWatchList {
+			err := informerToWatch.SetWatchErrorHandler(watchErrorHandler)
+			if err != nil {
+				log.Errorf("Failed to install watch error handler for namespace [%v]; will not detect if it gets deleted", namespace)
+			}
+		}
+	}
+
 	lister := &cacheLister{
 		deploymentLister:  sharedInformers.Apps().V1().Deployments().Lister(),
 		statefulSetLister: sharedInformers.Apps().V1().StatefulSets().Lister(),
@@ -541,7 +611,23 @@ func (c *kubeCache) getCacheLister(namespace string) *cacheLister {
 	if c.clusterScoped {
 		return c.clusterCacheLister
 	}
-	return c.nsCacheLister[namespace]
+
+	lister, ok := c.nsCacheLister[namespace]
+	if !ok {
+		logPrefix := fmt.Sprintf("Kiali Cache for namespace [%v] in cluster [%v]", namespace, c.client.ClusterInfo().Name)
+		log.Debugf("%v: attempting to restart informers", logPrefix)
+		if err := c.refresh(namespace); err != nil {
+			log.Errorf("%v: restarting informers failed with error: %v", logPrefix, err)
+		}
+		lister, ok = c.nsCacheLister[namespace]
+		if ok {
+			log.Debugf("%v: successfully obtained listers", logPrefix)
+		} else {
+			// this likely means the caller is going to segfault with nil pointer; TODO return error and let callers gracefully fail
+			log.Fatalf("%v: failed to obtain listers", logPrefix)
+		}
+	}
+	return lister
 }
 
 func (c *kubeCache) GetConfigMap(namespace, name string) (*core_v1.ConfigMap, error) {

--- a/kubernetes/cache/kube_cache_test.go
+++ b/kubernetes/cache/kube_cache_test.go
@@ -25,7 +25,7 @@ const IstioAPIEnabled = true
 func newTestingKubeCache(t *testing.T, cfg *config.Config, objects ...runtime.Object) *kubeCache {
 	t.Helper()
 
-	kubeCache, err := NewKubeCache(kubetest.NewFakeK8sClient(objects...), *cfg)
+	kubeCache, err := NewKubeCache(kubetest.NewFakeK8sClient(objects...), *cfg, nil)
 	if err != nil {
 		t.Fatalf("Unable to create kube cache for testing. Err: %s", err)
 	}
@@ -326,7 +326,7 @@ func TestIstioAPIDisabled(t *testing.T) {
 	cfg := config.NewConfig()
 	fakeClient := kubetest.NewFakeK8sClient(ns)
 	fakeClient.IstioAPIEnabled = false
-	kubeCache, err := NewKubeCache(fakeClient, *cfg)
+	kubeCache, err := NewKubeCache(fakeClient, *cfg, nil)
 	if err != nil {
 		t.Fatalf("Unable to create kube cache for testing. Err: %s", err)
 	}

--- a/kubernetes/cache/once_wrapper.go
+++ b/kubernetes/cache/once_wrapper.go
@@ -1,0 +1,28 @@
+package cache
+
+import (
+	"sync"
+)
+
+type OnceWrapper struct {
+	once *sync.Once
+	rwMu sync.RWMutex
+	err  error // the result of the last exection of the function passed to Do()
+}
+
+func (o *OnceWrapper) Do(callable func() error) error {
+	o.rwMu.RLock()
+	defer o.rwMu.RUnlock()
+	o.once.Do(func() {
+		o.err = callable()
+	})
+	return o.err
+}
+
+// Reset for the next Do
+func (o *OnceWrapper) Reset() {
+	o.rwMu.Lock()
+	defer o.rwMu.Unlock()
+	o.once = &sync.Once{}
+	o.err = nil
+}

--- a/kubernetes/cache/once_wrapper_test.go
+++ b/kubernetes/cache/once_wrapper_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func forConcurrentAccess(ow *OnceWrapper, lock *sync.Mutex, key int, value string, data map[int]string) {
+	// If this works like it should, for each concurrent set of calls, only one will be able to set a key value in the data map.
+	// This is simulating the usage of OnceWrapper that is implemented in the cache refresh function.
+	defer ow.Reset()
+	ow.Do(func() error { //nolint:errcheck
+		lock.Lock()
+		data[key] = value
+		lock.Unlock()
+		time.Sleep(1 * time.Second)
+		return nil
+	})
+}
+func TestOnceWrapper_Do(t *testing.T) {
+	assert := assert.New(t)
+
+	onceWrapper := &OnceWrapper{once: &sync.Once{}}
+	testBucket := map[int]string{}
+	lock := sync.Mutex{} // required to use a lock so we can pass the data race test
+
+	// make some concurrent calls - only one should actually do something
+	wg := sync.WaitGroup{}
+	for i := 1; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			forConcurrentAccess(onceWrapper, &lock, i, "A", testBucket)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// there should only be one data key in the testBucket - we aren't guaranteed which one, but only one should be there
+	lock.Lock()
+	assert.Len(testBucket, 1, "There should have only been one invocation of the function that sets testBucket data")
+	for _, v := range testBucket {
+		assert.Equal(v, "A")
+	}
+	lock.Unlock()
+
+	lock.Lock()
+	testBucket = map[int]string{}
+	lock.Unlock()
+
+	// Second round of calls to see OnceWrapper was reset and still works
+	wg = sync.WaitGroup{}
+	for i := 10; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			forConcurrentAccess(onceWrapper, &lock, i, "B", testBucket)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// there should only be one data key in the testBucket - we aren't guaranteed which one, but only one should be there
+	lock.Lock()
+	assert.Len(testBucket, 1, "There should have only been one invocation of the function that sets testBucket data")
+	for _, v := range testBucket {
+		assert.Equal(v, "B")
+	}
+	lock.Unlock()
+}

--- a/kubernetes/istio_test.go
+++ b/kubernetes/istio_test.go
@@ -20,7 +20,7 @@ func TestGetClusterInfoFromIstiod(t *testing.T) {
 
 	conf := config.NewConfig()
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "istiod",
@@ -57,7 +57,7 @@ func TestGetClusterInfoFromIstiodFails(t *testing.T) {
 
 	conf := config.NewConfig()
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "istiod",
@@ -88,7 +88,7 @@ func TestClusterNameFromIstiodUsesConfigWhenSet(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstiodDeploymentName = "different-istiod"
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "istiod",
@@ -142,7 +142,7 @@ func TestClusterNameFromIstiodResolvesClusterWithoutConfig(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstiodDeploymentName = ""
 	k8s := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "istio-system"}},
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "istiod",

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -279,9 +279,19 @@ func FakeIstioAmbientAnnotations() map[string]string {
 }
 
 func FakeNamespace(name string) *core_v1.Namespace {
+	return FakeNamespaceWithLabels(name, nil)
+}
+
+func FakeNamespaceWithLabels(name string, labels map[string]string) *core_v1.Namespace {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	// discovery selectors often match on the name, so let's make sure all our test namespaces have it
+	labels["kubernetes.io/metadata.name"] = name
 	return &core_v1.Namespace{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labels,
 		},
 	}
 }

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -90,7 +90,7 @@ operator-create: .ensure-operator-repo-exists .ensure-operator-helm-chart-exists
     --operator-install-kiali        "${OPERATOR_INSTALL_KIALI}" \
     --operator-namespace            "${OPERATOR_NAMESPACE}" \
     --operator-watch-namespace      "${OPERATOR_WATCH_NAMESPACE}" \
-    --accessible-namespaces         "${ACCESSIBLE_NAMESPACES}" \
+    --cluster-wide-access           "${CLUSTER_WIDE_ACCESS}" \
     --auth-strategy                 "${AUTH_STRATEGY}" \
     --kiali-image-name              "${CLUSTER_KIALI_INTERNAL_NAME}" \
     --kiali-image-pull-policy       "${KIALI_IMAGE_PULL_POLICY}" \
@@ -117,7 +117,7 @@ kiali-create: .ensure-operator-repo-exists .prepare-cluster
 	${OC} get namespace ${OPERATOR_INSTALL_KIALI_CR_NAMESPACE} &> /dev/null || ${OC} create namespace ${OPERATOR_INSTALL_KIALI_CR_NAMESPACE}
 	@echo Deploy Kiali using the settings found in ${KIALI_CR_FILE}
 	cat ${KIALI_CR_FILE} | \
-ACCESSIBLE_NAMESPACES="${ACCESSIBLE_NAMESPACES}" \
+CLUSTER_WIDE_ACCESS="${CLUSTER_WIDE_ACCESS}" \
 AUTH_STRATEGY="${AUTH_STRATEGY}" \
 KIALI_EXTERNAL_SERVICES_PASSWORD="$(shell ${OC} get secrets htpasswd -n ${NAMESPACE} -o jsonpath='{.data.rawPassword}' 2>/dev/null | base64 --decode)" \
 KIALI_IMAGE_NAME="${CLUSTER_KIALI_INTERNAL_NAME}" \

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -109,9 +109,9 @@ trustDomain: cluster.local
 	}
 
 	primaryClient := kubetest.NewFakeK8sClient(
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-1"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-2"}},
+		kubetest.FakeNamespace("istio-system"),
+		kubetest.FakeNamespace("data-plane-1"),
+		kubetest.FakeNamespace("data-plane-2"),
 		&istiodDeployment,
 		&istioConfigMap,
 		&sidecarConfigMap,
@@ -126,9 +126,10 @@ trustDomain: cluster.local
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{
 			Name:        "istio-system",
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
+			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-3"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "data-plane-4"}},
+		kubetest.FakeNamespace("data-plane-3"),
+		kubetest.FakeNamespace("data-plane-4"),
 	)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: primaryClient,

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -203,14 +203,18 @@
               "name": "data-plane-1",
               "cluster": "cluster-primary",
               "isAmbient": false,
-              "labels": null,
+              "labels": {
+                "kubernetes.io/metadata.name": "data-plane-1"
+              },
               "annotations": null
             },
             {
               "name": "data-plane-2",
               "cluster": "cluster-primary",
               "isAmbient": false,
-              "labels": null,
+              "labels": {
+                "kubernetes.io/metadata.name": "data-plane-2"
+              },
               "annotations": null
             }
           ],
@@ -305,14 +309,18 @@
               "name": "data-plane-3",
               "cluster": "cluster-remote",
               "isAmbient": false,
-              "labels": null,
+              "labels": {
+                "kubernetes.io/metadata.name": "data-plane-3"
+              },
               "annotations": null
             },
             {
               "name": "data-plane-4",
               "cluster": "cluster-remote",
               "isAmbient": false,
-              "labels": null,
+              "labels": {
+                "kubernetes.io/metadata.name": "data-plane-4"
+              },
               "annotations": null
             }
           ],

--- a/models/mesh.go
+++ b/models/mesh.go
@@ -2,7 +2,8 @@ package models
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/config"
 )
 
 const (
@@ -89,10 +90,10 @@ type Certificate struct {
 }
 
 type IstioMeshConfig struct {
-	Certificates            []Certificate           `yaml:"certificates,omitempty" json:"certificates,omitempty"`
-	DisableMixerHttpReports bool                    `yaml:"disableMixerHttpReports,omitempty"`
-	DiscoverySelectors      []*metav1.LabelSelector `yaml:"discoverySelectors,omitempty"`
-	EnableAutoMtls          *bool                   `yaml:"enableAutoMtls,omitempty"`
+	Certificates            []Certificate                 `yaml:"certificates,omitempty" json:"certificates,omitempty"`
+	DisableMixerHttpReports bool                          `yaml:"disableMixerHttpReports,omitempty"`
+	DiscoverySelectors      config.DiscoverySelectorsType `yaml:"discoverySelectors,omitempty"`
+	EnableAutoMtls          *bool                         `yaml:"enableAutoMtls,omitempty"`
 	MeshMTLS                struct {
 		MinProtocolVersion string `yaml:"minProtocolVersion"`
 	} `yaml:"meshMtls"`

--- a/tests/testutils/prepare_config.go
+++ b/tests/testutils/prepare_config.go
@@ -1,0 +1,23 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/config"
+)
+
+// GetConfigFromYaml provides a way for tests to write config as yaml. This gives a chance for tests to exercise the Unmarshal functionality.
+// This also provides an easy way for tests to set up the config object correctly. This comes into play when, for example,
+// you want cluster_wide_access set to false with discovery selectors set - the unmarshalling code this function utilizes will prepare the
+// accessible namespaces thus freeing the test authors from having to remember to do that explicitly in the test code.
+// This will provide easy-to-read failure log messages if the given yaml is malformed in some way (for easier debugging of test code).
+func GetConfigFromYaml(t *testing.T, yaml string) *config.Config {
+	if cfg, err := config.Unmarshal(yaml); err != nil {
+		// mark the test as a failure; we'll keep going so the log will show what test failed
+		t.Helper()
+		t.Fatalf("Test provided invalid config YAML.\nERROR: %v\nYAML:%v", err, yaml)
+		return &config.Config{InstallationTag: "TEST FAILED DUE TO INVALID YAML"}
+	} else {
+		return cfg
+	}
+}

--- a/tests/testutils/prepare_config.go
+++ b/tests/testutils/prepare_config.go
@@ -12,9 +12,9 @@ import (
 // accessible namespaces thus freeing the test authors from having to remember to do that explicitly in the test code.
 // This will provide easy-to-read failure log messages if the given yaml is malformed in some way (for easier debugging of test code).
 func GetConfigFromYaml(t *testing.T, yaml string) *config.Config {
+	t.Helper()
 	if cfg, err := config.Unmarshal(yaml); err != nil {
 		// mark the test as a failure; we'll keep going so the log will show what test failed
-		t.Helper()
 		t.Fatalf("Test provided invalid config YAML.\nERROR: %v\nYAML:%v", err, yaml)
 		return &config.Config{InstallationTag: "TEST FAILED DUE TO INVALID YAML"}
 	} else {


### PR DESCRIPTION
Implement the new discovery selector support in the server.

part of: kiali/kiali#7546
part of KEP: https://github.com/kiali/kiali/blob/master/design/KEPS/namespace-discovery/proposal.md

server PR: https://github.com/kiali/kiali/pull/7592
operator PR: https://github.com/kiali/kiali-operator/pull/797
helm chart PR: kiali/helm-charts#274
docs PR: https://github.com/kiali/kiali.io/pull/807

This also fixes: https://github.com/kiali/kiali/issues/7655

Some ways to test:
* Unit tests
* Molecule tests
* [manual tests](https://github.com/kiali/kiali/pull/7592#issuecomment-2276388510)
* [multicluster tests](https://github.com/kiali/kiali/pull/7592#issuecomment-2278416500)