### PR TITLE
Revert regresion introduced by backport #7627

### DIFF
--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -81,7 +81,6 @@ Feature: Kiali Overview page
     And the "healthy" application indicator should list the application
 
   @sleep-app
-  @error-rates-app
   @sleep-app-scaleup-after
   Scenario: The idle status of a logical mesh application is reported in the overview of a namespace
     Given an idle sleep application in the cluster


### PR DESCRIPTION
### Describe the change

This backport PR https://github.com/kiali/kiali/pull/7627 from 1.73 returned `@error-rates-app` which was removed by https://github.com/kiali/kiali/pull/7321