### PR TITLE
[hack] disable ambient cni ipv6

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -359,6 +359,12 @@ if [ "${IS_OPENSHIFT}" == "true" ]; then
   fi
 fi
 
+# If Ambient profile, disable ipv6; this is broken on minikube when not using docker driver (TODO: make ipv6 optional)
+if [ "${CONFIG_PROFILE}" == "ambient" ]; then
+  CNI_OPTIONS="${CNI_OPTIONS} --set values.cni.ambient.ipv6=false"
+  echo "Disabling Ambient CNI IPv6"
+fi
+
 MTLS_OPTIONS="--set values.meshConfig.enableAutoMtls=${MTLS}"
 
 NATIVE_SIDECARS_OPTIONS="--set values.pilot.env.ENABLE_NATIVE_SIDECARS=${ENABLE_NATIVE_SIDECARS}"


### PR DESCRIPTION
We need to disable ipv6 when installing Ambient because it breaks on minikube when not using docker driver (you get errors that say something like "Command error output: xtables parameter problem: ip6tables-restore: unable to initialize table 'nat'"

To test this:

1. Start minikube with some driver other than docker (our hack script defaults to kvm2, so this is a good test)
```
hack/k8s-minikube.sh start
```
2. Install Istio with Ambient using the hack script
```
hack/istio/install-istio-via-istioctl.sh -c kubectl -cp ambient
```

Istio with Ambient should install successfully now.