### PR TITLE
Upgrade CRC to 2.42.0 - OpenShift 4.17

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -504,10 +504,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="2.40.0"
+DEFAULT_CRC_DOWNLOAD_VERSION="2.42.0"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
-DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.16.4"
+DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.17.0"
 
 # The default virtual CPUs assigned to the CRC VM
 DEFAULT_CRC_CPUS="6"


### PR DESCRIPTION
### Describe the change

Modify `crc-openshift.sh` script to upgrade the CRC version to 2.42.0, which installs OpenShift 4.17.0

### Steps to test the PR

Execute `./hack/crc-openshift.sh start` and verify that OpenShift CRC version 4.17.0 is installed correctly

### Automation testing

N/A