### PR TITLE
Fix issue with minigraph node navigation

### DIFF
--- a/frontend/cypress/integration/common/app_details_multicluster-pf.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster-pf.ts
@@ -4,6 +4,7 @@ import { clusterParameterExists } from './navigation';
 import { ensureKialiFinishedLoading } from './transition';
 import { elems, nodeInfo } from './graph-pf';
 import { Visualization } from '@patternfly/react-topology';
+import { NodeType } from 'types/Graph';
 
 Then('user sees details information for the remote {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
@@ -100,13 +101,26 @@ Given(
         assert.isTrue(controller.hasGraph());
         const { nodes } = elems(controller);
 
-        const nodeExists = nodes.some(
-          node =>
+        const nodeExists = nodes.some(node => {
+          const nodeOk =
             node.getData().nodeType === nodeType &&
             node.getData().namespace === 'bookinfo' &&
             node.getData().cluster === cluster &&
-            node.getData().isBox === isBox
-        );
+            node.getData().isBox === isBox;
+          if (!nodeOk) {
+            return false;
+          }
+          switch (type) {
+            case NodeType.APP:
+              return node.getData().app === name;
+            case NodeType.SERVICE:
+              return node.getData().service === name;
+            case NodeType.WORKLOAD:
+              return node.getData().workload === name;
+            default:
+              return false;
+          }
+        });
 
         assert(nodeExists, `Node ${name} of type ${type} from cluster ${cluster} not found in the graph`);
       });
@@ -129,14 +143,26 @@ When(
         assert.isTrue(controller.hasGraph());
         const { nodes } = elems(controller);
 
-        const node = nodes.find(
-          node =>
+        const node = nodes.find(node => {
+          const nodeOk =
             node.getData().nodeType === nodeType &&
             node.getData().namespace === 'bookinfo' &&
             node.getData().cluster === cluster &&
-            node.getData().isBox === isBox &&
-            !node.getData().isInaccessible
-        );
+            node.getData().isBox === isBox;
+          if (!nodeOk) {
+            return false;
+          }
+          switch (type) {
+            case NodeType.APP:
+              return node.getData().app === name;
+            case NodeType.SERVICE:
+              return node.getData().service === name;
+            case NodeType.WORKLOAD:
+              return node.getData().workload === name;
+            default:
+              return false;
+          }
+        });
 
         assert(node, `Node ${name} of type ${type} from cluster ${cluster} not found in the graph`);
 

--- a/frontend/cypress/integration/featureFiles/app_details_multicluster_graph-pf.feature
+++ b/frontend/cypress/integration/featureFiles/app_details_multicluster_graph-pf.feature
@@ -28,9 +28,7 @@ Feature: Kiali App Details page minigraph in multicluster setup
       | type     | name       |
       | app      | reviews    |
       | service  | reviews    |
-
-  # TODO Fix issue https://github.com/kiali/kiali/issues/7839
-  #    | workload | reviews-v3 |
+      | workload | reviews-v3 |
 
   # This is a regression test for this bug (https://github.com/kiali/kiali/issues/6185)
   # This is only multi-primary because that is the suite that has openid setup.

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster_graph-pf.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster_graph-pf.feature
@@ -25,9 +25,7 @@ Feature: Kiali Workloads Details minigraph in multicluster setup
     Examples:
       | type     | name       |
       | service  | reviews    |
-
-  # TODO Fix issue https://github.com/kiali/kiali/issues/7839
-  #   | workload | reviews-v3 |
+      | workload | reviews-v3 |
 
   # This is a regression test for this bug (https://github.com/kiali/kiali/issues/6185)
   # This is only multi-primary because that is the suite that has openid setup.

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -21,6 +21,9 @@ import 'ace-builds/src-noconflict/theme-twilight';
 // Enables the search box for the ACE editor
 import 'ace-builds/src-noconflict/ext-searchbox';
 
+// A PFT dependency that is noisy console logging (see below)
+import { configure } from 'mobx';
+
 // i18n
 import './i18n';
 
@@ -53,5 +56,10 @@ setRouter([
 if (!window.location.pathname.includes(rootBasename)) {
   router.navigate(`/${window.location.search}`, { replace: true });
 }
+
+// Suppress thousands of console warnings when scrolling over PFT graphs
+configure({
+  enforceActions: 'never'
+});
 
 ReactDOM.render(<RouterProvider router={router} />, document.getElementById('root') as HTMLElement);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -21,9 +21,6 @@ import 'ace-builds/src-noconflict/theme-twilight';
 // Enables the search box for the ACE editor
 import 'ace-builds/src-noconflict/ext-searchbox';
 
-// A PFT dependency that is noisy console logging (see below)
-import { configure } from 'mobx';
-
 // i18n
 import './i18n';
 
@@ -56,10 +53,5 @@ setRouter([
 if (!window.location.pathname.includes(rootBasename)) {
   router.navigate(`/${window.location.search}`, { replace: true });
 }
-
-// Suppress thousands of console warnings when scrolling over PFT graphs
-configure({
-  enforceActions: 'never'
-});
 
 ReactDOM.render(<RouterProvider router={router} />, document.getElementById('root') as HTMLElement);

--- a/frontend/src/pages/GraphPF/GraphHighlighterPF.ts
+++ b/frontend/src/pages/GraphPF/GraphHighlighterPF.ts
@@ -23,7 +23,7 @@
 import { Edge, Node } from '@patternfly/react-topology';
 import { Controller, GraphElement } from '@patternfly/react-topology';
 import { BoxByType, NodeAttr } from 'types/Graph';
-import { ancestors, NodeData, predecessors, successors } from './GraphPFElems';
+import { ancestors, NodeData, predecessors, setObserved, successors } from './GraphPFElems';
 
 export class GraphHighlighterPF {
   controller: Controller;
@@ -68,12 +68,13 @@ export class GraphHighlighterPF {
   };
 
   clearHighlighting = (): void => {
-    this.controller.getElements().forEach(e => {
-      const data = e.getData() as NodeData;
-
-      if (data.isHighlighted || data.isUnhighlighted) {
-        e.setData({ ...data, isHighlighted: false, isUnhighlighted: false });
-      }
+    setObserved(() => {
+      this.controller.getElements().forEach(e => {
+        const data = e.getData() as NodeData;
+        if (data.isHighlighted || data.isUnhighlighted) {
+          e.setData({ ...data, isHighlighted: false, isUnhighlighted: false });
+        }
+      });
     });
   };
 
@@ -82,19 +83,20 @@ export class GraphHighlighterPF {
     if (!highlighted.toHighlight) {
       return;
     }
-
-    highlighted.toHighlight.forEach(e => {
-      e.setData({ ...e.getData(), isHighlighted: true });
-    });
-
-    if (highlighted.unhighlightOthers) {
-      this.controller.getElements().forEach(e => {
-        const data = e.getData() as NodeData;
-        if (!data.isHighlighted) {
-          e.setData({ ...data, isUnhighlighted: true });
-        }
+    setObserved(() => {
+      highlighted.toHighlight.forEach(e => {
+        e.setData({ ...e.getData(), isHighlighted: true });
       });
-    }
+
+      if (highlighted.unhighlightOthers) {
+        this.controller.getElements().forEach(e => {
+          const data = e.getData() as NodeData;
+          if (!data.isHighlighted) {
+            e.setData({ ...data, isUnhighlighted: true });
+          }
+        });
+      }
+    });
   };
 
   // Returns the nodes to highlight. Highlighting for a hovered or selected element

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -542,7 +542,7 @@ const TopologyContent: React.FC<{
           }
         } else {
           if (e.getType() !== 'graph') {
-            controller.removeElement(e);
+            setObserved(() => controller.removeElement(e));
           }
         }
       });

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -133,7 +133,6 @@ export function graphLayout(controller: Controller, layoutType: LayoutType, rese
   controller.getGraph().layout();
 }
 
-// TODO: Implement some sort of focus when provided
 export interface FocusNode {
   id: string;
   isSelected?: boolean;
@@ -222,7 +221,22 @@ const TopologyContent: React.FC<{
   // SelectedIds State
   //
   const [selectedIds, setSelectedIds] = useVisualizationState<string[]>(SELECTION_STATE, []);
+
+  // selectedRef holds the current selectedId to protect againt selecting the same element, and duplicating the
+  // work below. We could also have created a separate callback to update the selectedId, first comparing against
+  // "selectedIds", but 1) our code would have to remember to call it, and 2) I have seen situations where the
+  // node loses its selected styling and it only comes back on a repeat selection.
+  const selectedRef = React.useRef<string>();
   React.useEffect(() => {
+    if (selectedIds.length > 0) {
+      if (selectedRef.current === selectedIds[0]) {
+        return;
+      }
+      selectedRef.current = selectedIds[0];
+    } else {
+      selectedRef.current = undefined;
+    }
+
     if (isMiniGraph) {
       if (selectedIds.length > 0) {
         const elem = controller.getElementById(selectedIds[0]);
@@ -271,17 +285,7 @@ const TopologyContent: React.FC<{
       highlighter.setSelectedId(undefined);
       updateSummary({ isPF: true, summaryType: 'graph', summaryTarget: controller } as GraphEvent);
     }
-  }, [
-    controller,
-    graphData,
-    highlighter,
-    isMiniGraph,
-    onEdgeTap,
-    onNodeTap,
-    selectedIds,
-    setSelectedIds,
-    updateSummary
-  ]);
+  }, [controller, highlighter, isMiniGraph, onEdgeTap, onNodeTap, selectedIds, setSelectedIds, updateSummary]);
 
   //
   // TraceOverlay State
@@ -620,8 +624,8 @@ const TopologyContent: React.FC<{
     onReady,
     rankBy,
     setDetailsLevel,
-    setSelectedIds,
     setRankResult,
+    setSelectedIds,
     setUpdateTime,
     showRank
   ]);
@@ -639,7 +643,7 @@ const TopologyContent: React.FC<{
           node.setData({ ...(node.getData() as NodeData) });
         }
         // flash node
-        for (let i = 0; i < 10; ++i) {
+        for (let i = 0; i < 8; ++i) {
           setTimeout(() => {
             const data = node.getData() as NodeData;
             data.isFocus = !data.isFocus;

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -52,6 +52,7 @@ import {
   NodeData,
   selectAnd,
   SelectAnd,
+  setObserved,
   setEdgeOptions,
   setNodeAttachments,
   setNodeLabel
@@ -547,10 +548,12 @@ const TopologyContent: React.FC<{
       });
 
       controller.fromModel(model);
-      controller.getGraph().setData({
-        graphData: graphData,
-        onDeleteTrafficRouting: onDeleteTrafficRouting,
-        onLaunchWizard: onLaunchWizard
+      setObserved(() => {
+        controller.getGraph().setData({
+          graphData: graphData,
+          onDeleteTrafficRouting: onDeleteTrafficRouting,
+          onLaunchWizard: onLaunchWizard
+        });
       });
 
       const { nodes } = elems(controller);
@@ -601,7 +604,7 @@ const TopologyContent: React.FC<{
           data.isSelected = true;
           setSelectedIds([target.getId()]);
 
-          target.setData(data);
+          setObserved(() => target.setData(data));
         }
       }
     };
@@ -640,14 +643,14 @@ const TopologyContent: React.FC<{
         if (focusNode.isSelected) {
           data.isSelected = true;
           setSelectedIds([node.getId()]);
-          node.setData({ ...(node.getData() as NodeData) });
+          setObserved(() => node.setData({ ...(node.getData() as NodeData) }));
         }
         // flash node
         for (let i = 0; i < 8; ++i) {
           setTimeout(() => {
             const data = node.getData() as NodeData;
             data.isFocus = !data.isFocus;
-            node.setData({ ...(node.getData() as NodeData) });
+            setObserved(() => node.setData({ ...(node.getData() as NodeData) }));
           }, i * 500);
         }
       }

--- a/frontend/src/pages/GraphPF/GraphPFElems.tsx
+++ b/frontend/src/pages/GraphPF/GraphPFElems.tsx
@@ -15,6 +15,7 @@ import {
   NodeStatus,
   TopologyQuadrant
 } from '@patternfly/react-topology';
+import { action } from 'mobx';
 import { PFBadges, PFBadgeType } from 'components/Pf/PfBadges';
 import { homeCluster as kialiHomeCluster, icons } from 'config';
 import {
@@ -60,20 +61,10 @@ export type NodeData = DecoratedGraphNodeData & {
   badgeTextColor?: string;
   column?: number;
   component?: React.ReactNode;
-  hasSpans?: Span[];
-  icon?: React.ReactNode;
-  isFind?: boolean;
-  isFocus?: boolean;
-  isHighlighted?: boolean;
-  isSelected?: boolean;
-  isUnhighlighted?: boolean;
   labelIcon?: React.ReactNode;
   labelIconClass?: string;
   labelIconPadding?: number;
   labelPosition?: LabelPosition;
-  marginX?: number;
-  onHover?: (element: GraphElement, isMouseIn: boolean) => void;
-  row?: number;
   secondaryLabel?: string;
   setLocation?: boolean;
   showContextMenu?: boolean;
@@ -82,6 +73,14 @@ export type NodeData = DecoratedGraphNodeData & {
   truncateLength?: number;
   x?: number;
   y?: number;
+  // These are additions we've made for our own styling
+  hasSpans?: Span[];
+  isFind?: boolean;
+  isFocus?: boolean;
+  isHighlighted?: boolean;
+  isSelected?: boolean;
+  isUnhighlighted?: boolean;
+  onHover?: (element: GraphElement, isMouseIn: boolean) => void;
 };
 
 export type EdgeData = DecoratedGraphEdgeData & {
@@ -661,6 +660,17 @@ export const assignEdgeHealth = (
 };
 
 ///// PFT helpers
+
+// setObserved executes the provided setter func in a single mobx action. The setter is expected to make at least one element update.
+// like a call to elem.setData() or elem.setVisible(). PFT has these updates wrapped in a mobx observer and wants changes wrapper
+// in a mobx action. To limit renders, batch several data updates in one setDataFunc execution. If you see a console warning like
+// "[MobX] Since strict-mode is enabled, changing (observed) observable values without using an action is not allowed",
+// then you're missing this wrapper.
+export const setObserved = (setter: () => void): void => {
+  action(() => {
+    setter();
+  })();
+};
 
 export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
   const elems = c.getElements();

--- a/frontend/src/pages/GraphPF/GraphPagePF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPagePF.tsx
@@ -583,7 +583,7 @@ class GraphPagePFComponent extends React.Component<GraphPagePropsPF, GraphPageSt
         isLoading: false,
         fetchParams: fetchParams,
         timestamp: graphTimestamp * 1000
-      }
+      } as GraphData
     });
     this.props.setGraphDefinition(this.graphDataSource.graphDefinition);
   };

--- a/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
+++ b/frontend/src/pages/GraphPF/MiniGraphCardPF.tsx
@@ -131,6 +131,15 @@ class MiniGraphCardPFComponent extends React.Component<MiniGraphCardPropsPF, Min
       }
     }
 
+    // The parent component supplies the datasource and the target element. Here we protect against a lifecycle issue where the two
+    // can be out of sync. If so, just assume the parent is currently loading until it things get synchronized.
+    const isLoading =
+      (this.props.workload && this.props.workload?.name !== this.props.dataSource.fetchParameters.node?.workload) ||
+      (this.props.serviceDetails &&
+        this.props.serviceDetails?.service.name !== this.props.dataSource.fetchParameters.node?.service)
+        ? true
+        : this.props.dataSource.isLoading;
+
     const rangeEnd: TimeInMilliseconds = this.props.dataSource.graphTimestamp * 1000;
     const rangeStart: TimeInMilliseconds = rangeEnd - this.props.dataSource.graphDuration * 1000;
 
@@ -182,7 +191,7 @@ class MiniGraphCardPFComponent extends React.Component<MiniGraphCardPropsPF, Min
             <div id="pft-graph" style={{ height: '100%' }}>
               <EmptyGraphLayout
                 elements={this.state.graphData}
-                isLoading={this.props.dataSource.isLoading}
+                isLoading={isLoading}
                 isError={this.props.dataSource.isError}
                 isMiniGraph={true}
               >

--- a/frontend/src/pages/GraphPF/TracePF.ts
+++ b/frontend/src/pages/GraphPF/TracePF.ts
@@ -7,7 +7,7 @@ import {
   searchParentApp,
   searchParentWorkload
 } from 'utils/tracing/TracingHelper';
-import { edgesOut, elems, select, SelectAnd, selectAnd } from './GraphPFElems';
+import { edgesOut, elems, select, SelectAnd, selectAnd, setObserved } from './GraphPFElems';
 
 export const showTrace = (controller: Controller, graphType: GraphType, trace: JaegerTrace): void => {
   if (!controller.hasGraph()) {
@@ -144,7 +144,7 @@ const addSpan = (ele: Node | Edge | undefined, span: Span): void => {
     hasSpans = [span];
   }
   // must reset Data to get the element to re-render
-  ele.setData({ ...data, hasSpans: hasSpans });
+  setObserved(() => ele.setData({ ...data, hasSpans: hasSpans }));
 };
 
 export const hideTrace = (controller: Controller): void => {
@@ -152,9 +152,11 @@ export const hideTrace = (controller: Controller): void => {
     return;
   }
   // unhighlight old span-hits
-  const { nodes, edges } = elems(controller);
-  select(edges, { prop: 'hasSpans', op: 'truthy' }).forEach(e => e.setData({ ...e.getData(), hasSpans: undefined }));
-  select(nodes, { prop: 'hasSpans', op: 'truthy' }).forEach(e => e.setData({ ...e.getData(), hasSpans: undefined }));
+  setObserved(() => {
+    const { nodes, edges } = elems(controller);
+    select(edges, { prop: 'hasSpans', op: 'truthy' }).forEach(e => e.setData({ ...e.getData(), hasSpans: undefined }));
+    select(nodes, { prop: 'hasSpans', op: 'truthy' }).forEach(e => e.setData({ ...e.getData(), hasSpans: undefined }));
+  });
 };
 
 const getOutboundServiceEntry = (span: Span, nodes: Node[]): Node[] | undefined => {

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -42,6 +42,7 @@ import {
   elems,
   getNodeShape,
   getNodeStatus,
+  setObserved,
   setEdgeOptions,
   setNodeAttachments,
   setNodeLabel
@@ -403,7 +404,7 @@ const TopologyContent: React.FC<{
       });
 
       controller.fromModel(model);
-      controller.getGraph().setData({ meshData: meshData });
+      setObserved(() => controller.getGraph().setData({ meshData: meshData }));
 
       const { nodes } = elems(controller);
 

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -398,7 +398,7 @@ const TopologyContent: React.FC<{
           }
         } else {
           if (e.getType() !== 'graph') {
-            controller.removeElement(e);
+            setObserved(() => controller.removeElement(e));
           }
         }
       });

--- a/frontend/src/pages/Mesh/MeshElems.tsx
+++ b/frontend/src/pages/Mesh/MeshElems.tsx
@@ -14,6 +14,7 @@ import {
   NodeShape,
   NodeStatus
 } from '@patternfly/react-topology';
+import { action } from 'mobx';
 import { PFBadges, PFBadgeType } from 'components/Pf/PfBadges';
 import { DEGRADED, FAILURE } from 'types/Health';
 import { DecoratedMeshEdgeData, DecoratedMeshEdgeWrapper, DecoratedMeshNodeData, MeshInfraType } from 'types/Mesh';
@@ -39,20 +40,12 @@ export type NodeData = DecoratedMeshNodeData & {
   collapsible?: boolean; // for groups
   column?: number;
   component?: React.ReactNode;
-  icon?: React.ReactNode;
   isCollapsed?: boolean; // for groups
-  isFind?: boolean;
-  isHighlighted?: boolean;
-  isSelected?: boolean;
-  isUnhighlighted?: boolean;
   labelIcon?: React.ReactNode;
   labelIconClass?: string;
   labelIconPadding?: number;
   labelPosition?: LabelPosition;
-  marginX?: number;
   onCollapseChange?: (group: Node, collapsed: boolean) => void;
-  onHover?: (element: GraphElement, isMouseIn: boolean) => void;
-  row?: number;
   secondaryLabel?: string;
   setLocation?: boolean;
   showContextMenu?: boolean;
@@ -61,6 +54,13 @@ export type NodeData = DecoratedMeshNodeData & {
   truncateLength?: number;
   x?: number;
   y?: number;
+  // These are additions we've made for our own styling
+  isFind?: boolean;
+  isFocus?: boolean;
+  isHighlighted?: boolean;
+  isSelected?: boolean;
+  isUnhighlighted?: boolean;
+  onHover?: (element: GraphElement, isMouseIn: boolean) => void;
 };
 
 export type EdgeData = DecoratedMeshEdgeData & {
@@ -230,6 +230,17 @@ export const assignEdgeHealth = (_edges: DecoratedMeshEdgeWrapper[], _nodeMap: N
 };
 
 ///// PFT helpers
+
+// setObserved executes the provided setter func in a single mobx action. The setter is expected to make at least one element update.
+// like a call to elem.setData() or elem.setVisible(). PFT has these updates wrapped in a mobx observer and wants changes wrapper
+// in a mobx action. To limit renders, batch several data updates in one setDataFunc execution. If you see a console warning like
+// "[MobX] Since strict-mode is enabled, changing (observed) observable values without using an action is not allowed",
+// then you're missing this wrapper.
+export const setObserved = (setter: () => void): void => {
+  action(() => {
+    setter();
+  })();
+};
 
 export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
   const elems = c.getElements();

--- a/frontend/src/pages/Mesh/MeshHighlighter.ts
+++ b/frontend/src/pages/Mesh/MeshHighlighter.ts
@@ -22,7 +22,7 @@
 
 import { Edge, Node } from '@patternfly/react-topology';
 import { Controller, GraphElement } from '@patternfly/react-topology';
-import { NodeData, ancestors, predecessors, successors } from './MeshElems';
+import { NodeData, ancestors, predecessors, setObserved, successors } from './MeshElems';
 
 export class MeshHighlighter {
   controller: Controller;
@@ -67,12 +67,14 @@ export class MeshHighlighter {
   };
 
   clearHighlighting = (): void => {
-    this.controller.getElements().forEach(e => {
-      const data = e.getData() as NodeData;
+    setObserved(() => {
+      this.controller.getElements().forEach(e => {
+        const data = e.getData() as NodeData;
 
-      if (data.isHighlighted || data.isUnhighlighted) {
-        e.setData({ ...data, isHighlighted: false, isUnhighlighted: false });
-      }
+        if (data.isHighlighted || data.isUnhighlighted) {
+          e.setData({ ...data, isHighlighted: false, isUnhighlighted: false });
+        }
+      });
     });
   };
 
@@ -82,18 +84,20 @@ export class MeshHighlighter {
       return;
     }
 
-    highlighted.toHighlight.forEach(e => {
-      e.setData({ ...e.getData(), isHighlighted: true });
-    });
-
-    if (highlighted.unhighlightOthers) {
-      this.controller.getElements().forEach(e => {
-        const data = e.getData() as NodeData;
-        if (!data.isHighlighted) {
-          e.setData({ ...data, isUnhighlighted: true });
-        }
+    setObserved(() => {
+      highlighted.toHighlight.forEach(e => {
+        e.setData({ ...e.getData(), isHighlighted: true });
       });
-    }
+
+      if (highlighted.unhighlightOthers) {
+        this.controller.getElements().forEach(e => {
+          const data = e.getData() as NodeData;
+          if (!data.isHighlighted) {
+            e.setData({ ...data, isUnhighlighted: true });
+          }
+        });
+      }
+    });
   };
 
   // Returns the nodes to highlight. Highlighting for a hovered or selected element

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -35,6 +35,7 @@ import { MeshToolbarActions } from 'actions/MeshToolbarActions';
 import { MeshFindOptions } from './MeshFindOptions';
 import { MeshHelpFind } from '../MeshHelpFind';
 import { LayoutType, meshLayout } from '../Mesh';
+import { setObserved } from '../MeshElems';
 
 type ReduxStateProps = {
   findValue: string;
@@ -471,12 +472,16 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
   };
 
   // All edges have the graph as a parent
-  private unhideElement = (g: Graph, e: GraphElement): void => {
-    e.setVisible(true);
+  private unhideElements = (g: Graph, elems: GraphElement[]): void => {
+    setObserved(() => {
+      elems.forEach(e => {
+        e.setVisible(true);
 
-    if (!e.hasParent()) {
-      g.appendChild(e);
-    }
+        if (!e.hasParent()) {
+          g.appendChild(e);
+        }
+      });
+    });
   };
 
   private handleHide = (controller: Controller): void => {
@@ -488,7 +493,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
 
     // unhide any currently hidden elements, something changed so we'll redetermine what needs to be hidden
     if (this.hiddenElements) {
-      this.hiddenElements.forEach(e => this.unhideElement(mesh, e));
+      this.unhideElements(mesh, this.hiddenElements);
     }
     this.hiddenElements = undefined;
 
@@ -501,50 +506,60 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       // add elements described by the hide expression
       if (selector.nodeSelector) {
         hiddenNodes = selectOr(nodes, selector.nodeSelector);
-        hiddenNodes.forEach(n => n.setVisible(false));
+        setObserved(() => hiddenNodes.forEach(n => n.setVisible(false)));
       }
       if (selector.edgeSelector) {
         hiddenEdges = selectOr(edges, selector.edgeSelector);
-        hiddenEdges.forEach(e => e.setVisible(false));
+        setObserved(() => hiddenEdges.forEach(e => e.setVisible(false)));
       }
       if (hiddenEdges.length > 0) {
         // also hide nodes with only hidden edges (keep idle nodes as that is an explicit option)
-        nodes.forEach(n => {
-          if (n.isVisible()) {
-            const nodeData = n.getData();
-            const nodeEdges = n.getSourceEdges().concat(n.getTargetEdges());
-            if (!nodeData.isIdle && nodeEdges.length > 0 && nodeEdges.every(e => !e.isVisible())) {
-              n.setVisible(false);
+        setObserved(() => {
+          nodes.forEach(n => {
+            if (n.isVisible()) {
+              const nodeData = n.getData();
+              const nodeEdges = n.getSourceEdges().concat(n.getTargetEdges());
+              if (!nodeData.isIdle && nodeEdges.length > 0 && nodeEdges.every(e => !e.isVisible())) {
+                n.setVisible(false);
+              }
             }
-          }
+          });
         });
       }
 
       // also hide edges connected to hidden nodes
-      edges.forEach(e => {
-        if (e.isVisible() && !(e.getSource().isVisible() && e.getTarget().isVisible())) {
-          e.setVisible(false);
-        }
+      setObserved(() => {
+        edges.forEach(e => {
+          if (e.isVisible() && !(e.getSource().isVisible() && e.getTarget().isVisible())) {
+            e.setVisible(false);
+          }
+        });
       });
 
       // unhide any box hits, we only hide empty boxes
-      nodes.filter(n => n.isGroup() && !n.isVisible()).forEach(g => this.unhideElement(mesh, g));
+      this.unhideElements(
+        mesh,
+        nodes.filter(n => n.isGroup() && !n.isVisible())
+      );
 
       // now hide any boxes that don't have any visible children
-      nodes
-        .filter(n => n.isGroup())
-        .forEach(g => {
-          if (descendents(g).every(d => !d.isVisible())) {
-            g.setVisible(false);
-          }
-        });
+      setObserved(() => {
+        nodes
+          .filter(n => n.isGroup())
+          .forEach(g => {
+            if (descendents(g).every(d => !d.isVisible())) {
+              g.setVisible(false);
+            }
+          });
+      });
 
       const finalNodes = nodes.filter(n => !n.isVisible()) as GraphElement[];
       const finalEdges = edges.filter(e => !e.isVisible()) as GraphElement[];
 
       // we need to remove edges completely because an invisible edge is not
       // ignored by layout (I don't know why, nodes are ignored)
-      finalEdges.forEach(e => e.remove());
+      setObserved(() => finalEdges.forEach(e => e.remove()));
+
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 
@@ -558,9 +573,11 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
     console.debug(`Mesh Find selector=[${JSON.stringify(selector)}]`);
 
     // unhighlight old find-hits
-    this.findElements?.forEach(e => {
-      const data = e.getData() as MeshNodeData | MeshEdgeData;
-      e.setData({ ...data, isFind: false });
+    setObserved(() => {
+      this.findElements?.forEach(e => {
+        const data = e.getData() as MeshNodeData | MeshEdgeData;
+        e.setData({ ...data, isFind: false });
+      });
     });
 
     this.findElements = undefined;
@@ -580,9 +597,11 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       }
 
       this.findElements = findNodes.concat(findEdges);
-      this.findElements.forEach(e => {
-        const data = e.getData() as MeshNodeData | MeshEdgeData;
-        e.setData({ ...data, isFind: true });
+      setObserved(() => {
+        this.findElements?.forEach(e => {
+          const data = e.getData() as MeshNodeData | MeshEdgeData;
+          e.setData({ ...data, isFind: true });
+        });
       });
     }
   };


### PR DESCRIPTION
Protect against minigraph problems when the parent detail page component is changing its target element.

This is a semi-hack to prevent a major refactoring of how we work with the GraphDatasource object in the detail pages. Because we re-use the GraphDatasource, and it's an asynch fetch, it's possible that if the component gets re-used for a new workload/service/app, that things get out of sync.

In short, detect a mismatch between the target component and the datasource, and avoid updating the graph until things get back in sync.

Also:
- remove an unwanted dependency on "graphData" in effect that responds to a change in selectedIds
- slightly shorten the focus node flashing.
- suppress a bunch of console warnings.

Fixes https://github.com/kiali/kiali/issues/7839