### PR TITLE
Hide node kebab context menus from pft graph

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -210,8 +210,13 @@ export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSetti
 
 const labelIconStyle = kialiStyle({
   color: PFColors.White,
-  fontSize: '14px',
-  marginBottom: '1px'
+  marginLeft: '0.125rem'
+});
+
+const gatewayIconStyle = kialiStyle({
+  color: PFColors.White,
+  display: 'flex',
+  marginTop: '-0.125rem'
 });
 
 export const setNodeLabel = (
@@ -260,21 +265,17 @@ export const setNodeLabel = (
       data.isGateway?.ingressInfo?.hostnames?.length !== undefined ||
       data.isGateway?.gatewayAPIInfo?.hostnames?.length !== undefined
     ) {
-      data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${labelIconStyle}`}></span>;
+      data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${gatewayIconStyle}`}></span>;
     } else {
-      data.labelIcon = (
-        <span className={`${badgeMap.get('RO')?.className} ${labelIconStyle}`} style={{ marginLeft: '2px' }}></span>
-      );
+      data.labelIcon = <span className={`${badgeMap.get('RO')?.className} ${labelIconStyle}`}></span>;
     }
   } else {
     if (data.isGateway?.egressInfo?.hostnames?.length !== undefined) {
-      data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${labelIconStyle}`}></span>;
+      data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${gatewayIconStyle}`}></span>;
     }
     // A Waypoint should be mutually exclusive with being a traffic source
     if (data.isWaypoint) {
-      data.labelIcon = (
-        <span className={`${badgeMap.get('WA')?.className} ${labelIconStyle}`} style={{ marginLeft: '2px' }}></span>
-      );
+      data.labelIcon = <span className={`${badgeMap.get('WA')?.className} ${labelIconStyle}`}></span>;
     }
   }
 

--- a/frontend/src/pages/GraphPF/styles/styleGroup.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleGroup.tsx
@@ -38,6 +38,30 @@ const focusOverlayStyle = kialiStyle({
   stroke: ColorFocus
 });
 
+// the selected group has an active border, but the background remains unchanged
+const selectedGroupStyle = {
+  $nest: {
+    '& .pf-topology__group__background': {
+      fill: PFColors.BackgroundColorLight300,
+      stroke: PFColors.Active
+    },
+    '&.pf-m-alt-group .pf-topology__group__background': {
+      fill: 'var(--pf-topology__group--m-alt-group--topology__group__background--Fill)',
+      stroke: PFColors.Active
+    }
+  }
+};
+
+const groupClass = kialiStyle({
+  $nest: {
+    '&.pf-m-selected': selectedGroupStyle,
+    '&.pf-m-selected.pf-m-hover': selectedGroupStyle,
+    '&.pf-m-hover .pf-topology__group__background': {
+      stroke: PFColors.Color200
+    }
+  }
+});
+
 const StyleGroupComponent: React.FC<StyleGroupProps> = ({
   collapsedHeight = 75,
   collapsedWidth = 75,
@@ -60,30 +84,6 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
   const onMouseLeave = (): void => {
     data.onHover(element, false);
   };
-
-  // the selected group has an active border, but the background remains unchanged
-  const selectedGroupStyle = {
-    $nest: {
-      '& .pf-topology__group__background': {
-        fill: PFColors.BackgroundColorLight300,
-        stroke: PFColors.Active
-      },
-      '&.pf-m-alt-group .pf-topology__group__background': {
-        fill: 'var(--pf-topology__group--m-alt-group--topology__group__background--Fill)',
-        stroke: PFColors.Active
-      }
-    }
-  };
-
-  const groupClass = kialiStyle({
-    $nest: {
-      '&.pf-m-selected': selectedGroupStyle,
-      '&.pf-m-selected.pf-m-hover': selectedGroupStyle,
-      '&.pf-m-hover .pf-topology__group__background': {
-        stroke: PFColors.Color200
-      }
-    }
-  });
 
   const passedData = React.useMemo(() => {
     const newData = { ...data };

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -86,6 +86,7 @@ const nodeClass = kialiStyle({
   }
 });
 
+// Hide the kebab menu of Patternfly topology nodes
 const labelClass = kialiStyle({
   $nest: {
     '& text:not(.pf-m-secondary)': {

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -74,6 +74,32 @@ const getNodeShape = (node: Node): React.FunctionComponent<ShapeProps> => {
   }
 };
 
+const nodeClass = kialiStyle({
+  $nest: {
+    '&.pf-m-hover': {
+      cursor: 'pointer'
+    },
+    '&.pf-m-selected .pf-topology__node__background': {
+      stroke: PFColors.Active,
+      strokeWidth: 6
+    }
+  }
+});
+
+const labelClass = kialiStyle({
+  $nest: {
+    '& text:not(.pf-m-secondary)': {
+      transform: 'translateX(10px)'
+    },
+    '& .pf-topology__node__action-icon': {
+      display: 'none'
+    },
+    '& text ~ .pf-topology__node__separator': {
+      display: 'none'
+    }
+  }
+});
+
 const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
   const data = element.getData();
   const detailsLevel = useDetailsLevel();
@@ -117,18 +143,6 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
     data.onHover(element, false);
   };
 
-  const nodeClass = kialiStyle({
-    $nest: {
-      '&.pf-m-hover': {
-        cursor: 'pointer'
-      },
-      '&.pf-m-selected .pf-topology__node__background': {
-        stroke: PFColors.Active,
-        strokeWidth: 6
-      }
-    }
-  });
-
   const passedData = React.useMemo(() => {
     const newData = { ...data };
     if (detailsLevel !== ScaleDetailsLevel.high) {
@@ -153,6 +167,7 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
       {data.isFocus && <ShapeComponent className={focusOverlayStyle} width={width} height={height} element={element} />}
       <DefaultNode
         className={nodeClass}
+        labelClassName={labelClass}
         element={element}
         {...rest}
         {...passedData}

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -89,7 +89,7 @@ export const globalStyle = kialiStyle({
     },
 
     /**
-     * Hide kebab menu from Patternfly topology groups
+     * Hide the kebab menu of Patternfly topology groups
      */
     '& .pf-topology__group__label': {
       $nest: {

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -86,6 +86,23 @@ export const globalStyle = kialiStyle({
           color: 'var(--pf-v5-global--link--Color--light--hover)'
         }
       }
+    },
+
+    /**
+     * Hide kebab menu from Patternfly topology groups
+     */
+    '& .pf-topology__group__label': {
+      $nest: {
+        '& .pf-topology__node__label__badge ~ text:not(.pf-m-secondary)': {
+          transform: 'translateX(10px)'
+        },
+        '& .pf-topology__node__action-icon': {
+          display: 'none'
+        },
+        '& text ~ .pf-topology__node__separator': {
+          display: 'none'
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
### Describe the change

This PR hides the node kebab context menus in the PFT graph using CSS, as it is not possible to disable them within patternfly topology

![image](https://github.com/user-attachments/assets/011cb53d-f007-4790-88c4-61ea86f6f077)

I have been able to center the text in the label, but I couldn't reduce the size of the label's rectangle since it is defined programmatically in the `patternfly-topology` library. However, the labels still look nice.

**Bonus:** Fine-tune the CSS of the gateway icon within the gateway label node.

### Steps to test the PR

Look that the kebab menus are hiding in the pft graph and only the right-click action can display the context menu.

### Issue reference

Closes #7803 
