### PR TITLE
[v1.73][OSSM-6967] Clean up created resources in istio namespace after test

### DIFF
--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -89,3 +89,9 @@ Before({ tags: '@sleep-app' }, function () {
 After({ tags: '@sleep-app-scaleup-after' }, function () {
   cy.exec('kubectl scale -n sleep --replicas=1 deployment/sleep');
 });
+
+// remove resources created in the istio-system namespace to not influence istio instance after the test
+After({ tags: '@clean-istio-namespace-resources-after' }, function () {
+  cy.exec('kubectl -n istio-system delete PeerAuthentication default', { failOnNonZeroExit: false });
+  cy.exec('kubectl -n istio-system delete Sidecar default', { failOnNonZeroExit: false });
+});

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -169,6 +169,7 @@ Feature: Kiali Istio Config page
   @crd-validation
   @bookinfo-app
   @sleep-app
+  @clean-istio-namespace-resources-after
   Scenario: KIA0208 validation
     Given a "disable-mtls" DestinationRule in the "sleep" namespace for "*.sleep.svc.cluster.local" host
     And the DestinationRule disables mTLS
@@ -218,6 +219,7 @@ Feature: Kiali Istio Config page
   @crd-validation
   @bookinfo-app
   @sleep-app
+  @clean-istio-namespace-resources-after
   Scenario: KIA0506 validation
     Given a "enable-mtls" DestinationRule in the "sleep" namespace for "*.local" host
     And the DestinationRule enables mTLS
@@ -237,6 +239,7 @@ Feature: Kiali Istio Config page
 
   @crd-validation
   @bookinfo-app
+  @clean-istio-namespace-resources-after
   Scenario: KIA1006 validation
     Given there is a "default" Sidecar resource in the "istio-system" namespace that captures egress traffic for hosts "default/sleep.sleep.svc.cluster.local"
     And the Sidecar is applied to workloads with "app=grafana" labels


### PR DESCRIPTION
### Describe the change

After `@istio-config` test, there are leftovers resources in the istio namespace which block all communication after test suite is done

ref.: https://issues.redhat.com/browse/OSSM-6967

2 runs in a row without SMCP reinstalling:

1. https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/2915/
2. https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/2916/
