### PR TITLE
A single Before statement in Cypress is enough

### DIFF
--- a/frontend/cypress/integration/common/graph_display-cy.ts
+++ b/frontend/cypress/integration/common/graph_display-cy.ts
@@ -1,21 +1,5 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 When('user graphs {string} namespaces in the cytoscape graph', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing

--- a/frontend/cypress/integration/common/graph_display-pf.ts
+++ b/frontend/cypress/integration/common/graph_display-pf.ts
@@ -1,24 +1,8 @@
-import { Before, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 import { Visualization } from '@patternfly/react-topology';
 import { elems, select, selectAnd, selectOr } from './graph-pf';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 When('user graphs {string} namespaces', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing

--- a/frontend/cypress/integration/common/graph_replay.ts
+++ b/frontend/cypress/integration/common/graph_replay.ts
@@ -1,20 +1,4 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 When('user presses the Replay button', () => {
   cy.get('button[data-test="graph-replay-button"]').click();

--- a/frontend/cypress/integration/common/graph_toolbar-cy.ts
+++ b/frontend/cypress/integration/common/graph_toolbar-cy.ts
@@ -1,21 +1,5 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { CytoscapeGlobalScratchData, CytoscapeGlobalScratchNamespace } from 'types/Graph';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 When(
   'user graphs {string} namespaces with refresh {string} and duration {string} in the cytoscape graph',

--- a/frontend/cypress/integration/common/graph_toolbar-pf.ts
+++ b/frontend/cypress/integration/common/graph_toolbar-pf.ts
@@ -1,23 +1,7 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { EdgeAttr } from 'types/Graph';
 import { elems, select } from './graph-pf';
 import { Visualization } from '@patternfly/react-topology';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 When(
   'user graphs {string} namespaces with refresh {string} and duration {string}',

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -1,23 +1,7 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { Visualization } from '@patternfly/react-topology';
 import { MeshInfraType, MeshNodeData } from 'types/Mesh';
 import { elems } from './graph-pf';
-
-Before(() => {
-  // Copied from overview.ts.  This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 When('user closes mesh tour', () => {
   cy.waitForReact();

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -1,28 +1,9 @@
-import { Before, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 import { getClusterForSingleCluster } from './table';
 
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
-
-Before(() => {
-  // Focing to not stop cypress on unexpected errors not related to the tests.
-  // There are some random failures due timeouts/loadtime/framework that throws some error in the browser.
-  // After reviewing the tests failures, those are unrelated to the app, so,
-  // it needs this event to not fail the CI action due some "slow" action or similar.
-  // This is something to review in future iterations when tests are solid, but I haven't found a better way to
-  // solve this issue.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 Given('a healthy application in the cluster', function () {
   this.targetNamespace = 'bookinfo';

--- a/frontend/cypress/integration/common/wizard_request_routing.ts
+++ b/frontend/cypress/integration/common/wizard_request_routing.ts
@@ -1,27 +1,8 @@
-import { Before, Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
 
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
-
-Before(() => {
-  // Forcing to not stop cypress on unexpected errors not related to the tests.
-  // There are some random failures due timeouts/loadtime/framework that throws some error in the browser.
-  // After reviewing the tests failures, those are unrelated to the app, so,
-  // it needs this event to not fail the CI action due some "slow" action or similar.
-  // This is something to review in future iterations when tests are solid, but I haven't found a better way to
-  // solve this issue.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 Given('user opens the namespace {string} and {string} service details page', (namespace: string, service: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing


### PR DESCRIPTION
### Describe the change

This small PR prevents multiple executions of the same Before function within Cypress tests.

Before:

![image](https://github.com/user-attachments/assets/0d88595f-e240-4ae2-82f7-c65b71329c8b)

After:

![image](https://github.com/user-attachments/assets/9b92dbb6-ce9a-4295-b56e-7f5c0db3960e)

### Steps to test the PR

Verify that CI tests pass
