### PR TITLE
Set default graph impl to PFT

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -823,7 +823,7 @@ func NewConfig() (c *Config) {
 							Expression:  "rank > 2",
 						},
 					},
-					Impl: "cy",
+					Impl: "pf",
 					Settings: GraphSettings{
 						FontLabel:    13,
 						MinFontBadge: 7,

--- a/frontend/cypress/integration/common/authorization-pf.ts
+++ b/frontend/cypress/integration/common/authorization-pf.ts
@@ -11,7 +11,7 @@ Then(`user see the {string} link`, link => {
 
 Then('the nodes on the patternfly graph located in the {string} cluster should be restricted', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph-pf.ts
+++ b/frontend/cypress/integration/common/graph-pf.ts
@@ -20,7 +20,7 @@ Then(
   'user sees the {string} namespace deployed across the east and west clusters in the patternfly graph',
   (namespace: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')
@@ -42,7 +42,7 @@ Then(
   'nodes in the {string} cluster in the patternfly graph should contain the cluster name in their links',
   (cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')
@@ -66,7 +66,7 @@ Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster in the patternfly graph',
   (workload: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph_context_menu-pf.ts
+++ b/frontend/cypress/integration/common/graph_context_menu-pf.ts
@@ -6,7 +6,7 @@ When('user opens the context menu of the {string} service node in the patternfly
   ensureKialiFinishedLoading();
   cy.waitForReact();
 
-  cy.getReact('GraphPagePFComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPagePFComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('GraphPF').should('have.length', '1');
@@ -20,7 +20,7 @@ When(
   (svcName: string, cluster: string) => {
     ensureKialiFinishedLoading();
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph_display-pf.ts
+++ b/frontend/cypress/integration/common/graph_display-pf.ts
@@ -143,7 +143,7 @@ Then('the display menu has default settings', () => {
 
 Then('the patternfly graph reflects default settings', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -191,7 +191,7 @@ Then('user sees {string} edge labels in the patternfly graph', (el: string) => {
   }
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -212,7 +212,7 @@ Then('user does not see {string} boxing in the patternfly graph', (boxByType: st
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -236,7 +236,7 @@ Then('idle edges {string} in the patternfly graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -261,7 +261,7 @@ Then('idle nodes {string} in the patternfly graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -282,7 +282,7 @@ Then('ranks {string} in the patternfly graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -303,7 +303,7 @@ Then('user does not see service nodes in the patternfly graph', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -320,7 +320,7 @@ Then('security {string} in the patternfly graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -375,7 +375,7 @@ Then('the {string} option should {string} and {string}', (option: string, option
 
 Then('only a single cluster box should be visible in the patternfly graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -452,7 +452,7 @@ Then(
   'user double-clicks on the {string} {string} from the {string} cluster in the main patternfly graph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')
@@ -487,7 +487,7 @@ When('user {string} {string} traffic option', (action: string, option: string) =
 
 Then('{int} edges appear in the patternfly graph', (edges: number) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph_find_hide-pf.ts
+++ b/frontend/cypress/integration/common/graph_find_hide-pf.ts
@@ -30,7 +30,7 @@ Then('user sees unhealthy workloads highlighted on the patternfly graph', () => 
     }
   ];
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -54,7 +54,7 @@ Then('user sees nothing highlighted on the patternfly graph', () => {
   cy.contains('Loading Graph').should('not.exist');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -74,7 +74,7 @@ When('user hides unhealthy workloads', () => {
 
 Then('user sees no unhealthy workloads on the patternfly graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -111,7 +111,7 @@ When('user selects the preset hide option {string}', (option: string) => {
 
 Then('user sees no healthy workloads on the patternfly graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph_side_panel-pf.ts
+++ b/frontend/cypress/integration/common/graph_side_panel-pf.ts
@@ -2,7 +2,7 @@ import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 When('user clicks the {string} {string} node in the patternfly graph', (svcName: string, nodeType: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -19,7 +19,7 @@ When(
   'user clicks the edge from {string} {string} to {string} {string} in the patternfly graph',
   (svcName: string, nodeType: string, destSvcName: string, destNodeType: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')
@@ -141,7 +141,7 @@ When(
   'user clicks the {string} service node in the {string} namespace in the {string} cluster in the patternfly graph',
   (service: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { isReady: true } })
       .should('have.length', '1')
       .then(() => {
         cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/graph_toolbar-pf.ts
+++ b/frontend/cypress/integration/common/graph_toolbar-pf.ts
@@ -126,7 +126,7 @@ Then('user does not see graph traffic menu', () => {
 
 Then('user {string} {string} traffic', (action: string, protocol: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')
@@ -228,7 +228,7 @@ Then('user sees selected graph refresh {string}', (refresh: string) => {
 
 Then('user sees a {string} patternfly graph', graphType => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { isReady: true } })
     .should('have.length', '1')
     .then(() => {
       cy.getReact('CytoscapeGraph')

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -30,7 +30,7 @@ When('user opens mesh tour', () => {
 
 When('user selects cluster mesh node', () => {
   cy.waitForReact();
-  cy.getReact('MeshPageComponent', { state: { meshData: { isLoading: false } } })
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
@@ -46,7 +46,7 @@ When('user selects cluster mesh node', () => {
 
 When('user selects mesh node with label {string}', (label: string) => {
   cy.waitForReact();
-  cy.getReact('MeshPageComponent', { state: { meshData: { isLoading: false } } })
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
@@ -110,7 +110,7 @@ Then('user sees data plane side panel', () => {
 
 Then('user sees expected mesh infra', () => {
   cy.waitForReact();
-  cy.getReact('MeshPageComponent', { state: { meshData: { isLoading: false } } })
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {
@@ -134,7 +134,7 @@ Then(
   'user sees {int} {string} nodes on the {string} cluster',
   (numberOfDataplaneNodes: number, infraNodeType: MeshInfraType, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('MeshPageComponent', { state: { meshData: { isLoading: false } } })
+    cy.getReact('MeshPageComponent', { state: { isReady: true } })
       .should('have.length', 1)
       .getCurrentState()
       .then(state => {
@@ -151,7 +151,7 @@ Then(
 
 Then('user sees the istiod node connected to the dataplane nodes', () => {
   cy.waitForReact();
-  cy.getReact('MeshPageComponent', { state: { meshData: { isLoading: false } } })
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
     .should('have.length', 1)
     .getCurrentState()
     .then(state => {

--- a/frontend/cypress/integration/featureFiles/graph_toolbar-cy.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar-cy.feature
@@ -49,9 +49,9 @@ Feature: Kiali Graph page - Toolbar (various)
   Scenario: Enable http traffic
     When user disables all traffic
     When user enables "http" traffic
-    Then user "sees" "http" traffic
-    And user "does not see" "tcp" traffic
-    And user "does not see" "grpc" traffic
+    Then user "sees" "http" traffic in the cytoscape graph
+    And user "does not see" "tcp" traffic in the cytoscape graph
+    And user "does not see" "grpc" traffic in the cytoscape graph
 
   @error-rates-app
   Scenario: Close traffic dropdown

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -99,7 +99,7 @@ const defaultServerConfig: ComputedServerConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        impl: 'cy',
+        impl: 'pf',
         settings: {
           fontLabel: 13,
           minFontBadge: 7,
@@ -124,8 +124,7 @@ const defaultServerConfig: ComputedServerConfig = {
       },
       mesh: {
         findOptions: [],
-        hideOptions: [],
-        impl: 'classic'
+        hideOptions: []
       }
     }
   },

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -170,6 +170,7 @@ type WizardsData = {
 type GraphPageStatePF = {
   graphData: GraphData;
   graphRefs?: GraphRefs;
+  isReady: boolean;
   showConfirmDeleteTrafficRouting: boolean;
   wizardsData: WizardsData;
 };
@@ -313,7 +314,7 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
         isLoading: true,
         timestamp: 0
       },
-
+      isReady: false,
       wizardsData: {
         showWizard: false,
         wizardType: '',
@@ -558,7 +559,7 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
   };
 
   private handleReady = (refs: GraphRefs): void => {
-    this.setState({ graphRefs: refs });
+    this.setState({ graphRefs: refs, isReady: true });
   };
 
   private handleEmptyGraphAction = (): void => {

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -94,6 +94,7 @@ export type MeshRefs = {
 };
 
 type MeshPageState = {
+  isReady: boolean;
   meshData: MeshData;
   meshRefs?: MeshRefs;
 };
@@ -142,6 +143,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
     this.meshDataSource = new MeshDataSource();
 
     this.state = {
+      isReady: false,
       meshData: {
         elements: { edges: [], nodes: [] },
         elementsChanged: false,
@@ -263,7 +265,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
   }
 
   private handleReady = (refs: MeshRefs): void => {
-    this.setState({ meshRefs: refs });
+    this.setState({ isReady: true, meshRefs: refs });
   };
 
   private handleEmptyMeshAction = (): void => {

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -85,7 +85,7 @@ export const serverRateConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        impl: 'cy',
+        impl: 'pf',
         settings: {
           fontLabel: 13,
           minFontBadge: 7,
@@ -110,8 +110,7 @@ export const serverRateConfig = {
       },
       mesh: {
         findOptions: [],
-        hideOptions: [],
-        impl: 'classic'
+        hideOptions: []
       },
       metricsPerRefresh: '1m',
       namespaces: [],

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -67,7 +67,6 @@ interface ListUIDefaults {
 interface MeshUIDefaults {
   findOptions: GraphFindOption[];
   hideOptions: GraphFindOption[];
-  impl: string; // classic | topo | topo-no-overview
 }
 
 interface UIDefaults {

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -19,7 +19,7 @@ export const healthConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        impl: 'cy',
+        impl: 'pf',
         settings: {
           fontLabel: 13,
           minFontBadge: 7,
@@ -44,8 +44,7 @@ export const healthConfig = {
       },
       mesh: {
         findOptions: [],
-        hideOptions: [],
-        impl: 'classic'
+        hideOptions: []
       },
       metricsPerRefresh: '1m',
       namespaces: [],

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -182,6 +182,7 @@ deploy_kiali() {
     --set deployment.logger.log_level="debug"
     --set external_services.grafana.external_url="http://grafana.istio-system:3000"
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard"
+    --set kiali_feature_flags.ui_defaults.graph.impl="cy"
     --set health_config.rate[0].kind="service"
     --set health_config.rate[0].name="y-server"
     --set health_config.rate[0].namespace="alpha"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -316,6 +316,7 @@ setup_kind_tempo() {
     --set health_config.rate[0].tolerance[0].code="5xx" \
     --set health_config.rate[0].tolerance[0].degraded=2 \
     --set health_config.rate[0].tolerance[0].failure=100 \
+    --set kiali_feature_flags.ui_defaults.graph.impl="cy" \
     kiali-server \
     "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz
   

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -237,6 +237,7 @@ setup_kind_singlecluster() {
     --set health_config.rate[0].tolerance[0].code="5xx" \
     --set health_config.rate[0].tolerance[0].degraded=2 \
     --set health_config.rate[0].tolerance[0].failure=100 \
+    --set kiali_feature_flags.ui_defaults.graph.impl="cy" \
     kiali-server \
     "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz
 


### PR DESCRIPTION
Closes #7785 

- Set default graph impl to PFT
- also remove some old, hidden mesh page options
- maintains cytoscape in CI until we want to change the tests to PFT (WIP)
- fix an issue in the cy/pft test split
- also, this fixes test flakiness introduced in the recent PR to fix find/hide, as well as add support for PFT cypress testing.  That change slightly delayed when the PFT controller was made available to the test code, which could cause a flake when the test tried to access it prematurely.  This should ensure that the controller is available prior to the test trying to use it.
