### PR TITLE
[Tempo] Add test coverage for Tempo queries

### DIFF
--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -244,7 +244,7 @@ func convertSingleTrace(traces *otelModels.Data, id string) (*model.TracingRespo
 	return &response, nil
 }
 
-// prepareTraceQL returns a query in TraceQL format
+// prepareTraceQL set the query in TraceQL format
 func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, query models.TracingQuery) {
 	q := url.Values{}
 	q.Set("start", fmt.Sprintf("%d", query.Start.Unix()))
@@ -277,6 +277,12 @@ func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, q
 	}
 	u.RawQuery = q.Encode()
 	log.Debugf("Prepared Tempo API query: %v", u)
+}
+
+// GetTraceQLQuery returns the raw query in TraceQL format
+func (oc OtelHTTPClient) GetTraceQLQuery(u *url.URL, tracingServiceName string, query models.TracingQuery) string {
+	oc.prepareTraceQL(u, tracingServiceName, query)
+	return u.RawQuery
 }
 
 func makeRequest(client http.Client, endpoint string, body io.Reader) (response []byte, status int, err error) {

--- a/tracing/tempo/http_client_test.go
+++ b/tracing/tempo/http_client_test.go
@@ -1,6 +1,7 @@
 package tempo
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -129,4 +130,78 @@ func TestErrorResponse(t *testing.T) {
 	assert.NotNil(t, response)
 	assert.Nil(t, response.Data)
 	assert.Equal(t, response.TracingServiceName, serviceName)
+}
+
+// Test prepare query method
+func TestQuery(t *testing.T) {
+	baseUrl := getBaseUrl()
+
+	httpClient := http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader(`invalid TraceQL query: parse error at line 1, col 99: syntax error: unexpected IDENTIFIER`)),
+		}
+	})}
+
+	tempoClient, err := NewOtelClient(httpClient, baseUrl)
+	assert.Nil(t, err)
+	assert.NotNil(t, tempoClient)
+
+	q := models.TracingQuery{
+		Start:       time.Time{},
+		End:         time.Time{},
+		Tags:        nil,
+		MinDuration: 0,
+		Limit:       0,
+		Cluster:     "",
+	}
+	query := tempoClient.GetTraceQLQuery(baseUrl, serviceName, q)
+	assert.NotNil(t, query)
+	rawQuery, err := url.QueryUnescape(query)
+	assert.Nil(t, err)
+	assert.Contains(t, rawQuery, fmt.Sprintf(".service.name = \"%s\"", serviceName))
+	// Verify it contains all the selects
+	assert.Contains(t, rawQuery, "select(status, .service_name, .node_id, .component, .upstream_cluster, .http.method, .response_flags, resource.hostname)")
+	// Verify it doesn't contain the cluster tag
+	assert.NotContains(t, rawQuery, models.IstioClusterTag)
+	// Verify it contains spans limit
+	assert.Contains(t, rawQuery, "spss=10")
+	// Verify it contains start
+	assert.Contains(t, rawQuery, "start=")
+	// Verify it contains end
+	assert.Contains(t, rawQuery, "end=")
+
+	// Test tags
+	q2 := models.TracingQuery{
+		Start: time.Time{},
+		End:   time.Time{},
+		Tags: map[string]string{
+			"istio.mesh_id":    "mesh_hack",
+			"istio.cluster_id": "east",
+			"custom":           "value",
+		},
+		MinDuration: 0,
+		Limit:       0,
+		Cluster:     "",
+	}
+	query2 := tempoClient.GetTraceQLQuery(baseUrl, serviceName, q2)
+	assert.NotNil(t, query2)
+	rawQuery2, err2 := url.QueryUnescape(query2)
+	assert.Nil(t, err2)
+	assert.Contains(t, rawQuery2, fmt.Sprintf(".service.name = \"%s\"", serviceName))
+	assert.Contains(t, rawQuery2, ".istio.mesh_id = \"mesh_hack\"")
+	assert.Contains(t, rawQuery2, ".custom = \"value\"")
+	// Cluster tag is disabled
+	assert.NotContains(t, rawQuery2, ".istio.cluster_id = \"east\"")
+
+	// Force enable cluster tag
+	tempoClient.ClusterTag = true
+	query3 := tempoClient.GetTraceQLQuery(baseUrl, serviceName, q2)
+	assert.NotNil(t, query3)
+	rawQuery3, err3 := url.QueryUnescape(query3)
+	assert.Nil(t, err3)
+	assert.Contains(t, rawQuery3, fmt.Sprintf(".service.name = \"%s\"", serviceName))
+	assert.Contains(t, rawQuery3, ".istio.mesh_id = \"mesh_hack\"")
+	assert.Contains(t, rawQuery3, ".custom = \"value\"")
+	assert.Contains(t, rawQuery3, ".istio.cluster_id = \"east\"")
 }


### PR DESCRIPTION
### Describe the change

Added test coverage for prepare query for query the Tempo API. 

### Steps to test the PR

Run new test tracing/tempo/http_client_test and verify it passes (Also run in CI) 

### Automation testing

Unit tests

### Issue reference

Ref. #7658 
