### PR TITLE
Added missing K8sGateway label name check for MissingSidecar icon

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ const (
 const (
 	AmbientAnnotation        = "ambient.istio.io/redirection"
 	AmbientAnnotationEnabled = "enabled"
+	K8sGatewayLabelName      = "gateway.networking.k8s.io/gateway-name"
 	WaypointLabel            = "gateway.istio.io/managed"
 	WaypointLabelValue       = "istio.io-mesh-controller"
 	WaypointUseLabel         = "istio.io/use-waypoint"
@@ -346,6 +347,7 @@ type IstioLabels struct {
 	IngressGatewayLabel        string `yaml:"ingress_gateway_label,omitempty" json:"ingressGatewayLabel"`
 	InjectionLabelName         string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
+	K8sGatewayLabelName        string `yaml:"k8s_gateway_label_name,omitempty" json:"k8sGatewayLabelName"`
 	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
@@ -768,6 +770,7 @@ func NewConfig() (c *Config) {
 			IngressGatewayLabel:        "istio=ingressgateway",
 			InjectionLabelName:         "istio-injection",
 			InjectionLabelRev:          "istio.io/rev",
+			K8sGatewayLabelName:        K8sGatewayLabelName,
 			VersionLabelName:           "version",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -87,6 +87,7 @@ const defaultServerConfig: ComputedServerConfig = {
     ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
+    k8sGatewayLabelName: 'gateway.networking.k8s.io/gateway-name',
     versionLabelName: 'version'
   },
   kialiFeatureFlags: {

--- a/frontend/src/helpers/LabelFilterHelper.ts
+++ b/frontend/src/helpers/LabelFilterHelper.ts
@@ -114,12 +114,19 @@ export const isGateway = (labels: { [key: string]: string }): boolean => {
   return (
     labels &&
     ((ingress[0] in labels && labels[ingress[0]] === ingress[1]) ||
-      (egress[0] in labels && labels[egress[0]] === egress[1]))
+      (egress[0] in labels && labels[egress[0]] === egress[1]) ||
+      isK8sGateway(labels))
   );
+};
+
+export const isK8sGateway = (labels: { [key: string]: string }): boolean => {
+  return labels && serverConfig.istioLabels.k8sGatewayLabelName in labels;
 };
 
 export const isWaypoint = (labels: { [key: string]: string }): boolean => {
   return (
-    labels && 'gateway.istio.io/managed' in labels && labels['gateway.istio.io/managed'] === 'istio.io-mesh-controller'
+    labels &&
+    serverConfig.istioLabels.ambientWaypointLabel in labels &&
+    labels[serverConfig.istioLabels.ambientWaypointLabel] === serverConfig.istioLabels.ambientWaypointLabelValue
   );
 };

--- a/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,4 +1,4 @@
-import { filterByLabel, isGateway } from '../LabelFilterHelper';
+import { filterByLabel, isGateway, isK8sGateway } from '../LabelFilterHelper';
 import { AppListItem } from '../../types/AppList';
 import { AppHealth, WorkloadHealth, ServiceHealth } from '../../types/Health';
 import { WorkloadListItem } from '../../types/Workload';
@@ -325,5 +325,25 @@ describe('LabelFilter', () => {
   it('check is Egress Gateway when true', () => {
     const result = isGateway({ istio: 'egressgateway' });
     expect(result).toBeTruthy();
+  });
+
+  it('check is Gateway (K8s) when true', () => {
+    const result = isGateway({ 'gateway.networking.k8s.io/gateway-name': 'gateway-istio' });
+    expect(result).toBeTruthy();
+  });
+
+  it('check is Gateway (K8s) when false', () => {
+    const result = isGateway({ 'gateway.networking.k8s.io/wrong-gateway-name': 'gateway-istio' });
+    expect(result).toBeFalsy();
+  });
+
+  it('check is K8s Gateway when true', () => {
+    const result = isK8sGateway({ 'gateway.networking.k8s.io/gateway-name': 'gateway-istio' });
+    expect(result).toBeTruthy();
+  });
+
+  it('check is K8s Gateway when false', () => {
+    const result = isK8sGateway({ 'gateway.networking.k8s.io/wrong-gateway-name': 'gateway-istio' });
+    expect(result).toBeFalsy();
   });
 });

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -177,6 +177,7 @@ export const serverRateConfig = {
     ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
+    k8sGatewayLabelName: 'gateway.networking.k8s.io/gateway-name',
     versionLabelName: 'version'
   },
   prometheus: {

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -11,6 +11,7 @@ export type IstioLabelKey =
   | 'ingressGatewayLabel'
   | 'injectionLabelName'
   | 'injectionLabelRev'
+  | 'k8sGatewayLabelName'
   | 'versionLabelName';
 
 interface DeploymentConfig {
@@ -142,8 +143,8 @@ export interface ToleranceConfig {
 export interface ServerConfig {
   ambientEnabled: boolean;
   authStrategy: string;
-  clusters: { [key: string]: MeshCluster };
   clusterWideAccess: boolean;
+  clusters: { [key: string]: MeshCluster };
   deployment: DeploymentConfig;
   gatewayAPIClasses: GatewayAPIClass[];
   gatewayAPIEnabled: boolean;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -97,6 +97,7 @@ export const healthConfig = {
     ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
+    k8sGatewayLabelName: 'gateway.networking.k8s.io/gateway-name',
     versionLabelName: 'version'
   },
   prometheus: {

--- a/graph/telemetry/istio/appender/mesh_check.go
+++ b/graph/telemetry/istio/appender/mesh_check.go
@@ -61,13 +61,16 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 		// get the workloads for the node and check to see if they have sidecars. Note that
 		// if there are no workloads/pods we don't flag it as missing sidecars.  No pods means
 		// no missing sidecars.  (In most cases this means it was flagged as dead, and handled above)
+		// check if workload is Gateway (Istio or K8s)
 		hasIstioSidecar := true
 		hasIstioAmbient := true
+		hasGatewayLabel := true
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
 			if workload, found := getWorkload(n.Cluster, n.Namespace, n.Workload, globalInfo); found {
 				hasIstioSidecar = workload.IstioSidecar
 				hasIstioAmbient = workload.IsAmbient
+				hasGatewayLabel = workload.IsGateway
 			}
 		case graph.NodeTypeApp:
 			workloads := getAppWorkloads(n.Cluster, n.Namespace, n.App, n.Version, globalInfo)
@@ -79,7 +82,10 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 					if !workload.IsAmbient {
 						hasIstioAmbient = false
 					}
-					if !hasIstioSidecar && !hasIstioAmbient {
+					if !workload.IsGateway {
+						hasGatewayLabel = false
+					}
+					if !hasIstioSidecar && !hasIstioAmbient && !hasGatewayLabel {
 						break
 					}
 				}
@@ -91,7 +97,7 @@ func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalI
 		if hasIstioAmbient || n.Metadata[graph.IsWaypoint] == true {
 			n.Metadata[graph.IsAmbient] = true
 		}
-		if !hasIstioSidecar && !hasIstioAmbient && n.Metadata[graph.IsWaypoint] != true {
+		if !hasGatewayLabel && !hasIstioSidecar && !hasIstioAmbient && n.Metadata[graph.IsWaypoint] != true {
 			n.Metadata[graph.IsOutOfMesh] = true
 		}
 	}

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -213,6 +213,13 @@ func TestIsGatewayLabelsToWorkload(t *testing.T) {
 		"istio-system":                "ingressgateway",
 	}
 	assert.False(w.IsGateway())
+
+	w = Workload{}
+	w.Type = "Deployment"
+	w.Labels = map[string]string{
+		"gateway.networking.k8s.io/gateway-name": "gateway",
+	}
+	assert.True(w.IsGateway())
 }
 
 func fakeDeployment() *apps_v1.Deployment {


### PR DESCRIPTION
### Describe the change

Added missing `isK8sGateway` check while checking `isGateway` for `MissingSidecar` icon.
Added a new config `K8sGatewayLabelName` in IstioLabels. Currently has a default value as constant.

### Steps to test the PR

Setup Istio in ambient mode.
```
./hack/istio/install-istio-via-istioctl.sh -c kubectl -cp ambient 
./hack/istio/install-bookinfo-demo.sh -c kubectl -ai false -tg
kubectl apply -f _output/istio-1.23.0/samples/addons/kiali.yaml
./_output/istio-1.23.0/bin/istioctl x waypoint apply -n bookinfo
```
Go to bookinfo's 'bookinfo-gateway-istio' Workload or Service details.
You should not see the red icon "Out of mesh".
Same in Workload and Services lists page.

### Automation testing

unit tests added

### Issue reference

https://github.com/kiali/kiali/issues/7720
