### PR TITLE
[CI] go back to using the latest version of OLM

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -13,8 +13,7 @@ on:
       olm_version:
         description: "Version of OLM to install or 'latest'. e.g. v0.28.0"
         required: false
-        # change this to "latest" after the upstream OLM bug is fixed
-        default: "v0.28.0"
+        default: "latest"
         type: string
 
 jobs:

--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -14,11 +14,7 @@ OLM_INDEX_BASE_IMAGE ?= quay.io/openshift/origin-operator-registry:4.16
 OPM_VERSION ?= 1.47.0
 
 # which OLM to install (for olm-install target)
-# TODO OLM v0.29.0 has a bug and cannot start. When that bug is fixed, put OLM_VERSION back to "latest"
-# see https://github.com/operator-framework/operator-lifecycle-manager/issues/3419
-# This should be fixed with a new version during the week of Nov 3, 2024 - we can revert back to latest at that time.
-#OLM_VERSION ?= latest
-OLM_VERSION ?= v0.28.0
+OLM_VERSION ?= latest
 
 .prepare-olm-cluster-names: .determine-olm-operators-namespace .prepare-cluster
 ifeq ($(CLUSTER_TYPE),minikube)


### PR DESCRIPTION
Go back to using the latest version of OLM in our make and ci workflows.

Do NOT merge this until after the upstream OLM bug is fixed and a new release is published. We expect a v0.30.0 release to be published soon - when you see it here we can merge this PR: https://github.com/operator-framework/operator-lifecycle-manager/releases

For details, see: https://github.com/operator-framework/operator-lifecycle-manager/issues/3419#issuecomment-2451589801