### PR TITLE
Prevent service node injection for waypoint edges

### DIFF
--- a/graph/api/api.go
+++ b/graph/api/api.go
@@ -45,11 +45,12 @@ func GraphNamespaces(ctx context.Context, business *business.Layer, o graph.Opti
 func graphNamespacesIstio(ctx context.Context, business *business.Layer, prom *prometheus.Client, o graph.Options) (code int, config interface{}) {
 
 	// Create a 'global' object to store the business. Global only to the request.
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = business
 	globalInfo.Context = ctx
+	globalInfo.PromClient = prom
 
-	trafficMap := istio.BuildNamespacesTrafficMap(ctx, o.TelemetryOptions, prom, globalInfo)
+	trafficMap := istio.BuildNamespacesTrafficMap(ctx, o.TelemetryOptions, globalInfo)
 	code, config = generateGraph(trafficMap, o)
 
 	return code, config
@@ -80,14 +81,15 @@ func GraphNode(ctx context.Context, business *business.Layer, o graph.Options) (
 }
 
 // graphNodeIstio provides a test hook that accepts mock clients
-func graphNodeIstio(ctx context.Context, business *business.Layer, client *prometheus.Client, o graph.Options) (code int, config interface{}) {
+func graphNodeIstio(ctx context.Context, business *business.Layer, prom *prometheus.Client, o graph.Options) (code int, config interface{}) {
 
 	// Create a 'global' object to store the business. Global only to the request.
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = business
 	globalInfo.Context = ctx
+	globalInfo.PromClient = prom
 
-	trafficMap, _ := istio.BuildNodeTrafficMap(o.TelemetryOptions, client, globalInfo)
+	trafficMap, _ := istio.BuildNodeTrafficMap(o.TelemetryOptions, globalInfo)
 	code, config = generateGraph(trafficMap, o)
 
 	return code, config

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -3868,7 +3868,7 @@ func ambientWorkloads(t *testing.T) *business.Layer {
 		}}
 	k8spod4 := &core_v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "istio-waypoint",
+			Name:        "waypoint",
 			Namespace:   "bookinfo",
 			Labels:      map[string]string{"app": "waypoint", "version": "v1", config.WaypointLabel: config.WaypointLabelValue},
 			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
@@ -3892,7 +3892,7 @@ func ambientWorkloads(t *testing.T) *business.Layer {
 	return businessLayer
 }
 
-func ambientMockGraph(t *testing.T, api *prometheustest.PromAPIMock) {
+func ambientMockGraph(api *prometheustest.PromAPIMock) {
 	q0 := `round(sum(rate(istio_requests_total{reporter=~"source|waypoint",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0,0.001)`
 	v0 := model.Vector{}
 
@@ -4131,7 +4131,7 @@ func TestAmbientGraph(t *testing.T) {
 	}
 	client.Inject(api)
 
-	ambientMockGraph(t, api)
+	ambientMockGraph(api)
 
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/graph", func(w http.ResponseWriter, r *http.Request) {

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
@@ -3820,6 +3822,334 @@ func TestMultiClusterSourceGraph(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 	expected, _ := os.ReadFile("testdata/test_mc_source_graph.expected")
+	if runtime.GOOS == "windows" {
+		expected = bytes.Replace(expected, []byte("\r\n"), []byte("\n"), -1)
+	}
+	expected = expected[:len(expected)-1] // remove EOF byte
+
+	assertObjectsEqual(t, expected, actual)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+// ambientWorkloads most importantly adds a waypoint to the bookinfo namespace, but also adds the app workloads, just to be more realistic
+func ambientWorkloads(t *testing.T) *business.Layer {
+	k8spod1 := &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "productpage-v1",
+			Namespace:   "bookinfo",
+			Labels:      map[string]string{"app": "productpage", "version": "v1"},
+			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: core_v1.PodSpec{
+			Containers: []core_v1.Container{
+				{Name: "productpage-v1", Image: "whatever"},
+			},
+		}}
+	k8spod2 := &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "ratings-v1",
+			Namespace:   "bookinfo",
+			Labels:      map[string]string{"app": "ratings", "version": "v1"},
+			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: core_v1.PodSpec{
+			Containers: []core_v1.Container{
+				{Name: "ratings-v1", Image: "whatever"},
+			},
+		}}
+	k8spod3 := &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "reviews-v1",
+			Namespace:   "bookinfo",
+			Labels:      map[string]string{"app": "reviews", "version": "v1"},
+			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: core_v1.PodSpec{
+			Containers: []core_v1.Container{
+				{Name: "reviews-v1", Image: "whatever"},
+			},
+		}}
+	k8spod4 := &core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "istio-waypoint",
+			Namespace:   "bookinfo",
+			Labels:      map[string]string{"app": "waypoint", "version": "v1", config.WaypointLabel: config.WaypointLabelValue},
+			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
+		Spec: core_v1.PodSpec{
+			Containers: []core_v1.Container{
+				{Name: "istio-waypoint", Image: "whatever"},
+			},
+		}}
+
+	ns := kubetest.FakeNamespace("bookinfo")
+	k8s := kubetest.NewFakeK8sClient(k8spod1, k8spod2, k8spod3, k8spod4, ns)
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	business.SetupBusinessLayer(t, k8s, *conf)
+	k8sclients := make(map[string]kubernetes.ClientInterface)
+	k8sclients["Kubernetes"] = k8s
+	businessLayer := business.NewWithBackends(k8sclients, k8sclients, nil, nil)
+	return businessLayer
+}
+
+func ambientMockGraph(t *testing.T, api *prometheustest.PromAPIMock) {
+	q0 := `round(sum(rate(istio_requests_total{reporter=~"source|waypoint",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0,0.001)`
+	v0 := model.Vector{}
+
+	q1 := `round(sum(rate(istio_requests_total{reporter=~"destination|waypoint",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0,0.001)`
+	q1m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "details:9080",
+		"destination_service_name":       "details",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "details-v1",
+		"destination_canonical_service":  "details",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"grpc_response_status":           "0",
+		"response_flags":                 "-",
+	}
+	q1m1 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews:9080",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"grpc_response_status":           "0",
+		"response_flags":                 "-",
+	}
+	v1 := model.Vector{
+		&model.Sample{
+			Metric: q1m0,
+			Value:  10,
+		},
+		&model.Sample{
+			Metric: q1m1,
+			Value:  10,
+		},
+	}
+
+	q2 := `round(sum(rate(istio_requests_total{reporter=~"source|waypoint",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0,0.001)`
+	q2m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "details:9080",
+		"destination_service_name":       "details",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "details-v1",
+		"destination_canonical_service":  "details",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"grpc_response_status":           "0",
+		"response_flags":                 "-",
+	}
+	q2m1 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews:9080",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http",
+		"response_code":                  "200",
+		"grpc_response_status":           "0",
+		"response_flags":                 "-",
+	}
+	v2 := model.Vector{
+		&model.Sample{
+			Metric: q2m0,
+			Value:  10,
+		},
+		&model.Sample{
+			Metric: q2m1,
+			Value:  10,
+		},
+	}
+
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	v3 := model.Vector{}
+
+	q4 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q4m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "waypoint",
+		"source_canonical_service":       "waypoint",
+		"source_canonical_revision":      "latest",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "productpage.bookinfo.svc.cluster.local",
+		"destination_service_name":       "productpage",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "productpage-v1",
+		"destination_canonical_service":  "productpage",
+		"destination_canonical_revision": "v1",
+		"response_flags":                 "-",
+		"app":                            "ztunnel",
+	}
+	q4m1 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "waypoint",
+		"source_canonical_service":       "waypoint",
+		"source_canonical_revision":      "latest",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "details.bookinfo.svc.cluster.local",
+		"destination_service_name":       "details",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "details-v1",
+		"destination_canonical_service":  "details",
+		"destination_canonical_revision": "v1",
+		"response_flags":                 "-",
+		"app":                            "ztunnel",
+	}
+	q4m2 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "waypoint",
+		"source_canonical_service":       "waypoint",
+		"source_canonical_revision":      "latest",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1",
+		"response_flags":                 "-",
+		"app":                            "ztunnel",
+	}
+	v4 := model.Vector{
+		&model.Sample{
+			Metric: q4m0,
+			Value:  150,
+		},
+		&model.Sample{
+			Metric: q4m1,
+			Value:  50,
+		},
+		&model.Sample{
+			Metric: q4m2,
+			Value:  50,
+		},
+	}
+
+	q5 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q5m0 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "details.bookinfo.svc.cluster.local",
+		"destination_service_name":       "details",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "waypoint",
+		"destination_canonical_service":  "waypoint",
+		"destination_canonical_revision": "latest",
+		"response_flags":                 "-",
+		"app":                            "ztunnel",
+	}
+	q5m1 := model.Metric{
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"source_cluster":                 "Kubernetes",
+		"destination_cluster":            "Kubernetes",
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "waypoint",
+		"destination_canonical_service":  "waypoint",
+		"destination_canonical_revision": "latest",
+		"response_flags":                 "-",
+		"app":                            "ztunnel",
+	}
+	v5 := model.Vector{
+		&model.Sample{
+			Metric: q5m0,
+			Value:  50,
+		},
+		&model.Sample{
+			Metric: q5m1,
+			Value:  50,
+		},
+	}
+
+	mockQuery(api, q0, &v0)
+	mockQuery(api, q1, &v1)
+	mockQuery(api, q2, &v2)
+	mockQuery(api, q3, &v3)
+	mockQuery(api, q4, &v4)
+	mockQuery(api, q5, &v5)
+}
+
+// TestAmbientGraph tests some waypoint-specific graph features
+func TestAmbientGraph(t *testing.T) {
+	businessLayer := ambientWorkloads(t)
+
+	api := new(prometheustest.PromAPIMock)
+	client, err := prometheus.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Inject(api)
+
+	ambientMockGraph(t, api)
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/graph", func(w http.ResponseWriter, r *http.Request) {
+		code, config := graphNamespacesIstio(r.Context(), businessLayer, client, graph.NewOptions(r, &businessLayer.Namespace))
+		respond(w, code, config)
+	},
+	)
+
+	ts := httptest.NewServer(mr)
+	defer ts.Close()
+
+	url := ts.URL + "/api/namespaces/graph?namespaces=bookinfo&graphType=workload&appenders=ambient&queryTime=1523364075"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+	expected, _ := os.ReadFile("testdata/test_ambient_graph.expected")
 	if runtime.GOOS == "windows" {
 		expected = bytes.Replace(expected, []byte("\r\n"), []byte("\n"), -1)
 	}

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -906,10 +906,10 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, *prometheustest.PromA
 		},
 	}
 
-	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q3 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v3 := model.Vector{}
 
-	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q4 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q4m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -973,7 +973,7 @@ func mockNamespaceGraph(t *testing.T) (*prometheus.Client, *prometheustest.PromA
 		},
 	}
 
-	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q5 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q5m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1018,10 +1018,10 @@ func mockNamespaceRatesGraph(t *testing.T) (*prometheus.Client, *prometheustest.
 		return client, api, err, biz
 	}
 
-	q6 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q6 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v6 := model.Vector{}
 
-	q7 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q7 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q7m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -1085,7 +1085,7 @@ func mockNamespaceRatesGraph(t *testing.T) (*prometheus.Client, *prometheustest.
 		},
 	}
 
-	q8 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q8 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q8m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -1750,10 +1750,10 @@ func TestWorkloadNodeGraph(t *testing.T) {
 		},
 	}
 
-	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -2068,10 +2068,10 @@ func TestAppNodeGraph(t *testing.T) {
 		},
 	}
 
-	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -2386,10 +2386,10 @@ func TestVersionedAppNodeGraph(t *testing.T) {
 		},
 	}
 
-	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_canonical_service="productpage",destination_canonical_revision="v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_canonical_service="productpage",source_canonical_revision="v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q3m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -2477,7 +2477,7 @@ func TestServiceNodeGraph(t *testing.T) {
 		},
 	}
 
-	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_service=~"^productpage\\.bookinfo\\..*$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q2 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_service_namespace="bookinfo",destination_service=~"^productpage\\.bookinfo\\..*$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q2m0 := model.Metric{
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -2868,10 +2868,10 @@ func TestRatesNodeGraphTotal(t *testing.T) {
 		},
 	}
 
-	q6 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q6 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v6 := model.Vector{}
 
-	q7 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q7 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q7m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -2895,10 +2895,10 @@ func TestRatesNodeGraphTotal(t *testing.T) {
 		},
 	}
 
-	q8 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q8 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo",destination_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v8 := model.Vector{}
 
-	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q9 := `round(sum(rate(istio_tcp_sent_bytes_total{reporter="source",source_workload_namespace="bookinfo",source_workload="productpage-v1"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	q9m0 := model.Metric{
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "productpage-v1",
@@ -3146,13 +3146,13 @@ func TestComplexGraph(t *testing.T) {
 	q2 := `round(sum(rate(istio_requests_total{mesh_id="mesh1",reporter=~"source|waypoint",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0,0.001)`
 	v2 := model.Vector{}
 
-	q3 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v3 := model.Vector{}
 
-	q4 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q4 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v4 := model.Vector{}
 
-	q5 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q5 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v5 := model.Vector{}
 
 	// tutorial
@@ -3394,13 +3394,13 @@ func TestComplexGraph(t *testing.T) {
 		},
 	}
 
-	q9 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="tutorial",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.tutorial\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q9 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="tutorial",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.tutorial\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v9 := model.Vector{}
 
-	q10 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q10 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="tutorial"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v10 := model.Vector{}
 
-	q11 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="tutorial"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q11 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="tutorial"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v11 := model.Vector{}
 
 	// istio-system
@@ -3436,13 +3436,13 @@ func TestComplexGraph(t *testing.T) {
 		},
 	}
 
-	q15 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="istio-system",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.istio-system\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q15 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace!="istio-system",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.istio-system\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v15 := model.Vector{}
 
-	q16 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q16 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="destination",destination_workload_namespace="istio-system"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v16 := model.Vector{}
 
-	q17 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="istio-system"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
+	q17 := `round(sum(rate(istio_tcp_received_bytes_total{mesh_id="mesh1",reporter="source",source_workload_namespace="istio-system"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) > 0,0.001)`
 	v17 := model.Vector{}
 
 	clients := map[string]kubernetes.ClientInterface{
@@ -3771,13 +3771,13 @@ func TestMultiClusterSourceGraph(t *testing.T) {
 		},
 	}
 
-	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
+	q3 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace!="bookinfo",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.bookinfo\\..+$"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
 	v3 := model.Vector{}
 
-	q4 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
+	q4 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="destination",destination_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
 	v4 := model.Vector{}
 
-	q5 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
+	q5 := `round(sum(rate(istio_tcp_received_bytes_total{reporter="source",source_workload_namespace="bookinfo"} [600s])) by (app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags) ,0.001)`
 	v5 := model.Vector{}
 
 	clients := map[string]kubernetes.ClientInterface{

--- a/graph/api/testdata/test_ambient_graph.expected
+++ b/graph/api/testdata/test_ambient_graph.expected
@@ -1,0 +1,290 @@
+{
+  "timestamp": 1523364075,
+  "duration": 600,
+  "graphType": "workload",
+  "elements": {
+    "nodes": [
+      {
+        "data": {
+          "id": "e37e8a43eb2b1196c888957b6f4b7e1c",
+          "nodeType": "workload",
+          "cluster": "Kubernetes",
+          "namespace": "bookinfo",
+          "workload": "details-v1",
+          "app": "details",
+          "version": "v1",
+          "destServices": [
+            {
+              "cluster": "Kubernetes",
+              "namespace": "bookinfo",
+              "name": "details"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "10.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "50.00"
+              }
+            }
+          ],
+          "healthData": null
+        }
+      },
+      {
+        "data": {
+          "id": "1c14fb66e53814f9aada912a2fae5fad",
+          "nodeType": "workload",
+          "cluster": "Kubernetes",
+          "namespace": "bookinfo",
+          "workload": "productpage-v1",
+          "app": "productpage",
+          "version": "v1",
+          "destServices": [
+            {
+              "cluster": "Kubernetes",
+              "namespace": "bookinfo",
+              "name": "productpage"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpOut": "20.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "150.00",
+                "tcpOut": "100.00"
+              }
+            }
+          ],
+          "healthData": null
+        }
+      },
+      {
+        "data": {
+          "id": "689c88683346fc919da3ef7fd2b05435",
+          "nodeType": "workload",
+          "cluster": "Kubernetes",
+          "namespace": "bookinfo",
+          "workload": "reviews-v1",
+          "app": "reviews",
+          "version": "v1",
+          "destServices": [
+            {
+              "cluster": "Kubernetes",
+              "namespace": "bookinfo",
+              "name": "reviews"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "http",
+              "rates": {
+                "httpIn": "10.00"
+              }
+            },
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "50.00"
+              }
+            }
+          ],
+          "healthData": null
+        }
+      },
+      {
+        "data": {
+          "id": "759ea777f30ebc268ef182543a865ea4",
+          "nodeType": "workload",
+          "cluster": "Kubernetes",
+          "namespace": "bookinfo",
+          "workload": "waypoint",
+          "app": "waypoint",
+          "version": "latest",
+          "destServices": [
+            {
+              "cluster": "Kubernetes",
+              "namespace": "bookinfo",
+              "name": "details"
+            },
+            {
+              "cluster": "Kubernetes",
+              "namespace": "bookinfo",
+              "name": "reviews"
+            }
+          ],
+          "traffic": [
+            {
+              "protocol": "tcp",
+              "rates": {
+                "tcpIn": "100.00",
+                "tcpOut": "250.00"
+              }
+            }
+          ],
+          "healthData": null,
+          "isWaypoint": true
+        }
+      }
+    ],
+    "edges": [
+      {
+        "data": {
+          "id": "7516be3dddea88acf0dc274a11510964",
+          "source": "1c14fb66e53814f9aada912a2fae5fad",
+          "target": "689c88683346fc919da3ef7fd2b05435",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "10.00",
+              "httpPercentReq": "50.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "1bd0160d76e993db9e821ca2dfb66242",
+          "source": "1c14fb66e53814f9aada912a2fae5fad",
+          "target": "759ea777f30ebc268ef182543a865ea4",
+          "display": "reverse",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "100.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "details.bookinfo.svc.cluster.local": "50.0",
+                  "reviews.bookinfo.svc.cluster.local": "50.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "8cba8d4624976b47a323ba1d55426624",
+          "source": "1c14fb66e53814f9aada912a2fae5fad",
+          "target": "e37e8a43eb2b1196c888957b6f4b7e1c",
+          "traffic": {
+            "protocol": "http",
+            "rates": {
+              "http": "10.00",
+              "httpPercentReq": "50.0"
+            },
+            "responses": {
+              "200": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "details:9080": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "5a462f4f82cf52e74960330f85181507",
+          "source": "759ea777f30ebc268ef182543a865ea4",
+          "target": "1c14fb66e53814f9aada912a2fae5fad",
+          "display": "hide",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "150.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "productpage.bookinfo.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "e7f959973987d7b7e8fa18cae0b69c45",
+          "source": "759ea777f30ebc268ef182543a865ea4",
+          "target": "689c88683346fc919da3ef7fd2b05435",
+          "display": "hide",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "50.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "reviews.bookinfo.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "id": "7334ac26b2d2cfd53640a99cf11861ff",
+          "source": "759ea777f30ebc268ef182543a865ea4",
+          "target": "e37e8a43eb2b1196c888957b6f4b7e1c",
+          "display": "hide",
+          "traffic": {
+            "protocol": "tcp",
+            "rates": {
+              "tcp": "50.00"
+            },
+            "responses": {
+              "-": {
+                "flags": {
+                  "-": "100.0"
+                },
+                "hosts": {
+                  "details.bookinfo.svc.cluster.local": "100.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/graph/appender.go
+++ b/graph/appender.go
@@ -7,17 +7,17 @@ import (
 	"github.com/kiali/kiali/prometheus"
 )
 
-type AppenderVendorInfo map[string]interface{}
+type VendorInfo map[string]interface{}
 
-// AppenderGlobalInfo caches information relevant to a single graph. It allows
-// an appender to populate the cache and then it, or another appender
-// can re-use the information.  A new instance is generated for graph and
-// is initially empty.
-type AppenderGlobalInfo struct {
+// GlobalInfo caches information relevant to a single graph. It allows
+// the main graph code, or an appender, to populate the cache and then it,
+// or another appender can re-use the information.  A new instance is
+// generated for graph and is initially empty.
+type GlobalInfo struct {
 	Business   *business.Layer
 	Context    context.Context
 	PromClient *prometheus.Client
-	Vendor     AppenderVendorInfo // telemetry vendor's global info
+	Vendor     VendorInfo // telemetry vendor's global info
 }
 
 // AppenderNamespaceInfo caches information relevant to a single namespace. It allows
@@ -25,20 +25,20 @@ type AppenderGlobalInfo struct {
 // A new instance is generated for each namespace of a single graph and is initially
 // seeded with only Namespace.
 type AppenderNamespaceInfo struct {
-	Namespace string             // always provided
-	Vendor    AppenderVendorInfo // telemetry vendor's namespace info
+	Namespace string     // always provided
+	Vendor    VendorInfo // telemetry vendor's namespace info
 }
 
-func NewAppenderVendorInfo() AppenderVendorInfo {
+func NewVendorInfo() VendorInfo {
 	return make(map[string]interface{})
 }
 
-func NewAppenderGlobalInfo() *AppenderGlobalInfo {
-	return &AppenderGlobalInfo{Vendor: NewAppenderVendorInfo()}
+func NewGlobalInfo() *GlobalInfo {
+	return &GlobalInfo{Vendor: NewVendorInfo()}
 }
 
 func NewAppenderNamespaceInfo(namespace string) *AppenderNamespaceInfo {
-	return &AppenderNamespaceInfo{Namespace: namespace, Vendor: NewAppenderVendorInfo()}
+	return &AppenderNamespaceInfo{Namespace: namespace, Vendor: NewVendorInfo()}
 }
 
 // Appender is implemented by any code offering to append a service graph with
@@ -47,7 +47,7 @@ func NewAppenderNamespaceInfo(namespace string) *AppenderNamespaceInfo {
 type Appender interface {
 	// AppendGraph performs the appender work on the provided traffic map. The map may be initially empty.
 	// An appender is allowed to add or remove map entries. namespaceInfo will be nil for Finalizer appenders.
-	AppendGraph(trafficMap TrafficMap, globalInfo *AppenderGlobalInfo, namespaceInfo *AppenderNamespaceInfo)
+	AppendGraph(trafficMap TrafficMap, globalInfo *GlobalInfo, namespaceInfo *AppenderNamespaceInfo)
 
 	// IsFinalizer returns true if the appender should run only on the final TrafficMap, or false if the appender should
 	// run against every requested namespace.

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -396,9 +396,22 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// node may have destination service info
 		if val, ok := n.Metadata[graph.DestServices]; ok {
 			nd.DestServices = []graph.ServiceName{}
-			for _, val := range val.(graph.DestServicesMetadata) {
-				nd.DestServices = append(nd.DestServices, val)
+			for _, ds := range val.(graph.DestServicesMetadata) {
+				nd.DestServices = append(nd.DestServices, ds)
 			}
+			// sort destServices for better json presentation (and predictable testing)
+			sort.Slice(nd.DestServices, func(i, j int) bool {
+				ds1 := nd.DestServices[i]
+				ds2 := nd.DestServices[j]
+				switch {
+				case ds1.Cluster != ds2.Cluster:
+					return ds1.Cluster < ds2.Cluster
+				case ds1.Namespace != ds2.Namespace:
+					return ds1.Namespace < ds2.Namespace
+				default:
+					return ds1.Name < ds2.Name
+				}
+			})
 		}
 
 		// node may have service entry static info

--- a/graph/config/cytoscape/cytoscape.go
+++ b/graph/config/cytoscape/cytoscape.go
@@ -133,7 +133,6 @@ type EdgeData struct {
 
 	// App Fields (not required by Cytoscape)
 	Display         string          `json:"display,omitempty"`         // Used to hide edges for biderectional ones (Ambient graph simplification)
-	Direction       string          `json:"direction,omitempty"`       // Used to represent bidirectional edges (Ambient graph simplification)
 	DestPrincipal   string          `json:"destPrincipal,omitempty"`   // principal used for the edge destination
 	IsMTLS          string          `json:"isMTLS,omitempty"`          // set to the percentage of traffic using a mutual TLS connection
 	ResponseTime    string          `json:"responseTime,omitempty"`    // in millis
@@ -175,7 +174,7 @@ func NewConfig(trafficMap graph.TrafficMap, o graph.ConfigOptions) (result Confi
 	nodes := []*NodeWrapper{}
 	edges := []*EdgeWrapper{}
 
-	buildConfig(trafficMap, &nodes, &edges, o)
+	buildConfig(trafficMap, &nodes, &edges)
 
 	// Add compound nodes as needed, inner boxes first
 	if strings.Contains(o.BoxBy, graph.BoxByApp) || o.GraphType == graph.GraphTypeApp || o.GraphType == graph.GraphTypeVersionedApp {
@@ -242,7 +241,7 @@ func NewConfig(trafficMap graph.TrafficMap, o graph.ConfigOptions) (result Confi
 	return result
 }
 
-func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*EdgeWrapper, o graph.ConfigOptions) {
+func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*EdgeWrapper) {
 	for id, n := range trafficMap {
 		nodeID := nodeHash(id)
 

--- a/graph/telemetry.go
+++ b/graph/telemetry.go
@@ -10,10 +10,10 @@ type TelemetryVendor interface {
 	// BuildNamespaceTrafficMap is required by the TelemetryVendor interface.  It must produce a valid
 	// TrafficMap for the requested namespaces, It is recommended to use the graph/util.go definitions for
 	// error handling. It should be modeled after the Istio implementation.
-	BuildNamespacesTrafficMap(o TelemetryOptions, client *prometheus.Client, globalInfo *AppenderGlobalInfo) TrafficMap
+	BuildNamespacesTrafficMap(o TelemetryOptions, client *prometheus.Client, globalInfo *GlobalInfo) TrafficMap
 
 	// BuildNodeTrafficMap is required by the TelemetryVendor interface.  It must produce a valid
 	// TrafficMap for the requested node, It is recommended to use the graph/util.go definitions for
 	// error handling. It should be modeled after the Istio implementation.
-	BuildNodeTrafficMap(o TelemetryOptions, client *prometheus.Client, globalInfo *AppenderGlobalInfo) TrafficMap
+	BuildNodeTrafficMap(o TelemetryOptions, client *prometheus.Client, globalInfo *GlobalInfo) TrafficMap
 }

--- a/graph/telemetry/istio/appender/aggregate_node.go
+++ b/graph/telemetry/istio/appender/aggregate_node.go
@@ -41,7 +41,7 @@ func (a AggregateNodeAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a AggregateNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a AggregateNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -1,11 +1,8 @@
 package appender
 
 import (
-	"context"
-
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/sliceutil"
 )
 
@@ -30,80 +27,63 @@ func (a AmbientAppender) IsFinalizer() bool {
 
 // AppendGraph implements Appender
 func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+	log.Trace("Running ambient appender")
 
-	// **** JUST SKIP AND RETURN FOR NOW, WE'LL COME BACK TO THIS....
-	// ***************************************************************
-	if len(trafficMap) == 0 || true {
+	if len(trafficMap) == 0 {
 		return
 	}
 
-	log.Trace("Running ambient appender")
+	// We may not actually need these now that things are flagged in the base graph gen
+	/*
+		waypoints, ok := globalInfo.Vendor[AmbientWaypoints]
+		if !ok {
+			return
+		}
+	*/
 
-	a.handleWaypoints(trafficMap, globalInfo)
+	a.handleWaypoints(trafficMap)
 }
 
-// handleWaypoint identifies waypoint proxies quickly by name, and then validates
-// and then verifies by fetching the workload and checking labels.  It removes waypoint proxies
-// when ShowWaypoints is false
-// handleWaypoints flags or deletes waypoints, depending on the a.showWaypoints flag.  When showing waypoints we
-// remove outgoing edges from the waypoints, to simplify the graph and avoid highlight-looping.
-func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo) {
-
-	// Fetch the waypoint workloads. This is cached information, so no need to hold this in AppenderGlobalInfo
-	waypoints := globalInfo.Business.Workload.GetWaypoints(context.Background())
+// handleWaypoints
+func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap) {
 
 	waypointNodes := make(map[string]bool)
 
 	// Flag or Delete waypoint nodes in the TrafficMap
 	for _, n := range trafficMap {
-		waypointName := n.Workload
-		if waypointName == "" {
-			waypointName = n.App
-		}
-		if waypointName == "" {
-			waypointName = n.Service
-		}
-		if isWaypoint(&waypoints, n.Cluster, n.Namespace, waypointName) {
+		if _, ok := n.Metadata[graph.IsWaypoint]; ok {
 			waypointNodes[n.ID] = true
 			if !a.ShowWaypoints {
 				delete(trafficMap, n.ID)
 			} else {
 				n.Metadata[graph.IsOutOfMesh] = false
-				n.Metadata[graph.IsWaypoint] = true
 				for _, edge := range n.Edges {
 					// Just hide so we have all the information
+					// TODO: We may want to change the semantics/naming here, to avoid backend control of the UI
 					edge.Metadata[graph.Display] = "hide"
 				}
 			}
 		}
 	}
 
-	if len(waypointNodes) > 0 {
-		for _, n := range trafficMap {
-			// Delete edges
-			if !a.ShowWaypoints {
-				n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
-					return !waypointNodes[edge.Dest.ID]
-				})
-				continue
-			}
+	if len(waypointNodes) == 0 {
+		return
+	}
 
-			// Find duplicates
-			for _, edge := range n.Edges {
-				if waypointNodes[edge.Dest.ID] {
-					edge.Metadata[graph.Display] = "reverse"
-				}
+	for _, n := range trafficMap {
+		// Delete edges
+		if !a.ShowWaypoints {
+			n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
+				return !waypointNodes[edge.Dest.ID]
+			})
+			continue
+		}
+
+		// Find duplicates
+		for _, edge := range n.Edges {
+			if waypointNodes[edge.Dest.ID] {
+				edge.Metadata[graph.Display] = "reverse"
 			}
 		}
 	}
-}
-
-// isWaypoint returns true if the ns, name and cluster of a workload matches with one of the waypoints in the list
-func isWaypoint(waypointList *models.Workloads, cluster, namespace, app string) bool {
-	for _, w := range *waypointList {
-		if w.WorkloadListItem.Name == app && w.WorkloadListItem.Namespace == namespace && w.Cluster == cluster {
-			return true
-		}
-	}
-	return false
 }

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -12,11 +12,7 @@ import (
 const AmbientAppenderName = "ambient"
 const WaypointSuffix = "waypoint"
 
-// AmbientAppender adds all the Ambient logic to the graph
-// handleWaypoint Identifies the waypoint proxies
-// based on the name (Optmization) and verifies by getting the workload
-// and then, checking the labels
-// handleWaypoint removes the waypoint proxies when ShowWaypoint is false
+// AmbientAppender applies Ambient logic to the graph.
 type AmbientAppender struct {
 	AccessibleNamespaces graph.AccessibleNamespaces
 	ShowWaypoints        bool
@@ -33,8 +29,11 @@ func (a AmbientAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
-	if len(trafficMap) == 0 {
+func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+
+	// **** JUST SKIP AND RETURN FOR NOW, WE'LL COME BACK TO THIS....
+	// ***************************************************************
+	if len(trafficMap) == 0 || true {
 		return
 	}
 
@@ -43,11 +42,14 @@ func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *gr
 	a.handleWaypoints(trafficMap, globalInfo)
 }
 
+// handleWaypoint identifies waypoint proxies quickly by name, and then validates
+// and then verifies by fetching the workload and checking labels.  It removes waypoint proxies
+// when ShowWaypoints is false
 // handleWaypoints flags or deletes waypoints, depending on the a.showWaypoints flag.  When showing waypoints we
 // remove outgoing edges from the waypoints, to simplify the graph and avoid highlight-looping.
-func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo) {
+func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo) {
 
-	// Fetch the waypoint workloads
+	// Fetch the waypoint workloads. This is cached information, so no need to hold this in AppenderGlobalInfo
 	waypoints := globalInfo.Business.Workload.GetWaypoints(context.Background())
 
 	waypointNodes := make(map[string]bool)

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
@@ -22,67 +20,10 @@ const (
 	kubeNamespace  = "kube-system"
 )
 
-func setupWorkloadEntries(t *testing.T) *business.Layer {
-	k8spod1 := &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "workloadA",
-			Namespace:   appNamespace,
-			Labels:      map[string]string{"apps": "workloadA", "version": "v1"},
-			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
-		Spec: core_v1.PodSpec{
-			Containers: []core_v1.Container{
-				{Name: "workloadA", Image: "whatever"},
-			},
-		}}
-	k8spod2 := &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "workloadB",
-			Namespace:   appNamespace,
-			Labels:      map[string]string{"apps": "workloadB", "version": "v2"},
-			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
-		Spec: core_v1.PodSpec{
-			Containers: []core_v1.Container{
-				{Name: "workloadB", Image: "whatever"},
-			},
-		}}
-	k8spod3 := &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "fake-istio-waypoint",
-			Namespace:   appNamespace,
-			Labels:      map[string]string{"apps": "fake-istio-waypoint", "version": "v1"},
-			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
-		Spec: core_v1.PodSpec{
-			Containers: []core_v1.Container{
-				{Name: "fake-istio-waypoint", Image: "whatever"},
-			},
-		}}
-	k8spod4 := &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "namespace-istio-waypoint",
-			Namespace:   appNamespace,
-			Labels:      map[string]string{"apps": "namespace-istio-waypoint", "version": "v1", config.WaypointLabel: config.WaypointLabelValue},
-			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
-		Spec: core_v1.PodSpec{
-			Containers: []core_v1.Container{
-				{Name: "namespace-istio-waypoint", Image: "whatever"},
-			},
-		}}
-
-	k8spod5 := &core_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:        "workloadC",
-			Namespace:   kubeNamespace,
-			Labels:      map[string]string{"apps": "workloadB", "version": "v2"},
-			Annotations: map[string]string{"sidecar.istio.io/status": "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}"}},
-		Spec: core_v1.PodSpec{
-			Containers: []core_v1.Container{
-				{Name: "workloadB", Image: "whatever"},
-			},
-		}}
-
+func setupMocks(t *testing.T) *business.Layer {
 	ns := kubetest.FakeNamespace(appNamespace)
+	k8s := kubetest.NewFakeK8sClient(ns)
 
-	k8s := kubetest.NewFakeK8sClient(k8spod1, k8spod2, k8spod3, k8spod4, k8spod5, ns)
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	conf.KubernetesConfig.ClusterName = defaultCluster
@@ -113,6 +54,7 @@ func workloadEntriesTrafficMap() map[string]*graph.Node {
 	n3, _ := graph.NewNode(defaultCluster, appNamespace, appName, appNamespace, "fake-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
 	// v4 Waypoint proxy
 	n4, _ := graph.NewNode(defaultCluster, appNamespace, appName, appNamespace, "namespace-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
+	n4.Metadata[graph.IsWaypoint] = true // this metadata is provided by the base graph-gen
 
 	trafficMap[n0.ID] = n0
 	trafficMap[n1.ID] = n1
@@ -164,7 +106,7 @@ func workloadEntriesTrafficMapExcludedNs() map[string]*graph.Node {
 func TestRemoveWaypoint(t *testing.T) {
 	assert := require.New(t)
 
-	businessLayer := setupWorkloadEntries(t)
+	businessLayer := setupMocks(t)
 	trafficMap := workloadEntriesTrafficMap()
 
 	globalInfo := graph.NewGlobalInfo()
@@ -192,47 +134,10 @@ func TestRemoveWaypoint(t *testing.T) {
 	assert.False(found)
 }
 
-func TestIsWaypoint(t *testing.T) {
-	assert := require.New(t)
-
-	businessLayer := setupWorkloadEntries(t)
-	trafficMap := workloadEntriesTrafficMap()
-
-	globalInfo := graph.NewGlobalInfo()
-	globalInfo.Business = businessLayer
-	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
-
-	assert.Equal(5, len(trafficMap))
-
-	// Run the appender...
-
-	a := AmbientAppender{
-		AccessibleNamespaces: map[string]*graph.AccessibleNamespace{
-			fmt.Sprintf("%s:%s", defaultCluster, appNamespace): {
-				Cluster: defaultCluster,
-				Name:    appNamespace,
-			},
-		},
-		ShowWaypoints: true}
-	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
-
-	assert.Equal(5, len(trafficMap))
-
-	waypointWorkloadID, _, _ := graph.Id(defaultCluster, appNamespace, appName, appNamespace, "namespace-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
-	waypointNode, found := trafficMap[waypointWorkloadID]
-	assert.True(found)
-	assert.Contains(waypointNode.Metadata, graph.IsWaypoint)
-
-	fakeWaypointWorkloadID, _, _ := graph.Id(defaultCluster, appNamespace, appName, appNamespace, "fake-istio-waypoint", appName, "v2", graph.GraphTypeVersionedApp)
-	fakeWaypointNode, found := trafficMap[fakeWaypointWorkloadID]
-	assert.True(found)
-	assert.NotContains(fakeWaypointNode.Metadata, graph.IsWaypoint)
-}
-
 func TestIsWaypointExcludedNs(t *testing.T) {
 	assert := require.New(t)
 
-	businessLayer := setupWorkloadEntries(t)
+	businessLayer := setupMocks(t)
 	trafficMap := workloadEntriesTrafficMapExcludedNs()
 
 	globalInfo := graph.NewGlobalInfo()

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -167,7 +167,7 @@ func TestRemoveWaypoint(t *testing.T) {
 	businessLayer := setupWorkloadEntries(t)
 	trafficMap := workloadEntriesTrafficMap()
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 
@@ -198,7 +198,7 @@ func TestIsWaypoint(t *testing.T) {
 	businessLayer := setupWorkloadEntries(t)
 	trafficMap := workloadEntriesTrafficMap()
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 
@@ -235,7 +235,7 @@ func TestIsWaypointExcludedNs(t *testing.T) {
 	businessLayer := setupWorkloadEntries(t)
 	trafficMap := workloadEntriesTrafficMapExcludedNs()
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 

--- a/graph/telemetry/istio/appender/dead_node.go
+++ b/graph/telemetry/istio/appender/dead_node.go
@@ -30,7 +30,7 @@ func (a DeadNodeAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -51,7 +51,7 @@ func (a DeadNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 	}
 }
 
-func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) (numRemoved int) {
+func (a DeadNodeAppender) applyDeadNodes(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) (numRemoved int) {
 	for id, n := range trafficMap {
 		isDead := true
 

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -124,7 +124,7 @@ func TestDeadNode(t *testing.T) {
 	assert.Equal("istio-ingressgateway", ingressNode.Workload)
 	assert.Equal(10, len(ingressNode.Edges))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -288,7 +288,7 @@ func TestDeadNodeIssue2783(t *testing.T) {
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -347,7 +347,7 @@ func TestDeadNodeIssue2982(t *testing.T) {
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -404,7 +404,7 @@ func TestDeadNodeIssue7179(t *testing.T) {
 	assert.Equal(true, found)
 	assert.Equal(0, len(bNode.Edges))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 

--- a/graph/telemetry/istio/appender/health.go
+++ b/graph/telemetry/istio/appender/health.go
@@ -33,7 +33,7 @@ func (a HealthAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a HealthAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _ *graph.AppenderNamespaceInfo) {
+func (a HealthAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, _ *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -129,7 +129,7 @@ func initHealthData(node *graph.Node) {
 	}
 }
 
-func (a *HealthAppender) attachHealthConfig(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo) {
+func (a *HealthAppender) attachHealthConfig(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo) {
 	for _, n := range trafficMap {
 		// skip health for inaccessible nodes.  For now, include health for outsider nodes because edge health
 		// may depend on any health config for those nodes.  And, users likely find the health useful.
@@ -153,7 +153,7 @@ func (a *HealthAppender) attachHealthConfig(trafficMap graph.TrafficMap, globalI
 	}
 }
 
-func (a *HealthAppender) attachHealth(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo) {
+func (a *HealthAppender) attachHealth(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo) {
 	var nodesWithHealth []*graph.Node
 	type healthRequest struct {
 		app       bool

--- a/graph/telemetry/istio/appender/health_test.go
+++ b/graph/telemetry/istio/appender/health_test.go
@@ -36,7 +36,7 @@ func TestServicesHealthConfigPasses(t *testing.T) {
 	trafficMap := buildServiceTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -54,7 +54,7 @@ func TestServicesHealthNoConfigPasses(t *testing.T) {
 	trafficMap := buildServiceTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -72,7 +72,7 @@ func TestWorkloadHealthConfigPasses(t *testing.T) {
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -90,7 +90,7 @@ func TestWorkloadHealthNoConfigPasses(t *testing.T) {
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(""), buildFakeWorkloadDeploymentsHealth(""), buildFakePodsHealth(""))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -122,7 +122,7 @@ func TestHealthDataPresent(t *testing.T) {
 	}
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -187,7 +187,7 @@ func TestHealthDataPresent200SvcWk(t *testing.T) {
 	}
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -245,7 +245,7 @@ func TestHealthDataPresent200500WkSvc(t *testing.T) {
 	}
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -301,7 +301,7 @@ func TestHealthDataPresentToApp(t *testing.T) {
 	}
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -356,7 +356,7 @@ func TestHealthDataPresentFromApp(t *testing.T) {
 	}
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -417,7 +417,7 @@ func TestHealthDataBadResponses(t *testing.T) {
 	edge2.Metadata[graph.ProtocolKey] = 20000
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -449,7 +449,7 @@ func TestIdleNodesHaveHealthData(t *testing.T) {
 	idleNode.Metadata[graph.IsInaccessible] = true
 	businessLayer := setupHealthConfig(t, buildFakeServicesHealth(rateDefinition), buildFakeWorkloadDeploymentsHealth(rateWorkloadDefinition), buildFakePodsHealth(rateWorkloadDefinition))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -514,7 +514,7 @@ func TestErrorCausesPanic(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
 	businessLayer := business.NewWithBackends(k8sclients, k8sclients, prom, nil)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -571,7 +571,7 @@ func TestMultiClusterHealthConfig(t *testing.T) {
 	prom.MockAllRequestRates("testNamespace", conf.KubernetesConfig.ClusterName, "0s", time.Unix(0, 0), model.Vector{})
 	businessLayer := business.NewWithBackends(factory.GetSAClients(), factory.GetSAClients(), prom, nil)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -29,7 +29,7 @@ func (a IdleNodeAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a IdleNodeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if a.IsNodeGraph {
 		return
 	}

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -87,7 +87,7 @@ func TestCBAll(t *testing.T) {
 	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasVS])
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -154,7 +154,7 @@ func TestCBSubset(t *testing.T) {
 	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasVS])
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
@@ -218,7 +218,7 @@ func TestCBSubset(t *testing.T) {
 //	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 //	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
 //
-//	globalInfo := graph.NewAppenderGlobalInfo()
+//	globalInfo := graph.NewGlobalInfo()
 //	globalInfo.Business = businessLayer
 //	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 //
@@ -284,7 +284,7 @@ func TestCBSubset(t *testing.T) {
 //	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
 //	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasRequestRouting])
 //
-//	globalInfo := graph.NewAppenderGlobalInfo()
+//	globalInfo := graph.NewGlobalInfo()
 //	globalInfo.Business = businessLayer
 //	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 //
@@ -328,7 +328,7 @@ func TestSEInAppBox(t *testing.T) {
 	}
 	trafficMap[serviceEntryNode.ID] = serviceEntryNode
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 

--- a/graph/telemetry/istio/appender/labeler.go
+++ b/graph/telemetry/istio/appender/labeler.go
@@ -23,7 +23,7 @@ func (a LabelerAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (f *LabelerAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
+func (f *LabelerAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -32,7 +32,7 @@ func (f *LabelerAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 }
 
 // labelNodes puts all k8s labels in the metadata for all nodes.
-func labelNodes(trafficMap graph.TrafficMap, gi *graph.AppenderGlobalInfo) {
+func labelNodes(trafficMap graph.TrafficMap, gi *graph.GlobalInfo) {
 	// We need to know the names of the Istio labels for app and version because we do not label the nodes with those.
 	// There is no need to get the Istio label names multiple times, so get them once now.
 	istioLabelNames := config.Get().IstioLabels

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -122,7 +122,7 @@ func TestLabeler(t *testing.T) {
 	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.Labels])
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.Labels])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 
 	a := LabelerAppender{}

--- a/graph/telemetry/istio/appender/mesh_check.go
+++ b/graph/telemetry/istio/appender/mesh_check.go
@@ -26,7 +26,7 @@ func (a MeshCheckAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a MeshCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a MeshCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -34,7 +34,7 @@ func (a MeshCheckAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *
 	a.applyMeshChecks(trafficMap, globalInfo, namespaceInfo)
 }
 
-func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a *MeshCheckAppender) applyMeshChecks(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	for _, n := range trafficMap {
 		// skip if we've already determined the node is out-of-mesh. we may process the same
 		// node multiple times to ensure we check every node (e.g. missing sidecars indicate missing

--- a/graph/telemetry/istio/appender/mesh_check_test.go
+++ b/graph/telemetry/istio/appender/mesh_check_test.go
@@ -21,7 +21,7 @@ func TestWorkloadSidecarsPasses(t *testing.T) {
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, buildFakeWorkloadDeployments(), buildFakeWorkloadPods())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -45,7 +45,7 @@ func TestWorkloadWithMissingSidecarsIsFlagged(t *testing.T) {
 	trafficMap := buildWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, buildFakeWorkloadDeployments(), buildFakeWorkloadPodsNoSidecar())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -70,7 +70,7 @@ func TestInaccessibleWorkload(t *testing.T) {
 	trafficMap := buildInaccessibleWorkloadTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, buildFakeWorkloadDeployments(), buildFakeWorkloadPodsNoSidecar())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -94,7 +94,7 @@ func TestAppNoPodsPasses(t *testing.T) {
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, []apps_v1.Deployment{}, []core_v1.Pod{})
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -118,7 +118,7 @@ func TestAppSidecarsPasses(t *testing.T) {
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, []apps_v1.Deployment{}, buildFakeWorkloadPods())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -142,7 +142,7 @@ func TestAppWithMissingSidecarsIsFlagged(t *testing.T) {
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, []apps_v1.Deployment{}, buildFakeWorkloadPodsNoSidecar())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -167,7 +167,7 @@ func TestAppWithAmbientIsFlagged(t *testing.T) {
 	trafficMap := buildAppTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, []apps_v1.Deployment{}, buildFakeWorkloadPodsAmbient())
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -192,7 +192,7 @@ func TestServicesAreAlwaysValid(t *testing.T) {
 	trafficMap := buildServiceTrafficMap()
 	businessLayer := setupSidecarsCheckWorkloads(t, []apps_v1.Deployment{}, []core_v1.Pod{})
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")

--- a/graph/telemetry/istio/appender/outsider.go
+++ b/graph/telemetry/istio/appender/outsider.go
@@ -24,7 +24,7 @@ func (a OutsiderAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a *OutsiderAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a *OutsiderAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/outsider_test.go
+++ b/graph/telemetry/istio/appender/outsider_test.go
@@ -21,7 +21,7 @@ func TestOutsider(t *testing.T) {
 	accessible, _ := graph.NewNode(config.DefaultClusterID, "accessibleNamespace", "test", "accessibleNamespace", "test-v1", "test", "v1", graph.GraphTypeVersionedApp)
 	trafficMap[accessible.ID] = accessible
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 
 	a := OutsiderAppender{

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -46,7 +46,7 @@ func (a ResponseTimeAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -41,7 +41,7 @@ func (a SecurityPolicyAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a SecurityPolicyAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -57,7 +57,7 @@ func (a ServiceEntryAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -106,7 +106,7 @@ func (a ServiceEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 }
 
 // loadServiceEntryHosts loads serviceEntry hosts for the provided cluster and namespace. Returns true if any are found, otherwise false.
-func (a ServiceEntryAppender) loadServiceEntryHosts(cluster, namespace string, globalInfo *graph.AppenderGlobalInfo) bool {
+func (a ServiceEntryAppender) loadServiceEntryHosts(cluster, namespace string, globalInfo *graph.GlobalInfo) bool {
 	if !a.isAccessible(cluster, namespace) {
 		return false
 	}
@@ -143,7 +143,7 @@ func (a ServiceEntryAppender) loadServiceEntryHosts(cluster, namespace string, g
 	return len(serviceEntryHosts) > 0
 }
 
-func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, candidates []*graph.Node, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, candidates []*graph.Node, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	// a map from "service-entry" information to matching "se-service" nodes
 	seMap := make(map[*serviceEntry][]*graph.Node)
 
@@ -270,7 +270,7 @@ func (a ServiceEntryAppender) applyServiceEntries(trafficMap graph.TrafficMap, c
 // TODO: I don't know what happens (nothing good) if a ServiceEntry is defined in an inaccessible namespace
 // but exported to all namespaces (exportTo: *). It's possible that would allow traffic to flow from an
 // accessible workload through a serviceEntry whose definition we can't fetch.
-func (a ServiceEntryAppender) getServiceEntry(cluster, namespace, serviceName string, globalInfo *graph.AppenderGlobalInfo) (*serviceEntry, bool) {
+func (a ServiceEntryAppender) getServiceEntry(cluster, namespace, serviceName string, globalInfo *graph.GlobalInfo) (*serviceEntry, bool) {
 	serviceEntryHosts, _ := getServiceEntryHosts(cluster, namespace, globalInfo)
 
 	for host, serviceEntriesForHost := range serviceEntryHosts {

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -212,7 +212,7 @@ func TestServiceEntry(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -332,7 +332,7 @@ func TestServiceEntryExportAll(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -446,7 +446,7 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -560,7 +560,7 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -674,7 +674,7 @@ func TestServiceEntryMeshExportDefinitionNamespace(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -788,7 +788,7 @@ func TestServiceEntryMeshExportAll(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -902,7 +902,7 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -1014,7 +1014,7 @@ func TestKiali7153_1(t *testing.T) {
 	assert.Equal(0, len(internalSEHost2ServiceNode.Edges))
 	assert.Equal(nil, internalSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 
 	testNamespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
@@ -1128,7 +1128,7 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 	n0.AddEdge(n2).Metadata[graph.ProtocolKey] = graph.HTTP.Name
 
 	// Run the appender
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("namespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "namespace")
@@ -1271,7 +1271,7 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 	assert.Equal(0, len(SE2Host2ServiceNode.Edges))
 	assert.Equal(nil, SE2Host2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -1402,7 +1402,7 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 	assert.Equal(0, len(notSEHost2ServiceNode.Edges))
 	assert.Equal(nil, notSEHost2ServiceNode.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("otherNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "otherNamespace")
@@ -1514,7 +1514,7 @@ func TestServiceEntryMultipleEdges(t *testing.T) {
 	assert.Equal(0, len(v2Node.Edges))
 	assert.Equal(nil, v2Node.Metadata[graph.IsServiceEntry])
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -1577,7 +1577,7 @@ func TestSEKiali7305(t *testing.T) {
 
 	assert.Equal(2, len(trafficMap))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(config.DefaultClusterID, "testNamespace")
@@ -1669,7 +1669,7 @@ func TestSEKiali7589(t *testing.T) {
 	_, ok := trafficMap[n3.ID].Metadata[graph.IsServiceEntry]
 	assert.False(ok)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(namespace)
 	key1 := graph.GetClusterSensitiveKey("cluster1", namespace)

--- a/graph/telemetry/istio/appender/throughput.go
+++ b/graph/telemetry/istio/appender/throughput.go
@@ -43,7 +43,7 @@ func (a ThroughputAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a ThroughputAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a ThroughputAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/traffic_generator.go
+++ b/graph/telemetry/istio/appender/traffic_generator.go
@@ -12,7 +12,7 @@ type TrafficGeneratorAppender struct{}
 
 // Name implements Appender
 func (f *TrafficGeneratorAppender) Name() string {
-	return OutsiderAppenderName
+	return TrafficGeneratorAppenderName
 }
 
 // IsFinalizer implements Appender
@@ -21,7 +21,7 @@ func (a TrafficGeneratorAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (f *TrafficGeneratorAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
+func (f *TrafficGeneratorAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, _namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -31,7 +31,7 @@ func (a WorkloadEntryAppender) IsFinalizer() bool {
 }
 
 // AppendGraph implements Appender
-func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(trafficMap) == 0 {
 		return
 	}
@@ -41,7 +41,7 @@ func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalIn
 	a.applyWorkloadEntries(trafficMap, globalInfo, namespaceInfo)
 }
 
-func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
+func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	appLabel := config.Get().IstioLabels.AppLabelName
 	versionLabel := config.Get().IstioLabels.VersionLabelName
 

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -125,7 +125,7 @@ func TestWorkloadEntry(t *testing.T) {
 	assert.True(found)
 	assert.NotContains(v4Node.Metadata, graph.HasWorkloadEntry)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 	key := graph.GetClusterSensitiveKey(testCluster, appNamespace)
@@ -204,7 +204,7 @@ func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 	key := graph.GetClusterSensitiveKey(testCluster, appNamespace)
@@ -291,7 +291,7 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 	key := graph.GetClusterSensitiveKey(testCluster, appNamespace)
@@ -360,7 +360,7 @@ func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 	assert.True(found)
 	assert.NotContains(v3Node.Metadata, graph.HasWorkloadEntry)
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo(appNamespace)
 	key := graph.GetClusterSensitiveKey(testCluster, appNamespace)
@@ -409,7 +409,7 @@ func TestWEKiali7305(t *testing.T) {
 
 	assert.Equal(1, len(trafficMap))
 
-	globalInfo := graph.NewAppenderGlobalInfo()
+	globalInfo := graph.NewGlobalInfo()
 	globalInfo.Business = businessLayer
 	namespaceInfo := graph.NewAppenderNamespaceInfo("testNamespace")
 	key := graph.GetClusterSensitiveKey(testCluster, appNamespace)

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -72,7 +72,7 @@ func BuildNamespacesTrafficMap(ctx context.Context, o graph.TelemetryOptions, gl
 	if sliceutil.Some(finalizers, func(f graph.Appender) bool {
 		return f.Name() == appender.AmbientAppenderName
 	}) {
-		waypoints := globalInfo.Business.Workload.GetWaypoints(context.Background())
+		waypoints := globalInfo.Business.Workload.GetWaypoints(ctx)
 		globalInfo.Vendor[appender.AmbientWaypoints] = waypoints
 	}
 
@@ -1017,13 +1017,6 @@ func hasWaypoint(ztunnel bool, sourceCluster, sourceWlNs, srcWl, destCluster, de
 		return false, false
 	}
 
-	// first, try a simple substring check on the name, for a common waypoint giveaway
-	sourceIsWaypoint = strings.Contains(strings.ToLower(srcWl), "waypoint")
-	destIsWaypoint = strings.Contains(strings.ToLower(destWl), "waypoint")
-	if sourceIsWaypoint || destIsWaypoint {
-		return sourceIsWaypoint, destIsWaypoint
-	}
-
 	if waypoints, ok := globalInfo.Vendor[appender.AmbientWaypoints]; ok {
 		sourceIsWaypoint = sliceutil.Some(waypoints.(models.Workloads), func(wp *models.Workload) bool {
 			return isWaypoint(wp, sourceCluster, sourceWlNs, srcWl)
@@ -1038,6 +1031,6 @@ func hasWaypoint(ztunnel bool, sourceCluster, sourceWlNs, srcWl, destCluster, de
 }
 
 // isWaypoint returns true if the ns, name and cluster of a workload matches with one of the waypoints in the list
-func isWaypoint(w *models.Workload, cluster, namespace, app string) bool {
-	return w.WorkloadListItem.Name == app && w.WorkloadListItem.Namespace == namespace && w.Cluster == cluster
+func isWaypoint(w *models.Workload, cluster, namespace, name string) bool {
+	return w.WorkloadListItem.Name == name && w.WorkloadListItem.Namespace == namespace && w.Cluster == cluster
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -219,7 +219,7 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 	// TCP Byte traffic
 	if o.Rates.Tcp != graph.RateNone {
 		var metrics []string
-		groupBy := "app, source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags"
+		groupBy := "app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags"
 
 		// L4 telemetry is backwards, see https://github.com/istio/istio/issues/32399
 		switch o.Rates.Tcp {
@@ -324,12 +324,9 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, metri
 		}
 		ztunnel := false
 		if protocol == graph.TCP.Name {
-			lApp, appOk := m["app"]
-			if !appOk {
-				log.Warningf("Skipping %s, missing expected TS label [app]", m.String())
-				continue
+			if lApp, appOk := m["app"]; appOk {
+				ztunnel = string(lApp) == "ztunnel"
 			}
-			ztunnel = string(lApp) == "ztunnel"
 		}
 
 		// handle clusters
@@ -785,7 +782,7 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 	// TCP byte traffic
 	if o.Rates.Tcp != graph.RateNone {
 		var metrics []string
-		groupBy := "app, source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags"
+		groupBy := "app,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,response_flags"
 
 		inboundReporter := "destination"
 		outboutReporter := "source"

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -371,14 +371,14 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, metri
 		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
 		// - dest node is already a service node
 		// - source or dest workload is an ambient waypoint
-		var inject, sourceIsWaypoint, destIsWaypoint bool
+		var inject bool
+		sourceIsWaypoint, destIsWaypoint := hasWaypoint(ztunnel, sourceCluster, sourceWlNs, sourceWl, destCluster, destWlNs, destWl, globalInfo)
 		if o.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType, err := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, o.GraphType)
 			if err != nil {
 				log.Warningf("Skipping %s, %s", m.String(), err)
 				continue
 			}
-			sourceIsWaypoint, destIsWaypoint = hasWaypoint(ztunnel, sourceCluster, sourceWlNs, sourceWl, destCluster, destWlNs, destWl, globalInfo)
 			inject = (graph.NodeTypeService != destNodeType) && !sourceIsWaypoint && !destIsWaypoint
 		}
 		addTraffic(trafficMap, metric, inject, val, protocol, code, flags, host, sourceCluster, sourceWlNs, "", sourceWl, sourceApp, sourceVer, destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, sourceIsWaypoint, destIsWaypoint, o)

--- a/mesh/api/api.go
+++ b/mesh/api/api.go
@@ -42,7 +42,7 @@ func GraphMesh(
 	// defer promtimer.ObserveDuration()
 
 	// Create a 'global' object to store the business. Global only to the request.
-	globalInfo := mesh.NewAppenderGlobalInfo()
+	globalInfo := mesh.NewGlobalInfo()
 	globalInfo.Business = business
 	globalInfo.ClientFactory = clientFactory
 	globalInfo.Config = conf
@@ -57,7 +57,7 @@ func GraphMesh(
 }
 
 // graphMesh provides a test hook that accepts mock clients
-func graphMesh(ctx context.Context, globalInfo *mesh.AppenderGlobalInfo, o mesh.Options) (code int, config interface{}) {
+func graphMesh(ctx context.Context, globalInfo *mesh.GlobalInfo, o mesh.Options) (code int, config interface{}) {
 	meshMap, err := generator.BuildMeshMap(ctx, o, globalInfo)
 	if err != nil {
 		if errors.IsForbidden(err) {

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup mock
-func setupMocks(t *testing.T) *mesh.AppenderGlobalInfo {
+func setupMocks(t *testing.T) *mesh.GlobalInfo {
 	assert := assert.New(t)
 	require := require.New(t)
 	conf := config.NewConfig()
@@ -169,7 +169,7 @@ trustDomain: cluster.local
 	require.Len(a[0].KialiInstances, 1, "GetClusters didn't resolve the local Kiali instance")
 	assert.Equal("istio-system", a[0].KialiInstances[0].Namespace, "GetClusters didn't set the right namespace of the Kiali instance")
 
-	globalInfo := mesh.NewAppenderGlobalInfo()
+	globalInfo := mesh.NewGlobalInfo()
 	globalInfo.Business = layer
 	globalInfo.Discovery = discovery
 
@@ -177,7 +177,7 @@ trustDomain: cluster.local
 }
 
 // mockMeshGraph provides a common single-cluster mock
-func mockMeshGraph(t *testing.T) (*mesh.AppenderGlobalInfo, error) {
+func mockMeshGraph(t *testing.T) (*mesh.GlobalInfo, error) {
 	globalInfo := setupMocks(t)
 
 	mesh.StatusGetter = func(context.Context, *config.Config, kubernetes.ClientFactory, cache.KialiCache, *grafana.Service) status.StatusInfo {

--- a/mesh/appender.go
+++ b/mesh/appender.go
@@ -12,13 +12,13 @@ import (
 	"github.com/kiali/kiali/prometheus"
 )
 
-type AppenderVendorInfo map[string]interface{}
+type VendorInfo map[string]interface{}
 
-// AppenderGlobalInfo caches information relevant to a single graph. It allows
+// GlobalInfo caches information relevant to a single graph. It allows
 // an appender to populate the cache and then it, or another appender
 // can re-use the information.  A new instance is generated for graph and
 // is initially empty.
-type AppenderGlobalInfo struct {
+type GlobalInfo struct {
 	Business          *business.Layer
 	ClientFactory     kubernetes.ClientFactory
 	Config            *config.Config
@@ -28,7 +28,7 @@ type AppenderGlobalInfo struct {
 	KialiCache        cache.KialiCache
 	PromClient        *prometheus.Client
 
-	Vendor AppenderVendorInfo // telemetry vendor's global info
+	Vendor VendorInfo // telemetry vendor's global info
 }
 
 // AppenderNamespaceInfo caches information relevant to a single namespace. It allows
@@ -36,20 +36,20 @@ type AppenderGlobalInfo struct {
 // A new instance is generated for each namespace of a single graph and is initially
 // seeded with only Namespace.
 type AppenderNamespaceInfo struct {
-	Namespace string             // always provided
-	Vendor    AppenderVendorInfo // telemetry vendor's namespace info
+	Namespace string     // always provided
+	Vendor    VendorInfo // telemetry vendor's namespace info
 }
 
-func NewAppenderVendorInfo() AppenderVendorInfo {
+func NewVendorInfo() VendorInfo {
 	return make(map[string]interface{})
 }
 
-func NewAppenderGlobalInfo() *AppenderGlobalInfo {
-	return &AppenderGlobalInfo{Vendor: NewAppenderVendorInfo()}
+func NewGlobalInfo() *GlobalInfo {
+	return &GlobalInfo{Vendor: NewVendorInfo()}
 }
 
 func NewAppenderNamespaceInfo(namespace string) *AppenderNamespaceInfo {
-	return &AppenderNamespaceInfo{Namespace: namespace, Vendor: NewAppenderVendorInfo()}
+	return &AppenderNamespaceInfo{Namespace: namespace, Vendor: NewVendorInfo()}
 }
 
 // Appender is implemented by any code offering to append a service graph with
@@ -58,7 +58,7 @@ func NewAppenderNamespaceInfo(namespace string) *AppenderNamespaceInfo {
 type Appender interface {
 	// AppendGraph performs the appender work on the provided traffic map. The map may be initially empty.
 	// An appender is allowed to add or remove map entries. namespaceInfo will be nil for Finalizer appenders.
-	AppendGraph(meshMap MeshMap, globalInfo *AppenderGlobalInfo, namespaceInfo *AppenderNamespaceInfo)
+	AppendGraph(meshMap MeshMap, globalInfo *GlobalInfo, namespaceInfo *AppenderNamespaceInfo)
 
 	// IsFinalizer returns true if the appender should run only on the final TrafficMap, or false if the appender should
 	// run against every requested namespace.

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -32,7 +32,7 @@ func (c componentHealthKey) String() string {
 }
 
 // BuildMeshMap is required by the graph/TelemetryVendor interface
-func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.AppenderGlobalInfo) (mesh.MeshMap, error) {
+func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mesh.MeshMap, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "BuildMeshMap",
 		observability.Attribute("package", "generator"),
@@ -248,7 +248,7 @@ var inMeshUrlRegexp = []*regexp.Regexp{
 // discoverInfraService tries to determine the cluster and namespace of a service, from its URL. Currently it's only
 // targeting in-cluster URLs on the local cluster.  If it can't resolve the URL, or it can't fetch the resulting service,
 // it assumes the URL is outside the mesh and returns ("", "", true).
-func discoverInfraService(url string, ctx context.Context, gi *mesh.AppenderGlobalInfo) (cluster, namespace string, isExternal bool) {
+func discoverInfraService(url string, ctx context.Context, gi *mesh.GlobalInfo) (cluster, namespace string, isExternal bool) {
 	cluster = mesh.External
 	isExternal = true
 	namespace = ""

--- a/util/sliceutil/slice.go
+++ b/util/sliceutil/slice.go
@@ -27,3 +27,17 @@ func Map[S ~[]E, E any, T any](slice S, f func(E) T) []T {
 	}
 	return ret
 }
+
+// Some returns true if any of the elements satisfies the predicate, otherwise false
+func Some[S ~[]E, E any](slice S, f func(E) bool) bool {
+	if slice == nil {
+		return false
+	}
+
+	for _, e := range slice {
+		if f(e) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Relates to #7445 

The main change is to prevent service injection for ztunnel waypoint edges (i.e. edges where the source or dest workload is the waypoint. For the reasoning see the github issue discussion.

This moves waypoint node identification into the base graph-gen code, performed only when the `ambient` appender is requested from the client.  That means the ambient appender does not need to do waypoint detection, it can rely on nodes already being identified.  And so the appender is concerned with handling the showWaypoint option and any other special handling that we may want to do (like bidirectional edge detection, etc).

Some other stuff in this PR:
- Fix: treat ambient as a finalizer appender, it was declared a finalizer but treated as a namespace appender
- Fix: Health appender was being used as both a namespace and a finalizer appender.  Should only execute once, as a finalizer.
- Fix: TrafficGeneratorAppender.Name() returned the wrong appender name
- Add: sliceutil.Some()
- Refactors
  - Move PromClient into AppenderGlobalInfo
    - I don't see a reason why we can't use the same prom client across the graph generation, this is more tidy/efficient
  - Rename AppenderGlobalInfo to just GlobalInfo, AppenderVendorInfo to just VendorInfo
    - This information can be used by appenders but also in the main graph gen.
    - More tidy and allows for wider use of Vendor info (like for storing waypoint workloads)
    - Apply the same change in MeshPage code, for consistency

TODO: Follow-up PR may be needed for other "injection-aware" appenders...