### PR TITLE
Adapt cypress tests to OSSMC

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -83,11 +83,11 @@ Then('no cluster badge for the {string} should be visible', (type: string) => {
   if (type === 'Istio config') {
     cy.get('#pfbadge-C').should('not.exist');
   } else if (type === 'graph side panel') {
-    cy.get('#graph-side-panel').within($div => {
+    cy.get('#graph-side-panel').within(() => {
       cy.get('#pfbadge-C').should('not.exist');
     });
   } else {
-    cy.get(`#${type[0].toUpperCase()}${type.slice(1)}DescriptionCard`).within($article => {
+    cy.get(`#${type[0].toUpperCase()}${type.slice(1)}DescriptionCard`).within(() => {
       cy.get('#pfbadge-C').should('not.exist');
     });
   }
@@ -97,11 +97,11 @@ Then('cluster badge for the {string} should be visible', (type: string) => {
   if (type === 'Istio config') {
     cy.get('#pfbadge-C').should('be.visible');
   } else if (type === 'graph side panel') {
-    cy.get('#graph-side-panel').within($div => {
+    cy.get('#graph-side-panel').within(() => {
       cy.get('#pfbadge-C').should('be.visible');
     });
   } else {
-    cy.get(`#${type[0].toUpperCase()}${type.slice(1)}DescriptionCard`).within($article => {
+    cy.get(`#${type[0].toUpperCase()}${type.slice(1)}DescriptionCard`).within(() => {
       cy.get('#pfbadge-C').should('be.visible');
     });
   }

--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -26,7 +26,7 @@ Then('user sees inbound and outbound traffic information', () => {
 });
 
 Then('user sees inbound metrics information', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/${NAMESPACE}/apps/${APP}/dashboard*`).as('fetchMetrics');
+  cy.intercept(`**/api/namespaces/${NAMESPACE}/apps/${APP}/dashboard*`).as('fetchMetrics');
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
@@ -45,7 +45,7 @@ Then('user sees inbound metrics information', () => {
 });
 
 Then('user sees outbound metrics information', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/${NAMESPACE}/apps/${APP}/dashboard*`).as('fetchMetrics');
+  cy.intercept(`**/api/namespaces/${NAMESPACE}/apps/${APP}/dashboard*`).as('fetchMetrics');
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');

--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -16,7 +16,7 @@ Then('user sees details information for the remote {string} app', (name: string)
 Then(
   'user sees {string} metrics information for the remote {string} {string}',
   (metrics: string, name: string, type: string) => {
-    cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/bookinfo/${type}s/${name}/dashboard*`).as('fetchMetrics');
+    cy.intercept(`**/api/namespaces/bookinfo/${type}s/${name}/dashboard*`).as('fetchMetrics');
 
     openTab(`${metrics} Metrics`);
     cy.wait('@fetchMetrics');
@@ -45,9 +45,7 @@ Then('user does not see any inbound and outbound traffic information', () => {
 Then(
   'user does not see {string} metrics information for the {string} {string} {string}',
   (metrics: string, cluster: string, name: string, type: string) => {
-    cy.intercept(
-      `${Cypress.config('baseUrl')}/api/namespaces/bookinfo/${type}s/${name}/dashboard*&clusterName=${cluster}*`
-    ).as('fetchMetrics');
+    cy.intercept(`**/api/namespaces/bookinfo/${type}s/${name}/dashboard*&clusterName=${cluster}*`).as('fetchMetrics');
 
     openTab(`${metrics} Metrics`);
     cy.wait('@fetchMetrics');

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -70,7 +70,7 @@ Then('user sees span details', () => {
 });
 
 When('I fetch the list of applications', () => {
-  cy.visit('/console/applications?refresh=0');
+  cy.visit({ url: '/console/applications?refresh=0' });
 });
 
 When('user opens the namespace dropdown', () => {

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -117,7 +117,7 @@ Then('user sees Details information for Apps', () => {
 Then('user only sees the apps with the {string} name', (name: string) => {
   let count: number;
 
-  cy.request('GET', `/api/clusters/apps`).should(response => {
+  cy.request({ method: 'GET', url: `/api/clusters/apps` }).should(response => {
     count = response.body.applications.filter(item => item.name.includes(name)).length;
   });
 

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -74,7 +74,7 @@ When('I fetch the list of applications', () => {
 });
 
 When('user opens the namespace dropdown', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/`).as('getNamespaces');
+  cy.intercept(`**/api/namespaces/`).as('getNamespaces');
   cy.get('[data-test="namespace-dropdown"]').click();
 });
 

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -1,5 +1,5 @@
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
-import { GraphDataSource } from '../../../src/services/GraphDataSource';
+import { GraphDataSource } from 'services/GraphDataSource';
 
 Then(`user does not see the {string} link`, link => {
   cy.get('div[role="dialog"]').get(`#${link}`).should('not.exist');

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -2,11 +2,11 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { GraphDataSource } from 'services/GraphDataSource';
 
 Then(`user does not see the {string} link`, link => {
-  cy.get('div[role="dialog"]').get(`#${link}`).should('not.exist');
+  cy.get('div[role="dialog"]').find(`#${link}`).should('not.exist');
 });
 
 Then(`user see the {string} link`, link => {
-  cy.get('div[role="dialog"]').get(`#${link}`).should('exist');
+  cy.get('div[role="dialog"]').find(`#${link}`).should('exist');
 });
 
 Then('the nodes located in the {string} cluster should be restricted', (cluster: string) => {

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -1,8 +1,6 @@
 import { Before, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 
-const url = '/console';
-
 Before(() => {
   // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
   // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
@@ -23,7 +21,7 @@ When('user graphs {string} namespaces', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
 
-  cy.visit(`${url}/graph/namespaces?refresh=0&namespaces=${namespaces}`);
+  cy.visit({ url: `/console/graph/namespaces?refresh=0&namespaces=${namespaces}` });
 
   if (namespaces !== '') {
     cy.wait('@graphNamespaces');

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -58,6 +58,7 @@ When('user clicks graph duration menu', () => {
 
 When(`user selects graph duration {string}`, (duration: string) => {
   cy.get('button#time_range_duration-toggle').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get(`button[id="${duration}"]`).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
@@ -68,6 +69,7 @@ When('user clicks graph refresh menu', () => {
 
 When(`user selects graph refresh {string}`, (refresh: string) => {
   cy.get('button#time_range_refresh-toggle').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get(`button[id="${refresh}"]`).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
@@ -186,7 +188,7 @@ Then('user does not see graph duration menu', () => {
 
 Then('user sees selected graph duration {string}', (duration: string) => {
   cy.get('button#time_range_duration-toggle')
-    .find('span[class*="pf-v5-c-menu-toggle__text"]')
+    .find('span[class="pf-v5-c-menu-toggle__text"]')
     .contains(duration)
     .should('exist');
 });
@@ -211,7 +213,7 @@ Then('user does not see graph refresh menu', () => {
 
 Then('user sees selected graph refresh {string}', (refresh: string) => {
   cy.get('button#time_range_refresh-toggle')
-    .find('span[class*="pf-v5-c-menu-toggle__text"]')
+    .find('span[class="pf-v5-c-menu-toggle__text"]')
     .contains(refresh)
     .should('exist');
 });

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -141,7 +141,7 @@ Then('user sees graph duration menu', () => {
   cy.get('button#time_range_duration-toggle').invoke('attr', 'aria-expanded').should('eq', 'true');
 
   cy.get('div#time_range_duration').within(() => {
-    cy.request('GET', '/api/config').then(response => {
+    cy.request({ method: 'GET', url: '/api/config' }).then(response => {
       expect(response.status).to.equal(200);
 
       const scrapeInterval = response.body.prometheus.globalScrapeInterval;

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -58,7 +58,6 @@ When('user clicks graph duration menu', () => {
 
 When(`user selects graph duration {string}`, (duration: string) => {
   cy.get('button#time_range_duration-toggle').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get(`button[id="${duration}"]`).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
@@ -69,7 +68,6 @@ When('user clicks graph refresh menu', () => {
 
 When(`user selects graph refresh {string}`, (refresh: string) => {
   cy.get('button#time_range_refresh-toggle').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get(`button[id="${refresh}"]`).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -1,8 +1,6 @@
 import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from 'types/Graph';
 
-const url = '/console';
-
 Before(() => {
   // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
   // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
@@ -22,7 +20,7 @@ Before(() => {
 When(
   'user graphs {string} namespaces with refresh {string} and duration {string}',
   (namespaces: string, refresh: string, duration: string) => {
-    cy.visit(`${url}/graph/namespaces?refresh=${refresh}&duration=${duration}&namespaces=${namespaces}`);
+    cy.visit({ url: `/console/graph/namespaces?refresh=${refresh}&duration=${duration}&namespaces=${namespaces}` });
   }
 );
 

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -68,7 +68,8 @@ When('user clicks graph refresh menu', () => {
 
 When(`user selects graph refresh {string}`, (refresh: string) => {
   cy.get('button#time_range_refresh-toggle').click();
-  cy.get(`button[id="${refresh}"]`).click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get(`button[id="${refresh}"]`).click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When('user selects {string} graph type', (graphType: string) => {

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -1,5 +1,5 @@
 import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from '../../../src/types/Graph';
+import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from 'types/Graph';
 
 const url = '/console';
 

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -562,9 +562,11 @@ Then('only {string} are visible in the {string} namespace', (sees: string, ns: s
   let lowercaseSees: string = sees.charAt(0).toLowerCase() + sees.slice(1);
   let count: number;
 
-  cy.request('GET', `/api/namespaces/${ns}/istio?objects=${lowercaseSees}&validate=true`).then(response => {
-    count = response.body[lowercaseSees].length;
-  });
+  cy.request({ method: 'GET', url: `/api/namespaces/${ns}/istio?objects=${lowercaseSees}&validate=true` }).then(
+    response => {
+      count = response.body[lowercaseSees].length;
+    }
+  );
 
   cy.get('tbody').contains('tr', singularize(sees));
   cy.get('tbody').within(() => {
@@ -588,7 +590,7 @@ Then('the user can create a {string} Istio object', (object: string) => {
 });
 
 Then('the user can create a {string} K8s Istio object', (object: string) => {
-  cy.request('GET', '/api/config').then(response => {
+  cy.request({ method: 'GET', url: '/api/config' }).then(response => {
     expect(response.status).to.equal(200);
     const gatewayAPIEnabled = response.body.gatewayAPIEnabled;
 
@@ -621,7 +623,7 @@ function waitUntilConfigIsVisible(attempt: number, crdInstanceName: string, crdN
   if (attempt === 0) {
     return;
   }
-  cy.request('GET', `${Cypress.config('baseUrl')}/api/istio/config?refresh=0`);
+  cy.request({ method: 'GET', url: `${Cypress.config('baseUrl')}/api/istio/config?refresh=0` });
   cy.get('[data-test="refresh-button"]').click();
   ensureKialiFinishedLoading();
   let found = false;

--- a/frontend/cypress/integration/common/istio_config_editor.ts
+++ b/frontend/cypress/integration/common/istio_config_editor.ts
@@ -1,20 +1,19 @@
 import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
-When('user updates the {string} AuthorizationPolicy using the text field', (name:string) => {
-  cy.intercept('PATCH',`${Cypress.config('baseUrl')}/api/namespaces/bookinfo/istio/authorizationpolicies/${name}*`,{
-    statusCode:200
-  }).as(
-    `${name}-update`
-  );
-  cy.window().then((win) => { 
-    win.eval("let editor = ace.edit('ace-editor');editor.setValue(editor.getValue() + '     ');");
-  }).then(()=>{
-    cy.get('button').contains('Save').click();
-  });
-
+When('user updates the {string} AuthorizationPolicy using the text field', (name: string) => {
+  cy.intercept('PATCH', `**/api/namespaces/bookinfo/istio/authorizationpolicies/${name}*`, {
+    statusCode: 200
+  }).as(`${name}-update`);
+  cy.window()
+    .then(win => {
+      win.eval("let editor = ace.edit('ace-editor');editor.setValue(editor.getValue() + '     ');");
+    })
+    .then(() => {
+      cy.get('button').contains('Save').click();
+    });
 });
 
-When('user chooses to delete the object',()=>{
+When('user chooses to delete the object', () => {
   cy.get('button').contains('Actions').click();
   cy.contains('Delete').should('be.visible');
   cy.contains('Delete').click();
@@ -26,10 +25,10 @@ Then('user can see istio config editor', () => {
   cy.get('#ace-editor').should('be.visible');
 });
 
-Then('cluster badge for {string} cluster should be visible in the Istio config side panel',(cluster:string) => {
-  cy.get('#pfbadge-C').parent().parent().should('contain.text',cluster);
+Then('cluster badge for {string} cluster should be visible in the Istio config side panel', (cluster: string) => {
+  cy.get('#pfbadge-C').parent().parent().should('contain.text', cluster);
 });
 
-Then('the {string} configuration should be updated',(name:string) =>{
+Then('the {string} configuration should be updated', (name: string) => {
   cy.wait(`@${name}-update`).should('exist');
 });

--- a/frontend/cypress/integration/common/kiali_cookie.ts
+++ b/frontend/cypress/integration/common/kiali_cookie.ts
@@ -14,7 +14,7 @@ Given('user is at administrator perspective', () => {
 });
 
 Given('user visits base url', () => {
-  cy.visit('/');
+  cy.visit({ url: '/' });
 });
 
 Given('user is at limited user perspective', () => {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -11,7 +11,7 @@ Given('all sessions are cleared', () => {
 });
 
 Given('user opens base url', () => {
-  cy.visit('/');
+  cy.visit({ url: '/' });
   cy.log(auth_strategy);
   cy.window().then((win: any) => {
     if (auth_strategy !== 'openshift') {

--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -134,7 +134,7 @@ Then('user sees the Overview page', () => {
 });
 
 Then('the server will return a login error', () => {
-  cy.intercept({ url: `${Cypress.config('baseUrl')}/api/auth/callback*`, query: { code: '*' } }, req => {
+  cy.intercept({ url: `**/api/auth/callback*`, query: { code: '*' } }, req => {
     req.query['code'] = 'invalidcode';
   });
 });

--- a/frontend/cypress/integration/common/kiali_logout.ts
+++ b/frontend/cypress/integration/common/kiali_logout.ts
@@ -10,7 +10,7 @@ Given('user clicks on admin', () => {
 
 Given('user logout successfully', () => {
   if (auth_strategy === 'openshift') {
-    cy.intercept('api/logout').as('logout');
+    cy.intercept('**/api/logout').as('logout');
     cy.get('.pf-v5-c-dropdown__menu-item').click();
   }
 });

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -1,6 +1,6 @@
 import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, Visualization, isEdge, isNode } from '@patternfly/react-topology';
-import { MeshInfraType, MeshNodeData } from '../../../src/types/Mesh';
+import { MeshInfraType, MeshNodeData } from 'types/Mesh';
 
 Before(() => {
   // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -67,7 +67,7 @@ When('user sees mesh side panel', () => {
     .should('be.visible')
     .within(div => {
       // Get the name of the mesh from the API.
-      cy.request('api/mesh/graph').then(resp => {
+      cy.request({ url: 'api/mesh/graph' }).then(resp => {
         expect(resp.status).to.eq(200);
         expect(resp.body.meshName).to.not.equal(undefined);
         expect(resp.body.meshName).to.not.equal('');

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -65,7 +65,7 @@ When('user sees mesh side panel', () => {
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-mesh')
     .should('be.visible')
-    .within(div => {
+    .within(() => {
       // Get the name of the mesh from the API.
       cy.request({ url: 'api/mesh/graph' }).then(resp => {
         expect(resp.status).to.eq(200);
@@ -87,7 +87,7 @@ Then('user sees control plane side panel', () => {
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-control-plane')
     .should('be.visible')
-    .within(div => {
+    .within(() => {
       cy.contains('istiod');
       cy.contains('Control plane').should('be.visible');
       cy.contains('Outbound policy').should('be.visible');
@@ -105,7 +105,7 @@ Then('user sees data plane side panel', () => {
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-data-plane')
     .should('be.visible')
-    .within(div => {
+    .within(() => {
       cy.contains('Data Plane');
     });
 });
@@ -174,9 +174,9 @@ Then('user sees the istiod node connected to the dataplane nodes', () => {
 Then('user {string} mesh tour', (action: string) => {
   cy.waitForReact();
   if (action === 'sees') {
-    cy.get('div[role="dialog"]').find('span').contains('Shortcuts').should('exist');
+    cy.get('div[class*="pf-v5-c-popover"]').find('span').contains('Shortcuts').should('exist');
   } else {
-    cy.get('div[role="dialog"]').should('not.exist');
+    cy.get('div[class*="pf-v5-c-popover"]').should('not.exist');
   }
 });
 
@@ -185,7 +185,7 @@ Then('user sees {string} namespace side panel', (name: string) => {
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-namespace')
     .should('be.visible')
-    .within(div => {
+    .within(() => {
       cy.contains(name);
     });
 });
@@ -195,7 +195,7 @@ Then('user sees {string} node side panel', (name: string) => {
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.get('#target-panel-node')
     .should('be.visible')
-    .within(div => {
+    .within(() => {
       cy.contains(name);
     });
 });

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -96,7 +96,8 @@ Then('user sees control plane side panel', () => {
       cy.get('[data-test="label-TLS"]').contains('N/A');
       cy.get('[data-test="lockerCA"]').should('exist');
     });
-  cy.get('[data-test="lockerCA"]').trigger('mouseenter').get('[role="tooltip"]').contains('Valid From');
+  cy.get('[data-test="lockerCA"]').trigger('mouseenter');
+  cy.get('[role="tooltip"]').contains('Valid From');
 });
 
 Then('user sees data plane side panel', () => {

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -9,17 +9,14 @@ enum detailType {
 }
 
 Given('user is at the {string} list page', (page: string) => {
-  // enable toggles on the list pages so that they can be tested
-  cy.intercept(`**/api/config`, request => {
-    request.reply(response => {
-      response.body['kialiFeatureFlags']['uiDefaults']['list']['showIncludeToggles'] = true;
-      return response;
-    });
-  }).as('config');
-
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
   cy.visit({ url: `${Cypress.config('baseUrl')}/console/${page}?refresh=0` });
-  cy.wait('@config');
+
+  cy.request({ method: 'GET', url: `/api/config` }).then(response => {
+    response.body['kialiFeatureFlags']['uiDefaults']['list']['showIncludeToggles'] = true;
+
+    return response;
+  });
 });
 
 Given('user is at the {string} page', (page: string) => {

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -109,9 +109,9 @@ export const clusterParameterExists = (present: boolean): void => {
 };
 
 Then(`user doesn't see the {string} menu`, menu => {
-  cy.get('#page-sidebar').get(`#${menu}`).should('not.exist');
+  cy.get('#page-sidebar').find(`#${menu}`).should('not.exist');
 });
 
 Then(`user see the {string} menu`, menu => {
-  cy.get('#page-sidebar').get(`#${menu}`).should('exist');
+  cy.get('#page-sidebar').find(`#${menu}`).should('exist');
 });

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -10,7 +10,7 @@ enum detailType {
 
 Given('user is at the {string} list page', (page: string) => {
   // enable toggles on the list pages so that they can be tested
-  cy.intercept(`${Cypress.config('baseUrl')}/api/config`, request => {
+  cy.intercept(`**/api/config`, request => {
     request.reply(response => {
       response.body['kialiFeatureFlags']['uiDefaults']['list']['showIncludeToggles'] = true;
       return response;
@@ -57,7 +57,7 @@ Given(
       }).as('waitForCall');
     }
 
-    cy.visit(`${Cypress.config('baseUrl')}/console/namespaces/${namespace}/${pageDetail}/${name}`, { qs });
+    cy.visit({ url: `${Cypress.config('baseUrl')}/console/namespaces/${namespace}/${pageDetail}/${name}`, qs });
     ensureKialiFinishedLoading();
   }
 );

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -18,18 +18,18 @@ Given('user is at the {string} list page', (page: string) => {
   }).as('config');
 
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.visit(`${Cypress.config('baseUrl')}/console/${page}?refresh=0`);
+  cy.visit({ url: `${Cypress.config('baseUrl')}/console/${page}?refresh=0` });
   cy.wait('@config');
 });
 
 Given('user is at the {string} page', (page: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.visit(`${Cypress.config('baseUrl')}/console/${page}?refresh=0`);
+  cy.visit({ url: `${Cypress.config('baseUrl')}/console/${page}?refresh=0` });
 });
 
 Given('user is at the {string} page for the {string} namespace', (page: string, namespace: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.visit(`${Cypress.config('baseUrl')}/console/${page}?refresh=0&namespaces=${namespace}`);
+  cy.visit({ url: `${Cypress.config('baseUrl')}/console/${page}?refresh=0&namespaces=${namespace}` });
 });
 
 Given(

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -9,14 +9,17 @@ enum detailType {
 }
 
 Given('user is at the {string} list page', (page: string) => {
+  // enable toggles on the list pages so that they can be tested
+  cy.intercept(`${Cypress.config('baseUrl')}/api/config`, request => {
+    request.reply(response => {
+      response.body['kialiFeatureFlags']['uiDefaults']['list']['showIncludeToggles'] = true;
+      return response;
+    });
+  }).as('config');
+
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.visit({ url: `${Cypress.config('baseUrl')}/console/${page}?refresh=0` });
-
-  cy.request({ method: 'GET', url: `/api/config` }).then(response => {
-    response.body['kialiFeatureFlags']['uiDefaults']['list']['showIncludeToggles'] = true;
-
-    return response;
-  });
+  cy.visit(`${Cypress.config('baseUrl')}/console/${page}?refresh=0`);
+  cy.wait('@config');
 });
 
 Given('user is at the {string} page', (page: string) => {

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -69,7 +69,8 @@ When(`user filters {string} namespace`, (ns: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'Namespace').click();
 
-  cy.get('input#filter_input_value').type(ns).type('{enter}').get('#loading_kiali_spinner').should('not.exist');
+  cy.get('input#filter_input_value').type(ns).type('{enter}');
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`user filters {string} health`, (health: string) => {
@@ -82,16 +83,19 @@ When(`user filters {string} health`, (health: string) => {
 });
 
 When(`user selects Health for {string}`, (type: string) => {
-  cy.get('button#overview-type-toggle').click().get('#loading_kiali_spinner').should('not.exist');
-  cy.contains('div#overview-type button', type).click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get('button#overview-type-toggle').click();
+  cy.contains('div#overview-type button', type).click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`user sorts by name desc`, () => {
-  cy.get('button[data-sort-asc="true"]').click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get('button[data-sort-asc="true"]').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`user sorts by column {string} desc`, (column: string) => {
-  cy.get(`th[data-label=${column}]`).click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get(`th[data-label=${column}]`).click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`the list is sorted by {string} desc`, (column: string) => {
@@ -111,13 +115,15 @@ When(`the list is sorted by {string} desc`, (column: string) => {
 });
 
 When(`user selects {string} time range`, (interval: string) => {
-  cy.get('button#time_range_duration-toggle').click().get('#loading_kiali_spinner').should('not.exist');
-  cy.contains('div#time_range_duration button', interval).click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get('button#time_range_duration-toggle').click();
+  cy.contains('div#time_range_duration button', interval).click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`user selects {string} traffic direction`, (direction: string) => {
-  cy.get('button#direction-type-toggle').click().get('#loading_kiali_spinner').should('not.exist');
-  cy.contains('div#direction-type button', direction).click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get('button#direction-type-toggle').click();
+  cy.contains('div#direction-type button', direction).click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When('I fetch the overview of the cluster', () => {

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -84,6 +84,7 @@ When(`user filters {string} health`, (health: string) => {
 
 When(`user selects Health for {string}`, (type: string) => {
   cy.get('button#overview-type-toggle').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.contains('div#overview-type button', type).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
@@ -116,12 +117,14 @@ When(`the list is sorted by {string} desc`, (column: string) => {
 
 When(`user selects {string} time range`, (interval: string) => {
   cy.get('button#time_range_duration-toggle').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.contains('div#time_range_duration button', interval).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 When(`user selects {string} traffic direction`, (direction: string) => {
   cy.get('button#direction-type-toggle').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
   cy.contains('div#direction-type button', direction).click();
   cy.get('#loading_kiali_spinner').should('not.exist');
 });

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -121,7 +121,7 @@ When(`user selects {string} traffic direction`, (direction: string) => {
 });
 
 When('I fetch the overview of the cluster', () => {
-  cy.visit('/console/overview?refresh=0');
+  cy.visit({ url: '/console/overview?refresh=0' });
 });
 
 Then(`user sees the {string} namespace card`, (ns: string) => {

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -11,11 +11,15 @@ Given('a namespace without override configuration for automatic sidecar injectio
   this.targetNamespace = 'sleep';
 
   // Make sure that the target namespace does not have override configuration
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-    metadata: {
-      labels: {
-        'istio-injection': null,
-        'istio.io/rev': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}`,
+    body: {
+      metadata: {
+        labels: {
+          'istio-injection': null,
+          'istio.io/rev': null
+        }
       }
     }
   });
@@ -26,11 +30,15 @@ Given('a namespace which has override configuration for automatic sidecar inject
   this.istioInjection = 'enabled';
 
   // Make sure that the target namespace has some override configuration
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-    metadata: {
-      labels: {
-        'istio-injection': this.istioInjection,
-        'istio.io/rev': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}`,
+    body: {
+      metadata: {
+        labels: {
+          'istio-injection': this.istioInjection,
+          'istio.io/rev': null
+        }
       }
     }
   });
@@ -38,11 +46,15 @@ Given('a namespace which has override configuration for automatic sidecar inject
 
 Given('the override configuration for sidecar injection is {string}', function (enabledOrDisabled) {
   if (this.istioInjection !== enabledOrDisabled) {
-    cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-      metadata: {
-        labels: {
-          'istio-injection': enabledOrDisabled,
-          'istio.io/rev': null
+    cy.request({
+      method: 'PATCH',
+      url: `/api/namespaces/${this.targetNamespace}`,
+      body: {
+        metadata: {
+          labels: {
+            'istio-injection': enabledOrDisabled,
+            'istio.io/rev': null
+          }
         }
       }
     });
@@ -62,25 +74,33 @@ Given('a workload without a sidecar', function () {
   this.workloadHasAutoInjectionOverride = false;
 
   // Make sure that injection in the namespace is turned off
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-    metadata: {
-      labels: {
-        'istio-injection': null,
-        'istio.io/rev': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}`,
+    body: {
+      metadata: {
+        labels: {
+          'istio-injection': null,
+          'istio.io/rev': null
+        }
       }
     }
   });
 
   // Make sure that the workload does not have override configuration
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`, {
-    spec: {
-      template: {
-        metadata: {
-          labels: {
-            'sidecar.istio.io/inject': null
-          },
-          annotations: {
-            'sidecar.istio.io/inject': null
+  cy.request({
+    request: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    body: {
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              'sidecar.istio.io/inject': null
+            },
+            annotations: {
+              'sidecar.istio.io/inject': null
+            }
           }
         }
       }
@@ -102,11 +122,15 @@ Given('a workload with a sidecar', function () {
   this.workloadHasAutoInjectionOverride = false;
 
   // Make sure that injection in the namespace is turned on
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-    metadata: {
-      labels: {
-        'istio-injection': 'enabled',
-        'istio.io/rev': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}`,
+    body: {
+      metadata: {
+        labels: {
+          'istio-injection': 'enabled',
+          'istio.io/rev': null
+        }
       }
     }
   });
@@ -116,15 +140,19 @@ Given('a workload with a sidecar', function () {
   // Need some kind of tag to exclude certain tests based on the
   // platform or environment. The sidecar label really shouldn't be
   // present here for istio.
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`, {
-    spec: {
-      template: {
-        metadata: {
-          labels: {
-            'sidecar.istio.io/inject': 'true'
-          },
-          annotations: {
-            'sidecar.istio.io/inject': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    body: {
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              'sidecar.istio.io/inject': 'true'
+            },
+            annotations: {
+              'sidecar.istio.io/inject': null
+            }
           }
         }
       }
@@ -142,11 +170,15 @@ Given('the workload does not have override configuration for automatic sidecar i
       // enable injection at namespace level
       this.namespaceAutoInjectionEnabled = true;
 
-      cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-        metadata: {
-          labels: {
-            'istio-injection': 'enabled',
-            'istio.io/rev': null
+      cy.request({
+        method: 'PATCH',
+        url: `/api/namespaces/${this.targetNamespace}`,
+        body: {
+          metadata: {
+            labels: {
+              'istio-injection': 'enabled',
+              'istio.io/rev': null
+            }
           }
         }
       });
@@ -155,11 +187,15 @@ Given('the workload does not have override configuration for automatic sidecar i
       // disable injection at namespace level.
       this.namespaceAutoInjectionEnabled = false;
 
-      cy.request('PATCH', `/api/namespaces/${this.targetNamespace}`, {
-        metadata: {
-          labels: {
-            'istio-injection': 'disabled',
-            'istio.io/rev': null
+      cy.request({
+        method: 'PATCH',
+        url: `/api/namespaces/${this.targetNamespace}`,
+        body: {
+          metadata: {
+            labels: {
+              'istio-injection': 'disabled',
+              'istio.io/rev': null
+            }
           }
         }
       });
@@ -168,15 +204,19 @@ Given('the workload does not have override configuration for automatic sidecar i
     // Now, we can remove the override config at deployment level
     this.workloadHasAutoInjectionOverride = false;
 
-    cy.request('PATCH', `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`, {
-      spec: {
-        template: {
-          metadata: {
-            labels: {
-              'sidecar.istio.io/inject': null
-            },
-            annotations: {
-              'sidecar.istio.io/inject': null
+    cy.request({
+      method: 'PATCH',
+      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+      body: {
+        spec: {
+          template: {
+            metadata: {
+              labels: {
+                'sidecar.istio.io/inject': null
+              },
+              annotations: {
+                'sidecar.istio.io/inject': null
+              }
             }
           }
         }
@@ -193,15 +233,19 @@ Given('the workload has override configuration for automatic sidecar injection',
     // Add override configuration, matching sidecar state
     this.workloadHasAutoInjectionOverride = true;
 
-    cy.request('PATCH', `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`, {
-      spec: {
-        template: {
-          metadata: {
-            labels: {
-              'sidecar.istio.io/inject': this.workloadHasSidecar ? 'true' : 'false'
-            },
-            annotations: {
-              'sidecar.istio.io/inject': null
+    cy.request({
+      method: 'PATCH',
+      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+      body: {
+        spec: {
+          template: {
+            metadata: {
+              labels: {
+                'sidecar.istio.io/inject': this.workloadHasSidecar ? 'true' : 'false'
+              },
+              annotations: {
+                'sidecar.istio.io/inject': null
+              }
             }
           }
         }
@@ -216,15 +260,19 @@ Given('a workload with override configuration for automatic sidecar injection', 
 
   // At the moment, it does not matter if the sidecar is being injected or not. The goal is to have
   // the override annotation on it.
-  cy.request('PATCH', `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`, {
-    spec: {
-      template: {
-        metadata: {
-          labels: {
-            'sidecar.istio.io/inject': 'true'
-          },
-          annotations: {
-            'sidecar.istio.io/inject': null
+  cy.request({
+    method: 'PATCH',
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    body: {
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              'sidecar.istio.io/inject': 'true'
+            },
+            annotations: {
+              'sidecar.istio.io/inject': null
+            }
           }
         }
       }
@@ -239,10 +287,10 @@ When('I visit the overview page', () => {
 
 // Only works for single cluster.
 When('I override the default automatic sidecar injection policy in the namespace to enabled', function () {
-  cy.request('GET', '/api/status').then(response => {
+  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
     expect(response.status).to.equal(200);
 
-    cy.request('/api/config').then(response => {
+    cy.request({ url: '/api/config' }).then(response => {
       cy.wrap(response.isOkStatusCode).should('be.true');
 
       const clusters: { [key: string]: MeshCluster } = response.body.clusters;
@@ -267,10 +315,10 @@ When('I override the default automatic sidecar injection policy in the namespace
 When(
   'I change the override configuration for automatic sidecar injection policy in the namespace to {string} it',
   function (enabledOrDisabled: string) {
-    cy.request('GET', '/api/status').then(response => {
+    cy.request({ method: 'GET', url: '/api/status' }).then(response => {
       expect(response.status).to.equal(200);
 
-      cy.request('/api/config').then(response => {
+      cy.request({ url: '/api/config' }).then(response => {
         cy.wrap(response.isOkStatusCode).should('be.true');
 
         const clusters: { [key: string]: MeshCluster } = response.body.clusters;
@@ -296,10 +344,10 @@ When(
 );
 
 When('I remove override configuration for sidecar injection in the namespace', function () {
-  cy.request('GET', '/api/status').then(response => {
+  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
     expect(response.status).to.equal(200);
 
-    cy.request('/api/config').then(response => {
+    cy.request({ url: '/api/config' }).then(response => {
       cy.wrap(response.isOkStatusCode).should('be.true');
 
       const clusters: { [key: string]: MeshCluster } = response.body.clusters;
@@ -356,12 +404,12 @@ When('I remove override configuration for sidecar injection in the workload', fu
 Then('I should see the override annotation for sidecar injection in the namespace as {string}', function (
   enabled: string
 ) {
-  cy.request('GET', '/api/status').then(response => {
+  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
     expect(response.status).to.equal(200);
 
     const expectation = 'exist';
 
-    cy.request('/api/config').then(response => {
+    cy.request({ url: '/api/config' }).then(response => {
       cy.wrap(response.isOkStatusCode).should('be.true');
 
       const clusters: { [key: string]: MeshCluster } = response.body.clusters;
@@ -377,10 +425,10 @@ Then('I should see the override annotation for sidecar injection in the namespac
 });
 
 Then('I should see no override annotation for sidecar injection in the namespace', function () {
-  cy.request('GET', '/api/status').then(response => {
+  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
     expect(response.status).to.equal(200);
 
-    cy.request('/api/config').then(response => {
+    cy.request({ url: '/api/config' }).then(response => {
       cy.wrap(response.isOkStatusCode).should('be.true');
 
       const clusters: { [key: string]: MeshCluster } = response.body.clusters;

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -233,7 +233,7 @@ Given('a workload with override configuration for automatic sidecar injection', 
 });
 
 When('I visit the overview page', () => {
-  cy.visit('/console/overview?refresh=0');
+  cy.visit({ url: '/console/overview?refresh=0' });
   cy.contains('Inbound traffic', { matchCase: false }); // Make sure data finished loading, so avoid broken tests because of a re-render
 });
 
@@ -322,7 +322,7 @@ When('I remove override configuration for sidecar injection in the namespace', f
 });
 
 function switchWorkloadSidecarInjection(enableOrDisable: string): void {
-  cy.visit(`/console/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?refresh=0`);
+  cy.visit({ url: `/console/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?refresh=0` });
 
   cy.get('button[data-test="workload-actions-toggle"]').should('be.visible').click();
   cy.get(`li[data-test=${enableOrDisable}_auto_injection]`).find('button').should('be.visible').click();

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -1,6 +1,6 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
-import { MeshCluster } from '../../../src/types/Mesh';
+import { MeshCluster } from 'types/Mesh';
 
 // Most of these "Given" implementations are directly using the Kiali API
 // in order to reach a well known state in the environment before performing

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -1,6 +1,6 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { TableDefinition } from 'cypress-cucumber-preprocessor';
-import { MeshCluster } from '../../../src/types/Mesh';
+import { MeshCluster } from 'types/Mesh';
 
 enum SortOrder {
   Ascending = 'ascending',

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -215,7 +215,7 @@ export const checkHealthIndicatorInTable = (
   // TODO: Move this somewhere else since other tests will most likely need this info as well.
   // VirtualItem_Clustercluster-default_Nsbookinfo_details
   // VirtualItem_Clustercluster-default_Nsbookinfo_productpage
-  cy.request('/api/config').then(response => {
+  cy.request({ url: '/api/config' }).then(response => {
     cy.wrap(response.isOkStatusCode).should('be.true');
 
     const clusters: { [key: string]: MeshCluster } = response.body.clusters;
@@ -240,7 +240,7 @@ export const checkHealthStatusInTable = (
     ? `${targetNamespace}_${targetType}_${targetRowItemName}`
     : `${targetNamespace}_${targetRowItemName}`;
 
-  cy.request('/api/config').then(response => {
+  cy.request({ url: '/api/config' }).then(response => {
     cy.wrap(response.isOkStatusCode).should('be.true');
 
     const clusters: { [key: string]: MeshCluster } = response.body.clusters;

--- a/frontend/cypress/integration/common/wizard_request_routing.ts
+++ b/frontend/cypress/integration/common/wizard_request_routing.ts
@@ -1,8 +1,6 @@
 import { Before, Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 
-const url = '/console';
-
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
 
@@ -27,13 +25,13 @@ Before(() => {
 
 Given('user opens the namespace {string} and {string} service details page', (namespace: string, service: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-  cy.visit(`${url}/namespaces/${namespace}/services/${service}?refresh=0`);
+  cy.visit({ url: `/console/namespaces/${namespace}/services/${service}?refresh=0` });
 });
 
 Given(
   'user opens the namespace {string} and the {string} {string} service details page',
   (namespace: string, cluster: string, service: string) => {
-    cy.visit(`${url}/namespaces/${namespace}/services/${service}?refresh=0&clusterName=${cluster}`);
+    cy.visit({ url: `/console/namespaces/${namespace}/services/${service}?refresh=0&clusterName=${cluster}` });
   }
 );
 

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -1,13 +1,13 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 Given('I am on the {string} workload detail page of the {string} namespace', (workload: string, namespace: string) => {
-  cy.visit(`/console/namespaces/${namespace}/workloads/${workload}?refresh=0`);
+  cy.visit({ url: `/console/namespaces/${namespace}/workloads/${workload}?refresh=0` });
 });
 
 Given(
   'I am on the logs tab of the {string} workload detail page of the {string} namespace',
   (workload: string, namespace: string) => {
-    cy.visit(`/console/namespaces/${namespace}/workloads/${workload}?tab=logs&refresh=0`);
+    cy.visit({ url: `/console/namespaces/${namespace}/workloads/${workload}?tab=logs&refresh=0` });
   }
 );
 

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -52,7 +52,7 @@ Then('I should see the {string} container listed', (containerName: string) => {
 });
 
 Then('the {string} container should be checked', (containerName: string) => {
-  cy.get('[data-test=workload-logs-pod-containers]').get(`input#container-${containerName}`).should('be.checked');
+  cy.get('[data-test=workload-logs-pod-containers]').find(`input#container-${containerName}`).should('be.checked');
 });
 
 Then('I should see some {string} pod selected in the pod selector', (podNamePrefix: string) => {
@@ -61,7 +61,7 @@ Then('I should see some {string} pod selected in the pod selector', (podNamePref
 
 Then('the log pane should only show log lines containing {string}', (filterText: string) => {
   cy.get('#logsText')
-    .get('p')
+    .find('p')
     .each(line => {
       expect(line).to.contain(filterText);
     });
@@ -69,7 +69,7 @@ Then('the log pane should only show log lines containing {string}', (filterText:
 
 Then('the log pane should only show log lines not containing {string}', (filterText: string) => {
   cy.get('#logsText')
-    .get('p')
+    .find('p')
     .each(line => {
       expect(line).to.not.contain(filterText);
     });
@@ -79,11 +79,11 @@ Then(
   'the log pane should show at most {int} lines of logs of each selected container',
   (numberOfLinesPerContainer: number) => {
     cy.get('[data-test=workload-logs-pod-containers]')
-      .get('[type=checkbox]:checked')
+      .find('[type=checkbox]:checked')
       .its('length')
       .then(numContainersEnabled => {
         cy.get('#logsText')
-          .get('p')
+          .find('p')
           .its('length')
           .should('be.lte', numContainersEnabled * numberOfLinesPerContainer);
       });
@@ -92,13 +92,13 @@ Then(
 
 Then('the log pane should only show logs for the {string} container', (containerName: string) => {
   cy.get('[data-test=workload-logs-pod-containers]')
-    .get('label')
+    .find('label')
     .contains(containerName)
     .then($podLabel => {
       let logColor = $podLabel[0].style.color;
 
       cy.get('#logsText')
-        .get('p')
+        .find('p')
         .each(line => {
           expect(line[0].style.color).to.equal(logColor);
         });
@@ -110,6 +110,6 @@ Then('the log pane should show spans', () => {
     .find('span')
     .invoke('css', 'color')
     .then(spansColor => {
-      cy.get('#logsText').get('p').should('have.css', 'color', spansColor);
+      cy.get('#logsText').find('p').should('have.css', 'color', spansColor);
     });
 });

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -4,7 +4,8 @@ import { checkHealthIndicatorInTable, checkHealthStatusInTable, colExists } from
 const activateFilter = (state: string): void => {
   //decided to pause the refresh, because I'm intercepting the very same request that is used for the timed refresh
   cy.get('button#time_range_refresh-toggle').click();
-  cy.get('button[id="0"]').click().get('#loading_kiali_spinner').should('not.exist');
+  cy.get('button[id="0"]').click();
+  cy.get('#loading_kiali_spinner').should('not.exist');
 
   cy.intercept({
     pathname: '**/api/clusters/workloads',

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -29,9 +29,7 @@ Then('user sees workload inbound and outbound traffic information', () => {
 });
 
 Then('user sees workload inbound metrics information', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/bookinfo/workloads/details-v1/dashboard*`).as(
-    'fetchMetrics'
-  );
+  cy.intercept(`**/api/namespaces/bookinfo/workloads/details-v1/dashboard*`).as('fetchMetrics');
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
@@ -50,9 +48,7 @@ Then('user sees workload inbound metrics information', () => {
 });
 
 Then('user sees workload outbound metrics information', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/bookinfo/workloads/details-v1/dashboard*`).as(
-    'fetchMetrics'
-  );
+  cy.intercept(`**/api/namespaces/bookinfo/workloads/details-v1/dashboard*`).as('fetchMetrics');
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');
@@ -142,7 +138,7 @@ Then('the user sees config expected information', () => {
 });
 
 Then('the user sees the metrics tab', () => {
-  cy.intercept(`${Cypress.config('baseUrl')}/api/namespaces/bookinfo/customdashboard/envoy*`).as('fetchEnvoyMetrics');
+  cy.intercept(`**/api/namespaces/bookinfo/customdashboard/envoy*`).as('fetchEnvoyMetrics');
 
   openTab('Envoy');
   openEnvoyTab('Metrics');

--- a/frontend/cypress/integration/featureFiles/graph_replay.feature
+++ b/frontend/cypress/integration/featureFiles/graph_replay.feature
@@ -1,4 +1,5 @@
 @graph-page-replay
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Kiali Graph page - Replay

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -1,4 +1,5 @@
 @mesh-page
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Kiali Mesh page

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -53,9 +53,11 @@ Feature: Kiali Mesh page
     When user selects mesh node with label "istio-system"
     Then user sees "istio-system" namespace side panel
 
+  @skip-ossmc
   Scenario: See the Mesh menu link
     Then user see the "mesh" menu
 
+  @skip-ossmc
   Scenario: See the Mesh link in the about
     And user clicks on Help Button
     And user clicks on About Button

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -1,4 +1,5 @@
 @overview
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Kiali Overview page

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -12,6 +12,7 @@ Feature: Kiali Service Details page
     And user is at the details page for the "service" "bookinfo/productpage" located in the "" cluster
 
   @bookinfo-app
+  @skip-ossmc
   Scenario: See details for productpage
     Then sd::user sees a list with content "Overview"
     Then sd::user sees a list with content "Traffic"
@@ -70,6 +71,7 @@ Feature: Kiali Service Details page
     Then user sees span details
 
   @bookinfo-app
+  @skip-ossmc
   Scenario: Verify that the Graph type dropdown is disabled when changing to Show node graph
     When user sees a minigraph
     And user chooses the "Show node graph" option

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -1,4 +1,5 @@
 @service-details
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Kiali Service Details page
@@ -26,6 +27,7 @@ Feature: Kiali Service Details page
     But no cluster badge for the "service" should be visible
 
   @bookinfo-app
+  @skip-ossmc
   Scenario: See service minigraph for details app.
     Then sd::user sees a minigraph
 

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -18,6 +18,7 @@ Feature: Kiali Service Details page
     Then sd::user sees a list with content "Traffic"
     Then sd::user sees a list with content "Inbound Metrics"
     Then sd::user sees a list with content "Traces"
+    # todo: adapt to kiosk mode for OSSMC
     Then sd::user sees the actions button
 
   @bookinfo-app
@@ -29,6 +30,7 @@ Feature: Kiali Service Details page
 
   @bookinfo-app
   @skip-ossmc
+  # todo: adapt to PF graph
   Scenario: See service minigraph for details app.
     Then sd::user sees a minigraph
 
@@ -72,6 +74,7 @@ Feature: Kiali Service Details page
 
   @bookinfo-app
   @skip-ossmc
+  # todo: adapt to PF graph
   Scenario: Verify that the Graph type dropdown is disabled when changing to Show node graph
     When user sees a minigraph
     And user chooses the "Show node graph" option

--- a/frontend/cypress/integration/featureFiles/sidecar_injection.feature
+++ b/frontend/cypress/integration/featureFiles/sidecar_injection.feature
@@ -49,6 +49,7 @@ Feature: Controlling sidecar injection
 
 	@sleep-app
 	@skip-ossmc
+	# todo: adapt to kiosk mode for OSSMC
 	Scenario: Override the default policy for automatic sidecar injection by enabling it in a workload
 		Given a workload without a sidecar
 		And the workload does not have override configuration for automatic sidecar injection
@@ -58,6 +59,7 @@ Feature: Controlling sidecar injection
 
 	@sleep-app
 	@skip-ossmc
+	# todo: adapt to kiosk mode for OSSMC
 	Scenario: Override the default policy for automatic sidecar injection by disabling it in a workload
 		Given a workload with a sidecar
 		And the workload does not have override configuration for automatic sidecar injection
@@ -67,6 +69,7 @@ Feature: Controlling sidecar injection
 
 	@sleep-app
 	@skip-ossmc
+	# todo: adapt to kiosk mode for OSSMC
 	Scenario: Switch the override configuration for automatic sidecar injection in a workload to disabled
 		Given a workload with a sidecar
 		And the workload has override configuration for automatic sidecar injection
@@ -76,6 +79,7 @@ Feature: Controlling sidecar injection
 
 	@sleep-app
 	@skip-ossmc
+	# todo: adapt to kiosk mode for OSSMC
 	Scenario: Switch the override configuration for automatic sidecar injection in a workload to enabled
 		Given a workload without a sidecar
 		And the workload has override configuration for automatic sidecar injection
@@ -85,6 +89,7 @@ Feature: Controlling sidecar injection
 
 	@sleep-app
 	@skip-ossmc
+	# todo: adapt to kiosk mode for OSSMC
 	Scenario: Remove override configuration for automatic sidecar injection in a workload
 		Given a workload with override configuration for automatic sidecar injection
 		When I remove override configuration for sidecar injection in the workload

--- a/frontend/cypress/integration/featureFiles/sidecar_injection.feature
+++ b/frontend/cypress/integration/featureFiles/sidecar_injection.feature
@@ -1,4 +1,5 @@
 @sidecar-injection
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Controlling sidecar injection
@@ -47,6 +48,7 @@ Feature: Controlling sidecar injection
 		Then I should see no override annotation for sidecar injection in the namespace
 
 	@sleep-app
+	@skip-ossmc
 	Scenario: Override the default policy for automatic sidecar injection by enabling it in a workload
 		Given a workload without a sidecar
 		And the workload does not have override configuration for automatic sidecar injection
@@ -55,6 +57,7 @@ Feature: Controlling sidecar injection
 		Then the workload should get a sidecar
 
 	@sleep-app
+	@skip-ossmc
 	Scenario: Override the default policy for automatic sidecar injection by disabling it in a workload
 		Given a workload with a sidecar
 		And the workload does not have override configuration for automatic sidecar injection
@@ -63,6 +66,7 @@ Feature: Controlling sidecar injection
 		Then the sidecar of the workload should vanish
 
 	@sleep-app
+	@skip-ossmc
 	Scenario: Switch the override configuration for automatic sidecar injection in a workload to disabled
 		Given a workload with a sidecar
 		And the workload has override configuration for automatic sidecar injection
@@ -71,6 +75,7 @@ Feature: Controlling sidecar injection
 		Then the sidecar of the workload should vanish
 
 	@sleep-app
+	@skip-ossmc
 	Scenario: Switch the override configuration for automatic sidecar injection in a workload to enabled
 		Given a workload without a sidecar
 		And the workload has override configuration for automatic sidecar injection
@@ -79,6 +84,7 @@ Feature: Controlling sidecar injection
 		Then the workload should get a sidecar
 
 	@sleep-app
+	@skip-ossmc
 	Scenario: Remove override configuration for automatic sidecar injection in a workload
 		Given a workload with override configuration for automatic sidecar injection
 		When I remove override configuration for sidecar injection in the workload

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -1,4 +1,5 @@
 @workload-logs
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Workload logs tab

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -1,4 +1,5 @@
 @workload-details
+@ossmc
 # don't change first line of this file - the tag is used for the test scripts to identify the test suite
 
 Feature: Kiali Workload Details page

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -18,6 +18,8 @@ Feature: Kiali Workload Details page
     But no cluster badge for the "workload" should be visible
 
   @bookinfo-app
+  @skip-ossmc
+  # todo: adapt to PF graph
   Scenario: See minigraph for workload.
     Then user sees a minigraph
 

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
@@ -18,6 +18,8 @@ Feature: Kiali Workload Details page
     And links in the "Workload" description card should contain a reference to a "west" cluster
     And cluster badge for "west" cluster should be visible in the "Workload" description card
 
+  @skip-ossmc
+  # todo: adapt to PF graph
   Scenario: See minigraph for workload.
     Then user sees a minigraph
     And user sees "service" from a remote "west" cluster

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
@@ -18,8 +18,6 @@ Feature: Kiali Workload Details page
     And links in the "Workload" description card should contain a reference to a "west" cluster
     And cluster badge for "west" cluster should be visible in the "Workload" description card
 
-  @skip-ossmc
-  # todo: adapt to PF graph
   Scenario: See minigraph for workload.
     Then user sees a minigraph
     And user sees "service" from a remote "west" cluster

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -21,7 +21,8 @@ const measureLoadTime = (name: string, baseline: number, loadUrl: string, loadEl
     .each(() => {
       // Disabling refresh so that we can see how long it takes to load the page without additional requests
       // being made due to the refresh.
-      cy.visit(loadUrl, {
+      cy.visit({
+        url: loadUrl,
         onBeforeLoad(win) {
           win.performance.mark('start');
         }

--- a/frontend/cypress/perf/graphload.spec.ts
+++ b/frontend/cypress/perf/graphload.spec.ts
@@ -23,7 +23,8 @@ describe('Graph performance tests', () => {
     it('Measures Graph load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
       cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
 
-      cy.visit(graphUrl, {
+      cy.visit({
+        url: graphUrl,
         onBeforeLoad(win) {
           win.performance.mark('start');
         }

--- a/frontend/cypress/perf/overviewload.spec.ts
+++ b/frontend/cypress/perf/overviewload.spec.ts
@@ -21,7 +21,8 @@ describe('Overview performance tests', () => {
         .each(() => {
           // Disabling refresh so that we can see how long it takes to load the page without additional requests
           // being made due to the refresh.
-          cy.visit('/console/overview?refresh=0', {
+          cy.visit({
+            url: '/console/overview?refresh=0',
             onBeforeLoad(win) {
               win.performance.mark('start');
             }

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -117,7 +117,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
         cy.intercept('**/api/tracing').as('getTracing');
         cy.intercept('**/api/auth/info').as('getAuthInfo');
 
-        cy.visit('/');
+        cy.visit({ url: '/' });
         const authProvider = Cypress.env('AUTH_PROVIDER');
         if (authProvider !== '' && authProvider !== undefined) {
           cy.contains(authProvider).should('be.visible').click();

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -111,11 +111,11 @@ Cypress.Commands.add('login', (username: string, password: string) => {
           );
         }
 
-        cy.intercept('/api/namespaces').as('getNamespaces');
-        cy.intercept('/api/config').as('getConfig');
-        cy.intercept('/api/status').as('getStatus');
-        cy.intercept('/api/tracing').as('getTracing');
-        cy.intercept('/api/auth/info').as('getAuthInfo');
+        cy.intercept('**/api/namespaces').as('getNamespaces');
+        cy.intercept('**/api/config').as('getConfig');
+        cy.intercept('**/api/status').as('getStatus');
+        cy.intercept('**/api/tracing').as('getTracing');
+        cy.intercept('**/api/auth/info').as('getAuthInfo');
 
         cy.visit('/');
         const authProvider = Cypress.env('AUTH_PROVIDER');

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -68,12 +68,10 @@ declare namespace Cypress {
     logout(): Chainable<Subject>;
   }
 }
+
 const timeout = 300000; // 5 minutes
 
-function ensureMulticlusterApplicationsAreHealthy(): void {
-  const startTime = this.startTime || Date.now();
-  this.startTime = startTime;
-
+function ensureMulticlusterApplicationsAreHealthy(startTime: number): void {
   if (Date.now() - startTime > timeout) {
     cy.log('Timeout reached without meeting the condition.');
     return;
@@ -95,7 +93,7 @@ function ensureMulticlusterApplicationsAreHealthy(): void {
     } else {
       cy.log("'reviews' app in 'west' cluster is not healthy yet, checking again in 10 seconds...");
       cy.wait(10000);
-      ensureMulticlusterApplicationsAreHealthy();
+      ensureMulticlusterApplicationsAreHealthy(startTime);
     }
   });
 }
@@ -156,7 +154,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
           }).then(resp => {
             const $html = Cypress.$(resp.body);
             const postUrl = $html.find('form[id=kc-form-login]').attr('action');
-            const url = new URL(postUrl);
+            const url = new URL(postUrl!);
             cy.request({
               url: url.toString(),
               method: 'POST',
@@ -168,7 +166,7 @@ Cypress.Commands.add('login', (username: string, password: string) => {
             }).then(() => {
               const tags = Cypress.env('TAGS');
               if (tags.includes('multi-cluster') || tags.includes('multi-primary')) {
-                ensureMulticlusterApplicationsAreHealthy();
+                ensureMulticlusterApplicationsAreHealthy(Date.now());
               }
             });
           });

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig",
   "compilerOptions": {
     "esModuleInterop": true,
     "target": "es5",


### PR DESCRIPTION
### Describe the change

Adapt cypress tests to run with OSSMC:
- Add wildcard to the URLs intercepted to include the OSSMC proxy URL.
- Set the input parameters of the `visit` and `intercept` cypress commands as objects so they can be overwritten by OSSMC.
- Replace the relative paths of Kiali code imports with absolute paths since the folder structure in OSSMC is different. 
- Make some Cypress tests more specific to ensure they work in OSSMC.
- Add `@ossmc` and `@skip-ossmc` cypress tags to selectively execute tests with OSSMC.

### Steps to test the PR

Verify that CI tests pass

### Issue reference

https://github.com/kiali/openshift-servicemesh-plugin/issues/356