### PR TITLE
Graph toolbar: Replace disabled with active style

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -71,9 +71,8 @@ import { GraphRefs } from './GraphPagePF';
 import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
 import { ServiceDetailsInfo } from 'types/ServiceInfo';
 import { PeerAuthentication } from 'types/IstioObjects';
-import { kialiStyle } from 'styles/StyleUtils';
-import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
+import { toolbarActiveStyle } from 'styles/GraphStyle';
 
 let initialLayout = false;
 let requestFit = false;
@@ -109,17 +108,6 @@ export interface FocusNode {
   id: string;
   isSelected?: boolean;
 }
-
-const activeIconStyle = kialiStyle({
-  top: '0.25rem',
-  color: PFColors.Active,
-  $nest: {
-    '& svg': {
-      width: '1.25rem',
-      height: '1.25rem'
-    }
-  }
-});
 
 // The is the main graph rendering component
 const TopologyContent: React.FC<{
@@ -748,7 +736,7 @@ const TopologyContent: React.FC<{
                       },
                       icon: (
                         <KialiIcon.LongArrowRight
-                          className={EdgeMode.UNHEALTHY === edgeMode ? activeIconStyle : undefined}
+                          className={EdgeMode.UNHEALTHY === edgeMode ? toolbarActiveStyle : undefined}
                         />
                       ),
                       id: 'toolbar_edge_mode_unhealthy',
@@ -759,7 +747,7 @@ const TopologyContent: React.FC<{
                       id: 'toolbar_edge_mode_none',
                       icon: (
                         <KialiIcon.LongArrowRight
-                          className={EdgeMode.NONE === edgeMode ? activeIconStyle : undefined}
+                          className={EdgeMode.NONE === edgeMode ? toolbarActiveStyle : undefined}
                         />
                       ),
                       tooltip: 'Hide all edges',
@@ -771,7 +759,9 @@ const TopologyContent: React.FC<{
                       ariaLabel: 'Dagre - boxing layout',
                       id: 'toolbar_layout_dagre',
                       icon: (
-                        <KialiIcon.Topology className={LayoutName.Dagre === layoutName ? activeIconStyle : undefined} />
+                        <KialiIcon.Topology
+                          className={LayoutName.Dagre === layoutName ? toolbarActiveStyle : undefined}
+                        />
                       ),
                       tooltip: 'Dagre - boxing layout',
                       callback: () => {
@@ -782,7 +772,9 @@ const TopologyContent: React.FC<{
                       ariaLabel: 'Grid - non-boxing layout',
                       id: 'toolbar_layout_grid',
                       icon: (
-                        <KialiIcon.Topology className={LayoutName.Grid === layoutName ? activeIconStyle : undefined} />
+                        <KialiIcon.Topology
+                          className={LayoutName.Grid === layoutName ? toolbarActiveStyle : undefined}
+                        />
                       ),
                       tooltip: 'Grid - non-boxing layout',
                       callback: () => {
@@ -794,7 +786,7 @@ const TopologyContent: React.FC<{
                       id: 'toolbar_layout_concentric',
                       icon: (
                         <KialiIcon.Topology
-                          className={LayoutName.Concentric === layoutName ? activeIconStyle : undefined}
+                          className={LayoutName.Concentric === layoutName ? toolbarActiveStyle : undefined}
                         />
                       ),
                       tooltip: 'Concentric - non-boxing layout',
@@ -807,7 +799,7 @@ const TopologyContent: React.FC<{
                       id: 'toolbar_layout_breadth_first',
                       icon: (
                         <KialiIcon.Topology
-                          className={LayoutName.BreadthFirst === layoutName ? activeIconStyle : undefined}
+                          className={LayoutName.BreadthFirst === layoutName ? toolbarActiveStyle : undefined}
                         />
                       ),
                       tooltip: 'Breadth First - non-boxing layout',
@@ -832,7 +824,7 @@ const TopologyContent: React.FC<{
                     }
                   },
                   legend: true,
-                  legendIcon: <KialiIcon.Map className={showLegend ? activeIconStyle : undefined} />,
+                  legendIcon: <KialiIcon.Map className={showLegend ? toolbarActiveStyle : undefined} />,
                   legendTip: 'Legend',
                   legendCallback: () => {
                     if (toggleLegend) toggleLegend();

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import ReactResizeDetector from 'react-resize-detector';
-import { LongArrowAltRightIcon, TopologyIcon, MapIcon } from '@patternfly/react-icons';
 import {
   Controller,
   createTopologyControlButtons,
@@ -26,7 +26,6 @@ import {
   Edge
 } from '@patternfly/react-topology';
 import { GraphData } from 'pages/Graph/GraphPage';
-import * as React from 'react';
 import {
   BoxByType,
   EdgeLabelMode,
@@ -72,6 +71,9 @@ import { GraphRefs } from './GraphPagePF';
 import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
 import { ServiceDetailsInfo } from 'types/ServiceInfo';
 import { PeerAuthentication } from 'types/IstioObjects';
+import { kialiStyle } from 'styles/StyleUtils';
+import { PFColors } from 'components/Pf/PfColors';
+import { KialiIcon } from 'config/KialiIcon';
 
 let initialLayout = false;
 let requestFit = false;
@@ -108,7 +110,18 @@ export interface FocusNode {
   isSelected?: boolean;
 }
 
-// This is the main graph rendering component
+const activeIconStyle = kialiStyle({
+  top: '0.25rem',
+  color: PFColors.Active,
+  $nest: {
+    '& svg': {
+      width: '1.25rem',
+      height: '1.25rem'
+    }
+  }
+});
+
+// The is the main graph rendering component
 const TopologyContent: React.FC<{
   controller: Controller;
   edgeLabels: EdgeLabelMode[];
@@ -133,6 +146,7 @@ const TopologyContent: React.FC<{
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (val: LayoutName) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;
+  showLegend: boolean;
   showOutOfMesh: boolean;
   showSecurity: boolean;
   showTrafficAnimation: boolean;
@@ -157,6 +171,7 @@ const TopologyContent: React.FC<{
   setEdgeMode,
   setLayout: setLayoutName,
   setUpdateTime,
+  showLegend,
   showOutOfMesh,
   showSecurity,
   showTrafficAnimation,
@@ -726,46 +741,38 @@ const TopologyContent: React.FC<{
                   zoomIn: false,
                   zoomOut: false,
                   customButtons: [
-                    // TODO, get rid of the show all edges option, and the disabling, when we can set an option active
-                    {
-                      ariaLabel: 'Show All Edges',
-                      callback: () => {
-                        setEdgeMode(EdgeMode.ALL);
-                      },
-                      disabled: EdgeMode.ALL === edgeMode,
-                      icon: <LongArrowAltRightIcon />,
-                      id: 'toolbar_edge_mode_all',
-                      tooltip: 'Show all edges'
-                    },
                     {
                       ariaLabel: 'Hide Healthy Edges',
                       callback: () => {
-                        //change this back when we have the active styling
-                        //setEdgeMode(EdgeMode.UNHEALTHY === edgeMode ? EdgeMode.ALL : EdgeMode.UNHEALTHY);
-                        setEdgeMode(EdgeMode.UNHEALTHY);
+                        setEdgeMode(EdgeMode.UNHEALTHY === edgeMode ? EdgeMode.ALL : EdgeMode.UNHEALTHY);
                       },
-                      disabled: EdgeMode.UNHEALTHY === edgeMode,
-                      icon: <LongArrowAltRightIcon />,
+                      icon: (
+                        <KialiIcon.LongArrowRight
+                          className={EdgeMode.UNHEALTHY === edgeMode ? activeIconStyle : undefined}
+                        />
+                      ),
                       id: 'toolbar_edge_mode_unhealthy',
                       tooltip: 'Hide healthy edges'
                     },
                     {
                       ariaLabel: 'Hide All Edges',
                       id: 'toolbar_edge_mode_none',
-                      disabled: EdgeMode.NONE === edgeMode,
-                      icon: <LongArrowAltRightIcon />,
+                      icon: (
+                        <KialiIcon.LongArrowRight
+                          className={EdgeMode.NONE === edgeMode ? activeIconStyle : undefined}
+                        />
+                      ),
                       tooltip: 'Hide all edges',
                       callback: () => {
-                        //change this back when we have the active styling
-                        //setEdgeMode(EdgeMode.NONE === edgeMode ? EdgeMode.ALL : EdgeMode.NONE);
-                        setEdgeMode(EdgeMode.NONE);
+                        setEdgeMode(EdgeMode.NONE === edgeMode ? EdgeMode.ALL : EdgeMode.NONE);
                       }
                     },
                     {
                       ariaLabel: 'Dagre - boxing layout',
                       id: 'toolbar_layout_dagre',
-                      disabled: LayoutName.Dagre === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology className={LayoutName.Dagre === layoutName ? activeIconStyle : undefined} />
+                      ),
                       tooltip: 'Dagre - boxing layout',
                       callback: () => {
                         setLayoutName(LayoutName.Dagre);
@@ -774,8 +781,9 @@ const TopologyContent: React.FC<{
                     {
                       ariaLabel: 'Grid - non-boxing layout',
                       id: 'toolbar_layout_grid',
-                      disabled: LayoutName.Grid === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology className={LayoutName.Grid === layoutName ? activeIconStyle : undefined} />
+                      ),
                       tooltip: 'Grid - non-boxing layout',
                       callback: () => {
                         setLayoutName(LayoutName.Grid);
@@ -784,8 +792,11 @@ const TopologyContent: React.FC<{
                     {
                       ariaLabel: 'Concentric - non-boxing layout',
                       id: 'toolbar_layout_concentric',
-                      disabled: LayoutName.Concentric === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology
+                          className={LayoutName.Concentric === layoutName ? activeIconStyle : undefined}
+                        />
+                      ),
                       tooltip: 'Concentric - non-boxing layout',
                       callback: () => {
                         setLayoutName(LayoutName.Concentric);
@@ -794,8 +805,11 @@ const TopologyContent: React.FC<{
                     {
                       ariaLabel: 'Breadth First - non-boxing layout',
                       id: 'toolbar_layout_breadth_first',
-                      disabled: LayoutName.BreadthFirst === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology
+                          className={LayoutName.BreadthFirst === layoutName ? activeIconStyle : undefined}
+                        />
+                      ),
                       tooltip: 'Breadth First - non-boxing layout',
                       callback: () => {
                         setLayoutName(LayoutName.BreadthFirst);
@@ -818,7 +832,7 @@ const TopologyContent: React.FC<{
                     }
                   },
                   legend: true,
-                  legendIcon: <MapIcon />,
+                  legendIcon: <KialiIcon.Map className={showLegend ? activeIconStyle : undefined} />,
                   legendTip: 'Legend',
                   legendCallback: () => {
                     if (toggleLegend) toggleLegend();
@@ -857,6 +871,7 @@ export const GraphPF: React.FC<{
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (layout: Layout) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;
+  showLegend: boolean;
   showOutOfMesh: boolean;
   showSecurity: boolean;
   showTrafficAnimation: boolean;
@@ -879,6 +894,7 @@ export const GraphPF: React.FC<{
   setEdgeMode,
   setLayout,
   setUpdateTime,
+  showLegend,
   showOutOfMesh,
   showSecurity,
   showTrafficAnimation,
@@ -952,6 +968,7 @@ export const GraphPF: React.FC<{
         setEdgeMode={setEdgeMode}
         setLayout={setLayoutByName}
         setUpdateTime={setUpdateTime}
+        showLegend={showLegend}
         showOutOfMesh={showOutOfMesh}
         showSecurity={showSecurity}
         showTrafficAnimation={showTrafficAnimation}

--- a/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
+++ b/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
@@ -196,6 +196,7 @@ class MiniGraphCardPFComponent extends React.Component<MiniGraphCardPropsPF, Min
                 setLayout={this.props.setLayout}
                 setUpdateTime={this.props.setUpdateTime}
                 updateSummary={this.props.updateSummary}
+                showLegend={false}
                 showOutOfMesh={true}
                 showSecurity={true}
                 showTrafficAnimation={false}

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -1,5 +1,5 @@
+import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { MapIcon } from '@patternfly/react-icons';
 import ReactResizeDetector from 'react-resize-detector';
 import {
   Controller,
@@ -25,8 +25,6 @@ import {
   VisualizationSurface,
   Edge
 } from '@patternfly/react-topology';
-import { TopologyIcon } from '@patternfly/react-icons';
-import * as React from 'react';
 import { Layout } from 'types/Graph';
 import { elementFactory } from './elements/elementFactory';
 import { layoutFactory } from './layouts/layoutFactory';
@@ -52,6 +50,8 @@ import { MeshTourStops } from './MeshHelpTour';
 import { KialiMeshDagre } from './layouts/KialiMeshDagre';
 //import { KialiMeshCola } from './layouts/KialiMeshCola';
 import { KialiDagreGraph } from 'components/CytoscapeGraph/graphs/KialiDagreGraph';
+import { KialiIcon } from 'config/KialiIcon';
+import { toolbarActiveStyle } from 'styles/GraphStyle';
 
 let initialLayout = false;
 let requestFit = false;
@@ -93,6 +93,7 @@ const TopologyContent: React.FC<{
   setLayout: (val: LayoutName) => void;
   setTarget: (meshTarget: MeshTarget) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;
+  showLegend: boolean;
   toggleLegend?: () => void;
 }> = ({
   controller,
@@ -106,6 +107,7 @@ const TopologyContent: React.FC<{
   setLayout: _setLayoutName,
   setTarget,
   setUpdateTime,
+  showLegend,
   toggleLegend
 }) => {
   //
@@ -488,8 +490,11 @@ const TopologyContent: React.FC<{
                     {
                       ariaLabel: 'Layout - Dagre',
                       id: 'toolbar_layout_dagre',
-                      disabled: LayoutName.Dagre === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology
+                          className={LayoutName.Dagre === layoutName ? toolbarActiveStyle : undefined}
+                        />
+                      ),
                       tooltip: 'Layout - Dagre',
                       callback: () => {
                         _setLayoutName(LayoutName.Dagre);
@@ -498,8 +503,11 @@ const TopologyContent: React.FC<{
                     {
                       ariaLabel: 'Layout - Mesh Dagre',
                       id: 'toolbar_layout_mesh_dagre',
-                      disabled: LayoutName.MeshDagre === layoutName,
-                      icon: <TopologyIcon />,
+                      icon: (
+                        <KialiIcon.Topology
+                          className={LayoutName.MeshDagre === layoutName ? toolbarActiveStyle : undefined}
+                        />
+                      ),
                       tooltip: 'Layout - Mesh Dagre',
                       callback: () => {
                         _setLayoutName(LayoutName.MeshDagre);
@@ -522,7 +530,7 @@ const TopologyContent: React.FC<{
                     }
                   },
                   legend: true,
-                  legendIcon: <MapIcon />,
+                  legendIcon: <KialiIcon.Map className={showLegend ? toolbarActiveStyle : undefined} />,
                   legendTip: 'Legend',
                   legendCallback: () => {
                     if (toggleLegend) toggleLegend();
@@ -549,6 +557,7 @@ export const Mesh: React.FC<{
   setLayout: (layout: Layout) => void;
   setTarget: (meshTarget: MeshTarget) => void;
   setUpdateTime: (val: TimeInMilliseconds) => void;
+  showLegend: boolean;
   toggleLegend?: () => void;
 }> = ({
   isMiniMesh,
@@ -560,6 +569,7 @@ export const Mesh: React.FC<{
   setLayout,
   setTarget,
   setUpdateTime,
+  showLegend,
   toggleLegend
 }) => {
   //create controller on startup and register factories
@@ -616,6 +626,7 @@ export const Mesh: React.FC<{
         setLayout={setLayoutByName}
         setTarget={setTarget}
         setUpdateTime={setUpdateTime}
+        showLegend={showLegend}
         toggleLegend={toggleLegend}
       />
     </VisualizationProvider>

--- a/frontend/src/styles/GraphStyle.ts
+++ b/frontend/src/styles/GraphStyle.ts
@@ -1,0 +1,13 @@
+import { PFColors } from 'components/Pf/PfColors';
+import { kialiStyle } from './StyleUtils';
+
+export const toolbarActiveStyle = kialiStyle({
+  top: '0.25rem',
+  color: PFColors.Active,
+  $nest: {
+    '& svg': {
+      width: '1.25rem',
+      height: '1.25rem'
+    }
+  }
+});


### PR DESCRIPTION
### Describe the change

Currently, active options in the patternfly graph toolbar appear disabled. This is not ideal from a UX perspective, as they can be mistaken for actually disabled toolbar options. Therefore, this PR changes the toolbar icons to blue when they are active and slightly increases their size to better differentiate them from similar inactive icons. 

Before:

![image](https://github.com/user-attachments/assets/4be1d30a-cb12-4c1b-892e-bb8e6ef5c8c0)

After: 

![image](https://github.com/user-attachments/assets/28a1e190-8f68-4d93-906b-1e5c0d27a4b4)

To be consistent with the Cytoscape graph, options to hide edges can be activated and deactivated by clicking the same toolbar option (which was not possible with the disabled approach).

### Steps to test the PR

1. Go to graph page
2. Verify that the toolbar looks fine with the new active icon styles.

### Automation testing

N/A
