### PR TITLE
[hack] update dex

### DIFF
--- a/hack/k8s-minikube.sh
+++ b/hack/k8s-minikube.sh
@@ -24,7 +24,7 @@ set -u
 DEFAULT_CLIENT_EXE="kubectl"
 DEFAULT_DEX_ENABLED="false"
 DEFAULT_DEX_REPO="https://github.com/dexidp/dex"
-DEFAULT_DEX_VERSION="v2.30.2"
+DEFAULT_DEX_VERSION="v2.41.1"
 DEFAULT_DEX_USER_NAMESPACES="bookinfo"
 DEFAULT_INSECURE_REGISTRY_IP=""
 DEFAULT_K8S_CNI="auto"
@@ -165,10 +165,6 @@ EOF
 <   replicas: 3
 ---
 >   replicas: 1
-26c26
-<       - image: dexidp/dex:v2.27.0 #or quay.io/dexidp/dex:v2.26.0
----
->       - image: docker.io/dexidp/dex:${DEX_VERSION}
 41c41
 <         - name: GITHUB_CLIENT_ID
 ---
@@ -200,7 +196,7 @@ EOF
 <         org: kubernetes
 94a81
 >       responseTypes: ["code", "id_token"]
-96a84,89
+101a89,94
 >     - id: kiali-app
 >       redirectURIs:
 >       - 'http://${MINIKUBE_IP}/kiali'

--- a/hack/k8s-minikube.sh
+++ b/hack/k8s-minikube.sh
@@ -256,7 +256,7 @@ spec:
         - --config
         - /etc/oauthproxy/oauth2-proxy.conf
         env: []
-        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Update to Dex 2.41.1.

The reason for this is because currently, and for some unknown reason, the oauth proxy that gets started now hits this error (it did NOT get this error two days ago):

```
$ kubectl logs -n oauth2-proxy  deployments/oauth2-proxy 
[2024/10/03 20:09:10] [provider.go:55] Performing OIDC Discovery...
[2024/10/03 20:09:10] [main.go:59] ERROR: Failed to initialise OAuth2 Proxy: error initialising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: failed to discover OIDC configuration: error performing request: Get "https://192-168-39-217.nip.io:32000/.well-known/openid-configuration": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

Not sure what happened, but it looks like the root cert that is used is no longer valid.

This causes the header-auth-test molecule test to fail (simply because the oauth proxy in front of Dex is failing to start).

_UPDATE: Something broke in oauth2-proxy - known issue as of today. See https://github.com/oauth2-proxy/oauth2-proxy/issues/2802_