### PR TITLE
Check each cluster individually to see if they are openshift in namespace service

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -64,7 +64,7 @@ func NewNamespaceService(
 	}
 }
 
-func (in *NamespaceService) clusterIsOpenshift(cluster string) bool {
+func (in *NamespaceService) clusterIsOpenShift(cluster string) bool {
 	return in.hasProjects[cluster]
 }
 
@@ -163,7 +163,7 @@ func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster 
 	var namespaces []models.Namespace
 
 	// If we are running in OpenShift, we will use the project names since these are the list of accessible namespaces
-	if in.clusterIsOpenshift(cluster) {
+	if in.clusterIsOpenShift(cluster) {
 		projects, err := in.userClients[cluster].GetProjects(ctx, "")
 		if err != nil {
 			return nil, err
@@ -279,7 +279,7 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 	}
 
 	var result models.Namespace
-	if in.clusterIsOpenshift(cluster) {
+	if in.clusterIsOpenShift(cluster) {
 		project, err := client.GetProject(ctx, namespace)
 		if err != nil {
 			return nil, err

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -82,6 +82,11 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 
 	// TODO: We could parallelize this to potentially speed up the process.
 	for cluster, client := range kialiSAClients {
+		if !client.IsOpenShift() {
+			log.Infof("While setting up the OAuthService, skipping cluster [%s] because it is not an OpenShift cluster", cluster)
+			continue
+		}
+
 		log.Debugf("Getting OAuth config for cluster [%s]", cluster)
 		// Use CA info from kube config.
 		url := client.ClusterInfo().ClientConfig.Host + "/.well-known/oauth-authorization-server"

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -71,6 +71,7 @@ func TestNewOpenshiftAuthService(t *testing.T) {
 
 	metadataServer := fakeOAuthMetadataServer(t)
 	client := kubetest.NewFakeK8sClient(oAuthClient)
+	client.OpenShift = true
 	client.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: client}
 	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
@@ -144,6 +145,7 @@ func TestOpenshiftAuthController(t *testing.T) {
 		},
 	)
 	client.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+	client.OpenShift = true
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: client}
 	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
 
@@ -226,6 +228,7 @@ func TestUnauthorizedUserSessionGetsDropped(t *testing.T) {
 	client.UserFake.PrependReactor("get", "users", func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewUnauthorized("unauthorized")
 	})
+	client.OpenShift = true
 
 	client.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: client}
@@ -276,6 +279,7 @@ func TestMulticlusterUnauthorizedUserSessionGetsDropped(t *testing.T) {
 			},
 		},
 	)
+	eastClient.OpenShift = true
 
 	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	westClient := kubetest.NewFakeK8sClient(
@@ -291,6 +295,7 @@ func TestMulticlusterUnauthorizedUserSessionGetsDropped(t *testing.T) {
 			},
 		},
 	)
+	westClient.OpenShift = true
 	westClient.UserFake.PrependReactor("get", "users", func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewUnauthorized("unauthorized")
 	})
@@ -357,6 +362,7 @@ func TestTerminateSession(t *testing.T) {
 			},
 		},
 	)
+	eastClient.OpenShift = true
 
 	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	westClient := kubetest.NewFakeK8sClient(
@@ -372,6 +378,7 @@ func TestTerminateSession(t *testing.T) {
 			},
 		},
 	)
+	westClient.OpenShift = true
 	westClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	clients := map[string]kubernetes.ClientInterface{
 		"east": eastClient,


### PR DESCRIPTION
### Describe the change

Allows you to run multi-cluster Kiali with mixed openshift and kube clusters in `anonymous` mode.

### Steps to test the PR

1. Deploy Kiali on an openshift cluster
    ```
    hack/crc-openshift.sh start                                                                                                                                                          
    oc login -u kubeadmin -p kiali https://api.crc.testing:6443 --insecure-skip-tls-verify                                                                                                                                                                                                  
    podman login --tls-verify=false -u kiali -p (oc whoami -t) default-route-openshift-image-registry.apps-crc.testing                                                                                                                                                                      
    hack/istio/install-istio-via-istioctl.sh -iee true -cp openshift                                                                                                                                                                                                    
    make CLUSTER_TYPE=openshift AUTH_STRATEGY=anonymous build build-ui cluster-push operator-create kiali-create
    hack/istio/install-testing-demos.sh
    ```
2. Create a second cluster with istio installed

    ```
    kind create cluster
    hack/istio/install-istio-via-istioctl.sh -c kubectl -rr true
    hack/istio/install-testing-demos.sh -c kubectl
    ```
3. Create a remote cluster secret for the second cluster

    ```
    hack/istio/multicluster/kiali-prepare-remote-cluster.sh --remote-cluster-context kind-kind --kiali-cluster-context crc-admin --allow-skip-tls-verify true --remote-cluster-url https://$(kubectl get nodes kind-control-plane --context kind-kind -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443
    ```

4. Poke the Kiali operator to get it to reconcile the Kiali CR. Otherwise the Kiali operator won't mount the remote cluster secrets into the server pod.
    ```
    kubectl patch kialis kiali -n kiali-operator --type=json -p '[{"op":"add","path":"/metadata/annotations/reconcile","value":"now"}]'
    ```

5. Open Kiali and verify that there are no errors

### Automation testing

N/A

### Issue reference

Fixes #7665 
