### PR TITLE
Fine-tune Mesh topology style

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -208,7 +208,7 @@ export const setNodeAttachments = (node: Node<NodeModel>, settings: GraphPFSetti
   }
 };
 
-const labelIconStyle = kialiStyle({
+const rootIconStyle = kialiStyle({
   color: PFColors.White,
   display: 'flex',
   marginLeft: '0.125rem',
@@ -218,6 +218,13 @@ const labelIconStyle = kialiStyle({
 const gatewayIconStyle = kialiStyle({
   color: PFColors.White,
   display: 'flex',
+  marginTop: '-0.125rem'
+});
+
+const waypointIconStyle = kialiStyle({
+  color: PFColors.White,
+  display: 'flex',
+  marginLeft: '0.125rem',
   marginTop: '-0.125rem'
 });
 
@@ -269,7 +276,7 @@ export const setNodeLabel = (
     ) {
       data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${gatewayIconStyle}`}></span>;
     } else {
-      data.labelIcon = <span className={`${badgeMap.get('RO')?.className} ${labelIconStyle}`}></span>;
+      data.labelIcon = <span className={`${badgeMap.get('RO')?.className} ${rootIconStyle}`}></span>;
     }
   } else {
     if (data.isGateway?.egressInfo?.hostnames?.length !== undefined) {
@@ -277,7 +284,7 @@ export const setNodeLabel = (
     }
     // A Waypoint should be mutually exclusive with being a traffic source
     if (data.isWaypoint) {
-      data.labelIcon = <span className={`${badgeMap.get('WA')?.className} ${labelIconStyle}`}></span>;
+      data.labelIcon = <span className={`${badgeMap.get('WA')?.className} ${waypointIconStyle}`}></span>;
     }
   }
 

--- a/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
+++ b/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
@@ -179,7 +179,7 @@ class MiniGraphCardPFComponent extends React.Component<MiniGraphCardPropsPF, Min
           </CardHeader>
 
           <CardBody>
-            <div style={{ height: '100%' }}>
+            <div id="pft-graph" style={{ height: '100%' }}>
               <EmptyGraphLayout
                 elements={this.state.graphData}
                 isLoading={this.props.dataSource.isLoading}

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -74,7 +74,7 @@ const getNodeShape = (node: Node): React.FunctionComponent<ShapeProps> => {
   }
 };
 
-const nodeClass = kialiStyle({
+const nodeStyle = kialiStyle({
   $nest: {
     '&.pf-m-hover': {
       cursor: 'pointer'
@@ -87,7 +87,7 @@ const nodeClass = kialiStyle({
 });
 
 // Hide the kebab menu of Patternfly topology nodes
-const labelClass = kialiStyle({
+const labelStyle = kialiStyle({
   $nest: {
     '& text:not(.pf-m-secondary)': {
       transform: 'translateX(10px)'
@@ -167,14 +167,14 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
       {data.isFind && <ShapeComponent className={findOverlayStyle} width={width} height={height} element={element} />}
       {data.isFocus && <ShapeComponent className={focusOverlayStyle} width={width} height={height} element={element} />}
       <DefaultNode
-        className={nodeClass}
-        labelClassName={labelClass}
+        className={nodeStyle}
+        labelClassName={labelStyle}
         element={element}
         {...rest}
         {...passedData}
         attachments={hover || detailsLevel === ScaleDetailsLevel.high ? data.attachments : undefined}
         getCustomShape={getNodeShape}
-        scaleLabel={hover && detailsLevel !== ScaleDetailsLevel.low}
+        scaleLabel={hover && detailsLevel === ScaleDetailsLevel.high}
         scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
         showLabel={hover || detailsLevel === ScaleDetailsLevel.high}
         showStatusBackground={detailsLevel !== ScaleDetailsLevel.high}

--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -200,7 +200,7 @@ const getPathStyle = (data: EdgeData): React.CSSProperties => {
     case FAILURE.name:
     case DEGRADED.name:
       return {
-        strokeWidth: 3,
+        strokeWidth: 6,
         strokeDasharray: '10 10'
       } as React.CSSProperties;
     default:

--- a/frontend/src/pages/Mesh/MeshHighlighter.ts
+++ b/frontend/src/pages/Mesh/MeshHighlighter.ts
@@ -108,9 +108,9 @@ export class MeshHighlighter {
           if ((element as Node).isGroup()) {
             return this.getBoxHighlight(element as Node);
           }
-          return { toHighlight: this.getNodeHighlight(element as Node), unhighlightOthers: true };
+          return { toHighlight: this.getNodeHighlight(element as Node), unhighlightOthers: false };
         case 'edge':
-          return { toHighlight: this.getEdgeHighlight(element as Edge), unhighlightOthers: true };
+          return { toHighlight: this.getEdgeHighlight(element as Edge), unhighlightOthers: false };
 
         default:
         // fall through

--- a/frontend/src/pages/Mesh/components/meshComponentFactory.tsx
+++ b/frontend/src/pages/Mesh/components/meshComponentFactory.tsx
@@ -1,10 +1,8 @@
 import {
   ComponentFactory,
   GraphComponent,
-  GraphElement,
   ModelKind,
   nodeDragSourceSpec,
-  withContextMenu,
   withDragNode,
   withPanZoom,
   withSelection
@@ -14,30 +12,6 @@ import { MeshEdge } from '../styles/MeshEdge';
 import { MeshNode } from '../styles/MeshNode';
 import { MeshGroup } from '../styles/MeshGroup';
 
-// There are currently no actions to take on a mesh node, so these placeholders are just commented out
-
-/*
-type ContextMenuOptionPF = ContextMenuOption & {
-  altClickHandler?: (node: GraphElement) => void;
-  node?: GraphElement;
-};
-
-// There is no node-graph for mesh nodes, so currently this does nothing
-const doubleTapHandler = (node: GraphElement) => {
-  handleDoubleTap(node);
-};
-
-// There is no node-graph for mesh nodes, so currently this does nothing
-const handleDoubleTap = (_doubleTapNode: GraphElement) => {
-  return;
-};
-*/
-
-// There are currently no actiones to take on a mesh node, so this returns an empty array
-const nodeContextMenu = (_node: GraphElement): React.ReactElement[] => {
-  return [];
-};
-
 export const meshComponentFactory: ComponentFactory = (
   kind: ModelKind,
   type: string
@@ -45,23 +19,13 @@ export const meshComponentFactory: ComponentFactory = (
   switch (kind) {
     case ModelKind.edge:
       // Currently, no side panel for edges, nothing really to show but the connectivity
-      // return withSelection({ multiSelect: false, controlled: false })(MeshEdge as any);
       return MeshEdge as any;
     case ModelKind.graph:
       return withSelection({ multiSelect: false, controlled: false })(withPanZoom()(GraphComponent));
     case ModelKind.node: {
-      if (type === 'group') {
-        return withDragNode(nodeDragSourceSpec('node', true, true))(
-          // context menu is empty, this is just for global css compatibility
-          withContextMenu(e => nodeContextMenu(e))(
-            withSelection({ multiSelect: false, controlled: false })(MeshGroup as any)
-          )
-        );
-      } else {
-        return withDragNode(nodeDragSourceSpec('node', true, true))(
-          withSelection({ multiSelect: false, controlled: false })(MeshNode as any)
-        );
-      }
+      return withDragNode(nodeDragSourceSpec('node', true, true))(
+        withSelection({ multiSelect: false, controlled: false })((type === 'group' ? MeshGroup : MeshNode) as any)
+      );
     }
     default:
       return undefined;

--- a/frontend/src/pages/Mesh/styles/MeshEdge.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshEdge.tsx
@@ -42,9 +42,16 @@ const MeshEdgeComponent: React.FC<MeshEdgeProps> = ({ element, ...rest }) => {
   const edgeClass = kialiStyle({
     $nest: {
       '& .pf-topology__edge__link': data.pathStyle,
-      '& .pf-topology-connector-arrow': {
-        stroke: data.pathStyle.stroke,
-        fill: data.pathStyle.stroke
+
+      // remove the hover CSS change (edges cannot be selected on the mesh page)
+      '&.pf-m-hover': {
+        $nest: {
+          '& .pf-topology__edge__background': data.pathStyle,
+          '& .pf-topology__edge__link': {
+            ...data.pathStyle,
+            stroke: 'var(--edge--stroke)'
+          }
+        }
       }
     }
   });

--- a/frontend/src/pages/Mesh/styles/MeshNode.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshNode.tsx
@@ -75,6 +75,21 @@ const renderIcon = (element: Node): React.ReactNode => {
   );
 };
 
+const nodeStyle = kialiStyle({
+  $nest: {
+    '.pf-topology__node__background': {
+      strokeWidth: 3
+    },
+    '&.pf-m-hover': {
+      cursor: 'pointer'
+    },
+    '&.pf-m-selected .pf-topology__node__background': {
+      stroke: PFColors.Active,
+      strokeWidth: 6
+    }
+  }
+});
+
 const MeshNodeComponent: React.FC<MeshNodeProps> = ({ element, ...rest }) => {
   const data = element.getData();
   const detailsLevel = useDetailsLevel();
@@ -124,16 +139,16 @@ const MeshNodeComponent: React.FC<MeshNodeProps> = ({ element, ...rest }) => {
     <g style={{ opacity: opacity }} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} ref={hoverRef as any}>
       {data.isFind && <ShapeComponent className={findOverlayStyle} width={width} height={height} element={element} />}
       <DefaultNode
+        className={nodeStyle}
         element={element}
         {...rest}
         {...passedData}
         attachments={hover || detailsLevel === ScaleDetailsLevel.high ? data.attachments : undefined}
-        scaleLabel={hover && detailsLevel !== ScaleDetailsLevel.high}
-        // scaleNode={hover && detailsLevel === ScaleDetailsLevel.low}
+        scaleLabel={hover && detailsLevel === ScaleDetailsLevel.high}
+        scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
         showLabel={hover || detailsLevel === ScaleDetailsLevel.high}
-        showStatusBackground={detailsLevel === ScaleDetailsLevel.low}
       >
-        {(hover || detailsLevel !== ScaleDetailsLevel.low) && renderIcon(element)}
+        {renderIcon(element)}
       </DefaultNode>
     </g>
   );

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -91,7 +91,7 @@ export const globalStyle = kialiStyle({
     /**
      * Hide the kebab menu of Patternfly topology groups
      */
-    '& .pf-topology__group__label': {
+    '& #pft-graph .pf-topology__group__label': {
       $nest: {
         '& .pf-topology__node__label__badge ~ text:not(.pf-m-secondary)': {
           transform: 'translateX(10px)'


### PR DESCRIPTION
### Describe the change

This PR changes some mesh topology styles for a better appearance.
- Keep other nodes highlighted when a mesh node is selected or hovered. This feature is useful in the traffic graph, where many nodes are present, but it's less helpful in the mesh graph when there are only a few nodes.

- Hovering over an edge does not change its style. Since edges on the mesh page are not clickable, it's better to maintain a consistent CSS style to avoid user confusion.

- Don't hide the icons at low detail levels. The icons remain recognizable even at the lowest zoom levels.

![image](https://github.com/user-attachments/assets/88d940ef-79f7-421f-a0f0-8e186a32ff6d)

- Scale the nodes at low detail levels:

![image](https://github.com/user-attachments/assets/9d1dd4fb-6250-47ed-bd86-b5c44bf84c27)

- The selection stroke is wider and blue like in the traffic graph:

![image](https://github.com/user-attachments/assets/4fbac044-d574-402c-85ce-8e5141eece6e)

- Edges connected to failure nodes are thicker, making the failures more visible:

![image](https://github.com/user-attachments/assets/f7f72305-db22-4767-b776-fdf17bf562b9)


**Bonus:**
- Adjusted the margin for the Waypoint proxy icon in the traffic graph.

Before:

![image](https://github.com/user-attachments/assets/bc410390-7916-429d-a502-31002c4a5e3e)

After:

![image](https://github.com/user-attachments/assets/1c743e04-0d9f-405c-a654-30d7e71a593e)
 

### Steps to test the PR

1. Go to the mesh page
2. Check that style changes look good

### Automation testing

N/A
