### PR TITLE
Verify uncommitted new i18n statements

### DIFF
--- a/hack/hooks/pre-commit.sh
+++ b/hack/hooks/pre-commit.sh
@@ -53,6 +53,6 @@ if [ -n "$yaml_unformatted" ] || [ -n "$go_unformatted" ]; then
 fi
 
 if [ -n "$i18n_files" ]; then
-  echo "New i18n statements have not been committed - the git commit is aborted."
+  echo "New i18n statements are generated but not committed - the git commit is aborted. Please include the updated translation files in the commit."
   exit 1
 fi

--- a/hack/hooks/pre-commit.sh
+++ b/hack/hooks/pre-commit.sh
@@ -39,8 +39,20 @@ if [ -n "$yaml_unformatted" ]; then
   yamlfmt $yaml_unformatted
 fi
 
+#### I18N missing statements ####
+cd frontend
+
+yarn i18n
+
+i18n_files=$(git diff --name-only HEAD --diff-filter=M | grep -E 'translation.json')
+
 #### Git commit check ####
 if [ -n "$yaml_unformatted" ] || [ -n "$go_unformatted" ]; then
   echo "Some files have been formatted - the git commit is aborted."
+  exit 1
+fi
+
+if [ -n "$i18n_files" ]; then
+  echo "New i18n statements have not been committed - the git commit is aborted."
   exit 1
 fi


### PR DESCRIPTION
### Describe the change

When a developer adds a new i18n label (e.g., t('label')), translation files must be re-generated with the new i18n statements. To avoid committing without the new i18n statements, this PR updates the pre-commit hook to re-generate the translation files and ensure that no new i18n statements remain uncommitted.

### Steps to test the PR

1. Add a new i18n label (e.g., change `Log In` to `t('Log In')` in [LoginPage.tsx](https://github.com/kiali/kiali/blob/86d5778217d5784aeb8bfbe4f6d712980378a91f/frontend/src/pages/Login/LoginPage.tsx#L191)).
2. Attempt to create a commit.
3. Verify that the commit is aborted because new i18n statements have not been committed and `translation.json` is modified with the new i18n statement.

### Automation testing

N/A

