### PR TITLE
[ambient] Updated styles for waypoint edges summary panel

### DIFF
--- a/frontend/src/config/Icons.ts
+++ b/frontend/src/config/Icons.ts
@@ -32,6 +32,18 @@ export type IconType = {
 // or from the font awesome site: https://fontawesome.com/icons
 const mutIcons = {
   istio: {
+    arrowLeftRight: {
+      ascii: '\u21c4 ',
+      name: 'arrowLeftRight',
+      text: 'Arrow Left Right',
+      type: 'fa'
+    },
+    arrowLeftRightV: {
+      ascii: '\u21c5 ',
+      name: 'arrowLeftRightV',
+      text: 'Arrow Left Right Vertical',
+      type: 'fa'
+    },
     circuitBreaker: {
       ascii: '\uf0e7 ',
       className: 'fa fa-bolt',

--- a/frontend/src/config/Icons.ts
+++ b/frontend/src/config/Icons.ts
@@ -32,18 +32,6 @@ export type IconType = {
 // or from the font awesome site: https://fontawesome.com/icons
 const mutIcons = {
   istio: {
-    arrowLeftRight: {
-      ascii: '\u21c4 ',
-      name: 'arrowLeftRight',
-      text: 'Arrow Left Right',
-      type: 'fa'
-    },
-    arrowLeftRightV: {
-      ascii: '\u21c5 ',
-      name: 'arrowLeftRightV',
-      text: 'Arrow Left Right Vertical',
-      type: 'fa'
-    },
     circuitBreaker: {
       ascii: '\uf0e7 ',
       className: 'fa fa-bolt',
@@ -164,6 +152,25 @@ const mutIcons = {
       name: 'infrastructure',
       text: 'Waypoint Proxy',
       type: 'pf'
+    }
+  },
+  unicode: {
+    // these are not fully defined icons, just unicode characters.
+    // see https://en.wikipedia.org/wiki/List_of_Unicode_characters#Arrows
+    arrowRightOverLeft: {
+      char: '\u21c4 ',
+      name: 'RightwardsArrowOverLeftwardsArrow',
+      text: 'Rightwards Arrow Over Leftwards Arrow'
+    },
+    arrowUpLeftofDown: {
+      char: '\u21c5 ',
+      name: 'UpwardsArrowLeftwardsofDownwardsArrow',
+      text: 'Upwards Arrow Leftwards of Downwards Arrow'
+    },
+    arrowDownLeftofUp: {
+      char: '\u21f5 ',
+      name: 'DownwardsArrowLeftwardsofUpwardsArrow ',
+      text: 'Downwards Arrow Leftwards of Upwards Arrow '
     }
   }
 };

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -36,7 +36,6 @@ import { KialiDispatch } from 'types/Redux';
 import { KialiCrippledFeatures } from 'types/ServerConfig';
 import { getCrippledFeatures } from 'services/Api';
 import { serverConfig } from '../../../config';
-import { PFColors } from 'components/Pf/PfColors';
 
 type ReduxStateProps = {
   boxByCluster: boolean;
@@ -646,14 +645,12 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
 
     if (serverConfig.ambientEnabled) {
       visibilityOptions.push({
-        iconColor: PFColors.Warning,
         id: 'filterWaypoints',
         isChecked: showWaypoints,
         labelText: 'Waypoint Proxies',
         onChange: toggleWaypoints,
         tooltip: (
           <div style={{ textAlign: 'left' }}>
-            <div>[Feature under development]</div>
             <div>Show waypoint proxies workloads.</div>
             <div>
               When enabled in an Ambient environment, include waypoint proxy telemetry in the graph. Waypoint nodes will

--- a/frontend/src/pages/Graph/SummaryLink.tsx
+++ b/frontend/src/pages/Graph/SummaryLink.tsx
@@ -202,12 +202,13 @@ export const renderBadgedLink = (
   nodeData: GraphNodeData,
   nodeType?: NodeType,
   label?: string,
-  linkGenerator?: () => LinkInfo
+  linkGenerator?: () => LinkInfo,
+  style?: string
 ): React.ReactNode => {
   const link = getLink(nodeData, nodeType, linkGenerator);
 
   return (
-    <div key={`node-${nodeData.id}`}>
+    <div key={`node-${nodeData.id}`} className={style}>
       <span className={badgeStyle}>
         {label && (
           <span style={{ whiteSpace: 'pre' }}>

--- a/frontend/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelEdge.tsx
@@ -211,15 +211,17 @@ export class SummaryPanelEdge extends React.Component<SummaryPanelPropType, Summ
             {renderBadgedLink(dest, undefined, 'To:        ', undefined, waypoint ? fromToStyle : undefined)}{' '}
             {waypoint && (
               <div className={switchWaypointIcon}>
-                <a
-                  href="#"
-                  onClick={this.updateTab}
-                  style={{ textDecoration: 'none', cursor: 'pointer', fontSize: '1.5em' }}
-                >
-                  {this.state.activePanel === 'main'
-                    ? icons.unicode.arrowDownLeftofUp.char
-                    : icons.unicode.arrowUpLeftofDown.char}
-                </a>
+                <Tooltip key="waypoint" position="top" content="Switch From/To">
+                  <a
+                    href="#"
+                    onClick={this.updateTab}
+                    style={{ textDecoration: 'none', cursor: 'pointer', fontSize: '1.5em' }}
+                  >
+                    {this.state.activePanel === 'main'
+                      ? icons.unicode.arrowDownLeftofUp.char
+                      : icons.unicode.arrowUpLeftofDown.char}
+                  </a>
+                </Tooltip>
               </div>
             )}
           </div>

--- a/frontend/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelEdge.tsx
@@ -97,12 +97,15 @@ const principalStyle = kialiStyle({
 });
 
 const switchWaypointIcon = kialiStyle({
-  marginLeft: '95%',
-  marginTop: '-40px'
+  marginTop: '-3em'
 });
 
 const hideStyle = kialiStyle({
   display: 'none'
+});
+
+const fromToStyle = kialiStyle({
+  marginLeft: '2em'
 });
 
 export class SummaryPanelEdge extends React.Component<SummaryPanelPropType, SummaryPanelEdgeState> {
@@ -204,8 +207,8 @@ export class SummaryPanelEdge extends React.Component<SummaryPanelPropType, Summ
         <div>
           <div className={panelHeadingStyle}>
             {getTitle(`Edge (${prettyProtocol(protocol)})`)}
-            {renderBadgedLink(source, undefined, 'From:  ')}
-            {renderBadgedLink(dest, undefined, 'To:        ')}{' '}
+            {renderBadgedLink(source, undefined, 'From:  ', undefined, waypoint ? fromToStyle : undefined)}
+            {renderBadgedLink(dest, undefined, 'To:        ', undefined, waypoint ? fromToStyle : undefined)}{' '}
             {waypoint && (
               <div className={switchWaypointIcon}>
                 <a
@@ -213,7 +216,9 @@ export class SummaryPanelEdge extends React.Component<SummaryPanelPropType, Summ
                   onClick={this.updateTab}
                   style={{ textDecoration: 'none', cursor: 'pointer', fontSize: '1.5em' }}
                 >
-                  {icons.istio.arrowLeftRightV.ascii}
+                  {this.state.activePanel === 'main'
+                    ? icons.unicode.arrowDownLeftofUp.char
+                    : icons.unicode.arrowUpLeftofDown.char}
                 </a>
               </div>
             )}

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -413,9 +413,13 @@ const getEdgeLabel = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphPFSettin
             }
             break;
           case Protocol.TCP:
-            labels.push(toFixedByteRate(rate, includeUnits));
             if (data.waypoint?.direction === 'to' && data.waypoint?.fromEdge) {
-              labels.push(toFixedByteRate(data.waypoint.fromEdge.tcp, includeUnits));
+              const waypointLabel = `${toFixedByteRate(rate, includeUnits)} ${
+                icons.istio.arrowLeftRight.ascii
+              } ${toFixedByteRate(data.waypoint.fromEdge.tcp, includeUnits)}`;
+              labels.push(waypointLabel);
+            } else {
+              labels.push(toFixedByteRate(rate, includeUnits));
             }
             break;
           default:

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -415,7 +415,7 @@ const getEdgeLabel = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphPFSettin
           case Protocol.TCP:
             if (data.waypoint?.direction === 'to' && data.waypoint?.fromEdge) {
               const waypointLabel = `${toFixedByteRate(rate, includeUnits)} ${
-                icons.istio.arrowLeftRight.ascii
+                icons.unicode.arrowRightOverLeft.char
               } ${toFixedByteRate(data.waypoint.fromEdge.tcp, includeUnits)}`;
               labels.push(waypointLabel);
             } else {


### PR DESCRIPTION
### Describe the change

Use right left arrows to indicate the direction:
![image](https://github.com/user-attachments/assets/189cd0e7-941e-438e-9008-4f04706a2a52)

- Remove "Feature Under Development" For the Graph Display option "Waypoint"

### Steps to test the PR

- `minikube start`
- Install istio with Ambient profile: `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo (ztunnel and waypoint): `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Display `waypoint`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. #7706
