### PR TITLE
Fix margin issue in the label graph in Firefox

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -210,7 +210,9 @@ export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSetti
 
 const labelIconStyle = kialiStyle({
   color: PFColors.White,
-  marginLeft: '0.125rem'
+  display: 'flex',
+  marginLeft: '0.125rem',
+  marginTop: '0.125rem'
 });
 
 const gatewayIconStyle = kialiStyle({

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -93,10 +93,10 @@ const labelClass = kialiStyle({
       transform: 'translateX(10px)'
     },
     '& .pf-topology__node__action-icon': {
-      display: 'none'
+      visibility: 'hidden'
     },
     '& text ~ .pf-topology__node__separator': {
-      display: 'none'
+      visibility: 'hidden'
     }
   }
 });

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -97,10 +97,10 @@ export const globalStyle = kialiStyle({
           transform: 'translateX(10px)'
         },
         '& .pf-topology__node__action-icon': {
-          display: 'none'
+          visibility: 'hidden'
         },
         '& text ~ .pf-topology__node__separator': {
-          display: 'none'
+          visibility: 'hidden'
         }
       }
     }


### PR DESCRIPTION
### Describe the change

PR https://github.com/kiali/kiali/pull/7805 introduces a small margin CSS issue in the Firefox browser. 

![image](https://github.com/user-attachments/assets/aa507fc4-c7f8-4a73-9f4d-64244c67f195)

This PR fixes this small margin issue.

![image](https://github.com/user-attachments/assets/9bfe71db-53c7-4534-af37-98db7a8aab4d)

### Steps to test the PR

Verify that the margin issue is fixed in the Firefox browser

### Automation testing

N/A

### Issue reference

https://github.com/kiali/kiali/issues/7803
