### PR TITLE
Registry Service ExportTo is now map[string]struct{}. (#6866)

### DIFF
--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -231,8 +231,8 @@ func CreateFakeRegistryService(host string, namespace string, exportToNamespace 
 	registryService.Hostname = host
 	registryService.IstioService.Attributes.Namespace = namespace
 	registryService.IstioService.Attributes.Labels = labels
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]struct{})
+	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = struct{}{}
 
 	return &registryService
 }

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -265,8 +265,8 @@ type IstioService struct {
 		// ".":		Private implies namespace local config
 		// "*":		Public implies config is visible to all
 		// "~":		None implies service is visible to no one. Used for services only
-		ExportTo       map[string]bool   `json:"ExportTo,omitempty"`
-		LabelSelectors map[string]string `json:"LabelSelectors,omitempty"`
+		ExportTo       map[string]struct{} `json:"ExportTo,omitempty"`
+		LabelSelectors map[string]string   `json:"LabelSelectors,omitempty"`
 		// ClusterExternalAddresses and ClusterExternalPorts are not mapped into the model
 		// Kiali won't use it yet and these attributes changes between Istio 1.11.x and Istio 1.12.x and may bring conflicts
 	} `json:"Attributes,omitempty"`

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -15,8 +15,8 @@ func CreateFakeRegistryServicesLabels(service string, namespace string) []*kuber
 	registryService.Hostname = service + "." + namespace + ".svc.cluster.local"
 	registryService.IstioService.Attributes.Name = service
 	registryService.IstioService.Attributes.Namespace = namespace
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo["*"] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]struct{})
+	registryService.IstioService.Attributes.ExportTo["*"] = struct{}{}
 	registryService.IstioService.Attributes.Labels = make(map[string]string)
 	registryService.IstioService.Attributes.Labels["app"] = service
 	registryService.IstioService.Attributes.Labels["version"] = "v1"
@@ -31,8 +31,8 @@ func CreateFakeRegistryServices(host string, namespace string, exportToNamespace
 	registryService.Hostname = host
 	registryService.IstioService.Attributes.Namespace = namespace
 	registryService.IstioService.Attributes.Name = strings.Split(host, ".")[0]
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]struct{})
+	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = struct{}{}
 
 	return []*kubernetes.RegistryService{&registryService}
 }

--- a/tests/data/service_entry_data.go
+++ b/tests/data/service_entry_data.go
@@ -10,6 +10,7 @@ func CreateExternalServiceEntry() *networking_v1beta1.ServiceEntry {
 	se.Name = "external-svc-wikipedia"
 	se.Namespace = "wikipedia"
 	se.Spec.Hosts = []string{"wikipedia.org"}
+	se.Spec.ExportTo = []string{"*"}
 	se.Spec.Location = api_networking_v1beta1.ServiceEntry_MESH_EXTERNAL
 	se.Spec.Ports = []*api_networking_v1beta1.ServicePort{
 		{
@@ -38,6 +39,7 @@ func CreateEmptyMeshExternalServiceEntry(name, namespace string, hosts []string)
 	se.Name = name
 	se.Namespace = namespace
 	se.Spec.Hosts = hosts
+	se.Spec.ExportTo = []string{"*"}
 	se.Spec.Location = api_networking_v1beta1.ServiceEntry_MESH_EXTERNAL
 	se.Spec.Resolution = api_networking_v1beta1.ServiceEntry_DNS
 	return &se
@@ -48,6 +50,7 @@ func CreateEmptyMeshInternalServiceEntry(name, namespace string, hosts []string)
 	se.Name = name
 	se.Namespace = namespace
 	se.Spec.Hosts = hosts
+	se.Spec.ExportTo = []string{"*"}
 	se.Spec.Location = api_networking_v1beta1.ServiceEntry_MESH_INTERNAL
 	se.Spec.Resolution = api_networking_v1beta1.ServiceEntry_NONE
 	return &se


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/6866
Issue https://github.com/kiali/kiali/issues/6856

