### PR TITLE
[Tempo] View in Tracing url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -255,8 +255,9 @@ type GrafanaVariablesConfig struct {
 }
 
 type TempoConfig struct {
-	OrgID         string `yaml:"org_id" json:"org_id,omitempty"`
 	DatasourceUID string `yaml:"datasource_uid" json:"datasource_uid,omitempty"`
+	OrgID         string `yaml:"org_id" json:"org_id,omitempty"`
+	URLFormat     string `yaml:"url_format" json:"url_format,omitempty"`
 }
 
 // TracingConfig describes configuration used for tracing links

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -7,8 +7,8 @@ export enum StatusKey {
 }
 
 export enum TempoUrlFormat {
-  JAEGER = 'Jaeger',
-  GRAFANA = 'Grafana'
+  JAEGER = 'jaeger',
+  GRAFANA = 'grafana'
 }
 
 export type Status = { [K in StatusKey]?: string };

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -6,11 +6,17 @@ export enum StatusKey {
   KIALI_STATE = 'Kiali state'
 }
 
+export enum TempoUrlFormat {
+  JAEGER = 'Jaeger',
+  GRAFANA = 'Grafana'
+}
+
 export type Status = { [K in StatusKey]?: string };
 
 export type TempoConfig = {
   datasource_uid: string;
   org_id: string;
+  url_format: TempoUrlFormat;
 };
 
 export interface ExternalServiceInfo {

--- a/frontend/src/types/Tracing.ts
+++ b/frontend/src/types/Tracing.ts
@@ -44,6 +44,7 @@ export interface TracingUrlProvider {
 // Require that all properties are required and not null/undefined
 export type ConcreteService = {
   name: string;
+  url: string;
 };
 
 export const TEMPO = 'tempo';

--- a/frontend/src/utils/tracing/UrlProviders/Jaeger.ts
+++ b/frontend/src/utils/tracing/UrlProviders/Jaeger.ts
@@ -5,7 +5,6 @@ import { SpanData, TraceData } from '../../../types/TracingInfo';
 
 interface JaegerExternalService extends ConcreteService {
   name: typeof JAEGER;
-  url: string;
 }
 
 export function isJaegerService(svc: ExternalServiceInfo): svc is JaegerExternalService {
@@ -13,10 +12,10 @@ export function isJaegerService(svc: ExternalServiceInfo): svc is JaegerExternal
 }
 
 export class JaegerUrlProvider implements TracingUrlProvider {
-  private service: JaegerExternalService;
+  private service: ConcreteService;
   readonly valid: boolean = true;
 
-  constructor(service: JaegerExternalService) {
+  constructor(service: ConcreteService) {
     this.service = service;
   }
 

--- a/frontend/src/utils/tracing/UrlProviders/index.ts
+++ b/frontend/src/utils/tracing/UrlProviders/index.ts
@@ -1,6 +1,6 @@
 import { isTempoService, TempoUrlProvider } from './Tempo';
 import { isJaegerService, JaegerUrlProvider } from './Jaeger';
-import { ExternalServiceInfo } from 'types/StatusState';
+import { ExternalServiceInfo, TempoUrlFormat } from 'types/StatusState';
 import { JAEGER, TEMPO, TracingUrlProvider } from 'types/Tracing';
 
 // Get a tracing url provider, assuming some is configured
@@ -22,7 +22,11 @@ export function GetTracingUrlProvider(
   // the wanted url provider
   let urlProvider: TracingUrlProvider | undefined = undefined;
   if (isTempoService(svc)) {
-    urlProvider = new TempoUrlProvider(svc, externalServices);
+    if (svc.tempoConfig?.url_format === TempoUrlFormat.JAEGER) {
+      urlProvider = new JaegerUrlProvider(svc);
+    } else {
+      urlProvider = new TempoUrlProvider(svc, externalServices);
+    }
   }
   if (isJaegerService(svc)) {
     urlProvider = new JaegerUrlProvider(svc);

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -205,7 +205,7 @@ spec:
             cpu: "2"
             memory: 2Gi
       jaegerQuery:
-        enabled: false
+        enabled: true
 EOF
   fi
 }


### PR DESCRIPTION
### Describe the change

Adds a new tempo config option to specify the tracing url format. So it is possible to link to the Jaeger UI or to a Grafana datasource.

### Steps to test the PR

- Create an environment with Tempo. It can be done with: `hack/istio/tempo/install-tempo-env.sh -c kubectl`
- Install Kiali in the cluster (needs the operator PR https://github.com/kiali/kiali-operator/pull/830 
- Update the Tracing settings: 
Using the Grafana Datasource: 
```
      grafana:
        enabled: true
        external_url: 'http://localhost:13000'
        health_check_url: ''
        internal_url: http://grafana.istio-system:3000
      tracing:
        enabled: true
        external_url: ''
        internal_url: http://localhost:3200
        provider: tempo
        tempo_config:
          datasource_uid: ''
          org_id: ''
          url_format: ''
        use_grpc: false
```
The Traces tab should contain traces, and the "View in tracing" should redirect to Grafana:
![image](https://github.com/user-attachments/assets/5161bfa9-d02d-4eed-8a01-2662fb8aa3a6)

(The datasource should be created and the datasource uid settings should be updated).

Using the Jaeger Query UI: 
```
      tracing:
        enabled: true
        external_url: 'http://localhost:16686'
        internal_url: http://tempo-cr-query-frontend.tempo:3200
        provider: tempo
        tempo_config:
          datasource_uid: ''
          org_id: ''
          url_format: 'jaeger'
        use_grpc: false
```
Traces should exist and the "View in tracing" should redirect to the external_url: 
![image](https://github.com/user-attachments/assets/1fa95086-4bf8-42eb-a5e2-332b0ab24716)

![image](https://github.com/user-attachments/assets/d8b957f0-96ce-4104-b068-511718d152d0)


### Automation testing

N/A

### Issue reference
Fixes #7822 
