### PR TITLE
Fix orphan edge hide issue in graph and mesh page

### DIFF
--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -642,10 +642,6 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
       const finalNodes = nodes.filter(n => !n.isVisible()) as GraphElement[];
       const finalEdges = edges.filter(e => !e.isVisible()) as GraphElement[];
 
-      // we need to remove edges completely because an invisible edge is not
-      // ignored by layout (I don't know why, nodes are ignored)
-      setObserved(() => finalEdges.forEach(e => e.remove()));
-
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -555,10 +555,6 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
       const finalNodes = nodes.filter(n => !n.isVisible()) as GraphElement[];
       const finalEdges = edges.filter(e => !e.isVisible()) as GraphElement[];
 
-      // we need to remove edges completely because an invisible edge is not
-      // ignored by layout (I don't know why, nodes are ignored)
-      setObserved(() => finalEdges.forEach(e => e.remove()));
-
       this.hiddenElements = finalNodes.concat(finalEdges);
     }
 


### PR DESCRIPTION
PFT Graph and Mesh hide had needed to call e.remove() to detach hidden edges from their parent group. I had inline comments stating that it really shouldn't be necessary. Now, either do to a PFT fix, and/or our recent change to wrap element updates in mobx actions, it seems unnecessary, and seems to be causing this orphan edge issue. Which makes sense because we're detaching it from its parent.

Fixes https://github.com/kiali/kiali/issues/7878

@jmazzitelli note: repro steps are in the issue.  Also, you reported this originally in https://github.com/kiali/kiali/pull/7836#issuecomment-2424905214.