### PR TITLE
[mesh page] [graph] Fix issue with laying out on an element change

### DIFF
--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -43,8 +43,8 @@ import {
   selectOr,
   SelectOr
 } from 'pages/GraphPF/GraphPFElems';
-import { FIT_PADDING } from 'pages/GraphPF/GraphPF';
 import { isArray } from 'lodash';
+import { graphLayout, LayoutType } from 'pages/GraphPF/GraphPF';
 
 type ReduxStateProps = {
   edgeLabels: EdgeLabelMode[];
@@ -647,9 +647,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     }
 
     if (needLayout || this.hiddenElements) {
-      controller.getGraph().reset();
-      controller.getGraph().layout();
-      controller.getGraph().fit(FIT_PADDING);
+      graphLayout(controller, graphChanged ? LayoutType.LayoutNoFit : LayoutType.Layout);
     }
   };
 

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -26,7 +26,6 @@ import { KialiIcon } from 'config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
-import { TimeInMilliseconds } from 'types/Common';
 import { KialiDispatch } from 'types/Redux';
 import { AutoComplete } from 'utils/AutoComplete';
 import { HEALTHY, NA, NOT_READY } from 'types/Health';
@@ -57,7 +56,6 @@ type ReduxStateProps = {
   showIdleNodes: boolean;
   showRank: boolean;
   showSecurity: boolean;
-  updateTime: TimeInMilliseconds;
 };
 
 type ReduxDispatchProps = {
@@ -222,9 +220,9 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
   shouldComponentUpdate(nextProps: GraphFindProps, nextState: GraphFindState): boolean {
     const controllerChanged = this.props.controller !== nextProps.controller;
     const edgeModeChanged = this.props.edgeMode !== nextProps.edgeMode;
+    const elementsChanged = !this.props.elementsChanged && nextProps.elementsChanged;
     const findChanged = this.props.findValue !== nextProps.findValue;
     const hideChanged = this.props.hideValue !== nextProps.hideValue;
-    const graphChanged = this.props.updateTime !== nextProps.updateTime;
     const showFindHelpChanged = this.props.showFindHelp !== nextProps.showFindHelp;
     const findErrorChanged = this.state.findError !== nextState.findError;
     const hideErrorChanged = this.state.hideError !== nextState.hideError;
@@ -232,9 +230,9 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     const shouldUpdate =
       controllerChanged ||
       edgeModeChanged ||
+      elementsChanged ||
       findChanged ||
       hideChanged ||
-      graphChanged ||
       showFindHelpChanged ||
       findErrorChanged ||
       hideErrorChanged;
@@ -254,9 +252,9 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
 
     const controllerChanged = this.props.controller !== prevProps.controller;
     const edgeModeChanged = this.props.edgeMode !== prevProps.edgeMode;
+    const elementsChanged = this.props.elementsChanged && !prevProps.elementsChanged;
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
-    const graphChanged = this.props.updateTime !== prevProps.updateTime;
 
     // ensure redux state and URL are aligned
     if (findChanged) {
@@ -275,7 +273,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     }
 
     // make sure the value is updated if there was a change
-    if (controllerChanged || findChanged || (graphChanged && this.props.findValue)) {
+    if (controllerChanged || findChanged || (elementsChanged && this.props.findValue)) {
       // ensure findInputValue is aligned if findValue is set externally (e.g. resetSettings)
       if (this.state.findInputValue !== this.props.findValue) {
         this.setFind(this.props.findValue);
@@ -287,7 +285,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     if (
       controllerChanged ||
       hideChanged ||
-      (graphChanged && this.props.hideValue) ||
+      (elementsChanged && this.props.hideValue) ||
       edgeModeChanged ||
       this.props.edgeMode !== EdgeMode.ALL
     ) {
@@ -295,7 +293,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       if (this.state.hideInputValue !== this.props.hideValue) {
         this.setHide(this.props.hideValue);
       }
-      this.handleHide(this.props.controller, graphChanged);
+      this.handleHide(this.props.controller);
     }
   }
 
@@ -554,20 +552,17 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
     }
   };
 
-  private handleHide = (controller: Controller, graphChanged: boolean): void => {
+  private handleHide = (controller: Controller): void => {
     const selector = this.parseValue(this.props.hideValue, false);
     const checkRemovals = selector.nodeSelector || selector.edgeSelector || this.props.edgeMode !== EdgeMode.ALL;
     const graph = controller.getGraph();
-    let needLayout = false;
 
     console.debug(`Hide selector=[${JSON.stringify(selector)}]`);
 
-    // unhide hidden elements when we are dealing with the same graph. Either way,release for garbage collection
-    if (this.hiddenElements && !graphChanged) {
-      needLayout = true;
+    // unhide any currently hidden elements, something changed so we'll redetermine what needs to be hidden
+    if (this.hiddenElements) {
       this.hiddenElements.forEach(e => this.unhideElement(graph, e));
     }
-
     this.hiddenElements = undefined;
 
     // select the new hide-hits
@@ -646,9 +641,9 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 
-    if (needLayout || this.hiddenElements) {
-      graphLayout(controller, graphChanged ? LayoutType.LayoutNoFit : LayoutType.Layout);
-    }
+    // always perform a full layout, because if this function is invoked at all, we know either we're dealing with either
+    // a new controller, a different topology, a new hide expression, etc
+    graphLayout(controller, LayoutType.Layout);
   };
 
   private handleFind = (controller: Controller): void => {
@@ -1197,8 +1192,7 @@ const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   showFindHelp: state.graph.toolbarState.showFindHelp,
   showIdleNodes: state.graph.toolbarState.showIdleNodes,
   showRank: state.graph.toolbarState.showRank,
-  showSecurity: state.graph.toolbarState.showSecurity,
-  updateTime: state.graph.updateTime
+  showSecurity: state.graph.toolbarState.showSecurity
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -575,10 +575,11 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
     fetchParams: FetchParams
   ): void => {
     const prevElements = this.state.graphData.elements;
+    const elementsChanged = CytoscapeGraphUtils.elementsChanged(prevElements, elements);
     this.setState({
       graphData: {
         elements: elements,
-        elementsChanged: CytoscapeGraphUtils.elementsChanged(prevElements, elements),
+        elementsChanged: elementsChanged,
         isLoading: false,
         fetchParams: fetchParams,
         timestamp: graphTimestamp * 1000

--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -19,6 +19,7 @@ import { DEGRADED, FAILURE } from 'types/Health';
 import { DecoratedMeshEdgeData, DecoratedMeshEdgeWrapper, DecoratedMeshNodeData, MeshInfraType } from 'types/Mesh';
 import { BoxByType } from 'types/Graph';
 import { NamespaceInfo } from 'types/NamespaceInfo';
+import { PFColors } from 'components/Pf/PfColors';
 
 // Utilities for working with PF Topology
 // - most of these add cytoscape-like functions
@@ -165,6 +166,8 @@ export const setNodeLabel = (node: NodeModel, _nodeMap: NodeMap): void => {
   }
   if (pfBadge) {
     data.badge = pfBadge.badge;
+    data.badgeColor = PFColors.BackgroundColor100;
+    data.badgeBorderColor = PFColors.Blue300;
   }
   node.label = content.shift();
   if (content.length > 0) {

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -279,11 +279,11 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
     fetchParams: MeshFetchParams
   ): void => {
     const prevElements = this.state.meshData.elements;
-
+    const elementsChanged = this.elementsChanged(prevElements, elements);
     this.setState({
       meshData: {
         elements: elements,
-        elementsChanged: this.elementsChanged(prevElements, elements),
+        elementsChanged: elementsChanged,
         fetchParams: fetchParams,
         isLoading: false,
         name: meshName,

--- a/frontend/src/pages/Mesh/components/meshComponentFactory.tsx
+++ b/frontend/src/pages/Mesh/components/meshComponentFactory.tsx
@@ -1,8 +1,10 @@
 import {
   ComponentFactory,
   GraphComponent,
+  GraphElement,
   ModelKind,
   nodeDragSourceSpec,
+  withContextMenu,
   withDragNode,
   withPanZoom,
   withSelection
@@ -32,11 +34,9 @@ const handleDoubleTap = (_doubleTapNode: GraphElement) => {
 */
 
 // There are currently no actiones to take on a mesh node, so this returns an empty array
-/*
 const nodeContextMenu = (_node: GraphElement): React.ReactElement[] => {
   return [];
 };
-*/
 
 export const meshComponentFactory: ComponentFactory = (
   kind: ModelKind,
@@ -50,11 +50,18 @@ export const meshComponentFactory: ComponentFactory = (
     case ModelKind.graph:
       return withSelection({ multiSelect: false, controlled: false })(withPanZoom()(GraphComponent));
     case ModelKind.node: {
-      return withDragNode(nodeDragSourceSpec('node', true, true))(
-        // withContextMenu(e => nodeContextMenu(e))( // currently no context menu options
-        withSelection({ multiSelect: false, controlled: false })((type === 'group' ? MeshGroup : MeshNode) as any)
-        //)
-      );
+      if (type === 'group') {
+        return withDragNode(nodeDragSourceSpec('node', true, true))(
+          // context menu is empty, this is just for global css compatibility
+          withContextMenu(e => nodeContextMenu(e))(
+            withSelection({ multiSelect: false, controlled: false })(MeshGroup as any)
+          )
+        );
+      } else {
+        return withDragNode(nodeDragSourceSpec('node', true, true))(
+          withSelection({ multiSelect: false, controlled: false })(MeshNode as any)
+        );
+      }
     }
     default:
       return undefined;

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -22,7 +22,6 @@ import { KialiIcon } from 'config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
 import { TourStop } from 'components/Tour/TourStop';
 import { MeshTourStops } from 'pages/Mesh/MeshHelpTour';
-import { TimeInMilliseconds } from 'types/Common';
 import { KialiDispatch } from 'types/Redux';
 import { AutoComplete } from 'utils/AutoComplete';
 import { HEALTHY, NA, NOT_READY } from 'types/Health';
@@ -42,7 +41,6 @@ type ReduxStateProps = {
   hideValue: string;
   layout: Layout;
   showFindHelp: boolean;
-  updateTime: TimeInMilliseconds;
 };
 
 type ReduxDispatchProps = {
@@ -155,18 +153,18 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
   // wait for the mesh change to do the update.
   shouldComponentUpdate(nextProps: MeshFindProps, nextState: MeshFindState): boolean {
     const controllerChanged = this.props.controller !== nextProps.controller;
+    const elementsChanged = !this.props.elementsChanged && nextProps.elementsChanged;
     const findChanged = this.props.findValue !== nextProps.findValue;
     const hideChanged = this.props.hideValue !== nextProps.hideValue;
-    const meshChanged = this.props.updateTime !== nextProps.updateTime;
     const showFindHelpChanged = this.props.showFindHelp !== nextProps.showFindHelp;
     const findErrorChanged = this.state.findError !== nextState.findError;
     const hideErrorChanged = this.state.hideError !== nextState.hideError;
 
     const shouldUpdate =
       controllerChanged ||
+      elementsChanged ||
       findChanged ||
       hideChanged ||
-      meshChanged ||
       showFindHelpChanged ||
       findErrorChanged ||
       hideErrorChanged;
@@ -185,9 +183,9 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     }
 
     const controllerChanged = this.props.controller !== prevProps.controller;
+    const elementsChanged = this.props.elementsChanged && !prevProps.elementsChanged;
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
-    const meshChanged = this.props.updateTime !== prevProps.updateTime;
 
     // ensure redux state and URL are aligned
     if (findChanged) {
@@ -206,7 +204,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     }
 
     // make sure the value is updated if there was a change
-    if (controllerChanged || findChanged || (meshChanged && this.props.findValue)) {
+    if (controllerChanged || findChanged || (elementsChanged && this.props.findValue)) {
       // ensure findInputValue is aligned if findValue is set externally (e.g. resetSettings)
       if (this.state.findInputValue !== this.props.findValue) {
         this.setFind(this.props.findValue);
@@ -215,12 +213,12 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       this.handleFind(this.props.controller);
     }
 
-    if (controllerChanged || hideChanged || (meshChanged && this.props.hideValue)) {
+    if (controllerChanged || hideChanged || (elementsChanged && this.props.hideValue)) {
       // ensure hideInputValue is aligned if hideValue is set externally (e.g. resetSettings)
       if (this.state.hideInputValue !== this.props.hideValue) {
         this.setHide(this.props.hideValue);
       }
-      this.handleHide(this.props.controller, meshChanged);
+      this.handleHide(this.props.controller);
     }
   }
 
@@ -481,20 +479,17 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     }
   };
 
-  private handleHide = (controller: Controller, meshChanged: boolean): void => {
+  private handleHide = (controller: Controller): void => {
     const selector = this.parseValue(this.props.hideValue, false);
     const checkRemovals = selector.nodeSelector || selector.edgeSelector;
     const mesh = controller.getGraph();
-    let needLayout = false;
 
     console.debug(`Mesh Hide selector=[${JSON.stringify(selector)}]`);
 
-    // unhide hidden elements when we are dealing with the same mesh. Either way,release for garbage collection
-    if (this.hiddenElements && !meshChanged) {
-      needLayout = true;
+    // unhide any currently hidden elements, something changed so we'll redetermine what needs to be hidden
+    if (this.hiddenElements) {
       this.hiddenElements.forEach(e => this.unhideElement(mesh, e));
     }
-
     this.hiddenElements = undefined;
 
     // select the new hide-hits
@@ -553,9 +548,9 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 
-    if (needLayout || this.hiddenElements) {
-      meshLayout(controller, meshChanged ? LayoutType.LayoutNoFit : LayoutType.Layout);
-    }
+    // always perform a full layout, because if this function is invoked at all, we know either we're dealing with either
+    // a new controller, a different topology, a new hide expression, etc
+    meshLayout(controller, LayoutType.Layout);
   };
 
   private handleFind = (controller: Controller): void => {
@@ -881,8 +876,7 @@ const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   findValue: meshFindValueSelector(state),
   hideValue: meshHideValueSelector(state),
   layout: state.mesh.layout,
-  showFindHelp: state.mesh.toolbarState.showFindHelp,
-  updateTime: state.mesh.updateTime
+  showFindHelp: state.mesh.toolbarState.showFindHelp
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -29,13 +29,13 @@ import { HEALTHY, NA, NOT_READY } from 'types/Health';
 import { location, HistoryManager, URLParam } from '../../../app/History';
 import { isValid } from 'utils/Common';
 import { descendents, elems, SelectAnd, SelectExp, selectOr, SelectOr } from 'pages/GraphPF/GraphPFElems';
-import { FIT_PADDING } from 'pages/GraphPF/GraphPF';
 import { isArray } from 'lodash';
 import { MeshAttr, MeshEdgeData, MeshInfraType, MeshNodeData } from 'types/Mesh';
 import { Layout } from 'types/Graph';
 import { MeshToolbarActions } from 'actions/MeshToolbarActions';
 import { MeshFindOptions } from './MeshFindOptions';
 import { MeshHelpFind } from '../MeshHelpFind';
+import { LayoutType, meshLayout } from '../Mesh';
 
 type ReduxStateProps = {
   findValue: string;
@@ -554,9 +554,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     }
 
     if (needLayout || this.hiddenElements) {
-      controller.getGraph().reset();
-      controller.getGraph().layout();
-      controller.getGraph().fit(FIT_PADDING);
+      meshLayout(controller, meshChanged ? LayoutType.LayoutNoFit : LayoutType.Layout);
     }
   };
 

--- a/frontend/src/pages/Mesh/toolbar/__tests__/MeshFind.test.tsx
+++ b/frontend/src/pages/Mesh/toolbar/__tests__/MeshFind.test.tsx
@@ -19,7 +19,6 @@ describe('Parse find value test', () => {
         setHideValue={testSetter}
         toggleFindHelp={testHandler}
         layout={{ name: '' }}
-        updateTime={0}
       />
     );
 


### PR DESCRIPTION
Fix issue with laying out on an element change in both the traffic graph and the mesh page.

Also, fix a resize issue for mesh page.

Fixes https://github.com/kiali/kiali/issues/7835

To test:
- try the repro steps in the issue.  
- for the resize issue on the mesh page, try collapse and expand of the side panel
- also try resizing, graph hide/unhide (refresh with hide), eliminating/adding things via the Traffic dropdown, refreshing when you have changed the default layout (like zooming in/out, dragging etc) and make sure your custom view is maintained (unless there is an element change).
