### PR TITLE
Fix sleep hack and TestDiscoverWorkload test to run on the latest fips ocp cluster

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -233,7 +233,6 @@ if [ "${DELETE_BOOKINFO}" == "true" ]; then
   echo "====== UNINSTALLING ANY EXISTING BOOKINFO DEMO ====="
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     $CLIENT_EXE delete network-attachment-definition istio-cni -n ${NAMESPACE}
-    $CLIENT_EXE delete scc bookinfo-scc
     $CLIENT_EXE delete project ${NAMESPACE}
     # oc delete project does not wait for a namespace to be removed, we need to also call 'oc delete namespace'
     $CLIENT_EXE delete namespace ${NAMESPACE}
@@ -260,26 +259,6 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: istio-cni
 NAD
-  cat <<SCC | $CLIENT_EXE apply -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: bookinfo-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-priority: 9
-users:
-- "system:serviceaccount:${NAMESPACE}:bookinfo-details"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-productpage"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-reviews"
-- "system:serviceaccount:${NAMESPACE}:default"
-SCC
 fi
 
 if [ "${AUTO_INJECTION}" == "true" ]; then

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -415,28 +415,6 @@ users:
 - "system:serviceaccount:${NAMESPACE}:prometheus"
 - "system:serviceaccount:${NAMESPACE}:grafana"
 SCC
-    else
-      echo "Creating SCC for OpenShift for the Istio addons"
-      cat <<SCC | ${CLIENT_EXE} apply -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: istio-addons-openshift-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-fsGroup:
-  type: RunAsAny
-seccompProfiles:
-- '*'
-priority: 9
-users:
-- "system:serviceaccount:${NAMESPACE}:prometheus"
-- "system:serviceaccount:${NAMESPACE}:grafana"
-SCC
     fi
   else
     if ! ${CLIENT_EXE} get namespace ${NAMESPACE}; then

--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -99,7 +99,7 @@ if [ "${DELETE_SLEEP}" == "true" ]; then
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     ${CLIENT_EXE} delete network-attachment-definition istio-cni -n sleep
-    ${CLIENT_EXE} delete scc sleep-scc
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:sleep:sleep
     ${CLIENT_EXE} delete project sleep
   fi
   ${CLIENT_EXE} delete namespace sleep
@@ -150,22 +150,6 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: istio-cni
 NAD
-    cat <<SCC | $CLIENT_EXE apply -n sleep -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: sleep-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-priority: 9
-users:
-- "system:serviceaccount:sleep:default"
-- "system:serviceaccount:sleep:sleep"
-SCC
   fi
 
   if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then

--- a/tests/integration/assets/bookinfo-workloads.yaml
+++ b/tests/integration/assets/bookinfo-workloads.yaml
@@ -71,6 +71,9 @@ metadata:
     app: details
     version: v2
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: details
     image: istio/examples-bookinfo-details-v1:1.8.0


### PR DESCRIPTION
### Describe the change

Fix for https://github.com/kiali/kiali/issues/7837

Verified ( with the latest kiali and istio via `upstream-istio-pipeline`) on clusters:

| OCP  | integration tests | cypress tests
| ------------- | ------------- | ------------- |
| OCP 4.18-ec2-fips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3006/)  | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3225/) |
| OCP 4.18-ec2 | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3011/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3226/) |
| OCP 4.17 GA | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3012/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3227/) |
| OCP 4.14 -fips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3014/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3234/) |
| OCP 4.14 -noFips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3013/) |  [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3228/) |


