### PR TITLE
Update tempo resources for Sail hack script

### DIFF
--- a/hack/istio/sail/README-RELEASE.md
+++ b/hack/istio/sail/README-RELEASE.md
@@ -1,5 +1,7 @@
 # Installing Istio with the Latest Sail and Kiali Operators
 
+## Quick installation guide
+
 To install Istio (including Kiali), use the script `install-ossm-release.sh`. This will utilize the Sail operator and Kiali operator to install the latest released images via OLM using either the Red Hat repository or the public Community repository or the public OperatorHub.io.
 
 Here's what you need to do in order to install everything.
@@ -21,6 +23,23 @@ Once the operators have been given time to start up, now install a control plane
 ```
 
 Pass in `--help` for available options.
+
+## Detailed steps for a vanilla Kubernetes (not OpenShift)
+
+* Requirements: the kiali source repo git cloned locally.
+
+These steps will get Sail operator and its Istio installation, Kiali operator and Kiali UI, along with Tempo operator and Tempo (for tracing backend and JaegerUI), Grafana, and Prometheus. It also installs bookinfo and adds the auto injection label. 
+A loadBalancer is added to have access to the Jaeger UI.
+
+1. `hack/k8s-minikube.sh --load-balancer-addrs "70-84" start` 
+2. `hack/istio/sail/install-ossm-release.sh -c kubectl install-operators` 
+3. `sleep 30` # (wait a little bit for the operators to start installing - just wait 30 seconds or so for OLM to start installing things)
+4. `hack/istio/sail/install-ossm-release.sh -c kubectl install-istio`
+5. `hack/istio/install-bookinfo-demo.sh -tg -c kubectl -ail istio.io/rev=default-v1-23-0`
+6. `hack/kiali-port-forward.sh`
+7. Point your browser to Kiali UI at http://localhost:20001/kiali/console
+
+Notice the auto injection label for bookinfo namespace is set to `istio.io/rev=default-v1-23-0`
 
 ## Uninstall
 

--- a/hack/istio/sail/func-tempo.sh
+++ b/hack/istio/sail/func-tempo.sh
@@ -161,11 +161,6 @@ spec:
     secret:
       type: s3
       name: "${MINIO_SECRET_NAME}"
-  resources:
-    total:
-      limits:
-        memory: 2Gi
-        cpu: 2000m
   template:
     distributor:
       tls:


### PR DESCRIPTION
### Describe the change

Update tempo resources for Sail hack script.

I think this resources specification are not enough for Tempo operator. This resources specification splits the resources between all the components, which is not enough for the Tempo query-frontend component. 

The tests can be done with the url and a simple query (With master code), for one minute: 

http://localhost:3200/api/search?end=1727106314&q={+.service.name+=+%22reviews.bookinfo%22}&start=1727106301

![image](https://github.com/user-attachments/assets/eb2d8a03-24a4-4569-9771-8ba9142dc24d)

It takes around ~30 request to be OOM killed. 

In the query that we do, takes ~10 requests to be OOM killed (There is more data requested in order to create the chart): 

`http://localhost:3200/api/search?end=1727106314&limit=100&q={+.service.name+=+"reviews.bookinfo"++&&+.istio.mesh_id+=+"cluster.local"+++}+&&+{++}+|+select(status,+.service_name,+.node_id,+.component,+.upstream_cluster,+.http.method,+.response_flags,+resource.hostname)&spss=10&start=1727106301`

For reference: https://github.com/grafana/tempo-operator/issues/726 

* update readme based on this: https://github.com/kiali/kiali/pull/7761

### Steps to test the PR

* Tests using the updated README instructions (But in a kind cluster). 
* This is a first PR to have tracing stable. Second PR will be investigate Kiali and the use of Tempo (See https://github.com/kiali/kiali/issues/7769)

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/issues/7769
