### PR TITLE
Refactor : Gateway Selector - Form Select to Select

### DIFF
--- a/frontend/src/components/IstioWizards/GatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/GatewaySelector.tsx
@@ -69,19 +69,12 @@ export class GatewaySelector extends React.Component<Props, GatewaySelectorState
     this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
   };
 
-  onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
-    this.setState({ selectedGateway: value as string, isOpen: false });
-  };
-
   toggle = (toggleRef: React.Ref<any>) => (
     <MenuToggle
       ref={toggleRef}
       onClick={this.onToggleClick}
       isExpanded={this.state.isOpen} 
       isDisabled={!this.state.addGateway || this.state.newGateway || this.props.gateways.length === 0} 
-      style={{
-        width: '200px',
-      } as React.CSSProperties}
     >
       {this.state.selectedGateway ?? this.props.gateways[0]}
     </MenuToggle>
@@ -142,7 +135,8 @@ export class GatewaySelector extends React.Component<Props, GatewaySelectorState
       case GatewayForm.GATEWAY_SELECTED:
         this.setState(
           {
-            selectedGateway: value
+            selectedGateway: value,
+            isOpen: false,
           },
           () => this.props.onGatewayChange(this.isGatewayValid(), this.state)
         );
@@ -248,7 +242,7 @@ export class GatewaySelector extends React.Component<Props, GatewaySelectorState
                   id="selectGateway"
                   isOpen={this.state.isOpen}
                   selected={this.state.selectedGateway}
-                  onSelect={this.onSelect}
+                  onSelect={(_event, gw) => this.onFormChange(GatewayForm.GATEWAY_SELECTED, gw as string)}
                   onOpenChange={(isOpen: boolean) => {
                     this.setState({ isOpen });
                   }}

--- a/frontend/src/components/IstioWizards/GatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/GatewaySelector.tsx
@@ -4,11 +4,13 @@ import {
   Form,
   FormGroup,
   FormHelperText,
-  FormSelect,
-  FormSelectOption,
   HelperText,
   HelperTextItem,
+  MenuToggle,
   Radio,
+  Select,
+  SelectList,
+  SelectOption,
   Switch,
   TextInput
 } from '@patternfly/react-core';
@@ -35,6 +37,7 @@ export type GatewaySelectorState = {
   gatewayClass: string;
   addMesh: boolean;
   port: number;
+  isOpen: boolean;
 };
 
 enum GatewayForm {
@@ -57,9 +60,32 @@ export class GatewaySelector extends React.Component<Props, GatewaySelectorState
       selectedGateway: props.gateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.gateways[0]) : '',
       gatewayClass: '',
       addMesh: props.isMesh,
-      port: 80
+      port: 80,
+      isOpen: false,
     };
   }
+
+  onToggleClick = () => {
+    this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
+  };
+
+  onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    this.setState({ selectedGateway: value as string, isOpen: false });
+  };
+
+  toggle = (toggleRef: React.Ref<any>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={this.onToggleClick}
+      isExpanded={this.state.isOpen} 
+      isDisabled={!this.state.addGateway || this.state.newGateway || this.props.gateways.length === 0} 
+      style={{
+        width: '200px',
+      } as React.CSSProperties}
+    >
+      {this.state.selectedGateway ?? this.props.gateways[0]}
+    </MenuToggle>
+  );
 
   checkGwHosts = (gwHosts: string): boolean => {
     const hosts = gwHosts.split(',');
@@ -217,20 +243,29 @@ export class GatewaySelector extends React.Component<Props, GatewaySelectorState
             </FormGroup>
             {!this.state.newGateway && (
               <FormGroup fieldId="selectGateway" label={t('Gateway')}>
-                {this.props.gateways.length > 0 && (
-                  <FormSelect
-                    id="selectGateway"
-                    value={this.state.selectedGateway}
-                    isDisabled={!this.state.addGateway || this.state.newGateway || this.props.gateways.length === 0}
-                    onChange={(_event, gw: string) => this.onFormChange(GatewayForm.GATEWAY_SELECTED, gw)}
-                  >
+              {this.props.gateways.length > 0 && (
+                <Select
+                  id="selectGateway"
+                  isOpen={this.state.isOpen}
+                  selected={this.state.selectedGateway}
+                  onSelect={this.onSelect}
+                  onOpenChange={(isOpen: boolean) => {
+                    this.setState({ isOpen });
+                  }}
+                  toggle={this.toggle}
+                  shouldFocusToggleOnSelect
+                >
+                  <SelectList>
                     {this.props.gateways.map(gw => (
-                      <FormSelectOption key={gw} value={gw} label={gw} />
+                      <SelectOption key={gw} value={gw}>
+                        {gw}
+                      </SelectOption>
                     ))}
-                  </FormSelect>
-                )}
-                {this.props.gateways.length === 0 && <>There are no gateways to select.</>}
-              </FormGroup>
+                  </SelectList>
+                </Select>
+              )}
+              {this.props.gateways.length === 0 && <>There are no gateways to select.</>}
+            </FormGroup>
             )}
             {this.state.newGateway && (
               <>

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -269,7 +269,8 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
         selectedGateway: '',
         gatewayClass: '',
         addMesh: false,
-        port: 80
+        port: 80,
+        isOpen: false,
       };
 
       const k8sGateway: K8sGatewaySelectorState = {
@@ -846,6 +847,7 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
 
   render(): React.ReactNode {
     const [gatewaySelected, isMesh] = getInitGateway(this.props.virtualServices);
+    console.log(gatewaySelected, 'ded');
     const k8sGatewaySelected = getInitK8sGateway(this.props.k8sHTTPRoutes, this.props.k8sGRPCRoutes);
 
     const titleAction =

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -847,7 +847,6 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
 
   render(): React.ReactNode {
     const [gatewaySelected, isMesh] = getInitGateway(this.props.virtualServices);
-    console.log(gatewaySelected, 'ded');
     const k8sGatewaySelected = getInitK8sGateway(this.props.k8sHTTPRoutes, this.props.k8sGRPCRoutes);
 
     const titleAction =


### PR DESCRIPTION
### Describe the change

Refactor: Use Select from @patternfly/react-core instead of FormSelect

### Steps to test the PR 

Render GatewaySelector component

Issue : https://github.com/kiali/kiali/issues/7277

![image](https://github.com/user-attachments/assets/9f41502d-981d-4204-8ae2-416868e5b471)
