### PR TITLE
[v1.65] Fix sleep hack and TestDiscoverWorkload test to run on the latest fips ocp cluster

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -189,7 +189,12 @@ if [ "${DELETE_BOOKINFO}" == "true" ]; then
     else
       $CLIENT_EXE delete smm default -n ${NAMESPACE}
     fi
-    $CLIENT_EXE delete scc bookinfo-scc
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-details
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-productpage
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-reviews
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:default
     $CLIENT_EXE delete project ${NAMESPACE}
     # oc delete project does not wait for a namespace to be removed, we need to also call 'oc delete namespace'
     $CLIENT_EXE delete namespace ${NAMESPACE}
@@ -220,25 +225,12 @@ metadata:
   name: istio-cni
 NAD
   fi
-  cat <<SCC | $CLIENT_EXE apply -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: bookinfo-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-users:
-- "system:serviceaccount:${NAMESPACE}:bookinfo-details"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-productpage"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings=v2"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-reviews"
-- "system:serviceaccount:${NAMESPACE}:default"
-SCC
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-details
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-productpage
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-reviews
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:default
 fi
 
 if [ "${ENABLE_INJECTION}" == "true" ]; then

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -37,21 +37,6 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: istio-cni
 NAD
-    cat <<SCC | $CLIENT_EXE apply -n sleep -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: sleep-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-users:
-- "system:serviceaccount:sleep:default"
-- "system:serviceaccount:sleep:sleep"
-SCC
   fi
   if [ "${ARCH}" == "s390x" ]; then
     echo "Using s390x specific images for curl in sleep.yaml"
@@ -206,7 +191,7 @@ else
   fi
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     ${CLIENT_EXE} delete network-attachment-definition istio-cni -n sleep
-    ${CLIENT_EXE} delete scc sleep-scc
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:sleep:sleep
     ${CLIENT_EXE} delete project sleep
   fi
   ${CLIENT_EXE} delete namespace sleep

--- a/tests/integration/assets/bookinfo-workloads.yaml
+++ b/tests/integration/assets/bookinfo-workloads.yaml
@@ -71,6 +71,9 @@ metadata:
     app: details
     version: v2
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: details
     image: istio/examples-bookinfo-details-v1:1.8.0


### PR DESCRIPTION
### Describe the change

Fix for https://github.com/kiali/kiali/issues/7837

Verified on clusters:

| OCP  | Kiali integration tests | Kiali cypress tests |
| ------------- | ------------- | ------------- |
| OCP 4.18-ec2-fips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2978/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3201/) |
| OCP 4.17 GA | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2979/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3202/) |
| OCP 4.14 -fips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2964/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3194/) |
| OCP 4.14 -noFips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2970/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3195/) |
