### PR TITLE
Add isWaypoint info to node to create node link

### DIFF
--- a/frontend/src/components/Nav/NavUtils.tsx
+++ b/frontend/src/components/Nav/NavUtils.tsx
@@ -61,6 +61,12 @@ export const makeNamespacesGraphUrlFromParams = (params: GraphUrlParams, isPf = 
 export const makeNodeGraphUrlFromParams = (params: GraphUrlParams, isPf = false): string => {
   const route = isPf ? 'graphpf' : 'graph';
   const node = params.node;
+
+  if (node?.isWaypoint && node?.nodeType === NodeType.APP) {
+    // Waypoints are not part of the app, so make a correction to redirect properly
+    node.nodeType = NodeType.WORKLOAD;
+  }
+
   if (node) {
     switch (node.nodeType) {
       case NodeType.AGGREGATE:

--- a/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
+++ b/frontend/src/pages/GraphPF/components/stylesComponentFactory.tsx
@@ -161,8 +161,17 @@ const handleDoubleTap = (doubleTapNode: GraphElement, kiosk: string): void => {
     }
   }
 
-  const { app, cluster, namespace, nodeType, service, version, workload } = dtNodeData;
-  const event = { app, cluster, namespace, nodeType, service, version, workload } as GraphNodeDoubleTapEvent;
+  const { app, cluster, namespace, nodeType, service, version, workload, isWaypoint } = dtNodeData;
+  const event = {
+    app,
+    cluster,
+    namespace,
+    nodeType,
+    service,
+    version,
+    workload,
+    isWaypoint
+  } as GraphNodeDoubleTapEvent;
   const targetNode: NodeParamsType = { ...event, namespace: { name: dtNodeData.namespace } };
 
   // If, while in the drilled-down graph, the user double clicked the same

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -203,6 +203,7 @@ export interface NodeParamsType {
   aggregateValue?: string;
   app: string;
   cluster?: string;
+  isWaypoint?: boolean;
   namespace: Namespace;
   nodeType: NodeType;
   service: string;


### PR DESCRIPTION
### Describe the change

- Update the waypoint node graph url to avoid to redirect to an empty graph page. 
- Lint changes 

### Steps to test the PR

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

Verification in cytoscape graph: 

- Go to bookinfo traffic graph 
- Click the Display option "waypoint proxies"
- Double click in the waypoint node
- verify it redirects to the workload waypoint graph: 

![image](https://github.com/user-attachments/assets/4713748c-8bf7-4e30-84c2-5c9b433e6e8e)

Click in other nodes, verify it redirects to service/application graph. 

Verification in patternfly graph: 

- Go to bookinfo traffic graph 
- Click the Display option "waypoint proxies"
- Right click in the waypoint node -> Node graph
- verify it redirects to the workload waypoint graph: 

![image](https://github.com/user-attachments/assets/186e9f80-8604-4743-90c1-704f04a310ef)


Click in other nodes, verify it redirects to service/application graph. 

### Automation testing

N/A

### Issue reference

Fixes #7702 
