### PR TITLE
Fixed hardcoded App param for CustomMetrics Links

### DIFF
--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -353,8 +353,8 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
             <GrafanaLinks
               links={this.state.grafanaLinks}
               namespace={this.props.namespace}
-              object={this.props.app}
-              objectType={MetricsObjectTypes.APP}
+              object={this.props.workload ? this.props.workload : this.props.app}
+              objectType={this.props.workload ? MetricsObjectTypes.WORKLOAD : MetricsObjectTypes.APP}
               version={this.props.version}
             />
           </ToolbarGroup>


### PR DESCRIPTION
### Describe the change

Workload's Custom dashboard's Link to Grafana had hardcoded 'App' instead of checking the object type.
Now it sets 'Workload' for workloads.

### Steps to test the PR

Create Custom Dashboard on Grafana side.
Add that custom dashboard into Kiali CR, and make sure `variables` ar also set:
```
custom_dashboards:
  - discoverOn: envoy_server_uptime
    externalLinks:
    - name: grafana
      type: grafana
      variables:
        namespace: "var-namespace"
        service: "var-service"
        workload: "var-workload"
    items:
    - chart:
        dataType: raw
        metricName: envoy_server_uptime
        name: Pods uptime
        spans: 12
    name: grafana-test
    runtime: GRAFANA
    title: Grafana metrics
```
Workload details should have the 'Graffana metrics' tab with "View in Grafana" link.
Verify that the link contains variables 'var-namespace' and 'var-workload'. The issue was that here there was hardcoded "var-app" param.
![Screenshot from 2024-09-05 10-41-29](https://github.com/user-attachments/assets/00065012-17ab-4b1c-ad15-79b7e8b635a3)


### Automation testing
n/a

### Issue reference
https://github.com/kiali/kiali/issues/7638
