### PR TITLE
Fix sidecar injection flaky test

### DIFF
--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -87,10 +87,8 @@ Given('a workload without a sidecar', function () {
     }
   });
 
-  // Restart the workload to ensure changes are applied.
-  cy.exec(`kubectl scale -n ${this.targetNamespace} --replicas=1 deployment/${this.targetWorkload}`);
-  cy.exec(`kubectl rollout restart deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
-  cy.exec(`kubectl rollout status deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
+  // Restart the workload to ensure the changes are applied.
+  restartWorkload(this.targetNamespace, this.targetWorkload);
 });
 
 Given('a workload with a sidecar', function () {
@@ -133,10 +131,8 @@ Given('a workload with a sidecar', function () {
     }
   });
 
-  // Restart the workload to ensure changes are applied.
-  cy.exec(`kubectl scale -n ${this.targetNamespace} --replicas=1 deployment/${this.targetWorkload}`);
-  cy.exec(`kubectl rollout restart deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
-  cy.exec(`kubectl rollout status deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
+  // Restart the workload to ensure the changes are applied.
+  restartWorkload(this.targetNamespace, this.targetWorkload);
 });
 
 Given('the workload does not have override configuration for automatic sidecar injection', function () {
@@ -187,10 +183,8 @@ Given('the workload does not have override configuration for automatic sidecar i
       }
     });
 
-    // Restart the workload to ensure changes are applied.
-    cy.exec(`kubectl scale -n ${this.targetNamespace} --replicas=1 deployment/${this.targetWorkload}`);
-    cy.exec(`kubectl rollout restart deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
-    cy.exec(`kubectl rollout status deployment ${this.targetWorkload} -n ${this.targetNamespace}`);
+    // Restart the workload to ensure the changes are applied.
+    restartWorkload(this.targetNamespace, this.targetWorkload);
   }
 });
 
@@ -333,7 +327,16 @@ function switchWorkloadSidecarInjection(enableOrDisable: string): void {
   cy.get('button[data-test="workload-actions-toggle"]').should('be.visible').click();
   cy.get(`li[data-test=${enableOrDisable}_auto_injection]`).find('button').should('be.visible').click();
 
+  // Restart the workload to ensure the changes are applied.
+  restartWorkload(this.targetNamespace, this.targetWorkload);
+
   ensureKialiFinishedLoading();
+}
+
+function restartWorkload(targetNamespace: string, targetWorkload: string): void {
+  cy.exec(`kubectl scale -n ${targetNamespace} --replicas=1 deployment/${targetWorkload}`);
+  cy.exec(`kubectl rollout restart deployment ${targetWorkload} -n ${targetNamespace}`);
+  cy.exec(`kubectl rollout status deployment ${targetWorkload} -n ${targetNamespace}`);
 }
 
 When(

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -333,11 +333,11 @@ function switchWorkloadSidecarInjection(enableOrDisable: string): void {
   ensureKialiFinishedLoading();
 }
 
-function restartWorkload(targetNamespace: string, targetWorkload: string): void {
+const restartWorkload = (targetNamespace: string, targetWorkload: string): void => {
   cy.exec(`kubectl scale -n ${targetNamespace} --replicas=1 deployment/${targetWorkload}`);
   cy.exec(`kubectl rollout restart deployment ${targetWorkload} -n ${targetNamespace}`);
   cy.exec(`kubectl rollout status deployment ${targetWorkload} -n ${targetNamespace}`);
-}
+};
 
 When(
   'I override the default policy for automatic sidecar injection in the workload to {string} it',


### PR DESCRIPTION
### Describe the change

Fix the flaky sidecar injection test by restarting the `sleep` workload when sidecar injection is enabled or disabled in the Kiali Cypress tests.

### Steps to test the PR

Verify that the sidecar injection tests pass on an OpenShift console (the same tests already pass in the e2e GitHub Action).
 
### Automation testing

Fixes two flaky tests in the sidecar injection feature scenario.

### Issue reference

Fixes #7714 
