### PR TITLE
[v1.73][OSSM-6835][OSSM-6843] Fix for cypress flakiness on OCP 4.16

### DIFF
--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -1,4 +1,4 @@
-import { Before } from '@badeball/cypress-cucumber-preprocessor';
+import { Before, After } from '@badeball/cypress-cucumber-preprocessor';
 
 function install_demoapp(demoapp: string) {
   var namespaces: string = 'bookinfo';
@@ -84,4 +84,8 @@ Before({ tags: '@error-rates-app' }, function () {
 
 Before({ tags: '@sleep-app' }, function () {
   install_demoapp('sleep');
+});
+
+After({ tags: '@sleep-app-scaleup-after' }, function () {
+  cy.exec('kubectl scale -n sleep --replicas=1 deployment/sleep');
 });

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -25,7 +25,8 @@ Given('a healthy application in the cluster', function () {
   this.targetApp = 'productpage';
 });
 
-Given('an idle application in the cluster', function () {
+//When you use this, you need to annotate test by @sleep-app-scaleup-after to revert this change after the test
+Given('an idle sleep application in the cluster', function () {
   this.targetNamespace = 'sleep';
   this.targetApp = 'sleep';
 

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -20,7 +20,8 @@ Given('a healthy workload in the cluster', function () {
   this.targetWorkload = 'productpage-v1';
 });
 
-Given('an idle workload in the cluster', function () {
+//When you use this, you need to annotate test by @sleep-app-scaleup-after to revert this change after the test
+Given('an idle sleep workload in the cluster', function () {
   this.targetNamespace = 'sleep';
   this.targetWorkload = 'sleep';
 

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -75,8 +75,9 @@ Feature: Kiali Apps List page
 
   @bookinfo-app
   @sleep-app
+  @sleep-app-scaleup-after
   Scenario: The idle status of a logical mesh application is reported in the list of applications
-    Given an idle application in the cluster
+    Given an idle sleep application in the cluster
     When I fetch the list of applications
     And user selects the "sleep" namespace
     Then the application should be listed as "idle"

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -79,8 +79,9 @@ Feature: Kiali Overview page
     And the "healthy" application indicator should list the application
 
   @error-rates-app
+  @sleep-app-scaleup-after
   Scenario: The idle status of a logical mesh application is reported in the overview of a namespace
-    Given an idle application in the cluster
+    Given an idle sleep application in the cluster
     When I fetch the overview of the cluster
     Then there should be a "idle" application indicator in the namespace
     And the "idle" application indicator should list the application

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -102,8 +102,9 @@ Feature: Kiali Workloads page
     Then the workload should be listed as "healthy"
 
   @sleep-app
+  @sleep-app-scaleup-after
   Scenario: The idle status of a workload is reported in the list of workloads
-    Given an idle workload in the cluster
+    Given an idle sleep workload in the cluster
     When user selects the "sleep" namespace
     Then the workload should be listed as "idle"
     And the health status of the workload should be "Not Ready"


### PR DESCRIPTION
### Describe the change
The `sleep` application is scaled down in one test but it does not scale up after the test, which causes failures in the next tests.

The test `The idle status of a logical mesh application is reported in the list of applications` in the `apps.feature` scale down `sleep` application, so before the `services.feature` tests start, the `sleep` application is installed again (because there is no sleep pod ready) by the hack script which causes restarting of Kiali pod. 

However, the session had already been saved before that, so after the Kiali restart, the tests could not continue because they contained old session info.

ref.: https://issues.redhat.com/browse/OSSM-6835 and also https://issues.redhat.com/browse/OSSM-6843 ( the big number of restarts were already fixed by https://github.com/kiali/kiali/pull/7576 )

~~So I have introduced new `SKIP_INSTALL_DEMOS` env to disable reinstalling demo apps if needed (by default, it is enabled as it is working now) ( e.g. running on OCP ) and a fix to scale sleep application up after the test.~~


All tests passed with this fix: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/2876/ 

Backports:

- https://github.com/kiali/kiali/pull/7626
- https://github.com/kiali/kiali/pull/7627
