### PR TITLE
Be able to tell our test scripts what version of OLM to use.

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -10,6 +10,12 @@ on:
         required: false
         default: ""
         type: string
+      olm_version:
+        description: "Version of OLM to install or 'latest'. e.g. v0.28.0"
+        required: false
+        # change this to "latest" after the upstream OLM bug is fixed
+        default: "v0.28.0"
+        type: string
 
 jobs:
   molecules:
@@ -31,4 +37,4 @@ jobs:
     - name: Run molecule tests using helm
       run: ./hack/ci-kind-molecule-tests.sh --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer helm --olm-enabled false
     - name: Run molecule tests using OLM
-      run: ./hack/ci-kind-molecule-tests.sh --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer skip --olm-enabled true
+      run: ./hack/ci-kind-molecule-tests.sh --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer skip --olm-enabled true --olm-version "${{ inputs.olm_version }}"

--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -123,6 +123,10 @@ Options:
     than to install its own operator.
     Default: helm
 
+-ov|--olm-version <version>
+    Defines the version of OLM to test with. This is ignored if --olm-enabled=false.
+    Default: latest
+
 -rc|--rebuild-cluster <true|false>
     If true, any existing cluster will be destroyed and a new one will be rebuilt.
     Default: false
@@ -183,6 +187,7 @@ while [[ $# -gt 0 ]]; do
     -lpn|--logs-project-name)     LOGS_PROJECT_NAME="$2";     shift;shift; ;;
     -oe|--olm-enabled)            OLM_ENABLED="$2";           shift;shift; ;;
     -oi|--operator-installer)     OPERATOR_INSTALLER="$2";    shift;shift; ;;
+    -ov|--olm-version)            OLM_VERSION="$2";           shift;shift; ;;
     -rc|--rebuild-cluster)        REBUILD_CLUSTER="$2";       shift;shift; ;;
     -sd|--src-dir)                SRC="$2";                   shift;shift; ;;
     -st|--skip-tests)             SKIP_TESTS="$2";            shift;shift; ;;
@@ -203,6 +208,7 @@ SRC="${SRC:-/tmp/KIALI-GIT-KIND}"
 DORP="${DORP:-docker}"
 GIT_CLONE_PROTOCOL="${GIT_CLONE_PROTOCOL:-git}"
 OLM_ENABLED="${OLM_ENABLED:-false}"
+OLM_VERSION="${OLM_VERSION:-latest}"
 REBUILD_CLUSTER="${REBUILD_CLUSTER:-false}"
 
 CLIENT_EXE="$(which ${CLIENT_EXE} 2>/dev/null || echo "invalid kubectl: ${CLIENT_EXE}")"
@@ -291,6 +297,7 @@ LOGS_LOCAL_SUBDIR=$LOGS_LOCAL_SUBDIR
 LOGS_LOCAL_SUBDIR_ABS=$LOGS_LOCAL_SUBDIR_ABS
 LOGS_PROJECT_NAME=$LOGS_PROJECT_NAME
 OLM_ENABLED=$OLM_ENABLED
+OLM_VERSION=$OLM_VERSION
 OPERATOR_INSTALLER=$OPERATOR_INSTALLER
 REBUILD_CLUSTER=$REBUILD_CLUSTER
 SKIP_TESTS=$SKIP_TESTS
@@ -463,8 +470,6 @@ fi
 
 # if requested, install OLM and the Kiali Operator via OLM
 if [ "${OLM_ENABLED}" == "true" ]; then
-  OLM_VERSION="latest" # TODO might be nice to allow the user to set this via a command line option --olm-version
-
   if [ "${OLM_VERSION}" == "latest" ]; then
     OLM_VERSION="$(curl -s https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)"
     if [ -z "${OLM_VERSION}" ]; then
@@ -473,6 +478,8 @@ if [ "${OLM_ENABLED}" == "true" ]; then
     else
       infomsg "Github reports the latest OLM version is: ${OLM_VERSION}"
     fi
+  else
+      infomsg "Using the specified OLM version: ${OLM_VERSION}"
   fi
 
   # force the install.sh script to go through our client executable when it executes kubectl commands

--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -16,6 +16,7 @@ OPM_VERSION ?= 1.47.0
 # which OLM to install (for olm-install target)
 # TODO OLM v0.29.0 has a bug and cannot start. When that bug is fixed, put OLM_VERSION back to "latest"
 # see https://github.com/operator-framework/operator-lifecycle-manager/issues/3419
+# This should be fixed with a new version during the week of Nov 3, 2024 - we can revert back to latest at that time.
 #OLM_VERSION ?= latest
 OLM_VERSION ?= v0.28.0
 


### PR DESCRIPTION
OLM has a bug that causes it to be uninstallable so we need a way to install an older version to continue being able to test.

Right now the github action molecule tests are failing - that's the reason why I'm doing this now.

See https://github.com/operator-framework/operator-lifecycle-manager/issues/3419#issuecomment-2451589801

(when that bug is fixed and a new OLM release is published, we will follow up and reset to the "latest" olm release in our tests by merging this second PR: https://github.com/kiali/kiali/pull/7881)