### PR TITLE
Convert infraData type from unknown to any

### DIFF
--- a/frontend/src/types/Mesh.ts
+++ b/frontend/src/types/Mesh.ts
@@ -65,21 +65,21 @@ export interface DataPlaneNodeData extends BaseNodeData {
 export interface GrafanaNodeData extends BaseNodeData {
   // Grafana node data is the raw grafana config. We don't actually care about what
   // each field is since we just display the whole config in the side panel as is.
-  infraData: unknown;
+  infraData: any;
   infraType: MeshInfraType.GRAFANA;
 }
 
 export interface KialiNodeData extends BaseNodeData {
   // Kiali node data is the raw kiali config. We don't actually care about what
   // each field is since we just display the whole config in the side panel as is.
-  infraData: unknown;
+  infraData: any;
   infraType: MeshInfraType.KIALI;
 }
 
 export interface MetricStoreNodeData extends BaseNodeData {
   // MetricStore node data is the raw metric store config. We don't actually care about what
   // each field is since we just display the whole config in the side panel as is.
-  infraData: unknown;
+  infraData: any;
   infraType: MeshInfraType.METRIC_STORE;
 }
 


### PR DESCRIPTION
### Describe the change

The `infraData` variable of type `unknown` throws an error in OSSMC because the version of the `redux` library used (v4.0.1) has a known issue (see https://www.github.com/reduxjs/redux/issues/3368). This issue has been resolved in the `redux` library version used by the Kiali application. However, OSSMC cannot update its `redux` version, as it is dictated by the OpenShift Console dynamic plugin. To work around this, the `infraData` type must be converted to `any`.

### Steps to test the PR

Verify that Kiali works as expected

### Automation testing

N/A
