### PR TITLE
[v1.89] Upgrade images for IBM

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -18,8 +18,8 @@ SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 # CLIENT_EXE_NAME is going to either be "oc" or "kubectl"
 ISTIO_DIR=
 AMBIENT="false"
-ARCH="amd64"
-CLIENT_EXE="oc"
+: ${ARCH:=amd64}
+: ${CLIENT_EXE:=oc}
 DELETE_SLEEP="false"
 : ${ISTIO_NAMESPACE:=istio-system}
 : ${ENABLE_INJECTION:=true}
@@ -82,15 +82,16 @@ if [[ "${CLIENT_EXE}" = *"oc" ]]; then
 fi
 
 echo "CLIENT_EXE=${CLIENT_EXE}"
+echo "ARCH=${ARCH}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
 
 if [ "${DELETE_SLEEP}" == "true" ]; then
   set +e
 
   echo "Deleting the 'sleep' app in the 'sleep' namespace..."
-  # s390x specific images for curl in sleep.yaml (OSSM-6012)
-  if [ "${ARCH}" == "s390x" ]; then
-    sed -i.bak -E '/curlimages\/curl:8\.4\.0/! s;curlimages/curl;curlimages/curl:8.4.0;g' ${ISTIO_DIR}/samples/sleep/sleep.yaml 
+  # s390x/ppc64le specific images for curl in sleep.yaml (OSSM-6012)
+  if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
+    sed -i "s;curlimages/curl;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
   else
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
@@ -167,9 +168,9 @@ users:
 SCC
   fi
 
-  if [ "${ARCH}" == "s390x" ]; then
-    echo "Using s390x specific images for curl in sleep.yaml"
-    sed -i.bak -E '/curlimages\/curl:8\.4\.0/! s;curlimages/curl;curlimages/curl:8.4.0;g' ${ISTIO_DIR}/samples/sleep/sleep.yaml 
+  if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
+    echo "Using s390x/ppc64le specific images for curl in sleep.yaml"
+    sed -i "s;curlimages/curl;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
   fi
   ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
 

--- a/hack/istio/kustomization/bookinfo-ppc64le.yaml
+++ b/hack/istio/kustomization/bookinfo-ppc64le.yaml
@@ -4,19 +4,19 @@ images:
 # bookinfo.yaml
 - name: docker.io/istio/examples-bookinfo-details-v1
   newName: quay.io/maistra/examples-bookinfo-details-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-ratings-v1
   newName: quay.io/maistra/examples-bookinfo-ratings-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v1
   newName: quay.io/maistra/examples-bookinfo-reviews-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v2
   newName: quay.io/maistra/examples-bookinfo-reviews-v2
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-reviews-v3
   newName: quay.io/maistra/examples-bookinfo-reviews-v3
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p
 - name: docker.io/istio/examples-bookinfo-productpage-v1
   newName: quay.io/maistra/examples-bookinfo-productpage-v1
-  newTag: 2.0.0-ibm-p
+  newTag: 2.6.0-ibm-p

--- a/hack/istio/kustomization/bookinfo-s390x.yaml
+++ b/hack/istio/kustomization/bookinfo-s390x.yaml
@@ -3,19 +3,19 @@ resources:
 images:
 - name: docker.io/istio/examples-bookinfo-details-v1
   newName: quay.io/maistra/examples-bookinfo-details-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-ratings-v1
   newName: quay.io/maistra/examples-bookinfo-ratings-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v1
   newName: quay.io/maistra/examples-bookinfo-reviews-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v2
   newName: quay.io/maistra/examples-bookinfo-reviews-v2
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-reviews-v3
   newName: quay.io/maistra/examples-bookinfo-reviews-v3
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z
 - name: docker.io/istio/examples-bookinfo-productpage-v1
   newName: quay.io/maistra/examples-bookinfo-productpage-v1
-  newTag: 2.0.0-ibm-z
+  newTag: 2.6.0-ibm-z


### PR DESCRIPTION
### Describe the change

Upgrade IBM mirror images to the latest one. 
`quay.io/maistra/examples-bookinfo-details-v1:2.6` == `docker.io/istio/examples-bookinfo-details-v1:1.19.1`

Once, they create `s390x` and `ppc64le` variants of the latest upstream one `1.20.2`, the files `bookinfo-ppc64le.yaml` and `bookinfo-s390x.yaml` needs to be updated again. ( so now, it updates the bookinfo to the latest one which are available for IBM) 

Backports of:
- https://github.com/kiali/kiali/pull/7594
- https://github.com/kiali/kiali/pull/7692
