### PR TITLE
[hack] support Sail on vanilla Kubernetes now that OperatorHub.io has the Sail operator

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -109,7 +109,7 @@ while [[ $# -gt 0 ]]; do
 Valid command line arguments:
   -a|--arch <amd64|ppc64le|s390x|arm64>: Images for given arch will be used (default: amd64). Custom bookinfo yaml file provided via '-b' argument is ignored when using different arch than the default.
   -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
-  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. default: istio-injection=enabled).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -db|--delete-bookinfo <true|false>: If true, uninstall bookinfo. If false, install bookinfo. (default: false).
   -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
   -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -22,6 +22,7 @@ NAMESPACE="bookinfo"
 ISTIO_NAMESPACE="istio-system"
 RATE=1
 AUTO_INJECTION="true"
+AUTO_INJECTION_LABEL="istio-injection=enabled"
 MANUAL_INJECTION="false"
 DELETE_BOOKINFO="false"
 MINIKUBE_PROFILE="minikube"
@@ -41,6 +42,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -ai|--auto-injection)
       AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
       shift;shift
       ;;
     -db|--delete-bookinfo)
@@ -104,6 +109,7 @@ while [[ $# -gt 0 ]]; do
 Valid command line arguments:
   -a|--arch <amd64|ppc64le|s390x|arm64>: Images for given arch will be used (default: amd64). Custom bookinfo yaml file provided via '-b' argument is ignored when using different arch than the default.
   -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. default: istio-injection=enabled).
   -db|--delete-bookinfo <true|false>: If true, uninstall bookinfo. If false, install bookinfo. (default: false).
   -id|--istio-dir <dir>: Where Istio has already been downloaded. If not found, this script aborts.
   -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).
@@ -277,7 +283,7 @@ SCC
 fi
 
 if [ "${AUTO_INJECTION}" == "true" ]; then
-  $CLIENT_EXE label namespace ${NAMESPACE} "istio-injection=enabled"
+  $CLIENT_EXE label namespace ${NAMESPACE} "${AUTO_INJECTION_LABEL}"
   $CLIENT_EXE apply -n ${NAMESPACE} -f ${BOOKINFO_YAML}
 else
   if [ "${MANUAL_INJECTION}" == "true" ]; then

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -439,7 +439,7 @@ if [ "${TRAFFIC_GENERATOR_ENABLED}" == "true" ]; then
 
         echo "Wait for productpage to come up to see if it is accessible via minikube ingress"
         $CLIENT_EXE wait pods --all -n ${NAMESPACE} --for=condition=Ready --timeout=5m
-        if curl --fail http://${INGRESS_ROUTE}/productpage &> /dev/null; then
+        if [ -n "${INGRESS_PORT}" -a -n "${INGRESS_HOST}" ] && curl --fail http://${INGRESS_ROUTE}/productpage &> /dev/null; then
           echo "Traffic Generator will use the Kubernetes (minikube) ingress route of: ${INGRESS_ROUTE}"
         else
           INGRESS_HOST="productpage.${NAMESPACE}"

--- a/hack/istio/sail/README-RELEASE.md
+++ b/hack/istio/sail/README-RELEASE.md
@@ -1,10 +1,10 @@
 # Installing Istio with the Latest Sail and Kiali Operators
 
-To install Istio (including Kiali), use the script `install-ossm-release.sh`. This will utilize the Sail operator and Kiali operator to install the latest released images via OLM using either the public Red Hat repository or public Community repository.
+To install Istio (including Kiali), use the script `install-ossm-release.sh`. This will utilize the Sail operator and Kiali operator to install the latest released images via OLM using either the Red Hat repository or the public Community repository or the public OperatorHub.io.
 
 Here's what you need to do in order to install everything.
 
-First, install a Kubernetes cluster and make sure you do not already have Istio or Kiali installed. _(Note: currently non-OpenShift clusters are not supported. When the Sail operator is published on OperatorHub.io, then these scripts should be able to work with minor updates). So for now you need to use OpenShift._
+First, install an OpenShift or Kubernetes cluster and make sure you do not already have Istio or Kiali installed.
 
 Second, if using OpenShift, log into this cluster as a cluster admin user via 'oc'. Otherwise, make sure your current kube context is pointing to your Kubernetes cluster.
 

--- a/hack/istio/sail/func-kiali.sh
+++ b/hack/istio/sail/func-kiali.sh
@@ -131,7 +131,7 @@ spec:
     tracing:
       enabled: true
       provider: tempo
-      in_cluster_url: "http://tempo-tempo-query-frontend.${TEMPO_NAMESPACE}.svc.cluster.local:3200"
+      in_cluster_url: "http://tempo-tempo-query-frontend.${TEMPO_NAMESPACE}:3200"
       url: "${tracing_external_url}"
       use_grpc: false
 EOM

--- a/hack/istio/sail/func-kiali.sh
+++ b/hack/istio/sail/func-kiali.sh
@@ -79,7 +79,7 @@ install_kiali_cr() {
   local tracing_external_url=""
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     # we installed TempoStack CR configured for "route" when on OpenShift, so look for the route URL
-    tracing_external_url="$(${OC} get route -n ${TEMPO_NAMESPACE} -l app.kubernetes.io/name=tempo,app.kubernetes.io/component=query-frontend -o jsonpath='http://{..spec.host}')"
+    tracing_external_url="$(${OC} get route -n ${TEMPO_NAMESPACE} -l app.kubernetes.io/name=tempo,app.kubernetes.io/component=query-frontend -o jsonpath='https://{..spec.host}')"
     infomsg "The tracing external URL is the OpenShift route located at [${tracing_external_url}]"
   else
     # we installed TempoStack CR configured for "ingress" when on vanilla Kubernetes, so look for the ingress URL

--- a/hack/istio/sail/func-kiali.sh
+++ b/hack/istio/sail/func-kiali.sh
@@ -79,7 +79,7 @@ install_kiali_cr() {
   local tracing_external_url=""
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     # we installed TempoStack CR configured for "route" when on OpenShift, so look for the route URL
-    tracing_external_url="$(${OC} get route -n ${TEMPO_NAMESPACE} -l app.kubernetes.io/name=tempo,app.kubernetes.io/component=query-frontend -o jsonpath='https://{..spec.host}')"
+    tracing_external_url="$(${OC} get route -n ${TEMPO_NAMESPACE} -l app.kubernetes.io/name=tempo,app.kubernetes.io/component=query-frontend -o jsonpath='http://{..spec.host}')"
     infomsg "The tracing external URL is the OpenShift route located at [${tracing_external_url}]"
   else
     # we installed TempoStack CR configured for "ingress" when on vanilla Kubernetes, so look for the ingress URL
@@ -95,7 +95,7 @@ install_kiali_cr() {
   # Try to determine the external URL for the Grafana UI
   local grafana_external_url=""
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-    grafana_external_url="$(${OC} get route -n ${CONTROL_PLANE_NAMESPACE} grafana -o jsonpath='https://{..spec.host}')"
+    grafana_external_url="$(${OC} get route -n ${CONTROL_PLANE_NAMESPACE} grafana -o jsonpath='http://{..spec.host}')"
     infomsg "The Grafana external URL is the OpenShift route located at [${grafana_external_url}]"
   else
     local grafana_ingress_host="$(${OC} -n ${CONTROL_PLANE_NAMESPACE} get svc grafana -o jsonpath='{..status.loadBalancer.ingress[0].ip}' 2> /dev/null)"

--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -26,7 +26,7 @@ install_servicemesh_operators() {
     community)
       local servicemesh_subscription_source="community-operators"
       local servicemesh_subscription_name="sailoperator"
-      local servicemesh_subscription_channel="3.0-nightly"
+      local servicemesh_subscription_channel="candidates"
       ;;
     *)
       local servicemesh_subscription_source="${catalog_source}"

--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -177,7 +177,7 @@ EOMCNI
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
-  name: istio-${control_plane_namespace}
+  name: default
 spec:
   version: ${istio_version}
   namespace: ${control_plane_namespace}

--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -10,17 +10,9 @@ set -u
 
 install_servicemesh_operators() {
   # if not OpenShift, install from OperatorHub.io
-  # This will create a subscription with the name "my-sail"
   if [ "${IS_OPENSHIFT}" == "false" ]; then
-    errormsg "INSTALLING ON NON-OPENSHIFT CLUSTERS IS NOT YET SUPPORTED."
-    errormsg "THIS WILL BE SUPPORTED WHEN SAIL OPERATOR IS PUBLISHED ON OPERATORHUB.IO."
-    errormsg "WHEN THE FOLLOWING ISSUE IS FIXED, SUPPORT CAN BE ADDED: https://issues.redhat.com/browse/OSSM-4829"
-    exit 1
-    # TODO: When Sail is published on OperatorHub.io, delete the lines above, uncomment below,
-    # and confirm what the name will be of the created subscription - that name should be the same
-    # as the name of the subscription we create further below.
-    #${OC} apply -f https://operatorhub.io/install/sail.yaml
-    #return
+    ${OC} apply -f https://operatorhub.io/install/sailoperator.yaml
+    return
   fi
 
   local catalog_source="${1}"
@@ -48,7 +40,7 @@ install_servicemesh_operators() {
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: my-sail
+  name: my-sailoperator
   namespace: ${OLM_OPERATORS_NAMESPACE}
 spec:
   channel: ${servicemesh_subscription_channel}
@@ -72,8 +64,8 @@ install_istio() {
      destinationrules.networking.istio.io \
      envoyfilters.networking.istio.io \
      gateways.networking.istio.io \
-     istios.operator.istio.io \
-     istiocnis.operator.istio.io \
+     istios.sailoperator.io \
+     istiocnis.sailoperator.io \
      peerauthentications.security.istio.io \
      proxyconfigs.networking.istio.io \
      requestauthentications.security.istio.io \
@@ -125,6 +117,17 @@ install_istio() {
   #while [ "$(${OC} get mutatingwebhookconfigurations -o name | grep -E 'sail|servicemesh|istio')" == "" ]; do echo -n '.'; sleep 5; done
   #infomsg "done."
 
+  # "latest" is not a supported version when using a released version of Sail operator.
+  # We try to determine the latest version of Istio supported by examining the CRD.
+  if [ "${istio_version}" == "latest" ]; then
+    istio_version="$(${OC} get crd istios.sailoperator.io -o json | jq -r '.spec.versions | sort_by(.name) | .[-1].schema.openAPIV3Schema.properties.spec.properties.version.default')"
+    if [ -z "${istio_version}" -o "${istio_version}" == "null" ]; then
+      errormsg "Cannot determine the latest supported version of Istio. You must provide an explicit vX.Y.Z version to install via the --istio-version option"
+      exit 1
+    fi
+    infomsg "The latest supported version of Istio is [${istio_version}]. That version will be installed."
+  fi
+
   if ! ${OC} get namespace ${control_plane_namespace} >& /dev/null; then
     infomsg "Creating control plane namespace: ${control_plane_namespace}"
     ${OC} create namespace ${control_plane_namespace}
@@ -142,7 +145,7 @@ install_istio() {
       fi
       infomsg "Installing IstioCNI CR"
       cat <<EOMCNI > ${istiocni_yaml_file}
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: sailoperator.io/v1alpha1
 kind: IstioCNI
 metadata:
   name: ${istiocni_name}
@@ -171,7 +174,7 @@ EOMCNI
     fi
     local istio_yaml_file="/tmp/istio-cr.yaml"
     cat <<EOM > ${istio_yaml_file}
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
   name: istio-${control_plane_namespace}
@@ -216,7 +219,7 @@ delete_servicemesh_operators() {
   fi
 
   infomsg "Unsubscribing from the Sail operator"
-  ${OC} delete subscription --ignore-not-found=true --namespace ${OLM_OPERATORS_NAMESPACE} my-sail
+  ${OC} delete subscription --ignore-not-found=true --namespace ${OLM_OPERATORS_NAMESPACE} my-sailoperator
 
   infomsg "Deleting OLM CSVs which uninstalls the operators and their related resources"
   for csv in $(${OC} get csv --all-namespaces --no-headers -o custom-columns=NS:.metadata.namespace,N:.metadata.name | sed 's/  */:/g' | grep -E 'sail|servicemesh|istio')
@@ -272,7 +275,7 @@ delete_istio() {
 status_servicemesh_operators() {
   infomsg ""
   infomsg "===== SERVICEMESH OPERATOR SUBSCRIPTION"
-  local sub_name="$(${OC} get subscriptions -n ${OLM_OPERATORS_NAMESPACE} -o name my-sail)"
+  local sub_name="$(${OC} get subscriptions -n ${OLM_OPERATORS_NAMESPACE} -o name my-sailoperator)"
   if [ ! -z "${sub_name}" ]; then
     ${OC} get --namespace ${OLM_OPERATORS_NAMESPACE} ${sub_name}
     infomsg ""

--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -169,8 +169,10 @@ EOMCNI
   infomsg "Installing Istio CR"
   if [ "${istio_yaml_file}" == "" ]; then
     local global_platform=""
+    local istio_profile="demo"
     if [ "${IS_OPENSHIFT}" == "true" ]; then
       global_platform="openshift"
+      istio_profile="openshift"
     fi
     local istio_yaml_file="/tmp/istio-cr.yaml"
     cat <<EOM > ${istio_yaml_file}
@@ -184,7 +186,7 @@ spec:
   updateStrategy:
     type: RevisionBased
   values:
-    profile: demo
+    profile: ${istio_profile}
     global:
       platform: "${global_platform}"
     meshConfig:

--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -184,6 +184,7 @@ spec:
   updateStrategy:
     type: RevisionBased
   values:
+    profile: demo
     global:
       platform: "${global_platform}"
     meshConfig:

--- a/hack/istio/sail/install-ossm-release.sh
+++ b/hack/istio/sail/install-ossm-release.sh
@@ -75,7 +75,6 @@ Valid options:
   -c|--client <path to k8s client>
       A filename or path to the 'oc' or 'kubectl' client.
       If this is a path to 'oc' then it will be assumed OpenShift is being used.
-      (NOTE: Installing in a non-OpenShift cluster is currently not supported.)
       Default: ${DEFAULT_OC}
 
   -cpn|--control-plane-namespace <name>
@@ -103,6 +102,7 @@ Valid options:
 
   -eo|--enable-ossmconsole <true|false>
       If true, and you elect to enable Kiali (--enable-kiali) this will install OSSMC also.
+      This is ignored if you are installing on a non-OpenShift cluster.
       This is only used with the "install-istio" command.
       Default: ${DEFAULT_ENABLE_OSSMCONSOLE}
 
@@ -202,7 +202,7 @@ elif [ "${_CMD}" == "install-istio" ]; then
     exit 1
   fi
 
-  if ! ${OC} get crd istios.operator.istio.io >& /dev/null; then
+  if ! ${OC} get crd istios.sailoperator.io >& /dev/null; then
     errormsg "Cannot install Istio because the Sail Operator is either not installed or installation is in progress."
     exit 1
   fi
@@ -226,8 +226,10 @@ elif [ "${_CMD}" == "install-istio" ]; then
 
   if [ "${ENABLE_KIALI}" == "true" ]; then
     install_kiali_cr "${CONTROL_PLANE_NAMESPACE}"
-    if [ "${ENABLE_OSSMCONSOLE}" == "true" ]; then
-      install_ossmconsole_cr "ossmconsole"
+    if [ "${IS_OPENSHIFT}" == "true" ]; then
+      if [ "${ENABLE_OSSMCONSOLE}" == "true" ]; then
+        install_ossmconsole_cr "ossmconsole"
+      fi
     fi
   fi
 


### PR DESCRIPTION
These set of scripts will be able to install a full Istio-Kiali setup locally on a vanilla Kubernetes (not OpenShift).

You will get Sail operator and its Istio installation, Kiali operator and Kiali UI, along with Tempo operator and Tempo (for tracing backend and JaegerUI), Grafana, and Prometheus. The external services will have their UIs available assuming your k8s has a LoadBalancer (the steps below will give you that).

Here's how you can try it out.

For those that already have the kiali source repo git cloned locally and this PR branch checked out, here's a quick summary of the commands you can run to see everything... following this will be a more detailed set of instructions that even those that do not have the full source git cloned can run this stuff.

### Quick summary of the test steps

1. `hack/k8s-minikube.sh --load-balancer-addrs "70-84" start`
2. `hack/istio/sail/install-ossm-release.sh -c kubectl install-operators`
3. `sleep 30` # _(wait a little bit for the operators to start installing - just wait 30 seconds or so for OLM to start installing things)_
4. `hack/istio/sail/install-ossm-release.sh -c kubectl install-istio`
5. `hack/istio/install-bookinfo-demo.sh -tg -c kubectl -ail istio.io/rev=default-v1-23-0`
6. `hack/kiali-port-forward.sh`
7. Point your browser to Kiali UI at http://localhost:20001/kiali/console

Give it a minute or two for everything to start up and requests start flowing through the bookinfo traffic generator. Eventually you should see everything - bookinfo demo graph, you should be able to see traces, Jaeger UI , and Grafana UI links.

### More details on the test steps

1. Start minikube. You can put a loadBalancer in it if you want to try to access the Jaeger UI (but I haven't been able to get that to work yet.) You can use our hack script for this (not part of this PR) or just start minikube on your own. You can use KinD if you want, rather than minikube.
> If you want minikube (which is suggested for testing this stuff because this gives you a load balancer) - call k8s-minikube.sh with the arg ` --load-balancer-addrs "70-84"`. If you do not already have the entire kiali source repo git cloned locally, you can run this command so you just run the script without the need to clone everything):
```sh
bash <(curl -sk https://raw.githubusercontent.com/kiali/kiali/master/hack/k8s-minikube.sh) --load-balancer-addrs "70-84" start
```
> If you really want KinD (not sure how this works without a load balancer - might not be able to access grafana UI or jaeger UI, but other than that things should work)
```sh
kind create cluster
```
9. You need this PR checked out, obviously. For those that don't have the Kiali source code checked out, just pull down the script files from the PR branch using this (after this runs, you'll have the scripts in `./kiali/hack/istio/sail`):
```sh
git clone --filter=tree:0 --no-checkout --depth 1 --sparse --single-branch --branch hack-sail https://github.com/jmazzitelli/kiali.git kiali && \
  cd kiali && \
  git sparse-checkout set --no-cone hack/istio/sail && \
  git checkout
```
10. Make the current working directory the location where the scripts are (cd to the `hack/istio/sail` directory)
11. Install all the necessary operators (sail, kiali, tempo). This will also install base OLM, too:
```sh
./install-ossm-release.sh -c kubectl install-operators
```
12. Install Istio and Kiali and all other addons:
```sh
./install-ossm-release.sh -c kubectl install-istio
```
13. You can look at the status of everything:
```sh
./install-ossm-release.sh -c kubectl status
```
14. Confirm Istio pods and Kiali pod is running via `kubectl get pods -n istio-system` (the same info can be seen in step above, too)
15. At this point the Kiali UI should be available. You can port-forward to it and point your browser to it at http://localhost:20001/kiali/console:
```sh
kubectl port-forward -n istio-system $(kubectl get pods -n istio-system -l app.kubernetes.io/name=kiali -o jsonpath='{.items[0].metadata.name}') 20001:20001
```
16. Pass in `--help` to that `./install-ossm-release.sh` script for more commands (you can delete istio, delete the operators, etc).

**NOTE: Because this is revision based, and istio tags are not supported by sail yet, you have to label your mesh namespaces with `istio.io/rev=default-v1-23-0` ... you can see this work by installing bookinfo demo (using Kiali's hack script enhanced with -ail option that I added to this PR -- `hack/istio/install-bookinfo-demo.sh -tg -c kubectl -ail istio.io/rev=default-v1-23-0`).