### PR TITLE
Enable auto-injection for sleep pods

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -22,7 +22,7 @@ AMBIENT="false"
 : ${CLIENT_EXE:=oc}
 DELETE_SLEEP="false"
 : ${ISTIO_NAMESPACE:=istio-system}
-: ${ENABLE_INJECTION:=true}
+: ${AUTO_INJECTION:=true}
 
 # process command line args
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
While reviewing the logs, it was seen that the integration tests were trying to label the `sleep` namespace with an empty label, leading to the following error.

```
2024-09-20T21:23:12.1456607Z namespace/sleep created
2024-09-20T21:23:12.2852330Z error: at least one label update is required
2024-09-20T21:23:12.6840178Z serviceaccount/sleep created
```

I'm not sure if Kiali tests use sleep app or not, but configuring the default value of AUTO_INJECTION would avoid this error.