### PR TITLE
[v1.73] Handle structs or bools when unmarshaling service entries from the istio registry

### DIFF
--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -231,8 +231,8 @@ func CreateFakeRegistryService(host string, namespace string, exportToNamespace 
 	registryService.Hostname = host
 	registryService.IstioService.Attributes.Namespace = namespace
 	registryService.IstioService.Attributes.Labels = labels
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]StructOrBool)
+	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = struct{}{}
 
 	return &registryService
 }

--- a/kubernetes/types_test.go
+++ b/kubernetes/types_test.go
@@ -1,0 +1,39 @@
+package kubernetes_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestStructOrBool(t *testing.T) {
+	cases := map[string]struct {
+		jsonStr        string
+		expectErr      bool
+		expectedOutput struct{}
+	}{
+		"has bool":   {jsonStr: `true`},
+		"has struct": {jsonStr: `{}`},
+		"is empty":   {jsonStr: ``, expectErr: true},
+		"is null":    {jsonStr: `null`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			var sob kubernetes.StructOrBool
+			err := json.Unmarshal([]byte(tc.jsonStr), &sob)
+			if tc.expectErr {
+				require.Error(err)
+				return
+			} else {
+				require.NoError(err)
+			}
+			require.EqualValues(struct{}{}, sob)
+			require.NotNil(sob)
+		})
+	}
+}

--- a/tests/data/service_data.go
+++ b/tests/data/service_data.go
@@ -7,7 +7,7 @@ import (
 )
 
 func CreateEmptyRegistryServices() []*kubernetes.RegistryService {
-	return []*kubernetes.RegistryService{&kubernetes.RegistryService{}}
+	return []*kubernetes.RegistryService{{}}
 }
 
 func CreateFakeRegistryServicesLabels(service string, namespace string) []*kubernetes.RegistryService {
@@ -15,8 +15,8 @@ func CreateFakeRegistryServicesLabels(service string, namespace string) []*kuber
 	registryService.Hostname = service + "." + namespace + ".svc.cluster.local"
 	registryService.IstioService.Attributes.Name = service
 	registryService.IstioService.Attributes.Namespace = namespace
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo["*"] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]kubernetes.StructOrBool)
+	registryService.IstioService.Attributes.ExportTo["*"] = struct{}{}
 	registryService.IstioService.Attributes.Labels = make(map[string]string)
 	registryService.IstioService.Attributes.Labels["app"] = service
 	registryService.IstioService.Attributes.Labels["version"] = "v1"
@@ -31,8 +31,8 @@ func CreateFakeRegistryServices(host string, namespace string, exportToNamespace
 	registryService.Hostname = host
 	registryService.IstioService.Attributes.Namespace = namespace
 	registryService.IstioService.Attributes.Name = strings.Split(host, ".")[0]
-	registryService.IstioService.Attributes.ExportTo = make(map[string]bool)
-	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = true
+	registryService.IstioService.Attributes.ExportTo = make(map[string]kubernetes.StructOrBool)
+	registryService.IstioService.Attributes.ExportTo[exportToNamespace] = struct{}{}
 
 	return []*kubernetes.RegistryService{&registryService}
 }


### PR DESCRIPTION
### Describe the change

In istio 1.20 these are `map[string]struct{}` but in earlier versions they are `map[string]bool` so this change implements some custom json unmarshaling to handle both.

### Steps to test the PR

Deploy Kiali 1.73 with istio 1.20. Create a `ServiceEntry` with `exportTo` set:

```
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
    name: se-kiali-test
    namespace: kialitest
spec:
    exportTo:
    - .
    - istio-system
    hosts:
      - www.example.com
    location: MESH_EXTERNAL
    ports:
      - name: https
        number: 443
        protocol: HTTPS
        targetPort: 443
    resolution: DNS
```

### Automation testing

Not covered.

### Issue reference

Relates to https://github.com/kiali/kiali/issues/6856
