### PR TITLE
[1.73] Fix flaky int tests with tempo tracing

### DIFF
--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -93,9 +93,10 @@ type MetricsJson struct {
 var client = *NewKialiClient()
 
 const (
-	BOOKINFO = "bookinfo"
-	ASSETS   = "tests/integration/assets"
-	TIMEOUT  = 10 * time.Second
+	BOOKINFO        = "bookinfo"
+	ASSETS          = "tests/integration/assets"
+	TIMEOUT         = 10 * time.Second
+	TRACING_TIMEOUT = 60 * time.Second
 )
 
 func NewKialiClient() (c *KialiClient) {
@@ -324,7 +325,7 @@ func ServiceDetails(name, namespace string) (*ServiceDetailsJson, int, error) {
 }
 
 func Traces(objectType, name, namespace string) (*jaeger.JaegerResponse, int, error) {
-	body, code, _, err := httpGETWithRetry(fmt.Sprintf("%s/api/namespaces/%s/%s/%s/traces?startMicros=%d&tags=&limit=100", client.kialiURL, namespace, objectType, name, TimeSince()), client.GetAuth(), TIMEOUT, nil, client.kialiCookies)
+	body, code, _, err := httpGETWithRetry(fmt.Sprintf("%s/api/namespaces/%s/%s/%s/traces?startMicros=%d&tags=&limit=100", client.kialiURL, namespace, objectType, name, TimeSince()), client.GetAuth(), TRACING_TIMEOUT, nil, client.kialiCookies)
 	log.Debugf("Traces response: %s", body)
 	if err == nil {
 		traces := new(jaeger.JaegerResponse)
@@ -340,7 +341,7 @@ func Traces(objectType, name, namespace string) (*jaeger.JaegerResponse, int, er
 }
 
 func Spans(objectType, name, namespace string) ([]jaeger.JaegerSpan, int, error) {
-	body, code, _, err := httpGETWithRetry(fmt.Sprintf("%s/api/namespaces/%s/%s/%s/spans?startMicros=%d&tags=&limit=100", client.kialiURL, namespace, objectType, name, TimeSince()), client.GetAuth(), TIMEOUT, nil, client.kialiCookies)
+	body, code, _, err := httpGETWithRetry(fmt.Sprintf("%s/api/namespaces/%s/%s/%s/spans?startMicros=%d&tags=&limit=100", client.kialiURL, namespace, objectType, name, TimeSince()), client.GetAuth(), TRACING_TIMEOUT, nil, client.kialiCookies)
 	if err == nil {
 		spans := []jaeger.JaegerSpan{}
 		err = json.Unmarshal(body, &spans)


### PR DESCRIPTION
### Describe the change
The Kiali Integration tests related to `Tracing` are sometimes flaky when Tempo tracing is used (since the older jaeger collector is used for ossm 2.6 / Kiali 1.73, so query to tempo tracing can take longer )
In the Kiali CR, I increased the query timeout to 60s, however, the test uses hardcoded 10s.

This PR increases client timeout to 60s for Tracing and Spans tests. ( to be aligned with downstream pipeline where integration with tempo is tested )

The backport is not needed since the newer Kali version supports Tempo querier, which is faster than the old and, in a little while, deprecated Jaeger querier.

Tested this change 3x against clusters: OCP on OpenStack, ARM, IPv6, ARO, ROSA, IBM P and all integration tests passed. ( so they are not flaky anymore )