### PR TITLE
Add support for tags in mesh page

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -87,7 +87,7 @@ func (in *MeshService) CanaryUpgradeStatus() (*models.CanaryUpgradeStatus, error
 		}
 
 		// include not revision labeled namespaces into default ones
-		if revision == istio.DefaultRevisionLabel {
+		if revision == models.DefaultRevisionLabel {
 			pendingNss, err := in.homeClusterSAClient.GetNamespaces(fmt.Sprintf("%s=enabled", in.conf.IstioLabels.InjectionLabelName))
 			if err != nil {
 				return nil, err

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
@@ -159,7 +160,6 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 // getNamespacesByCluster returns the namespaces for the given cluster. The namespaces are filtered such
 // that only those namespaces that match discovery selectors are returned.
 func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster string) ([]models.Namespace, error) {
-
 	var namespaces []models.Namespace
 
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
@@ -215,7 +215,7 @@ func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster 
 		}
 	}
 
-	namespaces = filterNamespacesWithDiscoverySelectors(namespaces, getDiscoverySelectorsForCluster(cluster, in.conf))
+	namespaces = istio.FilterNamespacesWithDiscoverySelectors(namespaces, istio.GetDiscoverySelectorsForCluster(cluster, in.conf))
 
 	return namespaces, nil
 }
@@ -375,7 +375,7 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 // This ignores cluster-wide-access mode since we can have discovery selectors even when given cluster wide access.
 // Also, this may be asking for the accessibility of a namespace in a remote cluster, in which case cluster-wide-access is moot.
 func (in *NamespaceService) isAccessibleNamespace(namespace models.Namespace) bool {
-	selectors := getDiscoverySelectorsForCluster(namespace.Cluster, in.conf)
+	selectors := istio.GetDiscoverySelectorsForCluster(namespace.Cluster, in.conf)
 	// see if the discovery selectors match the one namespace we are checking
-	return len(filterNamespacesWithDiscoverySelectors([]models.Namespace{namespace}, selectors)) == 1
+	return len(istio.FilterNamespacesWithDiscoverySelectors([]models.Namespace{namespace}, selectors)) == 1
 }

--- a/business/tls.go
+++ b/business/tls.go
@@ -8,7 +8,6 @@ import (
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/models"
@@ -74,7 +73,7 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, cluster string, re
 
 	// Look for enabled if rev label isn't set: https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
 	namespacesForRevision := sliceutil.Filter(namespaces, func(ns models.Namespace) bool {
-		return ns.Labels[models.IstioRevisionLabel] == revision || ns.Labels[istio.IstioInjectionLabel] == "enabled"
+		return ns.Labels[models.IstioRevisionLabel] == revision || ns.Labels[models.IstioInjectionLabel] == "enabled"
 	})
 	namespaceNames := sliceutil.Map(namespacesForRevision, func(ns models.Namespace) string {
 		return ns.Name
@@ -206,7 +205,7 @@ func (in *TLSService) hasAutoMTLSEnabled(cluster string, namespace *models.Names
 	rev := namespace.Labels[models.IstioRevisionLabel]
 	if rev == "" {
 		// Assume that if there is no revision label, it is the default revision.
-		rev = istio.DefaultRevisionLabel
+		rev = models.DefaultRevisionLabel
 	}
 
 	// Find the controlplane that controls that namespace.

--- a/config/config.go
+++ b/config/config.go
@@ -425,8 +425,10 @@ type DeploymentConfig struct {
 
 // we need to play games with a custom unmarshaller/marshaller for metav1.LabelSelector because it has no yaml struct tags so
 // it is not processing it the way we want by default (it isn't using camelCase; the fields are lowercase - e.g. matchlabels/matchexpressions)
-type DiscoverySelectorType metav1.LabelSelector
-type DiscoverySelectorsType []*DiscoverySelectorType
+type (
+	DiscoverySelectorType  metav1.LabelSelector
+	DiscoverySelectorsType []*DiscoverySelectorType
+)
 
 func (dst *DiscoverySelectorType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Define a temporary struct to map YAML fields to Go struct fields

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -59,3 +59,18 @@ Feature: Kiali Mesh page
     And user clicks on Help Button
     And user clicks on About Button
     Then user see the "mesh" link
+
+  @multi-cluster
+  Scenario: Primary-remote: see one dataplane for each cluster and one controlplane on primary attached to both.
+    Then user sees 1 "dataplane" nodes on the "east" cluster
+    And user sees 1 "dataplane" nodes on the "west" cluster
+    And user sees 1 "istiod" nodes on the "east" cluster
+    And user sees the istiod node connected to the dataplane nodes
+  
+  @multi-cluster
+  @multi-primary
+  Scenario: Multi-primary: see one dataplane and one controlplane for each cluster and an edge between each.
+    Then user sees 1 "dataplane" nodes on the "east" cluster
+    And user sees 1 "dataplane" nodes on the "west" cluster
+    And user sees 1 "istiod" nodes on the "east" cluster
+    And user sees 1 "istiod" nodes on the "west" cluster

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -16,7 +16,6 @@
   "Apps": "应用",
   "Attribute": "Attribute",
   "Back": "Back",
-  "Canary: {{isCanary}}": "Canary: {{isCanary}}",
   "Cancel": "Cancel",
   "Choose the traffic rates used to generate the graph. Each supported protocol offers one or more options. Unused protocols can be omitted.": "Choose the traffic rates used to generate the graph. Each supported protocol offers one or more options. Unused protocols can be omitted.",
   "Circuit Breaker": "Circuit Breaker",

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlane.tsx
@@ -37,12 +37,7 @@ export const TargetPanelDataPlane: React.FC<TargetPanelCommonProps> = (props: Ta
           <span className={nodeStyle}>
             <PFBadge badge={PFBadges.DataPlane} size="global" />
             {data.infraName}
-            {data.version && (
-              <ControlPlaneVersionBadge
-                isCanary={data.isCanary ?? false}
-                version={data.version}
-              ></ControlPlaneVersionBadge>
-            )}
+            {data.version && <ControlPlaneVersionBadge version={data.version}></ControlPlaneVersionBadge>}
           </span>
         </Title>
         <span className={nodeStyle}>

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -59,7 +59,7 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
             })
             .map(node => renderInfraNodeSummary(node.getData()))}
 
-          {clusterDataPlanes.map(node => renderDataPlaneSummary(node.getData(), clusterDataPlanes.length > 1))}
+          {clusterDataPlanes.map(node => renderDataPlaneSummary(node.getData()))}
         </div>
       </div>
     );
@@ -81,18 +81,13 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
     );
   };
 
-  const renderDataPlaneSummary = (nodeData: MeshNodeData, showCanaryInfo: boolean): React.ReactNode => {
+  const renderDataPlaneSummary = (nodeData: MeshNodeData): React.ReactNode => {
     return (
       <div key={nodeData.id} className={summaryStyle}>
         {renderNodeHeader(nodeData, { nameOnly: true, smallSize: true })}
 
         <div className={infoStyle}>
-          {showCanaryInfo && (
-            <>
-              <div>{t('Canary: {{isCanary}}', { isCanary: nodeData.isCanary ?? false })}</div>
-              {nodeData.version && <div>{t('Revision: {{revision}}', { revision: nodeData.version })}</div>}
-            </>
-          )}
+          {nodeData.version && <div>{t('Revision: {{revision}}', { revision: nodeData.version })}</div>}
 
           {t('{{count}} namespace', {
             count: nodeData.infraData.length,

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -544,7 +544,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
           Object.keys(this.state.canaryUpgradeStatus!.namespacesPerRevision).map(
             revision =>
               !this.state.canaryUpgradeStatus!.namespacesPerRevision[revision].includes(ns.name) && (
-                <ControlPlaneVersionBadge version={revision} isCanary={false} />
+                <ControlPlaneVersionBadge version={revision} />
               )
           )}
 

--- a/frontend/src/pages/Overview/ControlPlaneVersionBadge.tsx
+++ b/frontend/src/pages/Overview/ControlPlaneVersionBadge.tsx
@@ -5,7 +5,6 @@ import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 type Props = {
-  isCanary: boolean;
   version: string;
 };
 
@@ -28,7 +27,7 @@ export const ControlPlaneVersionBadge: React.FC<Props> = (props: Props) => {
       }
       maxWidth="25rem"
     >
-      <Label style={{ marginLeft: '0.5rem' }} color={props.isCanary ? 'blue' : 'orange'} isCompact>
+      <Label style={{ marginLeft: '0.5rem' }} color={'orange'} isCompact>
         {props.version}
       </Label>
     </Tooltip>

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -1336,7 +1336,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
           Object.keys(this.state.canaryUpgradeStatus!.namespacesPerRevision).map(
             revision =>
               this.state.canaryUpgradeStatus!.namespacesPerRevision[revision].includes(ns.name) && (
-                <ControlPlaneVersionBadge version={revision} isCanary={false} />
+                <ControlPlaneVersionBadge version={revision} />
               )
           )}
 

--- a/frontend/src/types/Mesh.ts
+++ b/frontend/src/types/Mesh.ts
@@ -51,7 +51,6 @@ export interface MeshNodeData {
   infraType: MeshInfraType;
   isAmbient?: boolean;
   isBox?: string;
-  isCanary?: boolean;
   isExternal?: boolean;
   isInaccessible?: boolean;
   isMTLS?: boolean;

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -518,7 +518,7 @@ func (in *Discovery) getTags(ctx context.Context, controlPlanes []models.Control
 	var tags []models.Tag
 	for cluster, client := range in.kialiSAClients {
 		if !in.kialiCache.CanListWebhooks(cluster) {
-			log.Infof("Unable to list webhooks for cluster [%s]. Give Kiali permission to read 'mutatingwebhookconfigurations'. Skipping getting tags.", cluster)
+			log.Debugf("Unable to list webhooks for cluster [%s]. Give Kiali permission to read 'mutatingwebhookconfigurations'. Skipping getting tags.", cluster)
 			continue
 		}
 

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -23,6 +23,11 @@ import (
 )
 
 const (
+	AmbientDataplaneModeLabelValue = "ambient"
+	IstioDataplaneModeLabelKey     = "istio.io/dataplane-mode"
+)
+
+const (
 	istioControlPlaneClustersLabel        = "topology.istio.io/controlPlaneClusters"
 	istiodAppNameLabelKey                 = "app"
 	istiodAppNameLabelValue               = "istiod"
@@ -31,13 +36,6 @@ const (
 	istiodScopeGatewayEnvKey              = "PILOT_SCOPE_GATEWAY_TO_NAMESPACE"
 	baseIstioConfigMapName                = "istio"                  // As of 1.19 this is hardcoded in the helm charts.
 	baseIstioSidecarInjectorConfigMapName = "istio-sidecar-injector" // As of 1.19 this is hardcoded in the helm charts.
-)
-
-const (
-	// DefaultRevisionLabel is the value for the default revision.
-	DefaultRevisionLabel = "default"
-	// IstioInjectionLabel is the value for the istio injection label on a namespace.
-	IstioInjectionLabel = "istio-injection"
 )
 
 func parseIstioConfigMap(istioConfig *corev1.ConfigMap) (*models.IstioMeshConfig, error) {
@@ -76,7 +74,6 @@ func (in *Discovery) getControlPlaneConfiguration(kubeCache cache.KubeCache, con
 	}
 
 	configMap, err := kubeCache.GetConfigMap(controlPlane.IstiodNamespace, configMapName)
-
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +93,7 @@ func (in *Discovery) getControlPlaneConfiguration(kubeCache cache.KubeCache, con
 func revisionedConfigMapName(base string, revision string) string {
 	// If the revision is set, we should use the revisioned configmap name
 	// otherwise the hardcoded base value is used.
-	if revision == "" || revision == DefaultRevisionLabel {
+	if revision == "" || revision == models.DefaultRevisionLabel {
 		return base
 	}
 	return fmt.Sprintf("%s-%s", base, revision)
@@ -208,6 +205,11 @@ func (in *Discovery) Clusters() ([]models.KubeCluster, error) {
 	in.kialiCache.SetClusters(clusters)
 
 	return clusters, nil
+}
+
+type clusterRevisionKey struct {
+	Cluster  string
+	Revision string
 }
 
 // Mesh gathers information about the mesh and controlplanes running in the mesh
@@ -412,9 +414,152 @@ func (in *Discovery) Mesh(ctx context.Context) (*models.Mesh, error) {
 		}
 	}
 
+	// Get the tags for the mesh.
+	tags, err := in.getTags(ctx, mesh.ControlPlanes)
+	if err != nil {
+		return nil, err
+	}
+
+	mesh.Tags = tags
+
+	namespacesByClusterAndRev := map[clusterRevisionKey][]models.Namespace{}
+	// Multi-cluster is not supported without cluster wide access.
+	if !in.conf.AllNamespacesAccessible() {
+		// TODO: Namespace list / caching is probably something that other parts of Kiali need.
+		// This probably should moved outside of discovery.
+		for _, name := range in.conf.Deployment.AccessibleNamespaces {
+			homeClusterClient, ok := in.kialiSAClients[in.conf.KubernetesConfig.ClusterName]
+			if !ok {
+				log.Errorf("unable to get client for cluster [%s].", in.conf.KubernetesConfig.ClusterName)
+				continue
+			}
+
+			ns, err := homeClusterClient.GetNamespace(name)
+			if err != nil {
+				log.Errorf("unable to get namespace [%s] for cluster [%s]. Err: %s", name, in.conf.KubernetesConfig.ClusterName, err)
+				continue
+			}
+
+			n := models.CastNamespace(*ns, in.conf.KubernetesConfig.ClusterName)
+			rev := GetRevision(n)
+			if rev == "" {
+				// No revision label means there's no controlplane managing it.
+				// This happens is injection is not enabled for this namespace and it's not ambient.
+				continue
+			}
+			key := clusterRevisionKey{Cluster: in.conf.KubernetesConfig.ClusterName, Revision: rev}
+			namespacesByClusterAndRev[key] = append(namespacesByClusterAndRev[key], n)
+		}
+	} else {
+		for _, cluster := range clusters {
+			if !cluster.Accessible {
+				continue
+			}
+
+			client, ok := in.kialiSAClients[cluster.Name]
+			if !ok {
+				log.Errorf("unable to get client for cluster [%s].", cluster.Name)
+				continue
+			}
+
+			namespaces, err := client.GetNamespaces("")
+			if err != nil {
+				log.Errorf("unable to get namespaces for cluster [%s]. Err: %s", cluster.Name, err)
+				continue
+			}
+
+			for _, namespace := range namespaces {
+				n := models.CastNamespace(namespace, cluster.Name)
+				rev := GetRevision(n)
+				if rev == "" {
+					// No revision label means there's no controlplane managing it.
+					// This happens is injection is not enabled for this namespace and it's not ambient.
+					continue
+				}
+				key := clusterRevisionKey{Cluster: cluster.Name, Revision: rev}
+				namespacesByClusterAndRev[key] = append(namespacesByClusterAndRev[key], n)
+			}
+		}
+	}
+
+	for _, cp := range controlPlanes {
+		for _, cluster := range cp.ManagedClusters {
+			// Default to controlplane revision but if there's a tag then overwrite with that.
+			rev := cp.Revision
+			if cp.Tags != nil {
+				// Find the tag for that cluster.
+				for _, tag := range cp.Tags {
+					if tag.Cluster == cluster.Name && tag.Revision == cp.Revision {
+						rev = tag.Name
+						break
+					}
+				}
+			}
+			key := clusterRevisionKey{Cluster: cluster.Name, Revision: rev}
+			if namespaces, ok := namespacesByClusterAndRev[key]; ok {
+				cp.ManagedNamespaces = append(cp.ManagedNamespaces, namespaces...)
+			}
+		}
+	}
+
+	// Check if there are discovery selectors set and filter namespaces if there are.
+	for _, cp := range controlPlanes {
+		if cp.Config.DiscoverySelectors != nil {
+			cp.ManagedNamespaces = FilterNamespacesWithDiscoverySelectors(cp.ManagedNamespaces, cp.Config.DiscoverySelectors)
+		}
+	}
+
 	in.kialiCache.SetMesh(mesh)
 
 	return mesh, nil
+}
+
+func (in *Discovery) getTags(ctx context.Context, controlPlanes []models.ControlPlane) ([]models.Tag, error) {
+	var tags []models.Tag
+	for cluster, client := range in.kialiSAClients {
+		if !in.kialiCache.CanListWebhooks(cluster) {
+			log.Infof("Unable to list webhooks for cluster [%s]. Give Kiali permission to read 'mutatingwebhookconfigurations'. Skipping getting tags.", cluster)
+			continue
+		}
+
+		webhooks, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(
+			ctx, metav1.ListOptions{LabelSelector: models.IstioTagLabel},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, webhook := range webhooks.Items {
+			log.Debugf("Found webhook [%s/%s] on cluster: [%s].", webhook.Namespace, webhook.Name, cluster)
+			tag := models.Tag{
+				Cluster:  cluster,
+				Name:     webhook.Labels[models.IstioTagLabel],
+				Revision: webhook.Labels[models.IstioRevisionLabel],
+			}
+			tags = append(tags, tag)
+		}
+	}
+
+	tagsByClusterRev := map[string][]*models.Tag{}
+	for i := range tags {
+		tagsByClusterRev[tags[i].Cluster+tags[i].Revision] = append(tagsByClusterRev[tags[i].Cluster+tags[i].Revision], &tags[i])
+	}
+
+	for i := range controlPlanes {
+		controlPlane := &controlPlanes[i]
+		for _, cluster := range controlPlane.ManagedClusters {
+			key := cluster.Name + controlPlane.Revision
+			if cpTags, ok := tagsByClusterRev[key]; ok {
+				for _, tag := range cpTags {
+					tag := tag
+					tag.ControlPlane = controlPlane
+					controlPlane.Tags = append(controlPlane.Tags, *tag)
+				}
+			}
+		}
+	}
+
+	return tags, nil
 }
 
 func (in *Discovery) getKialiInstances(cluster models.KubeCluster) ([]models.KialiInstance, error) {

--- a/istio/discovery_selectors.go
+++ b/istio/discovery_selectors.go
@@ -1,4 +1,4 @@
-package business
+package istio
 
 import (
 	"regexp"
@@ -18,8 +18,8 @@ var systemNamespaceRegex = regexp.MustCompile(`^(kube-.*|openshift.*|ibm.*|kiali
 // If there are no overrides, but default discovery selectors are defined in the Kiali config, those will be returned.
 // If there are no selectors defined in the Kiali config, nil is returned (Istio's own discovery selectors will be ignored).
 // kialiConfig argument may be nil - if so, they are ignored and nil is returned.
-func getDiscoverySelectorsForCluster(cluster string, kialiConfig *config.Config) config.DiscoverySelectorsType {
-	ds := getKialiDiscoverySelectors(cluster, kialiConfig)
+func GetDiscoverySelectorsForCluster(cluster string, kialiConfig *config.Config) config.DiscoverySelectorsType {
+	ds := GetKialiDiscoverySelectors(cluster, kialiConfig)
 	return ds
 }
 
@@ -32,8 +32,7 @@ func getDiscoverySelectorsForCluster(cluster string, kialiConfig *config.Config)
 // will select the control plane namespace as defined in the Kiali config in order to assure Kiali will always match
 // the control plane namespace (Kiali should always see that namespace).
 // NOTE: You probably don't want to use this func; instead, see getDiscoverySelectorsForCluster()
-func getKialiDiscoverySelectors(cluster string, cfg *config.Config) config.DiscoverySelectorsType {
-
+func GetKialiDiscoverySelectors(cluster string, cfg *config.Config) config.DiscoverySelectorsType {
 	if cfg == nil {
 		return nil
 	}
@@ -69,8 +68,7 @@ func getKialiDiscoverySelectors(cluster string, cfg *config.Config) config.Disco
 // filterNamespacesWithDiscoverySelectors will look at the given list of namespaces and return a list
 // containing only those namespaces that match the given discovery selectors. If there are no discoverySelectors,
 // then the full list of namespaces is returned minus the system namespaces.
-func filterNamespacesWithDiscoverySelectors(namespaces []models.Namespace, discoverySelectors config.DiscoverySelectorsType) []models.Namespace {
-
+func FilterNamespacesWithDiscoverySelectors(namespaces []models.Namespace, discoverySelectors config.DiscoverySelectorsType) []models.Namespace {
 	if len(namespaces) == 0 || len(discoverySelectors) == 0 {
 		// We have no discovery selectors set. We want to provide all namespaces, but filter out system namespaces
 		// since in all likelihood the user does not want to see them. If for some reason they do want to see one or

--- a/istio/discovery_selectors_test.go
+++ b/istio/discovery_selectors_test.go
@@ -1,4 +1,4 @@
-package business
+package istio
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGetKialiDiscoverySelectors(t *testing.T) {
-	assert.Nil(t, getKialiDiscoverySelectors("a", nil))
+	assert.Nil(t, GetKialiDiscoverySelectors("a", nil))
 
 	// config with no selectors defined
 	cfgNoSelectors := config.Config{
@@ -294,15 +294,15 @@ func TestGetKialiDiscoverySelectors(t *testing.T) {
 			config, err := config.Unmarshal(yaml)
 			assert.Nil(err)
 
-			selectors := getKialiDiscoverySelectors(tc.clusterName, config)
-			filteredNamespaces := filterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
+			selectors := GetKialiDiscoverySelectors(tc.clusterName, config)
+			filteredNamespaces := FilterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
 			assert.Equal(tc.matchedNamespaces, filteredNamespaces)
 		})
 	}
 }
 
 func TestGetDiscoverySelectorsForCluster(t *testing.T) {
-	assert.Nil(t, getDiscoverySelectorsForCluster("cluster1", nil))
+	assert.Nil(t, GetDiscoverySelectorsForCluster("cluster1", nil))
 
 	// config with only "cluster1" override selectors
 	overrideSelectors := config.Config{
@@ -362,8 +362,8 @@ func TestGetDiscoverySelectorsForCluster(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			selectors := getDiscoverySelectorsForCluster(tc.clusterName, &tc.config)
-			filteredNamespaces := filterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
+			selectors := GetDiscoverySelectorsForCluster(tc.clusterName, &tc.config)
+			filteredNamespaces := FilterNamespacesWithDiscoverySelectors(tc.allNamespaces, selectors)
 			assert.Equal(tc.matchedNamespaces, filteredNamespaces)
 		})
 	}

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -177,6 +177,10 @@ func NewKialiCache(clientFactory kubernetes.ClientFactory, cfg config.Config) (K
 				break
 			}
 		}
+
+		if canReadMutatingWebhooks := kialiCacheImpl.canReadWebhookByCluster[cluster]; !canReadMutatingWebhooks {
+			log.Infof("[Kiali Cache] Unable to list webhooks for cluster [%s]. Give Kiali permission to read 'mutatingwebhookconfigurations'.", cluster)
+		}
 	}
 
 	// TODO: Treat all clusters the same way.

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -108,10 +108,12 @@ trustDomain: cluster.local
 		},
 	}
 
+	defaultInjection := map[string]string{models.IstioInjectionLabel: models.IstioInjectionEnabledLabelValue}
+	revLabel := map[string]string{models.IstioRevisionLabel: "default"}
 	primaryClient := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("istio-system"),
-		kubetest.FakeNamespace("data-plane-1"),
-		kubetest.FakeNamespace("data-plane-2"),
+		kubetest.FakeNamespaceWithLabels("data-plane-1", defaultInjection),
+		kubetest.FakeNamespaceWithLabels("data-plane-2", revLabel),
 		&istiodDeployment,
 		&istioConfigMap,
 		&sidecarConfigMap,
@@ -128,8 +130,8 @@ trustDomain: cluster.local
 			Annotations: map[string]string{business.IstioControlPlaneClustersLabel: conf.KubernetesConfig.ClusterName},
 			Labels:      map[string]string{"kubernetes.io/metadata.name": "istio-system"},
 		}},
-		kubetest.FakeNamespace("data-plane-3"),
-		kubetest.FakeNamespace("data-plane-4"),
+		kubetest.FakeNamespaceWithLabels("data-plane-3", defaultInjection),
+		kubetest.FakeNamespaceWithLabels("data-plane-4", revLabel),
 	)
 	clients := map[string]kubernetes.ClientInterface{
 		conf.KubernetesConfig.ClusterName: primaryClient,

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -204,6 +204,7 @@
               "cluster": "cluster-primary",
               "isAmbient": false,
               "labels": {
+                "istio-injection": "enabled",
                 "kubernetes.io/metadata.name": "data-plane-1"
               },
               "annotations": null
@@ -213,6 +214,7 @@
               "cluster": "cluster-primary",
               "isAmbient": false,
               "labels": {
+                "istio.io/rev": "default",
                 "kubernetes.io/metadata.name": "data-plane-2"
               },
               "annotations": null
@@ -310,6 +312,7 @@
               "cluster": "cluster-remote",
               "isAmbient": false,
               "labels": {
+                "istio-injection": "enabled",
                 "kubernetes.io/metadata.name": "data-plane-3"
               },
               "annotations": null
@@ -319,6 +322,7 @@
               "cluster": "cluster-remote",
               "isAmbient": false,
               "labels": {
+                "istio.io/rev": "default",
                 "kubernetes.io/metadata.name": "data-plane-4"
               },
               "annotations": null

--- a/mesh/config/cytoscape/cytoscape.go
+++ b/mesh/config/cytoscape/cytoscape.go
@@ -41,7 +41,6 @@ type NodeData struct {
 	InfraData      interface{} `json:"infraData,omitempty"`      // infraType-dependent data
 	IsAmbient      bool        `json:"isAmbient,omitempty"`      // true if configured for ambient
 	IsBox          string      `json:"isBox,omitempty"`          // set for NodeTypeBox, current values: [ 'cluster', 'dataplanes', 'namespace' ]
-	IsCanary       bool        `json:"isCanary,omitempty"`       // true if the data plane is canary
 	IsExternal     bool        `json:"isExternal,omitempty"`     // true if the infra is external to the mesh | false
 	IsInaccessible bool        `json:"isInaccessible,omitempty"` // true if the node exists in an inaccessible namespace
 	IsMTLS         bool        `json:"isMTLS,omitempty"`         // true if mesh-wide mTLS is enabled
@@ -172,10 +171,6 @@ func buildConfig(meshMap mesh.MeshMap, nodes *[]*NodeWrapper, edges *[]*EdgeWrap
 
 		if val, ok := n.Metadata[mesh.Version]; ok {
 			nd.Version = val.(string)
-		}
-
-		if val, ok := n.Metadata[mesh.IsCanary]; ok {
-			nd.IsCanary = val.(bool)
 		}
 
 		nw := NodeWrapper{

--- a/mesh/meta.go
+++ b/mesh/meta.go
@@ -15,7 +15,6 @@ func NewMetadata() Metadata {
 const (
 	HealthData     MetadataKey = "healthData"
 	InfraData      MetadataKey = "infraData"
-	IsCanary       MetadataKey = "isCanary"
 	IsExternal     MetadataKey = "isExternal"
 	IsInaccessible MetadataKey = "isInaccessible"
 	IsMTLS         MetadataKey = "isMTLS"

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -69,7 +69,7 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	namespace.Labels = ns.Labels
 	namespace.Annotations = ns.Annotations
 
-	if ns.Labels[istioLabels.AmbientNamespaceLabel] == istioLabels.AmbientNamespaceLabelValue {
+	if label, hasLabel := ns.Labels[istioLabels.AmbientNamespaceLabel]; hasLabel && label == istioLabels.AmbientNamespaceLabelValue {
 		namespace.IsAmbient = true
 	}
 	return namespace


### PR DESCRIPTION
### Describe the change

Adds support for tags to the mesh page. Now when a namespace has a tag that references a controlplane revision, the controlplane will properly have an edge to that dataplane.

This change requires adding `LIST` permissions for `mutatingwebhookconfigurations.admissionregistration.k8s.io`. Multi-cluster Kiali deployments will need to regenerate their remote cluster roles even after they have updated their Kiali helm deployment. However to be more backwards compatible, this change also checks for `LIST` permission to read mutating webhooks and if the kiali service account does not have the permission then a warning will be logged and tags will be ignored.

### Steps to test the PR

1. Deploy Kiali

    **Deploying with helm/kind:**

    Helm chart PR: https://github.com/kiali/helm-charts/pull/279
  
    In helm chart repo with above PR checked out, run:
    ```
    make build-helm-charts
    ```
    Build kiali server and UI then run setup. Example helm-charts-dir arg: `$HOME/kiali/helm-charts`:
    ```
    make build build-ui
    ./hack/run-integration-tests.sh --test-suite backend --setup-only true --helm-charts-dir <helm_charts_dir>
    ```
    **Deploying with minikube/operator:**
    ```
    hack/k8s-minikube.sh start 
    hack/k8s-minikube.sh istio
    hack/k8s-minikube.sh bookinfo
    make CLUSTER_TYPE=minikube build build-ui cluster-push operator-create kiali-create
    hack/istio/install-testing-demos.sh -c kubectl
    ```
    
2. Create two additional controlplanes
    ```
    istioctl install --revision=1-21-1 --set profile=minimal --set values.global.multiCluster.clusterName="cluster-default" --skip-confirmation                                                           
    istioctl install --revision=1-22-3 --set profile=minimal --set values.global.multiCluster.clusterName="cluster-default" --skip-confirmation
    ```
3. Create a tag for each
    ```
    istioctl tag set prod-stable --revision 1-21-1
    istioctl tag set prod-canary --revision 1-22-3
    ```
4. Create test namespaces and label each
    ```
    kubectl create ns app-ns-1
    kubectl label ns app-ns-1 istio.io/rev=prod-stable
    kubectl create ns app-ns-2
    kubectl label ns app-ns-2 istio.io/rev=prod-stable
    kubectl create ns app-ns-3
    kubectl label ns app-ns-3 istio.io/rev=prod-canary
    ```
5. Create an app in each namespace
    ```
    kubectl apply -n app-ns-1 -f https://raw.githubusercontent.com/istio/istio/master/samples/sleep/sleep.yaml
    kubectl apply -n app-ns-2 -f https://raw.githubusercontent.com/istio/istio/master/samples/sleep/sleep.yaml
    kubectl apply -n app-ns-3 -f https://raw.githubusercontent.com/istio/istio/master/samples/sleep/sleep.yaml
    ```
6. Visit the mesh page and verify that the 1-21-1 controlplane has an edge to the `prod-stable` dataplane and the 1-22-3 controlplane has an edge to the `prod-canary` dataplane.

    ![Screenshot from 2024-09-03 15-19-54](https://github.com/user-attachments/assets/81e3c60f-6ea7-4e96-81d1-ade526d5e5ed)

### Automation testing

Included with this PR.

### Issue reference

Fixes #7598 

[Helm chart PR](https://github.com/kiali/helm-charts/pull/279)
[Operator PR](https://github.com/kiali/kiali-operator/pull/816)
