### PR TITLE
[v1.65] Update axios version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "@patternfly/react-styles": "4.48.5",
     "@patternfly/react-table": "4.67.5",
     "@patternfly/react-tokens": "4.50.5",
-    "axios": "0.21.4",
+    "axios": "1.7.4",
     "bootstrap-slider-without-jquery": "10.0.0",
     "cy-node-html-label": "2.0.0",
     "cytoscape": "3.15.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "start:dev": "sh -ac '. ./.env.upstream; npm run start:kiali'",
     "start:kiali": "npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts start",
     "start:prod": "sh -ac '. ./.env.downstream; npm run start:kiali'",
-    "test": "npm run build-css && tsc -p . && TEST_RUNNER=1 react-scripts test --env=jsdom __tests__",
+    "test": "npm run build-css && tsc -p . && TEST_RUNNER=1 react-scripts test --env=jsdom __tests__ --transformIgnorePatterns='node_modules/(?!my-library-dir)/'",
     "prettier": "prettier --write \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\""
   },
   "dependencies": {
@@ -108,6 +108,7 @@
     "@types/cytoscape": "3.14.0",
     "@types/enzyme": "3.10.5",
     "@types/jest": "23.3.10",
+    "@types/js-yaml": "^4.0.5",
     "@types/lodash": "4.14.169",
     "@types/node": "17.0.21",
     "@types/react": "16.9.34",
@@ -115,7 +116,7 @@
     "@types/react-redux": "7.1.7",
     "@types/react-router-dom": "5.1.5",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",
-    "axios-mock-adapter": "1.16.0",
+    "axios-mock-adapter": "1.22.0",
     "cypress": "^10.7.0",
     "cypress-multi-reporters": "^1.6.0",
     "cypress-react-selector": "^2.3.17",
@@ -131,7 +132,7 @@
     "pretty-quick": "2.0.1",
     "react-scripts": "^5.0.1",
     "redux-mock-store": "1.5.4",
-    "typescript": "3.8.3"
+    "typescript": "4.6.4"
   },
   "resolutions": {
     "async": "^3.2.2",

--- a/frontend/src/actions/JaegerThunkActions.ts
+++ b/frontend/src/actions/JaegerThunkActions.ts
@@ -1,11 +1,10 @@
-import { AxiosError } from 'axios';
-
 import * as AlertUtils from '../utils/AlertUtils';
 import * as API from '../services/Api';
 import { KialiDispatch } from '../types/Redux';
 import { JaegerActions } from './JaegerActions';
 import { setTraceId as setURLTraceId } from 'utils/SearchParamUtils';
 import transformTraceData from 'utils/tracing/TraceTransform';
+import {ApiError} from "../types/Api";
 
 export const JaegerThunkActions = {
   setTraceId: (traceId?: string) => {
@@ -22,12 +21,12 @@ export const JaegerThunkActions = {
             }
           })
           .catch(error => {
-            if ((error as AxiosError).response?.status === 404) {
+            if ((error as ApiError).response?.status === 404) {
               setURLTraceId(undefined);
             }
             dispatch(JaegerActions.setTrace(undefined));
             AlertUtils.addMessage({
-              ...AlertUtils.extractAxiosError('Could not fetch trace', error),
+              ...AlertUtils.extractApiError('Could not fetch trace', error),
               showNotification: false
             });
           });

--- a/frontend/src/actions/LoginThunkActions.ts
+++ b/frontend/src/actions/LoginThunkActions.ts
@@ -75,7 +75,9 @@ const LoginThunkActions = {
           dispatch(LoginActions.logoutSuccess());
         }
       } catch (err) {
-        AlertUtils.addError('Logout failed', err);
+        if (err instanceof Error) {
+          AlertUtils.addError('Logout failed', err);
+        }
       }
     };
   }

--- a/frontend/src/app/StartupInitializer.tsx
+++ b/frontend/src/app/StartupInitializer.tsx
@@ -6,6 +6,7 @@ import { LoginSession } from '../store/Store';
 import { KialiDispatch } from '../types/Redux';
 import InitializingScreen from './InitializingScreen';
 import authenticationConfig from '../config/AuthenticationConfig';
+import {isApiError} from "../types/Api";
 
 interface InitializerComponentProps {
   setInitialAuthentication: (session: LoginSession) => void;
@@ -48,18 +49,20 @@ class InitializerComponent extends React.Component<InitializerComponentProps, In
 
       this.props.onInitializationFinished();
     } catch (err) {
-      let errDetails: string | undefined;
-      if (err.request) {
-        const response = (err.request as XMLHttpRequest).responseText;
-        if (response.trim().length > 0) {
-          errDetails = response;
+      if (isApiError(err)) {
+        let errDetails: string | undefined;
+        if (err.request) {
+          const response = (err.request as XMLHttpRequest).responseText;
+          if (response.trim().length > 0) {
+            errDetails = response;
+          }
         }
-      }
 
-      this.setState({
-        errorMsg: API.getErrorString(err),
-        errorDetails: errDetails
-      });
+        this.setState({
+          errorMsg: API.getErrorString(err),
+          errorDetails: errDetails
+        });
+      }
     }
   };
 }

--- a/frontend/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/frontend/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -341,7 +341,9 @@ export default class TrafficRenderer {
           point.renderer.render(this.context, pointInGraph);
         }
       } catch (error) {
-        console.log(`Error rendering TrafficEdge, it won't be rendered: ${error.message}`);
+        if (error instanceof Error) {
+          console.log(`Error rendering TrafficEdge, it won't be rendered: ${error.message}`);
+        }
       }
     });
   }
@@ -440,9 +442,11 @@ export default class TrafficRenderer {
       const edgeLength = this.edgeLength(edge);
       edgeLengthFactor = BASE_LENGTH / Math.max(edgeLength, 1);
     } catch (error) {
-      console.error(
-        `Error when finding the length of the edge for the traffic animation, this TrafficEdge won't be rendered: ${error.message}`
-      );
+      if (error instanceof Error) {
+        console.error(
+          `Error when finding the length of the edge for the traffic animation, this TrafficEdge won't be rendered: ${error.message}`
+        );
+      }
     }
 
     const edgeData = decoratedEdgeData(edge);

--- a/frontend/src/components/Details/__tests__/DetailObject.test.tsx
+++ b/frontend/src/components/Details/__tests__/DetailObject.test.tsx
@@ -27,7 +27,7 @@ describe('DetailObject test', () => {
   it('prints a nested list with all attributes in the detail', () => {
     mockRandom();
 
-    const wrapper = shallow(<DetailObject name={name} detail={detail} />);
+    const wrapper = shallow(<DetailObject name={"name"} detail={detail} />);
 
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -44,7 +44,7 @@ describe('DetailObject test', () => {
   it("doesn't print excluded fields", () => {
     mockRandom();
 
-    const wrapper = shallow(<DetailObject name={name} detail={detail} exclude={['port']} />);
+    const wrapper = shallow(<DetailObject name={"name"} detail={detail} exclude={['port']} />);
 
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -66,7 +66,7 @@ describe('DetailObject test', () => {
 
     mockRandom();
 
-    const wrapper = shallow(<DetailObject name={name} detail={detail} validation={validation} />);
+    const wrapper = shallow(<DetailObject name={"name"} detail={detail} validation={validation} />);
 
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -85,7 +85,7 @@ describe('DetailObject test', () => {
 
     mockRandom();
 
-    const wrapper = shallow(<DetailObject name={name} detail={detail} validation={validation} />);
+    const wrapper = shallow(<DetailObject name={"name"} detail={detail} validation={validation} />);
 
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();

--- a/frontend/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
+++ b/frontend/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`DetailObject test doesn't print any alert message 1`] = `
 <div>
   <div>
-    <strong />
+    <strong>
+      name
+    </strong>
     <ul
       className="details"
     >
@@ -106,7 +108,9 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
 exports[`DetailObject test doesn't print excluded fields 1`] = `
 <div>
   <div>
-    <strong />
+    <strong>
+      name
+    </strong>
     <ul
       className="details"
     >
@@ -173,7 +177,9 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
 exports[`DetailObject test prints a nested list with all attributes in the detail 1`] = `
 <div>
   <div>
-    <strong />
+    <strong>
+      name
+    </strong>
     <ul
       className="details"
     >
@@ -276,7 +282,9 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
 exports[`DetailObject test prints an alert message 1`] = `
 <div>
   <div>
-    <strong />
+    <strong>
+      name
+    </strong>
     <Validation
       message="Not all checks passed"
       messageColor={true}

--- a/frontend/src/components/FilterList/FilterComponent.tsx
+++ b/frontend/src/components/FilterList/FilterComponent.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { AxiosError } from 'axios';
 import * as FilterHelper from './FilterHelper';
 import { SortField } from '../../types/SortFilters';
 import * as API from '../../services/Api';
 import { HistoryManager, URLParam } from '../../app/History';
+import {ApiError} from "../../types/Api";
 
 export interface Props<R> {
   currentSortField: SortField<R>;
@@ -36,7 +36,7 @@ export abstract class Component<P extends Props<R>, S extends State<R>, R> exten
     FilterHelper.handleError(error);
   };
 
-  handleAxiosError(message: string, error: AxiosError) {
+  handleAxiosError(message: string, error: ApiError) {
     const errMsg = `${message}: ${API.getErrorString(error)}`;
     // TODO: Do we really need this console logging?
     console.error(errMsg);

--- a/frontend/src/components/IstioConfigPreview/EditorPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/EditorPreview.tsx
@@ -3,6 +3,7 @@ import { AuthorizationPolicy, Sidecar } from 'types/IstioObjects';
 import { AceValidations, jsYaml } from '../../types/AceValidations';
 import AceEditor from 'react-ace';
 import { aceOptions } from '../../types/IstioConfigDetails';
+import {YAMLException} from "js-yaml";
 
 type PolicyItem = AuthorizationPolicy | Sidecar;
 
@@ -36,24 +37,26 @@ export class EditorPreview extends React.Component<Props, State> {
         this.props.onChange(object);
       });
     } catch (e) {
-      const row = e.mark && e.mark.line ? e.mark.line : 0;
-      const col = e.mark && e.mark.column ? e.mark.column : 0;
-      const message = e.message ? e.message : '';
-      parsedValidations.markers.push({
-        startRow: row,
-        startCol: 0,
-        endRow: row + 1,
-        endCol: 0,
-        className: 'istio-validation-error',
-        type: 'fullLine'
-      });
-      parsedValidations.annotations.push({
-        row: row,
-        column: col,
-        type: 'error',
-        text: message
-      });
-      this.setState({ parsedValidations });
+      if (e instanceof YAMLException) {
+        const row = e.mark && e.mark.line ? e.mark.line : 0;
+        const col = e.mark && e.mark.column ? e.mark.column : 0;
+        const message = e.message ? e.message : '';
+        parsedValidations.markers.push({
+          startRow: row,
+          startCol: 0,
+          endRow: row + 1,
+          endCol: 0,
+          className: 'istio-validation-error',
+          type: 'fullLine'
+        });
+        parsedValidations.annotations.push({
+          row: row,
+          column: col,
+          type: 'error',
+          text: message
+        });
+        this.setState({parsedValidations});
+      }
     }
   };
 

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -92,5 +92,5 @@ const sendParentMessage = (msg: string): void => {
   // Kiosk parameter will capture the parent target when kiosk !== "true"
   // this will enable iframe -> parent communication
   const targetOrigin = store.getState().globalState.kiosk;
-  window.top.postMessage(msg, targetOrigin);
+  window.top?.postMessage(msg, targetOrigin);
 };

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -212,7 +212,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       })
       .catch(err => {
         AlertUtils.addMessage({
-          ...AlertUtils.extractAxiosError('Could not fetch Grafana info. Turning off links to Grafana.', err),
+          ...AlertUtils.extractApiError('Could not fetch Grafana info. Turning off links to Grafana.', err),
           group: 'default',
           type: MessageType.INFO,
           showNotification: false

--- a/frontend/src/hooks/services.ts
+++ b/frontend/src/hooks/services.ts
@@ -4,10 +4,10 @@ import * as API from '../services/Api';
 import { DurationInSeconds, TimeInMilliseconds } from '../types/Common';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import { getGatewaysAsList, PeerAuthentication } from '../types/IstioObjects';
-import { AxiosError } from 'axios';
 import { DecoratedGraphNodeData, NodeType } from '../types/Graph';
 import * as AlertUtils from '../utils/AlertUtils';
 import { useState } from 'react';
+import {ApiError} from "../types/Api";
 
 export function useServiceDetail(
   namespace: string,
@@ -16,7 +16,7 @@ export function useServiceDetail(
   updateTime?: TimeInMilliseconds
 ) {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
-  const [fetchError, setFetchError] = React.useState<AxiosError | null>(null);
+  const [fetchError, setFetchError] = React.useState<ApiError | null>(null);
 
   const [serviceDetails, setServiceDetails] = React.useState<ServiceDetailsInfo | null>(null);
   const [gateways, setGateways] = React.useState<string[] | null>(null);

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -44,7 +44,6 @@ import {
 } from '@patternfly/react-core';
 import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
-import { AxiosError } from 'axios';
 import RefreshContainer from '../../components/Refresh/Refresh';
 import IstioConfigOverview from './IstioObjectDetails/IstioConfigOverview';
 import { Annotation } from 'react-ace/types';
@@ -55,6 +54,7 @@ import RefreshNotifier from '../../components/Refresh/RefreshNotifier';
 import { isParentKiosk } from '../../components/Kiosk/KioskActions';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
+import {ApiError} from "../../types/Api";
 
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
@@ -289,7 +289,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
     });
   };
 
-  injectGalleyError = (error: AxiosError): AceValidations => {
+  injectGalleyError = (error: ApiError): AceValidations => {
     const msg: string[] = API.getErrorString(error).split(':');
     const errMsg: string = msg.slice(1, msg.length).join(':');
     const anno: Annotation = {

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -106,7 +106,9 @@ const MeshPage: React.FunctionComponent = () => {
       const meshClusters = await getClusters();
       setMeshClustersList(meshClusters.data);
     } catch (e) {
-      addError('Could not fetch the list of clusters that are part of the mesh.', e);
+      if (e instanceof Error) {
+        addError('Could not fetch the list of clusters that are part of the mesh.', e);
+      }
     }
   }
 

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -338,7 +338,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       })
       .catch(err => {
         AlertUtils.addMessage({
-          ...AlertUtils.extractAxiosError('Could not fetch Grafana info. Turning off links to Grafana.', err),
+          ...AlertUtils.extractApiError('Could not fetch Grafana info. Turning off links to Grafana.', err),
           group: 'default',
           type: MessageType.INFO,
           showNotification: false

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -17,7 +17,6 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { style } from 'typestyle';
-import { AxiosError } from 'axios';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import * as API from '../../services/Api';
@@ -81,6 +80,7 @@ import { IstiodResourceThresholds } from 'types/IstioStatus';
 import TLSInfo from 'components/Overview/TLSInfo';
 import CanaryUpgradeProgress from './CanaryUpgradeProgress';
 import ControlPlaneVersionBadge from './ControlPlaneVersionBadge';
+import {ApiError} from "../../types/Api";
 
 const gridStyleCompact = style({
   backgroundColor: '#f5f5f5',
@@ -538,7 +538,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       });
   }
 
-  handleAxiosError(message: string, error: AxiosError) {
+  handleAxiosError(message: string, error: ApiError) {
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -823,7 +823,9 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             this.setState({ showError: undefined });
           }
         } catch (e) {
-          this.setState({ showError: `Show: ${e.message}` });
+          if (e instanceof Error) {
+            this.setState({showError: `Show: ${e.message}`});
+          }
         }
       } else {
         filteredEntries = filteredEntries.filter(e => !e.logEntry || e.logEntry.message.includes(showValue));
@@ -839,7 +841,9 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
             this.setState({ hideError: undefined });
           }
         } catch (e) {
-          this.setState({ hideError: `Hide: ${e.message}` });
+          if (e instanceof Error) {
+            this.setState({hideError: `Hide: ${e.message}`});
+          }
         }
       } else {
         filteredEntries = filteredEntries.filter(e => !e.logEntry || !e.logEntry.message.includes(hideValue));

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError } from 'axios';
 import { config } from '../config';
 import { LoginSession } from '../store/Store';
 import { App } from '../types/App';
@@ -43,6 +42,8 @@ import { Span, TracingQuery } from 'types/Tracing';
 import { TLSStatus } from '../types/TLSStatus';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { CertsInfo } from 'types/CertsInfo';
+import axios from "axios";
+import {ApiError} from "../types/Api";
 export const ANONYMOUS_USER = 'anonymous';
 
 export interface Response<T> {
@@ -581,7 +582,7 @@ export const getPodEnvoyProxyResourceEntries = (namespace: string, pod: string, 
   );
 };
 
-export const getErrorString = (error: AxiosError): string => {
+export const getErrorString = (error: ApiError): string => {
   if (error && error.response) {
     if (error.response.data && error.response.data.error) {
       return error.response.data.error;
@@ -597,7 +598,7 @@ export const getErrorString = (error: AxiosError): string => {
   return '';
 };
 
-export const getErrorDetail = (error: AxiosError): string => {
+export const getErrorDetail = (error: ApiError): string => {
   if (error && error.response) {
     if (error.response.data && error.response.data.detail) {
       return error.response.data.detail;

--- a/frontend/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/frontend/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -1,10 +1,9 @@
 import * as API from '../Api';
-import { AxiosError } from 'axios';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 
 describe('#GetErrorString', () => {
   it('should return an error message with status', () => {
-    const axErr: AxiosError = {
+    const axErr: any = {
       config: { method: 'GET' },
       name: 'AxiosError',
       message: 'Error in Response',
@@ -15,12 +14,12 @@ describe('#GetErrorString', () => {
         headers: null,
         config: {}
       }
-    } as AxiosError;
+    };
     expect(API.getErrorString(axErr)).toEqual(`InternalError`);
   });
   it('should return an error message with data', () => {
     const responseServerError = 'Internal Error';
-    const axErr: AxiosError = {
+    const axErr: any = {
       config: { method: 'GET' },
       name: 'AxiosError',
       message: 'Error in Response',
@@ -31,13 +30,13 @@ describe('#GetErrorString', () => {
         headers: null,
         config: {}
       }
-    } as AxiosError;
+    };
     expect(API.getErrorString(axErr)).toEqual(`${responseServerError}`);
   });
   it('should return a detail error message with data', () => {
     const responseServerError = 'Internal Error';
     const responseServerDetail = 'Error Detail';
-    const axErr: AxiosError = {
+    const axErr: any = {
       config: { method: 'GET' },
       name: 'AxiosError',
       message: 'Error in Response',
@@ -48,11 +47,11 @@ describe('#GetErrorString', () => {
         headers: null,
         config: {}
       }
-    } as AxiosError;
+    };
     expect(API.getErrorDetail(axErr)).toEqual(`${responseServerDetail}`);
   });
   it('should return specific error message for unauthorized', () => {
-    const axErr: AxiosError = {
+    const axErr: any = {
       config: { method: 'GET' },
       name: 'AxiosError',
       message: 'Error in Response',
@@ -63,7 +62,7 @@ describe('#GetErrorString', () => {
         headers: null,
         config: {}
       }
-    } as AxiosError;
+    };
     expect(API.getErrorString(axErr)).toEqual(`Unauthorized: Has your session expired? Try logging in again.`);
   });
 });

--- a/frontend/src/store/Selectors/GraphData.ts
+++ b/frontend/src/store/Selectors/GraphData.ts
@@ -194,7 +194,7 @@ export const decorateGraphData = (graphData: GraphElements, duration: number): D
         }
         const isIstio = isIstioNamespace(decoratedNode.data.namespace) ? true : undefined;
         // prettier-ignore
-        decoratedNode.data = { isIstio: isIstio, ...elementsDefaults.nodes, ...decoratedNode.data } as DecoratedGraphNodeData;
+        decoratedNode.data = { ...elementsDefaults.nodes, ...decoratedNode.data, isIstio: isIstio } as DecoratedGraphNodeData;
         // prettier-ignore
         return decoratedNode as DecoratedGraphNodeWrapper;
       });

--- a/frontend/src/types/AceValidations.ts
+++ b/frontend/src/types/AceValidations.ts
@@ -1,6 +1,7 @@
 import { HelpMessage, ObjectCheck, ObjectValidation } from './IstioObjects';
 import { Annotation } from 'react-ace/types';
 import { IMarker } from 'react-ace';
+import {YAMLException} from "js-yaml";
 
 export const jsYaml = require('js-yaml');
 
@@ -284,23 +285,25 @@ export const parseYamlValidations = (yamlInput: string): AceValidations => {
   try {
     jsYaml.safeLoadAll(yamlInput);
   } catch (e) {
-    const row = e.mark && e.mark.line ? e.mark.line : 0;
-    const col = e.mark && e.mark.column ? e.mark.column : 0;
-    const message = e.message ? e.message : '';
-    parsedValidations.markers.push({
-      startRow: row,
-      startCol: 0,
-      endRow: row + 1,
-      endCol: 0,
-      className: 'istio-validation-error',
-      type: 'fullLine'
-    });
-    parsedValidations.annotations.push({
-      row: row,
-      column: col,
-      type: 'error',
-      text: message
-    });
+    if (e instanceof YAMLException) {
+      const row = e.mark && e.mark.line ? e.mark.line : 0;
+      const col = e.mark && e.mark.column ? e.mark.column : 0;
+      const message = e.message ? e.message : '';
+      parsedValidations.markers.push({
+        startRow: row,
+        startCol: 0,
+        endRow: row + 1,
+        endCol: 0,
+        className: 'istio-validation-error',
+        type: 'fullLine'
+      });
+      parsedValidations.annotations.push({
+        row: row,
+        column: col,
+        type: 'error',
+        text: message
+      });
+    }
   }
   return parsedValidations;
 };

--- a/frontend/src/types/Api.ts
+++ b/frontend/src/types/Api.ts
@@ -1,0 +1,14 @@
+import axios, { AxiosResponse, AxiosError } from 'axios';
+
+export interface KialiError {
+  detail: string;
+  error: string;
+}
+
+export type ApiResponse<T> = Partial<AxiosResponse<T>> & {
+  data: T;
+};
+
+export type ApiError = AxiosError<KialiError>;
+
+export const isApiError = axios.isAxiosError;

--- a/frontend/src/utils/AlertUtils.ts
+++ b/frontend/src/utils/AlertUtils.ts
@@ -1,8 +1,8 @@
 import { store } from '../store/ConfigStore';
 import { MessageType } from '../types/MessageCenter';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
-import { AxiosError } from 'axios';
 import * as API from '../services/Api';
+import {ApiError} from "../types/Api";
 
 export type Message = {
   content: string;
@@ -22,7 +22,7 @@ export const addMessage = (msg: Message) => {
   );
 };
 
-export const addError = (message: string, error?: AxiosError, group?: string, type?: MessageType, detail?: string) => {
+export const addError = (message: string, error?: ApiError, group?: string, type?: MessageType, detail?: string) => {
   if (!error) {
     store.dispatch(MessageCenterActions.addMessage(message, detail ? detail : '', group, MessageType.ERROR));
     return;
@@ -36,7 +36,7 @@ export const addError = (message: string, error?: AxiosError, group?: string, ty
   });
 };
 
-export const extractAxiosError = (message: string, error: AxiosError): { content: string; detail: string } => {
+export const extractAxiosError = (message: string, error: ApiError): { content: string; detail: string } => {
   const errorString: string = API.getErrorString(error);
   const errorDetail: string = API.getErrorDetail(error);
   if (message) {

--- a/frontend/src/utils/AlertUtils.ts
+++ b/frontend/src/utils/AlertUtils.ts
@@ -2,7 +2,7 @@ import { store } from '../store/ConfigStore';
 import { MessageType } from '../types/MessageCenter';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
 import * as API from '../services/Api';
-import {ApiError} from "../types/Api";
+import {ApiError, isApiError} from "../types/Api";
 
 export type Message = {
   content: string;
@@ -22,21 +22,23 @@ export const addMessage = (msg: Message) => {
   );
 };
 
-export const addError = (message: string, error?: ApiError, group?: string, type?: MessageType, detail?: string) => {
-  if (!error) {
+export const addError = (message: string, error?: Error, group?: string, type?: MessageType, detail?: string) => {
+  if (isApiError(error)) {
+    const finalType: MessageType = type ? type : MessageType.ERROR;
+    const err = extractApiError(message, error);
+    addMessage({
+      ...err,
+      group: group,
+      type: finalType
+    });
+  } else {
     store.dispatch(MessageCenterActions.addMessage(message, detail ? detail : '', group, MessageType.ERROR));
     return;
   }
-  const finalType: MessageType = type ? type : MessageType.ERROR;
-  const err = extractAxiosError(message, error);
-  addMessage({
-    ...err,
-    group: group,
-    type: finalType
-  });
+
 };
 
-export const extractAxiosError = (message: string, error: ApiError): { content: string; detail: string } => {
+export const extractApiError = (message: string, error: ApiError): { content: string; detail: string } => {
   const errorString: string = API.getErrorString(error);
   const errorDetail: string = API.getErrorDetail(error);
   if (message) {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4147,12 +4147,14 @@ axios-mock-adapter@1.16.0:
   dependencies:
     deep-equal "^1.0.1"
 
-axios@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
+  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -7486,7 +7488,7 @@ focus-trap@6.2.2:
   dependencies:
     tabbable "^5.1.4"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -7526,6 +7528,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -11655,6 +11666,11 @@ proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3228,6 +3228,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
   integrity sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ==
 
+"@types/js-yaml@^4.0.5":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -4140,12 +4145,13 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
-axios-mock-adapter@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz#cdd55bb60d8cb3fcd77fdb9cbb269e47b8b95180"
-  integrity sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==
+axios-mock-adapter@1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz#0f3e6be0fc9b55baab06f2d49c0b71157e7c053d"
+  integrity sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==
   dependencies:
-    deep-equal "^1.0.1"
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
 
 axios@1.7.4:
   version "1.7.4"
@@ -6057,7 +6063,7 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.1, deep-equal@^1.1.1:
+deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -8504,6 +8510,11 @@ is-buffer@^1.1.0, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.3:
   version "1.2.5"
@@ -13941,10 +13952,10 @@ typesafe-actions@3.2.1:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-3.2.1.tgz#833623a4079eda5dbcb775113f6dcf02b71c03f8"
   integrity sha512-hvhuNqsai6LzXQ+Hl6vajC9bGd/kHHL1hJvI4GQ0Rs6Fax1cjbNEsuFGy/RbfLPhBAL10n6DECEHUa+Q9E+MxQ==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 typestyle@2.0.4:
   version "2.0.4"


### PR DESCRIPTION
### Describe the change

Update axios 1.7.4.
It required: 

- Upgrade typescript version as the axios module was giving an error from typescript and required the upgrade from 3 to 4 (Updated to the one in master). 
- Upgrade source files due to library upgrades (Mainly axios and typescript).
- Add transformIgnorePatterns (Some tests failing) 
- Upgrade axios-mock-adapter

### Steps to test the PR

Run Kiali / Test everything works as expected.

### Automation testing

N/A

### Issue reference

Ref. https://github.com/kiali/kiali/pull/7641 backport v1.65