### PR TITLE
[ambient] Add to the Graph Traffic Dropdown

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -489,13 +489,15 @@ type GraphSettings struct {
 }
 
 // GraphTraffic defines the protocol-specific rates used to determine traffic for graph generation.
+// ambient options : none | total (traffic) | waypoint (only) | ztunnel (only)
 // grpc options : none | sent (messages) | received (messages) | requests (default) | total (messages)
 // http options : none | requests (default)
 // tcp options  : none | sent (bytes, default) | received (bytes) | total (bytes)
 type GraphTraffic struct {
-	Grpc string `yaml:"grpc,omitempty" json:"grpc,omitempty"`
-	Http string `yaml:"http,omitempty" json:"http,omitempty"`
-	Tcp  string `yaml:"tcp,omitempty" json:"tcp,omitempty"`
+	Ambient string `yaml:"ambient,omitempty" json:"ambient,omitempty"`
+	Grpc    string `yaml:"grpc,omitempty" json:"grpc,omitempty"`
+	Http    string `yaml:"http,omitempty" json:"http,omitempty"`
+	Tcp     string `yaml:"tcp,omitempty" json:"tcp,omitempty"`
 }
 
 // GraphUIDefaults defines UI Defaults specific to the UI Graph
@@ -832,9 +834,10 @@ func NewConfig() (c *Config) {
 						MinFontLabel: 10,
 					},
 					Traffic: GraphTraffic{
-						Grpc: "requests",
-						Http: "requests",
-						Tcp:  "sent",
+						Ambient: "total",
+						Grpc:    "requests",
+						Http:    "requests",
+						Tcp:     "sent",
 					},
 				},
 				I18n: I18nUIDefaults{

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -1,5 +1,4 @@
 import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { serverConfig } from 'config';
 import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from 'types/Graph';
 
 Before(() => {
@@ -96,15 +95,14 @@ Then('user sees default graph traffic menu', () => {
   cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'true');
 
   cy.get('div#graph-traffic-menu').within(() => {
-    if (serverConfig.ambientEnabled) {
-      cy.get('input').should('have.length', 15);
-      cy.get('input#ambient').should('exist').should('be.checked');
-      cy.get('input#ambientWaypoint').should('exist').should('not.be.checked');
-      cy.get('input#ambientZtunnel').should('exist').should('not.be.checked');
-      cy.get('input#ambientTotal').should('exist').should('be.checked');
-    } else {
-      cy.get('input').should('have.length', 11);
-    }
+    // if we enable ambient in the test setup then include:
+    // cy.get('input').should('have.length', 15);
+    // cy.get('input#ambient').should('exist').should('be.checked');
+    // cy.get('input#ambientWaypoint').should('exist').should('not.be.checked');
+    // cy.get('input#ambientZtunnel').should('exist').should('not.be.checked');
+    // cy.get('input#ambientTotal').should('exist').should('be.checked');
+
+    cy.get('input').should('have.length', 11);
     cy.get('input#grpc').should('exist').should('be.checked');
     cy.get('input#grpcReceived').should('exist').should('not.be.checked');
     cy.get('input#grpcRequest').should('exist').should('be.checked');

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -91,18 +91,19 @@ Then('user {string} graph tour', (action: string) => {
   }
 });
 
-Then('user sees default graph traffic menu', () => {
+Then('user sees {string} graph traffic menu', (menu: string) => {
   cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'true');
 
   cy.get('div#graph-traffic-menu').within(() => {
-    // if we enable ambient in the test setup then include:
-    // cy.get('input').should('have.length', 15);
-    // cy.get('input#ambient').should('exist').should('be.checked');
-    // cy.get('input#ambientWaypoint').should('exist').should('not.be.checked');
-    // cy.get('input#ambientZtunnel').should('exist').should('not.be.checked');
-    // cy.get('input#ambientTotal').should('exist').should('be.checked');
-
-    cy.get('input').should('have.length', 11);
+    if (menu === 'ambient') {
+      cy.get('input').should('have.length', 15);
+      cy.get('input#ambient').should('exist').should('be.checked');
+      cy.get('input#ambientWaypoint').should('exist').should('not.be.checked');
+      cy.get('input#ambientZtunnel').should('exist').should('not.be.checked');
+      cy.get('input#ambientTotal').should('exist').should('be.checked');
+    } else {
+      cy.get('input').should('have.length', 11);
+    }
     cy.get('input#grpc').should('exist').should('be.checked');
     cy.get('input#grpcReceived').should('exist').should('not.be.checked');
     cy.get('input#grpcRequest').should('exist').should('be.checked');

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -1,4 +1,5 @@
 import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { serverConfig } from 'config';
 import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from 'types/Graph';
 
 Before(() => {
@@ -95,7 +96,15 @@ Then('user sees default graph traffic menu', () => {
   cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'true');
 
   cy.get('div#graph-traffic-menu').within(() => {
-    cy.get('input').should('have.length', 11);
+    if (serverConfig.ambientEnabled) {
+      cy.get('input').should('have.length', 15);
+      cy.get('input#ambient').should('exist').should('be.checked');
+      cy.get('input#ambientWaypoint').should('exist').should('not.be.checked');
+      cy.get('input#ambientZtunnel').should('exist').should('not.be.checked');
+      cy.get('input#ambientTotal').should('exist').should('be.checked');
+    } else {
+      cy.get('input').should('have.length', 11);
+    }
     cy.get('input#grpc').should('exist').should('be.checked');
     cy.get('input#grpcReceived').should('exist').should('not.be.checked');
     cy.get('input#grpcRequest').should('exist').should('be.checked');

--- a/frontend/cypress/integration/featureFiles/graph_toolbar.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar.feature
@@ -37,7 +37,7 @@ Feature: Kiali Graph page - Toolbar (various)
   @error-rates-app
   Scenario: Open traffic dropdown
     When user clicks graph traffic menu
-    Then user sees default graph traffic menu
+    Then user sees "default" graph traffic menu
 
   @error-rates-app
   Scenario: Disable all traffic
@@ -63,7 +63,7 @@ Feature: Kiali Graph page - Toolbar (various)
   Scenario: User resets to factory default
     When user resets to factory default
     And user clicks graph traffic menu
-    Then user sees default graph traffic menu
+    Then user sees "default" graph traffic menu
 
   @error-rates-app
   Scenario: Open duration dropdown
@@ -114,3 +114,15 @@ Feature: Kiali Graph page - Toolbar (various)
   Scenario: graph type workload
     When user selects "WORKLOAD" graph type
     Then user sees a "workload" graph
+
+  @ambient
+  Scenario: Open traffic dropdown for ambient
+    When user graphs "" namespaces
+    And  user clicks graph traffic menu
+    Then user sees "ambient" graph traffic menu
+
+  @ambient
+  Scenario: Close traffic dropdown for ambient
+    When user clicks graph traffic menu
+    Then user does not see graph traffic menu
+

--- a/frontend/src/app/AuthenticationController.tsx
+++ b/frontend/src/app/AuthenticationController.tsx
@@ -24,7 +24,7 @@ import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { DurationInSeconds, IntervalInMilliseconds, PF_THEME_DARK, Theme } from 'types/Common';
 import { config } from 'config';
 import { store } from 'store/ConfigStore';
-import { toGrpcRate, toHttpRate, toTcpRate, TrafficRate } from 'types/Graph';
+import { toAmbientRate, toGrpcRate, toHttpRate, toTcpRate, TrafficRate } from 'types/Graph';
 import { GraphToolbarActions } from 'actions/GraphToolbarActions';
 import { StatusState, StatusKey } from 'types/StatusState';
 import { PromisesRegistry } from '../utils/CancelablePromises';
@@ -295,10 +295,15 @@ class AuthenticationControllerComponent extends React.Component<
       }
 
       // Graph Traffic
+      const ambientRate = toAmbientRate(uiDefaults.graph.traffic.ambient);
       const grpcRate = toGrpcRate(uiDefaults.graph.traffic.grpc);
       const httpRate = toHttpRate(uiDefaults.graph.traffic.http);
       const tcpRate = toTcpRate(uiDefaults.graph.traffic.tcp);
       const rates: TrafficRate[] = [];
+
+      if (ambientRate) {
+        rates.push(TrafficRate.AMBIENT_GROUP, ambientRate);
+      }
 
       if (grpcRate) {
         rates.push(TrafficRate.GRPC_GROUP, grpcRate);

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -109,6 +109,7 @@ const defaultServerConfig: ComputedServerConfig = {
           minFontLabel: 10
         },
         traffic: {
+          ambient: 'total',
           grpc: 'requests',
           http: 'requests',
           tcp: 'sent'

--- a/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
@@ -117,7 +117,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
         labelText: 'Waypoint',
         isChecked: trafficRates.includes(TrafficRate.AMBIENT_WAYPOINT),
         tooltip: (
-          <div style={{ textAlign: 'left' }}>Limit to only waypoint reported traffic, for the enabled protocols.</div>
+          <div style={{ textAlign: 'left' }}>Limit to only waypoint-reported traffic, for the enabled protocols.</div>
         )
       },
       {
@@ -125,7 +125,9 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
         labelText: 'ZTunnel',
         isChecked: trafficRates.includes(TrafficRate.AMBIENT_ZTUNNEL),
         tooltip: (
-          <div style={{ textAlign: 'left' }}>Limit to only ztunnel reported traffic, for the enabled protocols.</div>
+          <div style={{ textAlign: 'left' }}>
+            Limit to only ztunnel-reported traffic. Relevant only when TCP protocol is enabled.
+          </div>
         )
       },
       {

--- a/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
@@ -30,6 +30,7 @@ import {
   menuStyle,
   menuEntryStyle
 } from 'styles/DropdownStyles';
+import { serverConfig } from 'config';
 
 type ReduxProps = {
   setTrafficRates: (trafficRates: TrafficRate[]) => void;
@@ -44,6 +45,7 @@ interface TrafficRateOptionType {
   disabled?: boolean;
   id: string;
   isChecked: boolean;
+  isHidden?: boolean;
   labelText: string;
   onChange?: () => void;
   tooltip?: React.ReactNode;
@@ -66,6 +68,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
         id: TrafficRate.AMBIENT_GROUP,
         labelText: _.startCase(TrafficRate.AMBIENT_GROUP),
         isChecked: trafficRates.includes(TrafficRate.AMBIENT_GROUP),
+        isHidden: !serverConfig.ambientEnabled,
         tooltip: (
           <div style={{ textAlign: 'left' }}>
             Displays active Edges for the time period, as reported by the enabled Istio Ambient components. This is
@@ -222,171 +225,173 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
         maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: marginBottom }}
       >
         <div id="graph-traffic-menu" className={menuStyle} style={{ width: '16.5em' }}>
-          {trafficRateOptions.map((trafficRateOption: TrafficRateOptionType) => (
-            <div key={trafficRateOption.id} className={menuEntryStyle}>
-              <label
-                key={trafficRateOption.id}
-                className={!!trafficRateOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-              >
-                <Checkbox
-                  id={trafficRateOption.id}
-                  name="trafficRateOptions"
-                  isChecked={trafficRateOption.isChecked}
-                  isDisabled={props.disabled}
-                  label={trafficRateOption.labelText}
-                  onChange={(event, _) => toggleTrafficRate(_, event)}
-                  value={trafficRateOption.id}
-                />
-              </label>
-
-              {!!trafficRateOption.tooltip && (
-                <Tooltip
-                  key={`tooltip_${trafficRateOption.id}`}
-                  position={TooltipPosition.right}
-                  content={trafficRateOption.tooltip}
+          {trafficRateOptions
+            .filter((trafficRateOption: TrafficRateOptionType) => !trafficRateOption.isHidden)
+            .map((trafficRateOption: TrafficRateOptionType) => (
+              <div key={trafficRateOption.id} className={menuEntryStyle}>
+                <label
+                  key={trafficRateOption.id}
+                  className={trafficRateOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
                 >
-                  <KialiIcon.Info className={infoStyle} />
-                </Tooltip>
-              )}
+                  <Checkbox
+                    id={trafficRateOption.id}
+                    name="trafficRateOptions"
+                    isChecked={trafficRateOption.isChecked}
+                    isDisabled={props.disabled}
+                    label={trafficRateOption.labelText}
+                    onChange={(event, _) => toggleTrafficRate(_, event)}
+                    value={trafficRateOption.id}
+                  />
+                </label>
 
-              {trafficRateOption.id === TrafficRate.AMBIENT_GROUP && ambientOptions.some(o => o.isChecked) && (
-                <div>
-                  {ambientOptions.map((ambientOption: TrafficRateOptionType) => (
-                    <div key={ambientOption.id} className={menuEntryStyle}>
-                      <label
-                        key={ambientOption.id}
-                        className={!!ambientOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                        style={{ paddingLeft: '2rem' }}
-                      >
-                        <Radio
-                          id={ambientOption.id}
-                          style={{ paddingLeft: '0.25rem' }}
-                          name="ambientOptions"
-                          isChecked={ambientOption.isChecked}
-                          isDisabled={props.disabled}
-                          label={ambientOption.labelText}
-                          onChange={(event, _) => toggleTrafficRateAmbient(_, event)}
-                          value={ambientOption.id}
-                        />
-                      </label>
-                      {!!ambientOption.tooltip && (
-                        <Tooltip
-                          key={`tooltip_${ambientOption.id}`}
-                          position={TooltipPosition.right}
-                          content={ambientOption.tooltip}
+                {trafficRateOption.tooltip && (
+                  <Tooltip
+                    key={`tooltip_${trafficRateOption.id}`}
+                    position={TooltipPosition.right}
+                    content={trafficRateOption.tooltip}
+                  >
+                    <KialiIcon.Info className={infoStyle} />
+                  </Tooltip>
+                )}
+
+                {trafficRateOption.id === TrafficRate.AMBIENT_GROUP && ambientOptions.some(o => o.isChecked) && (
+                  <div>
+                    {ambientOptions.map((ambientOption: TrafficRateOptionType) => (
+                      <div key={ambientOption.id} className={menuEntryStyle}>
+                        <label
+                          key={ambientOption.id}
+                          className={ambientOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
+                          style={{ paddingLeft: '2rem' }}
                         >
-                          <KialiIcon.Info className={infoStyle} />
-                        </Tooltip>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+                          <Radio
+                            id={ambientOption.id}
+                            style={{ paddingLeft: '0.25rem' }}
+                            name="ambientOptions"
+                            isChecked={ambientOption.isChecked}
+                            isDisabled={props.disabled}
+                            label={ambientOption.labelText}
+                            onChange={(event, _) => toggleTrafficRateAmbient(_, event)}
+                            value={ambientOption.id}
+                          />
+                        </label>
+                        {ambientOption.tooltip && (
+                          <Tooltip
+                            key={`tooltip_${ambientOption.id}`}
+                            position={TooltipPosition.right}
+                            content={ambientOption.tooltip}
+                          >
+                            <KialiIcon.Info className={infoStyle} />
+                          </Tooltip>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
 
-              {trafficRateOption.id === TrafficRate.GRPC_GROUP && grpcOptions.some(o => o.isChecked) && (
-                <div>
-                  {grpcOptions.map((grpcOption: TrafficRateOptionType) => (
-                    <div key={grpcOption.id} className={menuEntryStyle}>
-                      <label
-                        key={grpcOption.id}
-                        className={!!grpcOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                        style={{ paddingLeft: '2rem' }}
-                      >
-                        <Radio
-                          id={grpcOption.id}
-                          style={{ paddingLeft: '0.25rem' }}
-                          name="grpcOptions"
-                          isChecked={grpcOption.isChecked}
-                          isDisabled={props.disabled}
-                          label={grpcOption.labelText}
-                          onChange={(event, _) => toggleTrafficRateGrpc(_, event)}
-                          value={grpcOption.id}
-                        />
-                      </label>
-                      {!!grpcOption.tooltip && (
-                        <Tooltip
-                          key={`tooltip_${grpcOption.id}`}
-                          position={TooltipPosition.right}
-                          content={grpcOption.tooltip}
+                {trafficRateOption.id === TrafficRate.GRPC_GROUP && grpcOptions.some(o => o.isChecked) && (
+                  <div>
+                    {grpcOptions.map((grpcOption: TrafficRateOptionType) => (
+                      <div key={grpcOption.id} className={menuEntryStyle}>
+                        <label
+                          key={grpcOption.id}
+                          className={grpcOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
+                          style={{ paddingLeft: '2rem' }}
                         >
-                          <KialiIcon.Info className={infoStyle} />
-                        </Tooltip>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+                          <Radio
+                            id={grpcOption.id}
+                            style={{ paddingLeft: '0.25rem' }}
+                            name="grpcOptions"
+                            isChecked={grpcOption.isChecked}
+                            isDisabled={props.disabled}
+                            label={grpcOption.labelText}
+                            onChange={(event, _) => toggleTrafficRateGrpc(_, event)}
+                            value={grpcOption.id}
+                          />
+                        </label>
+                        {grpcOption.tooltip && (
+                          <Tooltip
+                            key={`tooltip_${grpcOption.id}`}
+                            position={TooltipPosition.right}
+                            content={grpcOption.tooltip}
+                          >
+                            <KialiIcon.Info className={infoStyle} />
+                          </Tooltip>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
 
-              {trafficRateOption.id === TrafficRate.HTTP_GROUP && httpOptions.some(o => o.isChecked) && (
-                <div>
-                  {httpOptions.map((httpOption: TrafficRateOptionType) => (
-                    <div key={httpOption.id} className={menuEntryStyle}>
-                      <label
-                        key={httpOption.id}
-                        className={!!httpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                        style={{ paddingLeft: '2rem' }}
-                      >
-                        <Radio
-                          id={httpOption.id}
-                          style={{ paddingLeft: '0.25rem' }}
-                          name="httpOptions"
-                          isChecked={httpOption.isChecked}
-                          isDisabled={props.disabled}
-                          label={httpOption.labelText}
-                          onChange={(event, _) => toggleTrafficRateHttp(_, event)}
-                          value={httpOption.id}
-                        />
-                      </label>
-
-                      {!!httpOption.tooltip && (
-                        <Tooltip
-                          key={`tooltip_${httpOption.id}`}
-                          position={TooltipPosition.right}
-                          content={httpOption.tooltip}
+                {trafficRateOption.id === TrafficRate.HTTP_GROUP && httpOptions.some(o => o.isChecked) && (
+                  <div>
+                    {httpOptions.map((httpOption: TrafficRateOptionType) => (
+                      <div key={httpOption.id} className={menuEntryStyle}>
+                        <label
+                          key={httpOption.id}
+                          className={httpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
+                          style={{ paddingLeft: '2rem' }}
                         >
-                          <KialiIcon.Info className={infoStyle} />
-                        </Tooltip>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+                          <Radio
+                            id={httpOption.id}
+                            style={{ paddingLeft: '0.25rem' }}
+                            name="httpOptions"
+                            isChecked={httpOption.isChecked}
+                            isDisabled={props.disabled}
+                            label={httpOption.labelText}
+                            onChange={(event, _) => toggleTrafficRateHttp(_, event)}
+                            value={httpOption.id}
+                          />
+                        </label>
 
-              {trafficRateOption.id === TrafficRate.TCP_GROUP && tcpOptions.some(o => o.isChecked) && (
-                <div>
-                  {tcpOptions.map((tcpOption: TrafficRateOptionType) => (
-                    <div key={tcpOption.id} className={menuEntryStyle}>
-                      <label
-                        key={tcpOption.id}
-                        className={!!tcpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                        style={{ paddingLeft: '2rem' }}
-                      >
-                        <Radio
-                          id={tcpOption.id}
-                          style={{ paddingLeft: '0.25rem' }}
-                          name="tcpOptions"
-                          isChecked={tcpOption.isChecked}
-                          isDisabled={props.disabled}
-                          label={tcpOption.labelText}
-                          onChange={(event, _) => toggleTrafficRateTcp(_, event)}
-                          value={tcpOption.id}
-                        />
-                      </label>
-                      {!!tcpOption.tooltip && (
-                        <Tooltip
-                          key={`tooltip_${tcpOption.id}`}
-                          position={TooltipPosition.right}
-                          content={tcpOption.tooltip}
+                        {httpOption.tooltip && (
+                          <Tooltip
+                            key={`tooltip_${httpOption.id}`}
+                            position={TooltipPosition.right}
+                            content={httpOption.tooltip}
+                          >
+                            <KialiIcon.Info className={infoStyle} />
+                          </Tooltip>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {trafficRateOption.id === TrafficRate.TCP_GROUP && tcpOptions.some(o => o.isChecked) && (
+                  <div>
+                    {tcpOptions.map((tcpOption: TrafficRateOptionType) => (
+                      <div key={tcpOption.id} className={menuEntryStyle}>
+                        <label
+                          key={tcpOption.id}
+                          className={tcpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
+                          style={{ paddingLeft: '2rem' }}
                         >
-                          <KialiIcon.Info className={infoStyle} />
-                        </Tooltip>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
+                          <Radio
+                            id={tcpOption.id}
+                            style={{ paddingLeft: '0.25rem' }}
+                            name="tcpOptions"
+                            isChecked={tcpOption.isChecked}
+                            isDisabled={props.disabled}
+                            label={tcpOption.labelText}
+                            onChange={(event, _) => toggleTrafficRateTcp(_, event)}
+                            value={tcpOption.id}
+                          />
+                        </label>
+                        {tcpOption.tooltip && (
+                          <Tooltip
+                            key={`tooltip_${tcpOption.id}`}
+                            position={TooltipPosition.right}
+                            content={tcpOption.tooltip}
+                          >
+                            <KialiIcon.Info className={infoStyle} />
+                          </Tooltip>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
         </div>
       </BoundingClientAwareComponent>
     );

--- a/frontend/src/reducers/GraphDataState.ts
+++ b/frontend/src/reducers/GraphDataState.ts
@@ -38,6 +38,8 @@ export const INITIAL_GRAPH_STATE: GraphState = {
     showVirtualServices: true,
     showWaypoints: false,
     trafficRates: [
+      TrafficRate.AMBIENT_GROUP,
+      TrafficRate.AMBIENT_TOTAL,
       TrafficRate.GRPC_GROUP,
       TrafficRate.GRPC_REQUEST,
       TrafficRate.HTTP_GROUP,

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -290,6 +290,9 @@ export class GraphDataSource {
           break;
       }
     });
+    if (!serverConfig.ambientEnabled) {
+      restParams.ambientTraffic = 'none';
+    }
 
     let cluster: string | undefined;
 

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -245,14 +245,23 @@ export class GraphDataSource {
       }
     });
 
+    restParams.ambientTraffic = 'none';
     restParams.appenders = appenders;
-
     restParams.rateGrpc = 'none';
     restParams.rateHttp = 'none';
     restParams.rateTcp = 'none';
 
     fetchParams.trafficRates.forEach(trafficRate => {
       switch (trafficRate) {
+        case TrafficRate.AMBIENT_TOTAL:
+          restParams.ambientTraffic = 'total';
+          break;
+        case TrafficRate.AMBIENT_WAYPOINT:
+          restParams.ambientTraffic = 'waypoint';
+          break;
+        case TrafficRate.AMBIENT_ZTUNNEL:
+          restParams.ambientTraffic = 'ztunnel';
+          break;
         case TrafficRate.GRPC_RECEIVED:
           restParams.rateGrpc = 'received';
           break;

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -95,6 +95,7 @@ export const serverRateConfig = {
           minFontLabel: 10
         },
         traffic: {
+          ambient: 'total',
           grpc: 'requests',
           http: 'requests',
           tcp: 'sent'

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -88,6 +88,10 @@ export const numLabels = (modes: EdgeLabelMode[]): number => {
 };
 
 export enum TrafficRate {
+  AMBIENT_TOTAL = 'ambientTotal',
+  AMBIENT_GROUP = 'ambient',
+  AMBIENT_WAYPOINT = 'ambientWaypoint',
+  AMBIENT_ZTUNNEL = 'ambientZtunnel',
   GRPC_GROUP = 'grpc',
   GRPC_RECEIVED = 'grpcReceived', // response_messages
   GRPC_REQUEST = 'grpcRequest',
@@ -102,6 +106,8 @@ export enum TrafficRate {
 }
 
 export const DefaultTrafficRates: TrafficRate[] = [
+  TrafficRate.AMBIENT_GROUP,
+  TrafficRate.AMBIENT_TOTAL,
   TrafficRate.GRPC_GROUP,
   TrafficRate.GRPC_REQUEST,
   TrafficRate.HTTP_GROUP,
@@ -109,6 +115,28 @@ export const DefaultTrafficRates: TrafficRate[] = [
   TrafficRate.TCP_GROUP,
   TrafficRate.TCP_SENT
 ];
+
+export const isAmbientRate = (rate: TrafficRate): boolean => {
+  return (
+    rate === TrafficRate.AMBIENT_TOTAL ||
+    rate === TrafficRate.AMBIENT_GROUP ||
+    rate === TrafficRate.AMBIENT_WAYPOINT ||
+    rate === TrafficRate.AMBIENT_ZTUNNEL
+  );
+};
+
+export const toAmbientRate = (rate: string): TrafficRate | undefined => {
+  switch (rate) {
+    case 'total':
+      return TrafficRate.AMBIENT_TOTAL;
+    case 'waypoint':
+      return TrafficRate.AMBIENT_WAYPOINT;
+    case 'ztunnel':
+      return TrafficRate.AMBIENT_ZTUNNEL;
+    default:
+      return undefined;
+  }
+};
 
 export const isGrpcRate = (rate: TrafficRate): boolean => {
   return (
@@ -438,6 +466,7 @@ export interface GraphElements {
 }
 
 export interface GraphElementsQuery {
+  ambientTraffic?: string;
   appenders?: AppenderString;
   boxBy?: string;
   duration?: string;

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -32,6 +32,7 @@ interface GraphFindOption {
 }
 
 interface GraphTraffic {
+  ambient: string;
   grpc: string;
   http: string;
   tcp: string;

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -29,6 +29,7 @@ export const healthConfig = {
           minFontLabel: 10
         },
         traffic: {
+          ambient: 'total',
           grpc: 'requests',
           http: 'requests',
           tcp: 'sent'

--- a/graph/telemetry/istio/appender/aggregate_node_test.go
+++ b/graph/telemetry/istio/appender/aggregate_node_test.go
@@ -90,9 +90,10 @@ func TestNamespacesGraphWithServiceInjection(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -217,9 +218,10 @@ func TestNamespacesGraphNoServiceInjection(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		}}
 
 	appender.appendGraph(trafficMap, "bookinfo", client)
@@ -313,9 +315,10 @@ func TestNodeGraphWithServiceInjection(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 		Service: "reviews",
 	}
@@ -424,9 +427,10 @@ func TestNamespacesGraphWithServiceInjectionSkipRates(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateNone,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateNone,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -502,9 +506,10 @@ func TestNodeGraphNoServiceInjection(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -583,9 +588,10 @@ func TestNodeGraphWithServiceInjectionSkipRates(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateNone,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateNone,
+			Tcp:     graph.RateTotal,
 		},
 		Service: "reviews",
 	}

--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -39,12 +39,16 @@ func (a AmbientAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *gr
 func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap) {
 
 	waypointNodes := make(map[string]*graph.Node)
+	potentialOrphans := make(map[string]bool)
 
 	// Flag or Delete waypoint nodes in the TrafficMap
 	for _, n := range trafficMap {
 		if _, ok := n.Metadata[graph.IsWaypoint]; ok {
 			waypointNodes[n.ID] = n
 			if !a.ShowWaypoints {
+				for _, edge := range n.Edges {
+					potentialOrphans[edge.Dest.ID] = true
+				}
 				delete(trafficMap, n.ID)
 			} else {
 				n.Metadata[graph.IsOutOfMesh] = false
@@ -61,12 +65,16 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap) {
 	if len(waypointNodes) == 0 {
 		return
 	}
+
 	for _, n := range trafficMap {
 		// If not showing waypoints then delete edges going to a waypoint
 		if !a.ShowWaypoints {
 			n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
 				return waypointNodes[edge.Dest.ID] == nil
 			})
+			if len(n.Edges) == 0 {
+				potentialOrphans[n.ID] = true
+			}
 			continue
 		}
 
@@ -84,6 +92,24 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap) {
 				}
 				toEdge.Metadata[graph.Waypoint] = &toWaypointEdgeData
 			}
+		}
+	}
+
+	// after removing waypoints, remove any affected nodes that no longer have incoming or outgoing edges
+	if a.ShowWaypoints {
+		return
+	}
+
+	// don't delete any affected node that still has edges to it
+	for _, n := range trafficMap {
+		for _, e := range n.Edges {
+			potentialOrphans[e.Dest.ID] = false
+		}
+	}
+	// delete affected nodes with no incoming or outgoing edges
+	for id, noIncomingEdges := range potentialOrphans {
+		if noIncomingEdges && len(trafficMap[id].Edges) == 0 {
+			delete(trafficMap, id)
 		}
 	}
 }

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -214,9 +214,10 @@ func TestResponseTimeP95(t *testing.T) {
 		Quantile:  0.95,
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -487,9 +488,10 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		Quantile:  0.0,
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateNone,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateNone,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -760,9 +762,10 @@ func TestResponseTimeAvg(t *testing.T) {
 		Quantile:  0.0,
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 	}
 

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -64,8 +64,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 	groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy"
 	var query string
 	if a.Rates.Grpc == graph.RateRequests || a.Rates.Http == graph.RateRequests {
-		requestsQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
+		requestsQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_requests_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -73,8 +74,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		query = fmt.Sprintf(`(%s)`, requestsQuery)
 	}
 	if a.Rates.Grpc == graph.RateSent || a.Rates.Grpc == graph.RateTotal {
-		grpcSentQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
+		grpcSentQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_request_messages_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -86,8 +88,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Grpc == graph.RateReceived || a.Rates.Grpc == graph.RateTotal {
-		grpcReceivedQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
+		grpcReceivedQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_response_messages_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -99,8 +102,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Tcp == graph.RateSent || a.Rates.Tcp == graph.RateTotal {
-		tcpSentQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
+		tcpSentQuery := fmt.Sprintf(`sum(rate(%s{%sreporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_tcp_sent_bytes_total",
+			util.GetApp(a.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -112,8 +116,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Tcp == graph.RateReceived || a.Rates.Tcp == graph.RateTotal {
-		tcpReceivedQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
+		tcpReceivedQuery := fmt.Sprintf(`sum(rate(%s{%sreporter="destination",source_workload_namespace!="%v",destination_service_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_tcp_received_bytes_total",
+			util.GetApp(a.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -130,16 +135,18 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 	// 2) query for requests originating from a workload inside of the namespace
 	query = ""
 	if a.Rates.Grpc == graph.RateRequests || a.Rates.Http == graph.RateRequests {
-		requestsQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
+		requestsQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_requests_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
 		query = fmt.Sprintf(`(%s)`, requestsQuery)
 	}
 	if a.Rates.Grpc == graph.RateSent || a.Rates.Grpc == graph.RateTotal {
-		grpcSentQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
+		grpcSentQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_request_messages_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
@@ -150,8 +157,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Grpc == graph.RateReceived || a.Rates.Grpc == graph.RateTotal {
-		grpcReceivedQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
+		grpcReceivedQuery := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_response_messages_total",
+			util.GetReporter("destination", a.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
@@ -162,8 +170,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Tcp == graph.RateSent || a.Rates.Tcp == graph.RateTotal {
-		tcpSentQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
+		tcpSentQuery := fmt.Sprintf(`sum(rate(%s{%sreporter="destination",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_tcp_sent_bytes_total",
+			util.GetApp(a.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy)
@@ -174,8 +183,9 @@ func (a SecurityPolicyAppender) appendGraph(trafficMap graph.TrafficMap, namespa
 		}
 	}
 	if a.Rates.Tcp == graph.RateReceived || a.Rates.Tcp == graph.RateTotal {
-		tcpReceivedQuery := fmt.Sprintf(`sum(rate(%s{reporter="destination",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
+		tcpReceivedQuery := fmt.Sprintf(`sum(rate(%s{%sreporter="destination",source_workload_namespace="%v"}[%vs])) by (%s) > 0`,
 			"istio_tcp_received_bytes_total",
+			util.GetApp(a.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy)

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -88,9 +88,10 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateSent,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateSent,
 		},
 	}
 
@@ -193,9 +194,10 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateTotal,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateTotal,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 	}
 
@@ -268,9 +270,10 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateSent,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateSent,
 		},
 	}
 

--- a/graph/telemetry/istio/appender/throughput_test.go
+++ b/graph/telemetry/istio/appender/throughput_test.go
@@ -134,9 +134,10 @@ func TestResponseThroughput(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 		ThroughputType: "response",
 	}
@@ -309,9 +310,10 @@ func TestRequestThroughput(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateRequests,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateRequests,
+			Tcp:     graph.RateTotal,
 		},
 		ThroughputType: "request",
 	}
@@ -418,9 +420,10 @@ func TestRequestThroughputSkipRates(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Grpc: graph.RateRequests,
-			Http: graph.RateNone,
-			Tcp:  graph.RateTotal,
+			Ambient: graph.AmbientTrafficTotal,
+			Grpc:    graph.RateRequests,
+			Http:    graph.RateNone,
+			Tcp:     graph.RateTotal,
 		},
 		ThroughputType: "request",
 	}

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -135,8 +135,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 		groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
 
 		// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic (failed requests that never reach a dest)
-		query := fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+		query := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
 			metric,
+			util.GetReporter("source", o.Rates),
 			namespace,
 			namespace,
 			int(duration.Seconds()), // range duration for the query
@@ -146,8 +147,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 		populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 		// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic
-		query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+		query = fmt.Sprintf(`sum(rate(%s{%s,destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
 			metric,
+			util.GetReporter("destination", o.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy,
@@ -156,8 +158,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 		populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 		// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-		query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+		query = fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace="%s"} [%vs])) by (%s) %s`,
 			metric,
+			util.GetReporter("source", o.Rates),
 			namespace,
 			int(duration.Seconds()), // range duration for the query
 			groupBy,
@@ -184,8 +187,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 
 		for _, metric := range metrics {
 			// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
-			query := fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+			query := fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("source", o.Rates),
 				namespace,
 				namespace,
 				int(duration.Seconds()), // range duration for the query
@@ -195,8 +199,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 			populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 			// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic	query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_service_namespace="%s"} [%vs])) by (%s) %s`,
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s,destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("destination", o.Rates),
 				namespace,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
@@ -205,8 +210,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 			populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 			// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s,source_workload_namespace="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("source", o.Rates),
 				namespace,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
@@ -235,8 +241,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 
 		for _, metric := range metrics {
 			// 0) Incoming: query source telemetry to capture unserviced namespace services' incoming traffic
-			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
+			query := fmt.Sprintf(`sum(rate(%s{%sreporter="source",source_workload_namespace!="%s",destination_workload_namespace="unknown",destination_workload="unknown",destination_service=~"^.+\\.%s\\..+$"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetApp(o.Rates),
 				namespace,
 				namespace,
 				int(duration.Seconds()), // range duration for the query
@@ -246,8 +253,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 			populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 			// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic	query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_service_namespace="%s"} [%vs])) by (%s) %s`,
-			query = fmt.Sprintf(`sum(rate(%s{reporter="destination",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%sreporter="destination",destination_workload_namespace="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetApp(o.Rates),
 				namespace,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
@@ -256,8 +264,9 @@ func buildNamespaceTrafficMap(ctx context.Context, namespace string, o graph.Tel
 			populateTrafficMap(trafficMap, &incomingVector, metric, o, globalInfo)
 
 			// 2) Outgoing: query source telemetry to capture namespace workloads' outgoing traffic
-			query = fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%sreporter="source",source_workload_namespace="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetApp(o.Rates),
 				namespace,
 				int(duration.Seconds()), // range duration for the query
 				groupBy,
@@ -577,8 +586,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 		var query string
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("destination", o.Rates),
 				destCluster,
 				namespace,
 				n.Workload,
@@ -587,8 +597,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 				idleCondition)
 		case graph.NodeTypeApp:
 			if graph.IsOK(n.Version) {
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("destination", o.Rates),
 					destCluster,
 					namespace,
 					n.App,
@@ -597,8 +608,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					groupBy,
 					idleCondition)
 			} else {
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("destination", o.Rates),
 					destCluster,
 					namespace,
 					n.App,
@@ -609,8 +621,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 		case graph.NodeTypeService:
 			// Service nodes require two queries for incoming
 			// 1.a) query source telemetry for requests to the service that could not be serviced
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,destination_workload="unknown",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_workload="unknown",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("source", o.Rates),
 				destCluster,
 				n.Service,
 				namespace,
@@ -621,8 +634,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 			populateTrafficMap(trafficMap, &vector, metric, o, globalInfo)
 
 			// 1.b) query dest telemetry for requests to the service, serviced by service workloads
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("destination", o.Rates),
 				destCluster,
 				namespace,
 				n.Service,
@@ -639,8 +653,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 		// 2) query for outbound traffic
 		switch n.NodeType {
 		case graph.NodeTypeWorkload:
-			query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+			query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
 				metric,
+				util.GetReporter("source", o.Rates),
 				sourceCluster,
 				namespace,
 				n.Workload,
@@ -649,8 +664,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 				idleCondition)
 		case graph.NodeTypeApp:
 			if graph.IsOK(n.Version) {
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("source", o.Rates),
 					sourceCluster,
 					namespace,
 					n.App,
@@ -659,8 +675,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					groupBy,
 					idleCondition)
 			} else {
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("source", o.Rates),
 					sourceCluster,
 					namespace,
 					n.App,
@@ -698,8 +715,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("destination", o.Rates),
 					destCluster,
 					namespace,
 					n.Workload,
@@ -708,8 +726,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetReporter("destination", o.Rates),
 						destCluster,
 						namespace,
 						n.App,
@@ -718,8 +737,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetReporter("destination", o.Rates),
 						destCluster,
 						namespace,
 						n.App,
@@ -729,8 +749,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 				}
 			case graph.NodeTypeService:
 				// TODO: Do we need to handle requests from unknown in a special way (like in HTTP above)? Not sure how gRPC-messages is reported from unknown.
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("destination", o.Rates),
 					destCluster,
 					namespace,
 					n.Service,
@@ -747,8 +768,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 			// 2) query for outbound traffic
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetReporter("source", o.Rates),
 					sourceCluster,
 					namespace,
 					n.Workload,
@@ -757,8 +779,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetReporter("source", o.Rates),
 						sourceCluster,
 						namespace,
 						n.App,
@@ -767,8 +790,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter=~"source|waypoint"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%s%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetReporter("source", o.Rates),
 						sourceCluster,
 						namespace,
 						n.App,
@@ -814,8 +838,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,destination_workload_namespace="%s",destination_workload="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetApp(o.Rates),
 					inboundReporter,
 					destCluster,
 					namespace,
@@ -825,8 +850,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,destination_service_namespace="%s",destination_canonical_service="%s",destination_canonical_revision="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetApp(o.Rates),
 						inboundReporter,
 						destCluster,
 						namespace,
@@ -836,8 +862,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,destination_service_namespace="%s",destination_canonical_service="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetApp(o.Rates),
 						inboundReporter,
 						destCluster,
 						namespace,
@@ -848,8 +875,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 				}
 			case graph.NodeTypeService:
 				// TODO: Do we need to handle requests from unknown in a special way (like in HTTP above)? Not sure how tcp is reported from unknown.
-				query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,destination_service_namespace="%s",destination_service=~"^%s\\.%s\\..*$"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetApp(o.Rates),
 					inboundReporter,
 					destCluster,
 					namespace,
@@ -867,8 +895,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 			// 2) query for outbound traffic
 			switch n.NodeType {
 			case graph.NodeTypeWorkload:
-				query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
+				query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,source_workload_namespace="%s",source_workload="%s"} [%vs])) by (%s) %s`,
 					metric,
+					util.GetApp(o.Rates),
 					outboutReporter,
 					sourceCluster,
 					namespace,
@@ -878,8 +907,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 					idleCondition)
 			case graph.NodeTypeApp:
 				if graph.IsOK(n.Version) {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,source_workload_namespace="%s",source_canonical_service="%s",source_canonical_revision="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetApp(o.Rates),
 						outboutReporter,
 						sourceCluster,
 						namespace,
@@ -889,8 +919,9 @@ func buildNodeTrafficMap(cluster, namespace string, n *graph.Node, o graph.Telem
 						groupBy,
 						idleCondition)
 				} else {
-					query = fmt.Sprintf(`sum(rate(%s{reporter="%s"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
+					query = fmt.Sprintf(`sum(rate(%s{%sreporter="%s"%s,source_workload_namespace="%s",source_canonical_service="%s"} [%vs])) by (%s) %s`,
 						metric,
+						util.GetApp(o.Rates),
 						outboutReporter,
 						sourceCluster,
 						namespace,
@@ -955,8 +986,9 @@ func buildAggregateNodeTrafficMap(namespace string, n graph.Node, o graph.Teleme
 	}
 	metric := "istio_requests_total"
 	groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags"
-	httpQuery := fmt.Sprintf(`sum(rate(%s{reporter=~"destination|waypoint",destination_service_namespace="%s",%s="%s"%s}[%vs])) by (%s) > 0`,
+	httpQuery := fmt.Sprintf(`sum(rate(%s{%s,destination_service_namespace="%s",%s="%s"%s}[%vs])) by (%s) > 0`,
 		metric,
+		util.GetReporter("destination", o.Rates),
 		namespace,
 		n.Metadata[graph.Aggregate],
 		n.Metadata[graph.AggregateValue],

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -141,3 +141,19 @@ func AddQueryScope(query string) string {
 
 	return strings.ReplaceAll(query, "{", scope)
 }
+
+// GetReporter returns the "report=" prom query fragment based on whether the reporter must include waypoint traffic
+func GetReporter(reporter string, rates graph.RequestedRates) string {
+	if rates.Ambient == graph.AmbientTrafficWaypoint || rates.Ambient == graph.AmbientTrafficTotal {
+		return fmt.Sprintf(`reporter=~"%s|waypoint"`, reporter)
+	}
+	return fmt.Sprintf(`reporter="%s"`, reporter)
+}
+
+// GetApp returns the "app=" prom query fragment based on whether the reporter must exclude ztunnel data
+func GetApp(rates graph.RequestedRates) string {
+	if rates.Ambient == graph.AmbientTrafficWaypoint || rates.Ambient == graph.AmbientTrafficNone {
+		return "app!=\"ztunnel\","
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #6900 

Add to the Graph Traffic Dropdown, allowing the user to select no ambient reporting, full ambient reporting, only waypoint or only ztunnel.  This should help users identify or remove ambient-reported traffic.

![image](https://github.com/user-attachments/assets/f564af2a-1d19-4a2a-b6f1-02cd696e42cc)


