### PR TITLE
Fixed DaemonSet workload fetching error message

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1243,7 +1243,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods))
 				w.ParseDaemonSet(&daeset[iFound])
 			} else {
-				log.Errorf("Workload %s is not found as Deployment", controllerName)
+				log.Errorf("Workload %s is not found as DaemonSet", controllerName)
 				cnFound = false
 			}
 		default:


### PR DESCRIPTION
### Describe the change

Fixed DaemonSet workload fetching error message in business/workloads.go.
We use the alternative DaemonSet controller for `controller-main` workload and got the confusing error:

```
{"level":"error","time":"2024-10-15T13:25:37Z","message":"Workload controller-main is not found as Deployment"}
```


### Steps to test the PR

Deploy the alternative DaemonSet controller like [kruise](https://openkruise.io/docs/user-manuals/advanceddaemonset/). Then there must be an error:

```
{"level":"error","time":"2024-10-15T13:25:37Z","message":"Workload controller-main is not found as DaemonSet"}
```

### Automation testing

—

### Issue reference

—