### PR TITLE
Include url parameters on router basename redirect

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -51,7 +51,7 @@ setRouter([
 
 // redirect to the router basename if the pathname does not include it
 if (!window.location.pathname.includes(rootBasename)) {
-  router.navigate('/', { replace: true });
+  router.navigate(`/${window.location.search}`, { replace: true });
 }
 
 ReactDOM.render(<RouterProvider router={router} />, document.getElementById('root') as HTMLElement);


### PR DESCRIPTION
### Describe the change

In the React Router upgrade to v6 (https://github.com/kiali/kiali/pull/7482), we have to re-implement a feature provided by the previous v5 version, but not by v6.

The feature is that if you add a basename for your router (in our case `/console`), React Router v5 added it automatically when you navigate to the root URL (e.g., `http://localhost:20001/kiali`). However, this is not the case with v6. Therefore, we have to force the navigation to /console if this basename is not included in the URL pathname.

More info here: https://www.github.com/remix-run/react-router/issues/8427

In that PR, we missed that URL parameters should be included in the navigation to `/console` because Kiali takes these into account in the OpenShift authentication process (e.g. `openshift_error` url parameter). This oversight was causing the following Cypress test to fail. https://github.com/kiali/kiali/blob/ee2a226176ca9c6a9254fd0cf404297aabc7c6e4/frontend/cypress/integration/featureFiles/kiali_login.feature#L37

### Steps to test the PR

1. Execute `./hack/crc-openshift.sh start` to launch an OpenShift cluster
2. Install Istio via `./hack/istio/install-istio-via-istioctl.sh`
3. Cd to the kiali/kiali local repo and run this to prepare the image registry: `make cluster-status`
4. Look at the output of that make command to find the login command to the image registry and run that (it will be something like `podman login --tls-verify=false -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing`)
5. Run this to install dev builds of Kiali: `make build build-ui cluster-push operator-create kiali-create`
6. Configure cypress baseUrl, user and password in https://github.com/kiali/kiali/blob/ee2a226176ca9c6a9254fd0cf404297aabc7c6e4/frontend/cypress.config.ts
7. Execute `./frontend/yarn cypress`  to open cypress test and verify that `kiali_login` test pass.

Instead of executing cypress test, this PR can also be tested manually adding following URL search parameter to Kiali url (`https://<kiali-url>/?openshift_error=could+not+exchange+the+code+for+a+token%3A+oauth2%3A+%22unauthorized_client%22+%22The+client+is+not+authorized+to+request+a+token+using+this+method.%22`) and verify that an error message appears in the Kiali login page.

![image](https://github.com/user-attachments/assets/246eb8c2-85b6-4e18-a1dd-5c969a3f8dfd)

### Automation testing

Cypress test is fixed

### Issue reference

#7482 
