### PR TITLE
[v1.73] Adapt bookinfo for 4.18 fips

### DIFF
--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -226,7 +226,12 @@ if [ "${DELETE_BOOKINFO}" == "true" ]; then
     else
       $CLIENT_EXE delete smm default -n ${NAMESPACE}
     fi
-    $CLIENT_EXE delete scc bookinfo-scc
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-details
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-productpage
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-reviews
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:${NAMESPACE}:default
     $CLIENT_EXE delete project ${NAMESPACE}
     # oc delete project does not wait for a namespace to be removed, we need to also call 'oc delete namespace'
     $CLIENT_EXE delete namespace ${NAMESPACE}
@@ -257,25 +262,12 @@ metadata:
   name: istio-cni
 NAD
   fi
-  cat <<SCC | $CLIENT_EXE apply -f -
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: bookinfo-scc
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-users:
-- "system:serviceaccount:${NAMESPACE}:bookinfo-details"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-productpage"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-ratings=v2"
-- "system:serviceaccount:${NAMESPACE}:bookinfo-reviews"
-- "system:serviceaccount:${NAMESPACE}:default"
-SCC
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-details
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-productpage
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-ratings-v2
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:bookinfo-reviews
+  ${CLIENT_EXE} adm policy add-scc-to-user anyuid system:serviceaccount:${NAMESPACE}:default
 fi
 
 if [ "${AUTO_INJECTION}" == "true" ]; then

--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -91,7 +91,7 @@ if [ "${DELETE_SLEEP}" == "true" ]; then
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     ${CLIENT_EXE} delete network-attachment-definition istio-cni -n sleep
-    ${CLIENT_EXE} delete scc sleep-scc
+    ${CLIENT_EXE} adm policy remove-scc-from-user anyuid system:serviceaccount:sleep:sleep
     ${CLIENT_EXE} delete project sleep
   fi
   ${CLIENT_EXE} delete namespace sleep


### PR DESCRIPTION
### Describe the change

Additional fix for bookinfo regarding 4.18 fips cluster changes (https://github.com/kiali/kiali/issues/7837). (Needed for ossm 2.5 testing which uses 1.17.0 bookapp images, forgot about that in PR https://github.com/kiali/kiali/pull/7838 where only ossm 2.6 was used [and 1.19.1 bookapp images which have `USER 1000`]) 

Verified on clusters:

| OCP  | Kiali integration tests | Kiali cypress tests |
| ------------- | ------------- | ------------- |
| OCP 4.18-ec2-fips | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2982) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3203/) |
| OCP 4.17 GA | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/2983/) | [ok](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3204/) |

 
