### PR TITLE
[v1.89] Tempo query scope fix (#7662)

### DIFF
--- a/business/tracing.go
+++ b/business/tracing.go
@@ -50,10 +50,6 @@ func (in *TracingService) client() (tracing.ClientInterface, error) {
 }
 
 func (in *TracingService) getFilteredSpans(ns, app string, query models.TracingQuery, filter SpanFilter) ([]model.TracingSpan, error) {
-	// This is info needed for Tempo as it is not in the results by default
-	if in.conf.ExternalServices.Tracing.Provider == config.TempoProvider {
-		query.Tags["http.method"] = ".*"
-	}
 	r, err := in.GetAppTraces(ns, app, query)
 	if err != nil {
 		return []model.TracingSpan{}, err

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -163,13 +163,25 @@ deploy_kiali() {
     helm_args+=("--set kiali_route_url=${kiali_route_url}")
   fi
 
+  if [ "${TEMPO}" == "true" ]; then
+    helm_args+=(
+          "--set external_services.tracing.url=http://tempo-cr-query-frontend.tempo:3200"
+          "--set external_services.tracing.provider=tempo"
+          "--set external_services.tracing.in_cluster_url=http://tempo-cr-query-frontend.tempo:3200"
+          "--set external_services.tracing.use_grpc=false"
+        )
+  else
+    helm_args+=(
+          "--set external_services.tracing.url=http://tracing.istio-system:16685/jaeger"
+        )
+  fi
+
   helm_command='helm upgrade --install
     ${helm_args[@]}
     --namespace ${ISTIO_NAMESPACE}
     --set deployment.logger.log_level="debug"
     --set external_services.grafana.url="http://grafana.istio-system:3000"
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard"
-    --set external_services.tracing.url="http://tracing.istio-system:16685/jaeger"
     --set health_config.rate[0].kind="service"
     --set health_config.rate[0].name="y-server"
     --set health_config.rate[0].namespace="alpha"

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -94,6 +94,9 @@ CROSSNETWORK_GATEWAY_REQUIRED="true"
 # Under some conditions, manually configuring the mesh network will be required.
 MANUAL_MESH_NETWORK_CONFIG=""
 
+# Tempo instead of Jaeger
+TEMPO="${TEMPO:-false}"
+
 # The names of each cluster
 CLUSTER1_NAME="${CLUSTER1_NAME:-east}"
 CLUSTER2_NAME="${CLUSTER2_NAME:-west}"
@@ -351,6 +354,10 @@ while [[ $# -gt 0 ]]; do
       SINGLE_KIALI="$2"
       shift;shift
       ;;
+    -te|--tempo)
+      TEMPO="$2"
+      shift;shift
+      ;;
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
@@ -411,6 +418,7 @@ Valid command line arguments:
                        If this is left as empty string, it will be the same as --network1. (Default: "")
   -sc|--single-cluster <bool>: If "true", perform action just in CLUSTER 1. (Default: false)
   -sk|--single-kiali <bool>: If "true", a single kiali will be deployed for the whole mesh. (Default: true)
+  -te|--tempo <bool>: If "true", Tempo instead of Jaeger will be installed. (Default: false)
   -h|--help: this message
 HELPMSG
       exit 1
@@ -581,10 +589,12 @@ export BOOKINFO_ENABLED \
        NETWORK1_ID \
        NETWORK2_ID \
        SINGLE_KIALI \
-       SINGLE_CLUSTER
+       SINGLE_CLUSTER \
+       TEMPO
 
 cat <<EOM
 === SETTINGS ===
+AUTH_GROUPS=$AUTH_GROUPS
 BOOKINFO_ENABLED=$BOOKINFO_ENABLED
 BOOKINFO_NAMESPACE=$BOOKINFO_NAMESPACE
 CERTS_DIR=$CERTS_DIR
@@ -626,7 +636,7 @@ NETWORK1_ID=$NETWORK1_ID
 NETWORK2_ID=$NETWORK2_ID
 SINGLE_CLUSTER=$SINGLE_CLUSTER
 SINGLE_KIALI=$SINGLE_KIALI
-AUTH_GROUPS=$AUTH_GROUPS
+TEMPO=$TEMPO
 === SETTINGS ===
 EOM
 

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -63,7 +63,13 @@ fi
 if [ ! -z "${ISTIO_HUB}" ]; then
   image_hub_arg="--image-hub ${ISTIO_HUB}"
 fi
-${ISTIO_INSTALL_SCRIPT} ${image_tag_arg:-} ${image_hub_arg:-} --client-exe-path ${CLIENT_EXE} --cluster-name ${CLUSTER1_NAME} --istioctl ${ISTIOCTL} --istio-dir ${ISTIO_DIR} --mesh-id ${MESH_ID} --namespace ${ISTIO_NAMESPACE} --network ${NETWORK1_ID} --set values.pilot.env.EXTERNAL_ISTIOD=true --k8s-gateway-api-enabled true
+
+if [ "${TEMPO}" == "true" ]; then
+  "${SCRIPT_DIR}"/../tempo/install-tempo-env.sh -c ${CLIENT_EXE} -ot true
+  ${ISTIO_INSTALL_SCRIPT} ${image_tag_arg:-} ${image_hub_arg:-} --client-exe-path ${CLIENT_EXE} --cluster-name ${CLUSTER1_NAME} --istioctl ${ISTIOCTL} --istio-dir ${ISTIO_DIR} --mesh-id ${MESH_ID} --namespace ${ISTIO_NAMESPACE} --network ${NETWORK1_ID} --set values.pilot.env.EXTERNAL_ISTIOD=true --k8s-gateway-api-enabled true  -a "prometheus grafana" -s values.meshConfig.defaultConfig.tracing.zipkin.address="tempo-cr-distributor.tempo:9411"
+else
+  ${ISTIO_INSTALL_SCRIPT} ${image_tag_arg:-} ${image_hub_arg:-} --client-exe-path ${CLIENT_EXE} --cluster-name ${CLUSTER1_NAME} --istioctl ${ISTIOCTL} --istio-dir ${ISTIO_DIR} --mesh-id ${MESH_ID} --namespace ${ISTIO_NAMESPACE} --network ${NETWORK1_ID} --set values.pilot.env.EXTERNAL_ISTIOD=true --k8s-gateway-api-enabled true
+fi
 
 GEN_GATEWAY_SCRIPT="${ISTIO_DIR}/samples/multicluster/gen-eastwest-gateway.sh"
 ${GEN_GATEWAY_SCRIPT} --mesh ${MESH_ID} --cluster ${CLUSTER1_NAME} --network ${NETWORK1_ID} | ${ISTIOCTL} --context=${CLUSTER1_CONTEXT} install -y -f -

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -19,6 +19,7 @@ TEST_SUITE="${BACKEND}"
 SETUP_ONLY="false"
 TESTS_ONLY="false"
 WITH_VIDEO="false"
+TEMPO="false"
 
 # process command line args
 while [[ $# -gt 0 ]]; do
@@ -34,6 +35,10 @@ while [[ $# -gt 0 ]]; do
         echo "--setup-only option must be one of 'true' or 'false'"
         exit 1
       fi
+      shift;shift
+      ;;
+    -t|--tempo)
+      TEMPO="${2}"
       shift;shift
       ;;
     -to|--tests-only)
@@ -68,6 +73,9 @@ Valid command line arguments:
     Default: The latest release
   -so|--setup-only <true|false>
     If true, only setup the test environment and exit without running the tests.
+    Default: false
+  -t|--tempo <true|false>
+    If true, Tempo will be installed instead of Jaeger. Just for primary-remote suite
     Default: false
   -to|--tests-only <true|false>
     If true, only run the tests and skip the setup.
@@ -110,6 +118,7 @@ SETUP_ONLY=$SETUP_ONLY
 TESTS_ONLY=$TESTS_ONLY
 TEST_SUITE=$TEST_SUITE
 WITH_VIDEO=$WITH_VIDEO
+TEMPO=$TEMPO
 === SETTINGS ===
 EOM
 
@@ -363,7 +372,7 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_PRIMARY_REMOTE}" ]; then
   ensureCypressInstalled
   
   if [ "${TESTS_ONLY}" == "false" ]; then
-    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "primary-remote" ${ISTIO_VERSION_ARG}
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "primary-remote" ${ISTIO_VERSION_ARG} --tempo ${TEMPO}
   fi
 
   ensureKialiServerReady

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -29,6 +29,10 @@ type OtelHTTPClient struct {
 // New client
 func NewOtelClient(client http.Client, baseURL *url.URL) (otelClient *OtelHTTPClient, err error) {
 	url := *baseURL
+	// Istio adds the istio.cluster_id tag
+	// That allows to filter traces by cluster in MC environments
+	// This is a check to validate that this tag exists before use it
+	// To prevent empty tags results
 	url.Path = path.Join(url.Path, "/api/search/tags")
 	tags := false
 	r, status, _ := makeRequest(client, url.String(), nil)
@@ -41,7 +45,7 @@ func NewOtelClient(client http.Client, baseURL *url.URL) (otelClient *OtelHTTPCl
 			return nil, errMarshal
 		}
 
-		if util.InSlice(response.TagNames, "cluster") {
+		if util.InSlice(response.TagNames, models.IstioClusterTag) {
 			tags = true
 		}
 	}
@@ -249,7 +253,9 @@ func (oc OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, q
 
 	if len(query.Tags) > 0 {
 		for k, v := range query.Tags {
-			if k != models.IstioClusterTag && oc.ClusterTag {
+			if k == models.IstioClusterTag && !oc.ClusterTag {
+				log.Tracef("Cluster tag is disabled")
+			} else {
 				tag := TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
 				queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
 			}


### PR DESCRIPTION
### Describe the change

* Update hack scripts and Tempo query_scope

### Steps to test the PR

Single cluster: 

- `minikube start`
- `istio/tempo/install-tempo-env.sh -c kubectl`
- Verify there are traces

Multi cluster (Primary remote): 

- `hack/run-integration-tests.sh --test-suite frontend-primary-remote --setup-only true --tempo true`
- Verify there are traces filtered by cluster
- Add query_scope with valid value and verify there are traces
- Add query_scope with invalida value and verify there are no traces
```

    query_scope: 
      istio.mesh_id: "mesh-hack"
```

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/7662
