### PR TITLE
Fixed breadcrumb object name

### DIFF
--- a/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/frontend/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -33,7 +33,7 @@ export const BreadcrumbView: React.FC = () => {
     const page = Paths[match[3].toUpperCase()];
     const istioType = page === 'istio' ? kindToStringIncludeK8s(match[4], match[6]) : '';
     const urlParams = new URLSearchParams(search);
-    const itemPage = page !== 'istio' ? match[3] : match[7];
+    const itemPage = page !== 'istio' ? match[4] : match[7];
 
     setCluster(HistoryManager.getClusterName(urlParams));
     setIstioType(istioType);


### PR DESCRIPTION
### Describe the change

Breadcrumb name was wrong for Object details, such as App, Workloads and Services.
Before:
![Screenshot from 2024-10-15 13-12-57](https://github.com/user-attachments/assets/75f47505-563b-4934-af37-203e39184a04)

After:
![Screenshot from 2024-10-15 13-30-11](https://github.com/user-attachments/assets/883480c3-a709-4286-857d-28b72ffe4561)

### Issue reference
https://github.com/kiali/kiali/issues/7817
