### PR TITLE
Allow specifying prometheus version explicitly if endpoint is not available

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,7 @@ type ThanosProxy struct {
 	Enabled         bool   `yaml:"enabled,omitempty"`
 	RetentionPeriod string `yaml:"retention_period,omitempty"`
 	ScrapeInterval  string `yaml:"scrape_interval,omitempty"`
+	Version         string `yaml:"version,omitempty"`
 }
 
 // PrometheusConfig describes configuration of the Prometheus component

--- a/status/versions.go
+++ b/status/versions.go
@@ -167,6 +167,13 @@ func prometheusVersion(conf *config.Config, homeClusterSAClient kubernetes.Clien
 	prometheusV := new(p8sResponseVersion)
 	cfg := conf.ExternalServices.Prometheus
 
+	// If the version is specified in the thanos_proxy config, use it
+	if cfg.ThanosProxy.Version != "" {
+		product.Name = "Prometheus"
+		product.Version = cfg.ThanosProxy.Version
+		return &product, nil
+	}
+
 	// Be sure to copy config.Auth and not modify the existing
 	auth := cfg.Auth
 	if auth.UseKialiToken {


### PR DESCRIPTION
### Describe the change

Kiali attempts to load version/revision information from prometheus as part of the status checks. When using Grafana Mimir as the metrics datasource, this endpoint isn't available. There is a separate build info endpoint for Mimir, but the data is not structured in the way Kiali is expecting. This PR extends the functionality created to address https://github.com/kiali/kiali/pull/4386 to allow specifying a version manually to allow metrics queries to execute when using non-vanilla-prometheus metrics stores.

### Issue reference

https://github.com/kiali/kiali/pull/4386
