### PR TITLE
Enable rank feature in the patternfly graph

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -184,14 +184,12 @@ const TopologyContent: React.FC<{
       activeNamespaces: graphData.fetchParams.namespaces,
       edgeLabels: edgeLabels,
       graphType: graphData.fetchParams.graphType,
-      rankBy: rankBy,
       showOutOfMesh: showOutOfMesh,
-      showRank: showRank,
       showSecurity: showSecurity,
       showVirtualServices: showVirtualServices,
       trafficRates: graphData.fetchParams.trafficRates
     } as GraphPFSettings;
-  }, [graphData.fetchParams, edgeLabels, rankBy, showOutOfMesh, showRank, showSecurity, showVirtualServices]);
+  }, [graphData.fetchParams, edgeLabels, showOutOfMesh, showSecurity, showVirtualServices]);
 
   //
   // SelectedIds State
@@ -599,9 +597,12 @@ const TopologyContent: React.FC<{
     onDeleteTrafficRouting,
     onLaunchWizard,
     onReady,
+    rankBy,
     setDetailsLevel,
     setSelectedIds,
-    setUpdateTime
+    setRankResult,
+    setUpdateTime,
+    showRank
   ]);
 
   React.useEffect(() => {

--- a/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
+++ b/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
@@ -192,11 +192,14 @@ class MiniGraphCardPFComponent extends React.Component<MiniGraphCardPropsPF, Min
                 onLaunchWizard={this.handleLaunchWizard}
                 onNodeTap={this.handleNodeTap}
                 onReady={this.props.onReady}
+                rankBy={[]}
                 setEdgeMode={this.props.setEdgeMode}
                 setLayout={this.props.setLayout}
+                setRankResult={() => {}}
                 setUpdateTime={this.props.setUpdateTime}
                 updateSummary={this.props.updateSummary}
                 showLegend={false}
+                showRank={false}
                 showOutOfMesh={true}
                 showSecurity={true}
                 showTrafficAnimation={false}


### PR DESCRIPTION
### Describe the change

This PR enables the rank feature in the patternfly graph

### Steps to test the PR

1. Go to the traffic graph
2. Click on the `Display` dropdown, select `Rank` option, followed by `Inbound Edges`
3. Select any node in the graph
4. Verify that a rank value is displayed in the side panel

![image](https://github.com/user-attachments/assets/ca774682-a0a5-4f5a-96b3-9ed913a5eee1)

### Automation testing

Cypress test implemented in https://github.com/kiali/kiali/pull/7799

