### PR TITLE
[Ambient] Update bookinfo script for Istio 1.23 and waypoints

### DIFF
--- a/hack/istio/functions.sh
+++ b/hack/istio/functions.sh
@@ -14,3 +14,30 @@ is_cluster_wide() {
       return 1
   fi
 }
+
+# Returns 0 if the istio version is greater than specified, 0 otherwise.
+is_istio_version_eq_greater_than() {
+  local expected_version=$1
+  local istio_version=$(${ISTIOCTL} version)
+  istio_parsed_version=$(echo "$istio_version" | grep "client version" | awk '{print $3}' | cut -d'-' -f1)
+
+  istio_expected_version=$(echo "$expected_version" | cut -d'-' -f1)
+
+  IFS='.' read -r major minor patch <<< "$istio_parsed_version"
+  IFS='.' read -r major_expected minor_expected patch_expected <<< "$istio_expected_version"
+  IFS=' '
+  if [ "${major}" -lt "${major_expected}" ]; then
+    return 1
+  else
+    if [ "${major}" -eq "${major_expected}" ]; then
+      if [ "${minor}" -lt "${minor_expected}" ]; then
+        return 0
+      else
+        return 1
+      fi
+    else
+      return 0
+    fi
+  fi
+
+}

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -378,8 +378,16 @@ if [ "${AMBIENT_ENABLED}" == "true" ]; then
   # It could also be applied to service account
   if [ "${WAYPOINT}" == "true" ]; then
     # Create Waypoint proxy
-    echo "Create Waypoint proxy"
-    ${ISTIOCTL} x waypoint apply -n ${NAMESPACE} --enroll-namespace
+    is_istio_version_eq_greater_than "1.23.0"
+    version_greater=$?
+
+    if [ "${version_greater}" == "1" ]; then
+      echo "Create Waypoint proxy"
+      ${ISTIOCTL} waypoint apply -n ${NAMESPACE} --enroll-namespace
+    else
+      echo "Create -experimental- Waypoint proxy"
+      ${ISTIOCTL} x waypoint apply -n ${NAMESPACE} --enroll-namespace
+    fi
   fi
 else
   if [ "${AUTO_INJECTION}" == "false" -a "${MANUAL_INJECTION}" == "false" ]; then

--- a/hack/istio/install-travel-agency-demo.sh
+++ b/hack/istio/install-travel-agency-demo.sh
@@ -288,10 +288,19 @@ if [ "${WAYPOINT}" == "true" ]; then
 
   fi
 
+  # Create Waypoint proxy
+  is_istio_version_eq_greater_than "1.23.0"
+  version_greater=$?
+
   for NS in "${AMBIENT_NS[@]}"
   do
-    ${ISTIOCTL} x waypoint apply -n ${NS} --enroll-namespace
-    echo "Create Waypoint proxy for ${NS}"
+    if [ "${version_greater}" == "1" ]; then
+      ${ISTIOCTL} waypoint apply -n ${NS} --enroll-namespace
+      echo "Create Waypoint proxy for ${NS}"
+    else
+      ${ISTIOCTL} x waypoint apply -n ${NS} --enroll-namespace
+            echo "Create -experimental- Waypoint proxy for ${NS}"
+    fi
   done
 fi
 


### PR DESCRIPTION
### Describe the change

Update bookinfo and travel demo script in order to check the Istio version before create a waypoint and use the x (experimental) for Istio < 1.23.

### Steps to test the PR

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Verify the waypoint proxy is created:
![image](https://github.com/user-attachments/assets/9f3ff49f-ec71-4caf-8fbe-d5414e5bcc07)
- Install travels demo (ztunnel and waypoint): `istio/install-travel-agency-demo.sh -c kubectl -ei false -di travel-control,travel-agency,travel-portal -w true`
- Verify the waypoint proxy is created:
![image](https://github.com/user-attachments/assets/6498dec4-e2db-4424-a709-f9644a75b068)

### Automation testing

N/A

### Issue reference

Ref. https://github.com/kiali/kiali/issues/7624
