### PR TITLE
Sort the correct namespaces

### DIFF
--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -166,7 +166,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalIn
 		}
 		for clusterrev, dPNss := range dataplaneMap {
 			// sort namespaces by cluster,name. This is more for test data consistency than anything else, but it doesn't hurt
-			slices.SortFunc(namespaces, func(a, b models.Namespace) int {
+			slices.SortFunc(dPNss, func(a, b models.Namespace) int {
 				clusterComp := cmp.Compare(a.Cluster, b.Cluster)
 				if clusterComp != 0 {
 					return clusterComp


### PR DESCRIPTION
### Describe the change

Previously `namespaces` were passed to `addInfra` but now `dPNss` is passed so we need to sort that slice instead of `namespaces` before passing them to `addInfra`.

### Steps to test the PR

`for i in {1..20}; do go clean -testcache && make test; done`

### Automation testing

N/A

### Issue reference

N/A
