### PR TITLE
Apply our own bendpoint logic to parallel edges

### DIFF
--- a/frontend/src/pages/GraphPF/elements/extendedBaseEdge.ts
+++ b/frontend/src/pages/GraphPF/elements/extendedBaseEdge.ts
@@ -1,4 +1,4 @@
-import { BaseEdge, Point } from '@patternfly/react-topology';
+import { BaseEdge, Edge, Point } from '@patternfly/react-topology';
 
 // This extends BaseEdge to eliminate Bendpoints when possible (mainly because Dagre layout
 // does not provide an option to use or not use bendpoints). Bendpoints must be honored when
@@ -11,27 +11,78 @@ import { BaseEdge, Point } from '@patternfly/react-topology';
 //};
 
 export class ExtendedBaseEdge extends BaseEdge {
-  getBendpoints(): Point[] {
-    if (this.hasParallelEdge()) {
-      return super.getBendpoints();
+  // setBendpoint override ensures no bendpoints (straight edges) except when there are
+  // multiple (i.e. parallel) edges between the same source and dest (i.e. traffic for
+  // different protocols).
+  setBendpoints(points: Point[]): void {
+    if (points.length === 0) {
+      return super.setBendpoints([]);
     }
-    return [];
+
+    const parallelEdges = this.getParallelEdges();
+    if (parallelEdges.length === 0) {
+      return super.setBendpoints([]);
+    }
+
+    (this as ExtendedBaseEdge).setParallelBendpoints(parallelEdges);
   }
 
-  setBendpoints(_points: Point[]): void {
-    super.setBendpoints(this.hasParallelEdge() ? _points : []);
+  // setParallelBendpoints applies our custom "skinny diamond" bendpoint strategy. For two edges
+  // set a single bendpoint for each, mirrored over the imaginary straight edge. If there is a
+  // third edge (very unlikely, but covers tcp, http and grpc), use a straight edge for the 3rd.
+  setParallelBendpoints(parallelEdges: Edge[]): void {
+    const sortedSourceEdges = parallelEdges.sort((a, b) => a.getId().localeCompare(b.getId()));
+    sortedSourceEdges.forEach((e, i) =>
+      (e as ExtendedBaseEdge).setBendpointsDirect(ExtendedBaseEdge.getCustomBendpoints(e, i))
+    );
   }
 
-  private hasParallelEdge(): boolean {
+  setBendpointsDirect(points: Point[]): void {
+    super.setBendpoints(points);
+  }
+
+  private static getCustomBendpoints(e: Edge, edgeNum: number): Point[] {
+    let bendpoint: Point | undefined;
+    const x1 = e.getStartPoint().x;
+    const y1 = e.getStartPoint().y;
+    const x2 = e.getEndPoint().x;
+    const y2 = e.getEndPoint().y;
+    const len = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+    const xMid = (x1 + x2) / 2;
+    const yMid = (y1 + y2) / 2;
+    const h = 20; // arbitrary height that tries to be not too skinny or too wide
+    switch (edgeNum) {
+      case 0: {
+        // slightly to one side of center
+        const x = xMid + ((y2 - y1) / len) * h;
+        const y = yMid + ((x1 - x2) / len) * h;
+        bendpoint = new Point(x, y);
+        break;
+      }
+      case 1: {
+        // slightly to other side of center
+        const x = xMid - ((y2 - y1) / len) * h;
+        const y = yMid - ((x1 - x2) / len) * h;
+        bendpoint = new Point(x, y);
+        break;
+      }
+      default:
+      // in the case of a 3rd protocal, use a straight edge
+    }
+
+    return bendpoint ? [bendpoint] : [];
+  }
+
+  private getParallelEdges(): Edge[] {
+    // find source edges with the same destination
     const sourceEdges = this.getSource()
       .getSourceEdges()
-      .filter(e => e.getTarget() === this.getTarget());
+      .filter(e => e.getTarget().getId() === this.getTarget().getId());
 
     if (sourceEdges.length < 2) {
-      return false;
+      return [];
     }
 
-    const targets = new Set(sourceEdges.map(e => e.getTarget().getId()));
-    return targets.size < sourceEdges.length;
+    return sourceEdges;
   }
 }

--- a/frontend/src/pages/GraphPF/layouts/ExtendedDagreLayout.ts
+++ b/frontend/src/pages/GraphPF/layouts/ExtendedDagreLayout.ts
@@ -1,0 +1,29 @@
+import { DragEvent, DagreLayout, DragOperationWithType, Layout, Node } from '@patternfly/react-topology';
+import { descendents } from '../GraphPFElems';
+
+export class ExtendedDagreLayout extends DagreLayout implements Layout {
+  // endDrag override allows us to get around what I consider a PFT bug, and update any
+  // bendpoints after the drag operation.
+  protected endDrag(element: Node, event: DragEvent, operation: DragOperationWithType): void {
+    super.endDrag(element, event, operation);
+
+    if (element.isGroup()) {
+      this.endGroupDrag(element);
+    } else {
+      this.endNodeDrag(element, true);
+    }
+  }
+
+  private endGroupDrag(group: Node): void {
+    // to avoid processing both ends of every edge, just do the source edges
+    descendents(group).forEach(n => this.endNodeDrag(n, false));
+  }
+
+  private endNodeDrag(node: Node, includeTargetEdges: boolean): void {
+    // update bendpoints as needed
+    node.getSourceEdges().forEach(e => e.setBendpoints(e.getBendpoints()));
+    if (includeTargetEdges) {
+      node.getTargetEdges().forEach(e => e.setBendpoints(e.getBendpoints()));
+    }
+  }
+}

--- a/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
+++ b/frontend/src/pages/GraphPF/layouts/layoutFactory.ts
@@ -1,13 +1,13 @@
 import {
   Graph,
   Layout,
-  DagreLayout,
   GridLayout,
   ConcentricLayout,
   LayoutFactory,
   BreadthFirstLayout
 } from '@patternfly/react-topology';
 import { LayoutName } from '../GraphPF';
+import { ExtendedDagreLayout } from './ExtendedDagreLayout';
 
 /*
 This is just for reference, a copy of PFT defaults, so we can compare any tweaks we've made below...
@@ -35,7 +35,7 @@ export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
         nodeDistance: 50
       });
     default:
-      return new DagreLayout(graph, {
+      return new ExtendedDagreLayout(graph, {
         linkDistance: 40, // edgesep
         nodeDistance: 25, // nodesep
         ranksep: 15,


### PR DESCRIPTION
Fixes #7780

Apply our own bendpoint logic to parallel edges.  Use simple bendpoints and update them when needed (after drag).

@josunect This is what I came up with to solve the parallel edge issue.  Read the [issue description](https://github.com/kiali/kiali/issues/7780) and it talks about the problem and two options.  This is the second option.  We could still look at option 1 in the future, but I ended up going with something that was a smaller overall change.  The coding was a little tricky, but it's not as big as trying to merge edges, both in implementation and in UX impact