### PR TITLE
[CI] Install Istio with the Sail Operator

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v yq &> /dev/null; then
+  echo "yq is required but it is either not installed or not in the PATH."
+  exit 1
+fi
+
+CUSTOM_INSTALL_SETTINGS=""
+PATCH_FILE=""
+
+# process command line args
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -pf|--patch-file)
+      PATCH_FILE="$2"
+      shift;shift
+      ;;
+    -s|--set)
+      if [ -n "${CUSTOM_INSTALL_SETTINGS}" ]; then
+        CUSTOM_INSTALL_SETTINGS="${CUSTOM_INSTALL_SETTINGS} | $2"
+      else
+        CUSTOM_INSTALL_SETTINGS="$2"
+      fi
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -pf|--patch-file <name=value>:
+       filepath to a yaml file of an 'Istio' resource that will overlay the default 'Istio' resource. 
+       --patch-file /path/to/patch-file.yaml
+  -s|--set <name=value>:
+       Sets a name/value pair for a custom install setting. Some examples you may want to use:
+       --set installPackagePath=/git/clone/istio.io/installer
+  -h|--help:
+       this message
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "ERROR: Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+helm upgrade sail-operator sail-operator \
+  --install \
+  --create-namespace \
+  --namespace sail-operator \
+  --repo https://istio-ecosystem.github.io/sail-operator
+
+K8S_GATEWAY_API_VERSION=$(curl --head --silent "https://github.com/kubernetes-sigs/gateway-api/releases/latest" | grep "location: " | awk '{print $2}' | sed "s/.*tag\///g" | cat -v | sed "s/\^M//g")
+echo "Installing Gateway API version ${K8S_GATEWAY_API_VERSION}"
+kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${K8S_GATEWAY_API_VERSION}"
+
+ISTIO_YAML=$(
+cat <<EOF
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v1.23.0
+  namespace: istio-system
+  updateStrategy:
+    type: InPlace
+  values:
+    global:
+      proxy:
+        resources:
+          requests:
+            cpu: 1m
+            memory: 1Mi
+      proxy_init:
+        resources:
+          requests:
+            cpu: 1m
+            memory: 1Mi
+    pilot:
+      resources:
+        requests:
+          cpu: 1m
+          memory: 1Mi
+EOF
+)
+
+if [ -n "${PATCH_FILE}" ]; then
+  base_yaml=$(mktemp)
+  echo "$ISTIO_YAML" > "$base_yaml"
+  ISTIO_YAML=$(yq -n "load(\"$base_yaml\") * load(\"$PATCH_FILE\")")
+fi
+
+if [ -n "${CUSTOM_INSTALL_SETTINGS}" ]; then
+  ISTIO_YAML=$(printf "%s" "$ISTIO_YAML" | yq "$CUSTOM_INSTALL_SETTINGS")
+fi
+
+kubectl get ns istio-system || kubectl create ns istio-system
+kubectl apply -f - <<<"$ISTIO_YAML"
+kubectl wait --for=condition=Ready istios/default -n istio-system
+
+# Install addons
+addons=("prometheus" "grafana" "jaeger")
+for addon in "${addons[@]}"; do
+  kubectl apply -n istio-system -f "https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.23/samples/addons/$addon.yaml"
+done

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -299,12 +299,10 @@ ensureMulticlusterApplicationsAreHealthy() {
 infomsg "Running ${TEST_SUITE} integration tests"
 if [ "${TEST_SUITE}" == "${BACKEND}" ]; then
   if [ "${TESTS_ONLY}" == "false" ]; then
-    "${SCRIPT_DIR}"/setup-kind-in-ci.sh ${ISTIO_VERSION_ARG} ${HELM_CHARTS_DIR_ARG}
-
-    ISTIO_INGRESS_IP="$(kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --sail true ${ISTIO_VERSION_ARG} ${HELM_CHARTS_DIR_ARG}
 
     # Install demo apps
-    "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" -g "${ISTIO_INGRESS_IP}"
+    "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" --use-gateway-api true
 
     ensureKialiServerReady
     

--- a/tests/integration/assets/bookinfo-simple-gateway.yaml
+++ b/tests/integration/assets/bookinfo-simple-gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: ingress-app
+  namespace: bookinfo
+spec:
+  selector:
+    app: istio-ingressgateway
+  servers:
+  - hosts:
+    - bookinfo/app-rpc.bookinfo
+    port:
+      name: grpc
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: istio-icc-app
+      mode: SIMPLE

--- a/tests/integration/tests/istio_config_test.go
+++ b/tests/integration/tests/istio_config_test.go
@@ -130,8 +130,11 @@ func assertConfigs(configList models.IstioConfigList, namespace string, require 
 }
 
 func TestIstioConfigDetails(t *testing.T) {
-	name := "bookinfo"
 	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-traffic-shifting-reviews.yaml")
+	t.Cleanup(func() { utils.DeleteFile(filePath, kiali.BOOKINFO) })
+	require.True(utils.ApplyFile(filePath, kiali.BOOKINFO))
+	name := "virtual-service-reviews"
 	config, _, err := kiali.IstioConfigDetails(kiali.BOOKINFO, name, kubernetes.VirtualServices)
 
 	require.NoError(err)

--- a/tests/integration/tests/no_istiod_test.go
+++ b/tests/integration/tests/no_istiod_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,7 @@ import (
 	"github.com/kiali/kiali/tests/integration/utils"
 	"github.com/kiali/kiali/tests/integration/utils/kiali"
 	"github.com/kiali/kiali/tests/integration/utils/kube"
+	"github.com/kiali/kiali/tools/cmd"
 )
 
 func TestNoIstiod(t *testing.T) {
@@ -86,8 +88,11 @@ func noProxyStatus(t *testing.T) {
 }
 
 func emptyValidations(t *testing.T) {
-	name := "bookinfo-gateway"
+	name := "ingress-app"
 	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-simple-gateway.yaml")
+	t.Cleanup(func() { utils.DeleteFile(filePath, kiali.BOOKINFO) })
+	require.True(utils.ApplyFile(filePath, kiali.BOOKINFO))
 
 	config, err := getConfigForNamespace(kiali.BOOKINFO, name, k8s.Gateways)
 

--- a/tests/integration/tests/workloads_test.go
+++ b/tests/integration/tests/workloads_test.go
@@ -26,7 +26,7 @@ func TestWorkloadsList(t *testing.T) {
 		require.NotNil(wl.Health)
 		require.NotNil(wl.Labels)
 		require.Equal(kiali.BOOKINFO, wl.Namespace)
-		if !strings.Contains(wl.Name, "traffic-generator") {
+		if !strings.Contains(wl.Name, "traffic-generator") && !strings.Contains(wl.Name, "gateway") {
 			require.True(wl.IstioSidecar)
 			require.NotNil(wl.IstioReferences)
 		}
@@ -48,7 +48,7 @@ func TestWorkloadDetails(t *testing.T) {
 		require.NotEmpty(pod.Status)
 		require.NotEmpty(pod.Name)
 		// @TODO fails on CI
-		//require.NotNil(pod.ProxyStatus)
+		// require.NotNil(pod.ProxyStatus)
 	}
 	require.NotEmpty(wl.Services)
 	for _, wl := range wl.Services {
@@ -66,9 +66,9 @@ func TestWorkloadDetails(t *testing.T) {
 }
 
 func TestWorkloadIstioIngressEmptyProxyStatus(t *testing.T) {
-	name := "istio-ingressgateway"
+	name := "bookinfo-gateway-istio"
 	require := require.New(t)
-	wl, _, err := kiali.WorkloadDetails(name, "istio-system")
+	wl, _, err := kiali.WorkloadDetails(name, "bookinfo")
 
 	require.NoError(err)
 	require.NotNil(wl)


### PR DESCRIPTION
### Describe the change

Installs Istio with the Sail Operator rather than `istioctl` for the backend integration tests. The other test suites can be updated later.

### Steps to test the PR

```bash
hack/run-integration-tests.sh --test-suite backend
```

Ensure tests complete successfully.

### Automation testing

N/A

### Issue reference

#7830 
