### PR TITLE
Appender work related to waypoint service injection

### DIFF
--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -210,6 +210,8 @@ func (a ResponseTimeAppender) populateResponseTimeMap(responseTimeMap map[string
 		// - destSvcName is not set
 		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
 		// - dest node is already a service node
+		// - note: we ignore the waypoint injection problem here because that deals only with TCP traffic, and
+		//         does not apply to response time.
 		inject := false
 		if a.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType, err := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)

--- a/graph/telemetry/istio/appender/throughput.go
+++ b/graph/telemetry/istio/appender/throughput.go
@@ -166,6 +166,8 @@ func (a ThroughputAppender) populateThroughputMap(throughputMap map[string]float
 		// - destSvcName is not set
 		// - destSvcName is PassthroughCluster (see https://github.com/kiali/kiali/issues/4488)
 		// - dest node is already a service node
+		// - note: we ignore the waypoint injection problem here because ztunnel does not generate throughput
+		//         telemetry for waypoint source or destination traffic (see istio.go for where we do handle it)
 		inject := false
 		if a.InjectServiceNodes && graph.IsOK(destSvcName) && destSvcName != graph.PassthroughCluster {
 			_, destNodeType, err := graph.Id(destCluster, destSvcNs, destSvcName, destWlNs, destWl, destApp, destVer, a.GraphType)

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -134,7 +134,7 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 		metric := "istio_requests_total"
 		groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
 
-		// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
+		// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic (failed requests that never reach a dest)
 		query := fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
 			metric,
 			namespace,


### PR DESCRIPTION
partof https://github.com/kiali/kiali/issues/7445

Multiple appenders perform service node injection and could have been affected by the new code preventing injection for ztunnel waypoint edges.  Fortunately, only one required changes, the security appender, and in there we were able to make a fairly simple change.

Before: Note that some of the waypoint edges lack a lock icon and show no mTLS wuth graph find:
![image](https://github.com/user-attachments/assets/ec7969cf-5461-4d52-b445-6b65ac571484)

After: The waypoint edges show secure mTLS:
![image](https://github.com/user-attachments/assets/fb66725c-b215-4f61-ab6e-0061ea4e045f)
