### PR TITLE
Upgrade CRC to version 4.16

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -504,10 +504,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="2.36.0"
+DEFAULT_CRC_DOWNLOAD_VERSION="2.40.0"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
-DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.15.12"
+DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.16.4"
 
 # The default virtual CPUs assigned to the CRC VM
 DEFAULT_CRC_CPUS="6"


### PR DESCRIPTION
### Describe the change

Modify `crc-openshift.sh` script to upgrade the CRC version to 4.16

### Steps to test the PR

Execute `./hack/crc-openshift.sh start` and verify that OpenShift CRC version 4.16 is installed correctly

### Automation testing

N/A
