### PR TITLE
Fix issue with bookmarked find/hide not being evaluated in PFT graph or Mesh page

### DIFF
--- a/frontend/src/actions/GraphThunkActions.ts
+++ b/frontend/src/actions/GraphThunkActions.ts
@@ -1,3 +1,4 @@
+import { Controller } from '@patternfly/react-topology';
 import { KialiDispatch } from '../types/Redux';
 import { GraphActions } from './GraphActions';
 
@@ -12,7 +13,7 @@ export const GraphThunkActions = {
       );
     };
   },
-  graphPFReady: (controller: any) => {
+  graphPFReady: (controller: Controller) => {
     return (dispatch: KialiDispatch) => {
       dispatch(
         GraphActions.updateSummary({

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -190,22 +190,22 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     const urlParams = new URLSearchParams(location.getSearch());
     const urlFind = HistoryManager.getParam(URLParam.GRAPH_FIND, urlParams);
 
-    if (!!urlFind) {
+    if (urlFind) {
       if (urlFind !== findValue) {
         findValue = urlFind;
         props.setFindValue(urlFind);
       }
-    } else if (!!findValue) {
+    } else if (findValue) {
       HistoryManager.setParam(URLParam.GRAPH_FIND, findValue);
     }
 
     const urlHide = HistoryManager.getParam(URLParam.GRAPH_HIDE, urlParams);
-    if (!!urlHide) {
+    if (urlHide) {
       if (urlHide !== hideValue) {
         hideValue = urlHide;
         props.setHideValue(urlHide);
       }
-    } else if (!!hideValue) {
+    } else if (hideValue) {
       HistoryManager.setParam(URLParam.GRAPH_HIDE, hideValue);
     }
 
@@ -252,6 +252,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       return;
     }
 
+    const controllerChanged = this.props.controller !== prevProps.controller;
     const edgeModeChanged = this.props.edgeMode !== prevProps.edgeMode;
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
@@ -274,7 +275,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     }
 
     // make sure the value is updated if there was a change
-    if (findChanged || (graphChanged && !!this.props.findValue)) {
+    if (controllerChanged || findChanged || (graphChanged && this.props.findValue)) {
       // ensure findInputValue is aligned if findValue is set externally (e.g. resetSettings)
       if (this.state.findInputValue !== this.props.findValue) {
         this.setFind(this.props.findValue);
@@ -284,8 +285,9 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     }
 
     if (
+      controllerChanged ||
       hideChanged ||
-      (graphChanged && !!this.props.hideValue) ||
+      (graphChanged && this.props.hideValue) ||
       edgeModeChanged ||
       this.props.edgeMode !== EdgeMode.ALL
     ) {
@@ -427,7 +429,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       case 9: // tab (autocomplete)
         event.preventDefault();
         const next = this.findAutoComplete.next();
-        if (!!next) {
+        if (next) {
           this.findInputRef.value = next;
           this.findInputRef.scrollLeft = this.findInputRef.scrollWidth;
           this.setState({ findInputValue: next, findError: undefined });
@@ -488,7 +490,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
         event.preventDefault();
         const next = this.hideAutoComplete.next();
 
-        if (!!next) {
+        if (next) {
           this.hideInputRef.value = next;
           this.hideInputRef.scrollLeft = this.hideInputRef.scrollWidth;
           this.setState({ hideInputValue: next, hideError: undefined });
@@ -561,7 +563,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     console.debug(`Hide selector=[${JSON.stringify(selector)}]`);
 
     // unhide hidden elements when we are dealing with the same graph. Either way,release for garbage collection
-    if (!!this.hiddenElements && !graphChanged) {
+    if (this.hiddenElements && !graphChanged) {
       needLayout = true;
       this.hiddenElements.forEach(e => this.unhideElement(graph, e));
     }
@@ -640,10 +642,11 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       // we need to remove edges completely because an invisible edge is not
       // ignored by layout (I don't know why, nodes are ignored)
       finalEdges.forEach(e => e.remove());
+
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 
-    if (needLayout || !!this.hiddenElements) {
+    if (needLayout || this.hiddenElements) {
       controller.getGraph().reset();
       controller.getGraph().layout();
       controller.getGraph().fit(FIT_PADDING);
@@ -663,7 +666,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     this.findElements = undefined;
 
     // add new find-hits
-    if (!!selector.nodeSelector || !!selector.edgeSelector) {
+    if (selector.nodeSelector || selector.edgeSelector) {
       const { nodes, edges } = elems(controller);
       let findNodes = [] as GraphElement[];
       let findEdges = [] as GraphElement[];
@@ -686,10 +689,10 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
 
   private setError(error: string | undefined, isFind: boolean): undefined {
     if (isFind && error !== this.state.findError) {
-      const findError = !!error ? `Find: ${error}` : undefined;
+      const findError = error ? `Find: ${error}` : undefined;
       this.setState({ findError: findError });
     } else if (error !== this.state.hideError) {
-      const hideError = !!error ? `Hide: ${error}` : undefined;
+      const hideError = error ? `Hide: ${error}` : undefined;
       this.setState({ hideError: hideError });
     }
 

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -288,7 +288,7 @@ const TopologyContent: React.FC<{
       initialLayout = false;
       onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
     }
-  }, [fitView]);
+  }, [controller, fitView, onReady, setSelectedIds]);
 
   //
   // Set detail levels for graph (control zoom-sensitive labels)

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -68,6 +68,7 @@ import { tcpTimerConfig, timerConfig } from 'components/CytoscapeGraph/TrafficAn
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { supportsGroups } from 'utils/GraphUtils';
+import { GraphRefs } from './GraphPagePF';
 
 let initialLayout = false;
 let requestFit = false;
@@ -116,7 +117,7 @@ const TopologyContent: React.FC<{
   layoutName: LayoutName;
   onEdgeTap?: (edge: Edge<EdgeModel>) => void;
   onNodeTap?: (node: Node<NodeModel>) => void;
-  onReady: (controller: any) => void;
+  onReady: (refs: GraphRefs) => void;
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (val: LayoutName) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;
@@ -279,6 +280,13 @@ const TopologyContent: React.FC<{
     if (requestFit) {
       requestFit = false;
       fitView();
+    }
+
+    // we need to finish the initial layout before we advertise to the outside
+    // world that the graph is ready for external processing (like find/hide)
+    if (initialLayout) {
+      initialLayout = false;
+      onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
     }
   }, [fitView]);
 
@@ -519,13 +527,8 @@ const TopologyContent: React.FC<{
       }
     };
 
-    const initialGraph = !controller.hasGraph();
     console.debug(`updateModel`);
     updateModel(controller);
-    if (initialGraph) {
-      console.debug('onReady');
-      onReady(controller);
-    }
 
     // notify that the graph has been updated
     const updateModelTime = Date.now();
@@ -571,6 +574,7 @@ const TopologyContent: React.FC<{
   // Leave them for now, they are just good for understanding state changes while we develop this PFT graph.
   React.useEffect(() => {
     console.debug(`controller changed`);
+    initialLayout = true;
   }, [controller]);
 
   React.useEffect(() => {
@@ -591,7 +595,6 @@ const TopologyContent: React.FC<{
 
   React.useEffect(() => {
     console.debug(`onReady changed`);
-    initialLayout = true;
   }, [onReady]);
 
   React.useEffect(() => {
@@ -656,7 +659,6 @@ const TopologyContent: React.FC<{
 
     // When the initial layoutName property is set it is premature to perform a layout
     if (initialLayout) {
-      initialLayout = false;
       return;
     }
 
@@ -821,7 +823,7 @@ export const GraphPF: React.FC<{
   layout: Layout;
   onEdgeTap?: (edge: Edge<EdgeModel>) => void;
   onNodeTap?: (node: Node<NodeModel>) => void;
-  onReady: (controller: any) => void;
+  onReady: (refs: GraphRefs) => void;
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (layout: Layout) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -198,6 +198,13 @@ const TopologyContent: React.FC<{
       requestFit = false;
       fitView();
     }
+
+    // we need to finish the initial layout before we advertise to the outside
+    // world that the graph is ready for external processing (like find/hide)
+    if (initialLayout) {
+      initialLayout = false;
+      onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
+    }
   }, [fitView]);
 
   //
@@ -383,14 +390,8 @@ const TopologyContent: React.FC<{
       nodes.forEach(n => setNodeAttachments(n));
     };
 
-    const initialGraph = !controller.hasGraph();
     console.debug(`mesh updateModel`);
     updateModel(controller);
-
-    if (initialGraph) {
-      console.debug('mesh onReady');
-      onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
-    }
 
     // notify that the graph has been updated
     setUpdateTime(Date.now());
@@ -400,6 +401,7 @@ const TopologyContent: React.FC<{
   // Leave them for now, they are just good for understanding state changes while we develop this PFT graph.
   React.useEffect(() => {
     console.debug(`controller changed`);
+    initialLayout = true;
   }, [controller]);
 
   React.useEffect(() => {
@@ -416,7 +418,6 @@ const TopologyContent: React.FC<{
 
   React.useEffect(() => {
     console.debug(`onReady changed`);
-    initialLayout = true;
   }, [onReady]);
 
   React.useEffect(() => {
@@ -433,7 +434,6 @@ const TopologyContent: React.FC<{
 
     // When the initial layoutName property is set it is premature to perform a layout
     if (initialLayout) {
-      initialLayout = false;
       return;
     }
 

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -205,7 +205,7 @@ const TopologyContent: React.FC<{
       initialLayout = false;
       onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
     }
-  }, [fitView]);
+  }, [controller, fitView, onReady, setSelectedIds]);
 
   //
   // Set detail levels for graph (control zoom-sensitive labels)

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -123,23 +123,23 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     const urlParams = new URLSearchParams(location.getSearch());
     const urlFind = HistoryManager.getParam(URLParam.MESH_FIND, urlParams);
 
-    if (!!urlFind) {
+    if (urlFind) {
       if (urlFind !== findValue) {
         findValue = urlFind;
         props.setFindValue(urlFind);
       }
-    } else if (!!findValue) {
+    } else if (findValue) {
       HistoryManager.setParam(URLParam.MESH_FIND, findValue);
     }
 
     const urlHide = HistoryManager.getParam(URLParam.MESH_HIDE, urlParams);
 
-    if (!!urlHide) {
+    if (urlHide) {
       if (urlHide !== hideValue) {
         hideValue = urlHide;
         props.setHideValue(urlHide);
       }
-    } else if (!!hideValue) {
+    } else if (hideValue) {
       HistoryManager.setParam(URLParam.MESH_HIDE, hideValue);
     }
 
@@ -184,6 +184,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       return;
     }
 
+    const controllerChanged = this.props.controller !== prevProps.controller;
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
     const meshChanged = this.props.updateTime !== prevProps.updateTime;
@@ -205,7 +206,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     }
 
     // make sure the value is updated if there was a change
-    if (findChanged || (meshChanged && !!this.props.findValue)) {
+    if (controllerChanged || findChanged || (meshChanged && this.props.findValue)) {
       // ensure findInputValue is aligned if findValue is set externally (e.g. resetSettings)
       if (this.state.findInputValue !== this.props.findValue) {
         this.setFind(this.props.findValue);
@@ -214,7 +215,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       this.handleFind(this.props.controller);
     }
 
-    if (hideChanged || (meshChanged && !!this.props.hideValue)) {
+    if (controllerChanged || hideChanged || (meshChanged && this.props.hideValue)) {
       // ensure hideInputValue is aligned if hideValue is set externally (e.g. resetSettings)
       if (this.state.hideInputValue !== this.props.hideValue) {
         this.setHide(this.props.hideValue);
@@ -354,7 +355,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
         event.preventDefault();
         const next = this.findAutoComplete.next();
 
-        if (!!next) {
+        if (next) {
           this.findInputRef.value = next;
           this.findInputRef.scrollLeft = this.findInputRef.scrollWidth;
           this.setState({ findInputValue: next, findError: undefined });
@@ -416,7 +417,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
         event.preventDefault();
         const next = this.hideAutoComplete.next();
 
-        if (!!next) {
+        if (next) {
           this.hideInputRef.value = next;
           this.hideInputRef.scrollLeft = this.hideInputRef.scrollWidth;
           this.setState({ hideInputValue: next, hideError: undefined });
@@ -489,7 +490,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     console.debug(`Mesh Hide selector=[${JSON.stringify(selector)}]`);
 
     // unhide hidden elements when we are dealing with the same mesh. Either way,release for garbage collection
-    if (!!this.hiddenElements && !meshChanged) {
+    if (this.hiddenElements && !meshChanged) {
       needLayout = true;
       this.hiddenElements.forEach(e => this.unhideElement(mesh, e));
     }
@@ -552,7 +553,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 
-    if (needLayout || !!this.hiddenElements) {
+    if (needLayout || this.hiddenElements) {
       controller.getGraph().reset();
       controller.getGraph().layout();
       controller.getGraph().fit(FIT_PADDING);
@@ -572,7 +573,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     this.findElements = undefined;
 
     // add new find-hits
-    if (!!selector.nodeSelector || !!selector.edgeSelector) {
+    if (selector.nodeSelector || selector.edgeSelector) {
       const { nodes, edges } = elems(controller);
       let findNodes = [] as GraphElement[];
       let findEdges = [] as GraphElement[];
@@ -595,10 +596,10 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
 
   private setError(error: string | undefined, isFind: boolean): undefined {
     if (isFind && error !== this.state.findError) {
-      const findError = !!error ? `Find: ${error}` : undefined;
+      const findError = error ? `Find: ${error}` : undefined;
       this.setState({ findError: findError });
     } else if (error !== this.state.hideError) {
-      const hideError = !!error ? `Hide: ${error}` : undefined;
+      const hideError = error ? `Hide: ${error}` : undefined;
       this.setState({ hideError: hideError });
     }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/7781

- Fix issue with bookmarked find/hide not being evaluated in PFT graph or Mesh page

@leandroberetta - This fix also provides the infrastructure for PFT cypress tests to access the graph in the same way as the Mesh Page cypress tests.

To Test:
1. Define a graph find or hide expression. It should work fine.
2. Do a full refresh of the Bookmarked page

Before: The expression is populated in the toolbar but does not get applied until the first refresh.
After: The expression is populated in the toolbar and gets applied immediately.