### PR TITLE
Handle Security appender Ambient corner case

### DIFF
--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
 import { MeshCluster } from '../types/Mesh';
+import { TrafficRate } from 'types/Graph';
 
 export type Durations = { [key: number]: string };
 
@@ -169,6 +170,9 @@ export const setServerConfig = (cfg: ServerConfig): void => {
 
   homeCluster = getHomeCluster(serverConfig);
   isMultiCluster = isMC();
+  if (!serverConfig.ambientEnabled) {
+    serverConfig.kialiFeatureFlags.uiDefaults.graph.traffic.ambient = 'none';
+  }
 };
 
 export const isIstioNamespace = (namespace: string): boolean => {

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
 import { MeshCluster } from '../types/Mesh';
-import { TrafficRate } from 'types/Graph';
 
 export type Durations = { [key: number]: string };
 

--- a/graph/telemetry/istio/appender/security_policy_test.go
+++ b/graph/telemetry/istio/appender/security_policy_test.go
@@ -15,10 +15,16 @@ import (
 func TestSecurityPolicyDefaultRates(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round((sum(rate(istio_requests_total{mesh_id="mesh1",reporter=~"destination|waypoint",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q0 := fmt.Sprintf("round((%s) OR (%s),0.001)",
+		`sum(rate(istio_requests_total{mesh_id="mesh1",reporter=~"destination|waypoint",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	v0 := model.Vector{}
 
-	q1 := `round((sum(rate(istio_requests_total{mesh_id="mesh1",reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q1 := fmt.Sprintf("round((%s) OR (%s) OR (%s),0.001)",
+		`sum(rate(istio_requests_total{mesh_id="mesh1",reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{mesh_id="mesh1",app="ztunnel",reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
+	// edge 1, represents ztunnel dest reported
 	q1m0 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
@@ -35,7 +41,25 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"destination_principal":          "destination-principal-test",
 		"connection_security_policy":     "mutual_tls"}
+	// edge 1, same edge, represents ztunnel source reported, basically overwites dest reported
 	q1m1 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "istio-system",
+		"source_workload":                "ingressgateway-unknown",
+		"source_canonical_service":       "ingressgateway",
+		"source_canonical_revision":      model.LabelValue(graph.Unknown),
+		"source_principal":               "source-principal-test",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service_name":       "productpage",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "productpage-v1",
+		"destination_canonical_service":  "productpage",
+		"destination_canonical_revision": "v1",
+		"destination_principal":          "destination-principal-test",
+		"connection_security_policy":     "mutual_tls"}
+	// edge 2, represents ztunnel only source reported (see kiali7811)
+	q1m2 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -57,6 +81,9 @@ func TestSecurityPolicyDefaultRates(t *testing.T) {
 			Value:  10.0},
 		&model.Sample{
 			Metric: q1m1,
+			Value:  10.0},
+		&model.Sample{
+			Metric: q1m2,
 			Value:  10.0}}
 
 	client, api, err := setupMockedWithQueryScope("mesh1")
@@ -119,12 +146,14 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 		`sum(rate(istio_tcp_received_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	v0 := model.Vector{}
 
-	q1 := fmt.Sprintf("round((%s) OR (%s) OR (%s) OR (%s) OR (%s),0.001)",
+	q1 := fmt.Sprintf("round((%s) OR (%s) OR (%s) OR (%s) OR (%s) OR (%s) OR (%s),0.001)",
 		`sum(rate(istio_requests_total{reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
 		`sum(rate(istio_request_messages_total{reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
 		`sum(rate(istio_response_messages_total{reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
 		`sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
-		`sum(rate(istio_tcp_received_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
+		`sum(rate(istio_tcp_received_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{app="ztunnel",reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_received_bytes_total{app="ztunnel",reporter="source",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	q1m0 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
@@ -214,13 +243,17 @@ func TestSecurityPolicyTotalRates(t *testing.T) {
 	assert.Equal("v1", productpage.Version)
 }
 
-func TestSecurityPolicyWithServiceNodes(t *testing.T) {
+func TestSecurityPolicyWithServiceNodesAndNoZtunnel(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round((sum(rate(istio_requests_total{reporter=~"destination|waypoint",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q0 := fmt.Sprintf("round((%s) OR (%s),0.001)",
+		`sum(rate(istio_requests_total{reporter=~"destination|waypoint",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{app!="ztunnel",reporter="destination",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	v0 := model.Vector{}
 
-	q1 := `round((sum(rate(istio_requests_total{reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0) OR (sum(rate(istio_tcp_sent_bytes_total{reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0),0.001)`
+	q1 := fmt.Sprintf("round((%s) OR (%s),0.001)",
+		`sum(rate(istio_requests_total{reporter=~"destination|waypoint",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`,
+		`sum(rate(istio_tcp_sent_bytes_total{app!="ztunnel",reporter="destination",source_workload_namespace="bookinfo"}[60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,source_principal,destination_cluster,destination_service_namespace,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,destination_principal,connection_security_policy) > 0`)
 	q1m0 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
@@ -270,7 +303,7 @@ func TestSecurityPolicyWithServiceNodes(t *testing.T) {
 		},
 		QueryTime: time.Now().Unix(),
 		Rates: graph.RequestedRates{
-			Ambient: graph.AmbientTrafficTotal,
+			Ambient: graph.AmbientTrafficWaypoint,
 			Grpc:    graph.RateRequests,
 			Http:    graph.RateRequests,
 			Tcp:     graph.RateSent,


### PR DESCRIPTION
Fixes #7811 

Handle Security appender Ambient corner case. For ztunnel-to-sidecar traffic, we get source reporting only.  Historically we always use destination reporting to determine mtls.
- add necessary queries to security_appender
  - unfortunate but I don't see an alternative
- make sure we disable ambient traffic when ambient is not enabled
  - this saves unnecessary queries
- update unit test 

Test:
@josunect , you already have the environment because you were the one to figure out the problem :-)  I think I updated the queries as you suggested, to look for ztunnel source telem when needed.  Let me know if this solves the issue for you, and if the solution looks good.  It does add queries, and those queries may often return duplicate reporting (because ztunnel typically reports both source and dest telem when source and dest are both in the ambient mesh). Despite adding queries and pulling more date, any duplicates should basically overwrite the original with the same result.
