### PR TITLE
[ambient] waypoint arrows and PF fix

### DIFF
--- a/frontend/src/components/CytoscapeGraph/__tests__/GraphScore.test.ts
+++ b/frontend/src/components/CytoscapeGraph/__tests__/GraphScore.test.ts
@@ -55,6 +55,7 @@ describe('scoreNodes', () => {
     };
     edgeData = {
       id: 'any',
+      display: '',
       source: 'any',
       target: 'any',
       grpc: 0,

--- a/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -938,6 +938,9 @@ export class GraphStyles {
             return getEdgeColor(ele);
           },
           'line-style': 'solid',
+          'source-arrow-color': (ele: Cy.EdgeSingular) => {
+            return getEdgeColor(ele);
+          },
           'target-arrow-shape': 'vee',
           'target-arrow-color': (ele: Cy.EdgeSingular) => {
             return getEdgeColor(ele);
@@ -997,6 +1000,20 @@ export class GraphStyles {
           'overlay-color': PFColorVals.Purple200,
           'overlay-padding': '7px',
           'overlay-opacity': OpacityOverlay
+        }
+      },
+      {
+        selector: `edge[direction="reverse"]`,
+        style: {
+          'target-arrow-shape': 'triangle-cross',
+          'source-arrow-shape': 'triangle-cross',
+          'line-style': 'solid'
+        }
+      },
+      {
+        selector: `edge[display="hide"]`,
+        style: {
+          display: 'none'
         }
       }
     ];

--- a/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/frontend/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1003,7 +1003,7 @@ export class GraphStyles {
         }
       },
       {
-        selector: `edge[direction="reverse"]`,
+        selector: `edge[display="reverse"]`,
         style: {
           'target-arrow-shape': 'triangle-cross',
           'source-arrow-shape': 'triangle-cross',

--- a/frontend/src/pages/GraphPF/GraphHighlighterPF.ts
+++ b/frontend/src/pages/GraphPF/GraphHighlighterPF.ts
@@ -134,7 +134,8 @@ export class GraphHighlighterPF {
   };
 
   getNodeHighlight = (node: Node): GraphElement[] => {
-    const elems = predecessors(node).concat(successors(node));
+    let elems = [] as GraphElement[];
+    elems = predecessors(node, elems).concat(successors(node, elems));
     elems.push(node);
 
     return this.includeAncestorNodes(elems);
@@ -143,8 +144,10 @@ export class GraphHighlighterPF {
   getEdgeHighlight = (edge: Edge): GraphElement[] => {
     const source = edge.getSource();
     const target = edge.getTarget();
+    let emptyElems = [] as GraphElement[];
 
-    let elems = [edge, source, target, ...predecessors(source), ...successors(target)];
+    let elems = [] as GraphElement[];
+    elems = [edge, source, target, ...predecessors(source, emptyElems), ...successors(target, emptyElems)];
     elems = this.includeAncestorNodes(elems);
 
     return elems;
@@ -154,16 +157,17 @@ export class GraphHighlighterPF {
     // treat App boxes in a typical way, but to reduce "flashing", Namespace and Cluster
     // boxes highlight themselves and their anscestors.
     if (box.getData()[NodeAttr.isBox] === BoxByType.APP) {
+      let emptyElems = [] as GraphElement[];
       let elems: GraphElement[];
       const children = box.getChildren();
       elems = [...children];
 
       children.forEach(n => {
         elems = Array.from(
-          new Set<GraphElement>([...elems, ...predecessors(n as Node)])
+          new Set<GraphElement>([...elems, ...predecessors(n as Node, emptyElems)])
         );
         elems = Array.from(
-          new Set<GraphElement>([...elems, ...successors(n as Node)])
+          new Set<GraphElement>([...elems, ...successors(n as Node, emptyElems)])
         );
       });
 

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -90,6 +90,7 @@ export type EdgeData = DecoratedGraphEdgeData & {
   isUnhighlighted?: boolean;
   onHover?: (element: GraphElement, isMouseIn: boolean) => void;
   pathStyle?: React.CSSProperties;
+  startTerminalType?: EdgeTerminalType;
   tag?: string;
   tagStatus?: NodeStatus;
 };
@@ -576,7 +577,9 @@ const getPathStyle = (data: EdgeData): React.CSSProperties => {
 
 export const setEdgeOptions = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphPFSettings): void => {
   const data = edge.data as EdgeData;
-
+  if (data.display === 'reverse') {
+    data.startTerminalType = data.protocol === Protocol.TCP ? EdgeTerminalType.square : EdgeTerminalType.directional;
+  }
   data.endTerminalType = data.protocol === Protocol.TCP ? EdgeTerminalType.square : EdgeTerminalType.directional;
   data.pathStyle = getPathStyle(data);
   data.tag = getEdgeLabel(edge, nodeMap, settings);

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -764,21 +764,35 @@ export const nodesOut = (nodes: Node[]): Node[] => {
   return Array.from(new Set(result));
 };
 
-export const predecessors = (node: Node): GraphElement[] => {
+export const predecessors = (node: Node, processed: GraphElement[]): GraphElement[] => {
   let result = [] as GraphElement[];
   const targetEdges = node.getTargetEdges();
   const sourceNodes = targetEdges.map(e => e.getSource());
   result = result.concat(targetEdges, sourceNodes);
-  sourceNodes.forEach(n => (result = result.concat(predecessors(n))));
+
+  sourceNodes.forEach(n => {
+    if (processed.indexOf(n) === -1) {
+      // Processed nodes is used to avoid infinite loops
+      processed = processed.concat(n);
+      result = result.concat(predecessors(n, processed));
+    }
+  });
+
   return result;
 };
 
-export const successors = (node: Node): GraphElement[] => {
+export const successors = (node: Node, processed: GraphElement[]): GraphElement[] => {
   let result = [] as GraphElement[];
   const sourceEdges = node.getSourceEdges();
   const targetNodes = sourceEdges.map(e => e.getTarget());
   result = result.concat(sourceEdges, targetNodes);
-  targetNodes.forEach(n => (result = result.concat(successors(n))));
+  targetNodes.forEach(n => {
+    if (processed.indexOf(n) === -1) {
+      // Processed nodes is used to avoid infinite loops
+      processed = processed.concat(n);
+      result = result.concat(successors(n, processed));
+    }
+  });
   return result;
 };
 

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -486,6 +486,7 @@ export interface DecoratedGraphNodeData extends GraphNodeData {
 
 // Edge data after decorating at fetch-time (what is mainly used by ui code)
 export interface DecoratedGraphEdgeData extends GraphEdgeData {
+  display: string;
   grpc: number;
   grpcErr: number;
   grpcNoResponse: number;

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -448,9 +448,6 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 			if e.Metadata[graph.SourcePrincipal] != nil {
 				ed.SourcePrincipal = e.Metadata[graph.SourcePrincipal].(string)
 			}
-			if e.Metadata[graph.Direction] != nil {
-				ed.Direction = e.Metadata[graph.Direction].(string)
-			}
 			if e.Metadata[graph.Display] != nil {
 				ed.Display = e.Metadata[graph.Display].(string)
 			}

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -132,6 +132,8 @@ type EdgeData struct {
 	Target string `json:"target"` // child node ID
 
 	// App Fields (not required by Cytoscape)
+	Display         string          `json:"display,omitempty"`         // Used to hide edges for biderectional ones (Ambient graph simplification)
+	Direction       string          `json:"direction,omitempty"`       // Used to represent bidirectional edges (Ambient graph simplification)
 	DestPrincipal   string          `json:"destPrincipal,omitempty"`   // principal used for the edge destination
 	IsMTLS          string          `json:"isMTLS,omitempty"`          // set to the percentage of traffic using a mutual TLS connection
 	ResponseTime    string          `json:"responseTime,omitempty"`    // in millis
@@ -445,6 +447,12 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 			}
 			if e.Metadata[graph.SourcePrincipal] != nil {
 				ed.SourcePrincipal = e.Metadata[graph.SourcePrincipal].(string)
+			}
+			if e.Metadata[graph.Direction] != nil {
+				ed.Direction = e.Metadata[graph.Direction].(string)
+			}
+			if e.Metadata[graph.Display] != nil {
+				ed.Display = e.Metadata[graph.Display].(string)
 			}
 			addEdgeTelemetry(e, &ed)
 

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -15,6 +15,8 @@ func NewMetadata() Metadata {
 const (
 	Aggregate             MetadataKey = "aggregate" // the prom attribute used for aggregation
 	AggregateValue        MetadataKey = "aggregateValue"
+	Direction             MetadataKey = "direction"
+	Display               MetadataKey = "display"
 	DestPrincipal         MetadataKey = "destPrincipal"
 	DestServices          MetadataKey = "destServices"
 	HealthData            MetadataKey = "healthData"

--- a/graph/meta.go
+++ b/graph/meta.go
@@ -15,7 +15,6 @@ func NewMetadata() Metadata {
 const (
 	Aggregate             MetadataKey = "aggregate" // the prom attribute used for aggregation
 	AggregateValue        MetadataKey = "aggregateValue"
-	Direction             MetadataKey = "direction"
 	Display               MetadataKey = "display"
 	DestPrincipal         MetadataKey = "destPrincipal"
 	DestServices          MetadataKey = "destServices"

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -83,15 +83,13 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 				n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
 					return !waypointsNodes[edge.Dest.ID]
 				})
+				continue
 			}
 
 			// Find duplicates
 			for _, edge := range n.Edges {
-				// If not show the waypoint, mark the nodes
-				if a.ShowWaypoints {
-					if waypointsNodes[edge.Dest.ID] {
-						edge.Metadata[graph.Display] = "reverse"
-					}
+				if waypointsNodes[edge.Dest.ID] {
+					edge.Metadata[graph.Display] = "reverse"
 				}
 			}
 		}

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -90,7 +90,7 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 				// If not show the waypoint, mark the nodes
 				if a.ShowWaypoints {
 					if waypointsNodes[edge.Dest.ID] {
-						edge.Metadata[graph.Direction] = "reverse"
+						edge.Metadata[graph.Display] = "reverse"
 					}
 				}
 			}

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -50,7 +50,7 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 	// Fetch the waypoint workloads
 	waypoints := globalInfo.Business.Workload.GetWaypoints(context.Background())
 
-	waypointsNodes := make(map[string]bool)
+	waypointNodes := make(map[string]bool)
 
 	// Flag or Delete waypoint nodes in the TrafficMap
 	for _, n := range trafficMap {

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -62,7 +62,7 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 			waypointName = n.Service
 		}
 		if isWaypoint(&waypoints, n.Cluster, n.Namespace, waypointName) {
-			waypointsNodes[n.ID] = true
+			waypointNodes[n.ID] = true
 			if !a.ShowWaypoints {
 				delete(trafficMap, n.ID)
 			} else {
@@ -76,19 +76,19 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo
 		}
 	}
 
-	if len(waypointsNodes) > 0 {
+	if len(waypointNodes) > 0 {
 		for _, n := range trafficMap {
 			// Delete edges
 			if !a.ShowWaypoints {
 				n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
-					return !waypointsNodes[edge.Dest.ID]
+					return !waypointNodes[edge.Dest.ID]
 				})
 				continue
 			}
 
 			// Find duplicates
 			for _, edge := range n.Edges {
-				if waypointsNodes[edge.Dest.ID] {
+				if waypointNodes[edge.Dest.ID] {
 					edge.Metadata[graph.Display] = "reverse"
 				}
 			}


### PR DESCRIPTION
### Describe the change

This PR: 
- Adds a double arrow in the same edge for the waypoint proxies. This aims to simplify the number of edges in the graph
 
![image](https://github.com/user-attachments/assets/bd6c883d-1a43-4084-8ac4-afbeaed49082)

- Fixes patternfly graph to avoid infinite loops on hover: 
![image](https://github.com/user-attachments/assets/6bc9ddbf-fbc0-41fa-b334-3e8607fe85b0)


This error: 
![image](https://github.com/user-attachments/assets/fd0ea56c-8934-4499-a359-44e66747ec39)

The specific error cannot be reproduced in master, just when the waypoint appender does not delete the double edges.

### Steps to test the PR

Install Kiali and Ambient: 

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

### Automation testing

New tests will be added in a separate PR.

### Issue reference

Ref. #7445 

TODO: 

This is just a proposal, but in order to be merged, it would need some improvements like: 
- Traffic animation
- Traffic rate: (It is needed to add both send/received?) 
- Summary panel 