### PR TITLE
Include namespace in service versions yaml from Ambient hack bookinfo script

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -284,9 +284,6 @@ else
     $ISTIOCTL kube-inject -f ${BOOKINFO_YAML} | $CLIENT_EXE apply -n ${NAMESPACE} -f -
   else
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${BOOKINFO_YAML}
-    if [ "${AMBIENT_ENABLED}" == "true" ]; then
-      $CLIENT_EXE apply -f "${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-versions.yaml"
-    fi
   fi
 fi
 

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -284,6 +284,9 @@ else
     $ISTIOCTL kube-inject -f ${BOOKINFO_YAML} | $CLIENT_EXE apply -n ${NAMESPACE} -f -
   else
     $CLIENT_EXE apply -n ${NAMESPACE} -f ${BOOKINFO_YAML}
+    if [ "${AMBIENT_ENABLED}" == "true" ]; then
+      $CLIENT_EXE apply -f "${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-versions.yaml" -n ${NAMESPACE}
+    fi
   fi
 fi
 


### PR DESCRIPTION
### Describe the change

Apply the correct namespace as this is creating the additional services in the default namespace.

### Steps to test the PR

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Verify no additional services are created in the default namespace.
- Verify the graph works as expected: 

![image](https://github.com/user-attachments/assets/4fa3bd0b-bee3-4f92-9784-17e12a3d539e)


### Automation testing

Waypoint e2e added in a follow up PR.

### Issue reference

N/A
