### PR TITLE
[hack] k8s-minikube.sh to pin to oauth v7.6.0 

### DIFF
--- a/hack/k8s-minikube.sh
+++ b/hack/k8s-minikube.sh
@@ -260,7 +260,7 @@ spec:
         - --config
         - /etc/oauthproxy/oauth2-proxy.conf
         env: []
-        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
due to https://github.com/oauth2-proxy/oauth2-proxy/issues/2802

Without this fix, some of the molecule tests fail
