### PR TITLE
[Ambiet] Update separator 

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -413,9 +413,14 @@ const getEdgeLabel = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphPFSettin
             }
             break;
           case Protocol.TCP:
-            labels.push(toFixedByteRate(rate, includeUnits));
             if (data.waypoint?.direction === 'to' && data.waypoint?.fromEdge) {
-              labels.push(toFixedByteRate(data.waypoint.fromEdge.tcp, includeUnits));
+              const waypointLabel = `${toFixedByteRate(rate, includeUnits)} | ${toFixedByteRate(
+                data.waypoint.fromEdge.tcp,
+                includeUnits
+              )}`;
+              labels.push(waypointLabel);
+            } else {
+              labels.push(toFixedByteRate(rate, includeUnits));
             }
             break;
           default:
@@ -454,7 +459,7 @@ const getEdgeLabel = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphPFSettin
     }
   }
 
-  let label = labels.join(' | ');
+  let label = labels.join('\n');
 
   if (isVerbose) {
     const protocol = data.protocol;


### PR DESCRIPTION
### Describe the change
The separator was changed for all the labels in this PR: https://github.com/kiali/kiali/pull/7719 But it should just be changed for the waypoint edges

### Steps to test the PR

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

### Automation testing

N/A (New e2e test added in https://github.com/kiali/kiali/pull/7763)

### Issue reference
Ref. #7706 
