### PR TITLE
Autodetect gateways across namespaces

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -108,23 +108,21 @@ func (iss *IstioStatusService) getIstioComponentStatus(ctx context.Context, clus
 	}
 
 	// Autodiscover gateways.
-	workloads, err := iss.workloads.GetAllWorkloads(ctx, cluster)
+	gateways, err := iss.workloads.GetAllGateways(ctx, cluster)
 	if err != nil {
 		// Don't error on gateways since they are non-essential.
 		log.Debugf("Unable to get gateway workloads when building istio component status. Cluster: %s. Err: %s", cluster, err)
 		return istiodStatus, nil
 	}
 
-	for _, workload := range workloads {
-		if workload.IsGateway() {
-			istiodStatus = append(istiodStatus, kubernetes.ComponentStatus{
-				Cluster:   workload.Cluster,
-				Name:      workload.Name,
-				Namespace: workload.Namespace,
-				Status:    GetWorkloadStatus(*workload),
-				IsCore:    false,
-			})
-		}
+	for _, workload := range gateways {
+		istiodStatus = append(istiodStatus, kubernetes.ComponentStatus{
+			Cluster:   workload.Cluster,
+			Name:      workload.Name,
+			Namespace: workload.Namespace,
+			Status:    GetWorkloadStatus(*workload),
+			IsCore:    false,
+		})
 	}
 
 	return istiodStatus, nil

--- a/business/services.go
+++ b/business/services.go
@@ -258,6 +258,7 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 		if !onlyDefinitions {
 			sPods := kubernetes.FilterPodsByService(&item, pods)
 			/** Check if Service has istioSidecar deployed */
+			// TODO: This won't work if pods are scaled to zero.
 			mPods := models.Pods{}
 			mPods.Parse(sPods)
 			hasSidecar = mPods.HasAnyIstioSidecar()

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -148,6 +148,33 @@ func (in *WorkloadService) getWorkloadValidations(authpolicies []*security_v1.Au
 	return validations
 }
 
+// GetAllWorkloads fetches all workloads across every namespace in the cluster.
+func (in *WorkloadService) GetAllWorkloads(ctx context.Context, cluster string) (models.Workloads, error) {
+	var end observability.EndFunc
+	ctx, end = observability.StartSpan(ctx, "GetAllWorkloads",
+		observability.Attribute("package", "business"),
+		observability.Attribute("cluster", cluster),
+	)
+	defer end()
+
+	namespaces, err := in.businessLayer.Namespace.GetClusterNamespaces(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	var workloads models.Workloads
+	for _, namespace := range namespaces {
+		w, err := in.fetchWorkloadsFromCluster(ctx, cluster, namespace.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		workloads = append(workloads, w...)
+	}
+
+	return workloads, nil
+}
+
 // GetWorkloadList is the API handler to fetch the list of workloads in a given namespace.
 func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria WorkloadCriteria) (models.WorkloadList, error) {
 	var end observability.EndFunc
@@ -1263,7 +1290,6 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			if pod.HasIstioSidecar() && !w.IsGateway() && config.Get().ExternalServices.Istio.IstioAPIEnabled {
 				pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name)
 			}
-
 		}
 
 		if cnFound {
@@ -1858,7 +1884,6 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 
 // GetWaypoints: Return the list of workloads when the waypoint proxy is applied per namespace
 func (in *WorkloadService) GetWaypoints(ctx context.Context) models.Workloads {
-
 	if !in.cache.IsWaypointListExpired() {
 		log.Tracef("GetWaypoints: Returning list from cache")
 		return in.cache.GetWaypointList()
@@ -1974,7 +1999,6 @@ func (in *WorkloadService) getWaypointsForWorkload(ctx context.Context, namespac
 // listWaypointWorkloads returns the list of workloads when the waypoint proxy is applied per namespace
 // Maybe use some cache?
 func (in *WorkloadService) listWaypointWorkloads(ctx context.Context, name, cluster string) []models.Workload {
-
 	// Get all the workloads for a namespaces labeled
 	labelSelector := fmt.Sprintf("%s=%s", config.WaypointUseLabel, name)
 	nslist, errNs := in.userClients[cluster].GetNamespaces(labelSelector)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/util/sliceutil"
 )
 
 func NewWorkloadService(
@@ -173,6 +174,18 @@ func (in *WorkloadService) GetAllWorkloads(ctx context.Context, cluster string) 
 	}
 
 	return workloads, nil
+}
+
+// GetAllGateways fetches all gateway workloads across every namespace in the cluster.
+func (in *WorkloadService) GetAllGateways(ctx context.Context, cluster string) (models.Workloads, error) {
+	workloads, err := in.GetAllWorkloads(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return sliceutil.Filter(workloads, func(w *models.Workload) bool {
+		return w.IsGateway()
+	}), nil
 }
 
 // GetWorkloadList is the API handler to fetch the list of workloads in a given namespace.

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1859,6 +1859,8 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			w.SetPods(cPods)
 		}
 
+		w.WorkloadListItem.IsGateway = w.IsGateway()
+
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
 			if pod.HasIstioSidecar() && !w.IsGateway() && config.Get().ExternalServices.Istio.IstioAPIEnabled {

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -759,7 +759,6 @@ func TestGetZtunnelPodLogsProxy(t *testing.T) {
 	assert.Equal("spiffe://cluster.local/ns/travel-agency/sa/default", entryQuotes.AccessLog.UpstreamCluster)
 	assert.Equal("mysqldb.travel-agency.svc.cluster.local", entryQuotes.AccessLog.RequestedServer)
 	assert.Equal(int64(1719927663203), entryQuotes.TimestampUnix)
-
 }
 
 func TestDuplicatedControllers(t *testing.T) {
@@ -1293,4 +1292,37 @@ func TestValidateWaypointService(t *testing.T) {
 
 	assert.Equal(1, len(workloadProductPage.Pods))
 	assert.Equal(0, len(workloadProductPage.WaypointWorkloads))
+}
+
+func TestGetWorkloadSetsIsGateway(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "Namespace"}},
+		&apps_v1.Deployment{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "ingress-gateway",
+				Namespace: "Namespace",
+			},
+			Spec: apps_v1.DeploymentSpec{
+				Template: core_v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{
+							"istio.io/gateway-name": "ingress-gateway",
+						},
+					},
+				},
+			},
+		},
+	)
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
+
+	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "ingress-gateway", IncludeServices: false}
+	workload, err := svc.GetWorkload(context.TODO(), criteria)
+	require.NoError(err)
+
+	require.True(workload.WorkloadListItem.IsGateway, "Expected IsGateway to be True but it was false")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,6 @@ const (
 const (
 	AmbientAnnotation        = "ambient.istio.io/redirection"
 	AmbientAnnotationEnabled = "enabled"
-	K8sGatewayLabelName      = "gateway.networking.k8s.io/gateway-name"
 	WaypointLabel            = "gateway.istio.io/managed"
 	WaypointLabelValue       = "istio.io-mesh-controller"
 	WaypointUseLabel         = "istio.io/use-waypoint"
@@ -292,10 +291,8 @@ type RegistryConfig struct {
 type IstioConfig struct {
 	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty"`
 	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
-	EgressGatewayNamespace            string            `yaml:"egress_gateway_namespace,omitempty"`
 	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
-	IngressGatewayNamespace           string            `yaml:"ingress_gateway_namespace,omitempty"`
 	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
 	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`
@@ -356,11 +353,8 @@ type IstioLabels struct {
 	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
 	AmbientWaypointUseLabel    string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
 	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	EgressGatewayLabel         string `yaml:"egress_gateway_label,omitempty" json:"egressGatewayLabel"`
-	IngressGatewayLabel        string `yaml:"ingress_gateway_label,omitempty" json:"ingressGatewayLabel"`
 	InjectionLabelName         string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
-	K8sGatewayLabelName        string `yaml:"k8s_gateway_label_name,omitempty" json:"k8sGatewayLabelName"`
 	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
@@ -724,9 +718,7 @@ func NewConfig() (c *Config) {
 					Components: []ComponentStatus{},
 				},
 				ConfigMapName:                     "",
-				EgressGatewayNamespace:            "",
 				EnvoyAdminLocalPort:               15000,
-				IngressGatewayNamespace:           "",
 				IstioAPIEnabled:                   true,
 				IstioIdentityDomain:               "svc.cluster.local",
 				IstioInjectionAnnotation:          "sidecar.istio.io/inject",
@@ -783,11 +775,8 @@ func NewConfig() (c *Config) {
 			AmbientWaypointLabelValue:  WaypointLabelValue,
 			AmbientWaypointUseLabel:    WaypointUseLabel,
 			AppLabelName:               "app",
-			EgressGatewayLabel:         "istio=egressgateway",
-			IngressGatewayLabel:        "istio=ingressgateway",
 			InjectionLabelName:         "istio-injection",
 			InjectionLabelRev:          "istio.io/rev",
-			K8sGatewayLabelName:        K8sGatewayLabelName,
 			VersionLabelName:           "version",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
@@ -973,14 +962,6 @@ func (conf *Config) AllNamespacesAccessible() bool {
 // IsServerHTTPS returns true if the server endpoint should use HTTPS. If false, only plaintext HTTP is supported.
 func (conf *Config) IsServerHTTPS() bool {
 	return conf.Identity.CertFile != "" && conf.Identity.PrivateKeyFile != ""
-}
-
-func (conf *Config) GatewayLabel(labelConfig string) []string {
-	label := strings.Split(labelConfig, "=")
-	if len(label) == 2 {
-		return label
-	}
-	return []string{}
 }
 
 func (conf *Config) IsRBACDisabled() bool {
@@ -1330,14 +1311,6 @@ func Validate(cfg Config) error {
 	cfgTracing := cfg.ExternalServices.Tracing
 	if cfgTracing.Enabled && cfgTracing.Provider != JaegerProvider && cfgTracing.Provider != TempoProvider {
 		return fmt.Errorf("error in configuration options for the external services tracing provider. Invalid provider type [%s]", cfgTracing.Provider)
-	}
-
-	if len(cfg.GatewayLabel(cfg.IstioLabels.IngressGatewayLabel)) != 2 {
-		return fmt.Errorf("error parsing key=value configuration. Invalid ingress gateway label [%s]", cfg.IstioLabels.IngressGatewayLabel)
-	}
-
-	if len(cfg.GatewayLabel(cfg.IstioLabels.EgressGatewayLabel)) != 2 {
-		return fmt.Errorf("error parsing key=value configuration. Invalid egress gateway label [%s]", cfg.IstioLabels.EgressGatewayLabel)
 	}
 
 	return nil

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://172.18.255.71/kiali",
   "name": "@kiali/kiali-ui",
   "version": "2.1.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,4 @@
 {
-  "proxy": "http://172.18.255.71/kiali",
   "name": "@kiali/kiali-ui",
   "version": "2.1.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -12,9 +12,9 @@ import { KialiIcon, createIcon } from '../../config/KialiIcon';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../Kiosk/KioskActions';
-import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
-import { isMultiCluster, serverConfig } from '../../config';
+import { isMultiCluster } from '../../config';
 import { Workload } from '../../types/Workload';
+import { hasMissingSidecar } from 'components/VirtualList/Config';
 import { healthIndicatorStyle } from 'styles/HealthStyle';
 
 type ReduxProps = {
@@ -203,19 +203,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
           <KialiIcon.Info className={infoStyle} />
         </Tooltip>
 
-        {((!workload.istioSidecar &&
-          !workload.isAmbient &&
-          !isWaypoint(workload.labels) &&
-          serverConfig.ambientEnabled) ||
-          (!workload.istioSidecar && !serverConfig.ambientEnabled)) && (
-          <MissingSidecar
-            namespace={props.namespace}
-            isGateway={isGateway(workload.labels)}
-            tooltip={true}
-            className={infoStyle}
-            text=""
-          />
-        )}
+        {hasMissingSidecar(workload) && <MissingSidecar tooltip={true} className={infoStyle} text="" />}
       </span>
     );
   };
@@ -275,16 +263,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
             <span style={{ marginLeft: '0.5rem' }}>{createIcon(sub.status)}</span>
           </Tooltip>
 
-          {((!workload.istioSidecar && !workload.isAmbient && serverConfig.ambientEnabled) ||
-            (!workload.istioSidecar && !serverConfig.ambientEnabled)) && (
-            <MissingSidecar
-              namespace={props.namespace}
-              isGateway={isGateway(workload.labels)}
-              tooltip={true}
-              className={infoStyle}
-              text=""
-            />
-          )}
+          {hasMissingSidecar(workload) && <MissingSidecar tooltip={true} className={infoStyle} text="" />}
         </span>
       );
     } else {

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -66,8 +66,8 @@ import { QUERY_PARAMS, PATH, HEADERS, METHOD } from './K8sRequestRouting/K8sMatc
 import { ServiceOverview } from '../../types/ServiceList';
 import { ADD, SET, REQ_MOD, RESP_MOD, REQ_RED, REQ_MIR } from './K8sRequestRouting/K8sFilterBuilder';
 import { ANYTHING, PRESENCE } from './RequestRouting/MatchBuilder';
-import { getGatewayLabels } from '../../helpers/LabelFilterHelper';
 import { t } from 'utils/I18nUtils';
+import { defaultGatewayLabel, defaultGatewayLabelValue } from 'config/Constants';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -691,7 +691,6 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
     };
 
     // Wizard is optional, only when user has explicitly selected "Create a Gateway or K8s API Gateway"
-    const ingressLabels = getGatewayLabels(serverConfig.istioLabels.ingressGatewayLabel);
     wizardGW =
       wState.gateway && wState.gateway.addGateway && wState.gateway.newGateway
         ? {
@@ -706,7 +705,7 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
             },
             spec: {
               selector: {
-                [ingressLabels[0]]: ingressLabels[1]
+                [defaultGatewayLabel]: defaultGatewayLabelValue
               },
               servers: [
                 {

--- a/frontend/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/frontend/src/components/MissingSidecar/MissingSidecar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
-import { isIstioNamespace, serverConfig } from 'config/ServerConfig';
+import { serverConfig } from 'config/ServerConfig';
 import { icons } from 'config';
 import { KialiIcon } from '../../config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -11,9 +11,7 @@ type MissingSidecarProps = {
   color?: string;
   dataTest?: string;
   icon?: React.ComponentClass<SVGIconProps>;
-  isGateway?: boolean;
   meshtooltip?: string;
-  namespace: string;
   text?: string;
   textmesh?: string;
   texttooltip?: string;
@@ -33,9 +31,7 @@ export const MissingSidecar: React.FC<MissingSidecarProps> = ({
   icon = icons.istio.missingSidecar.icon,
   color = icons.istio.missingSidecar.color,
   className,
-  dataTest,
-  namespace,
-  isGateway
+  dataTest
 }) => {
   const iconComponent = (
     <span className={className} data-test={dataTest}>
@@ -55,10 +51,6 @@ export const MissingSidecar: React.FC<MissingSidecarProps> = ({
       )}
     </span>
   );
-
-  if (isIstioNamespace(namespace) || isGateway) {
-    return <></>;
-  }
 
   return tooltip ? (
     <Tooltip

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -1,6 +1,8 @@
 import deepFreeze from 'deep-freeze';
 import { AppListItem } from '../../types/AppList';
-import { WorkloadListItem } from '../../types/Workload';
+import { AppWorkload } from 'types/App';
+import { isWaypoint } from 'helpers/LabelFilterHelper';
+import { WorkloadListItem, Workload } from '../../types/Workload';
 import { ServiceListItem } from '../../types/ServiceList';
 import { dicIstioTypeToGVK, IstioConfigItem } from '../../types/IstioConfigList';
 import * as Renderers from './Renderers';
@@ -9,7 +11,6 @@ import { isIstioNamespace } from 'config/ServerConfig';
 import { NamespaceInfo } from '../../types/NamespaceInfo';
 import { StatefulFiltersRef } from '../Filters/StatefulFilters';
 import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
-import { isGateway, isWaypoint } from '../../helpers/LabelFilterHelper';
 import { getGVKTypeString } from '../../utils/IstioConfigUtils';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
@@ -28,8 +29,17 @@ export const hasHealth = (r: RenderResource): r is SortResource => {
   return (r as SortResource).health !== undefined;
 };
 
-export const hasMissingSidecar = (r: SortResource): boolean => {
-  return !isIstioNamespace(r.namespace) && !r.istioSidecar && !isGateway(r.labels) && !isWaypoint(r.labels);
+export const hasMissingSidecar = (workload: Workload | WorkloadListItem | AppWorkload | AppListItem): boolean => {
+  return (
+    // TODO:
+    // Are we missing an ambient case here where ambient is enabled AND we are missing the ambient labels AND we are missing the sidecar?
+    // hasMissingSC && hasMissingA && serverConfig.ambientEnabled
+    !workload.istioSidecar &&
+    !workload.isAmbient &&
+    !isWaypoint(workload.labels) &&
+    !workload.isGateway &&
+    !isIstioNamespace(workload.namespace)
+  );
 };
 
 export const noAmbientLabels = (r: SortResource): boolean => {

--- a/frontend/src/config/Constants.ts
+++ b/frontend/src/config/Constants.ts
@@ -1,0 +1,2 @@
+export const defaultGatewayLabel = 'istio';
+export const defaultGatewayLabelValue = 'ingressgateway';

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -83,11 +83,8 @@ const defaultServerConfig: ComputedServerConfig = {
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
-    egressGatewayLabel: 'istio=egressgateway',
-    ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
-    k8sGatewayLabelName: 'gateway.networking.k8s.io/gateway-name',
     versionLabelName: 'version'
   },
   kialiFeatureFlags: {

--- a/frontend/src/helpers/LabelFilterHelper.ts
+++ b/frontend/src/helpers/LabelFilterHelper.ts
@@ -100,29 +100,6 @@ const getKeyAndValues = (filters: string[]): { keyValues: string[]; keys: string
   return { keyValues, keys };
 };
 
-export const getGatewayLabels = (labelConfig: string): string[] => {
-  const label = labelConfig.split('=');
-  if (label.length === 2) {
-    return label;
-  }
-  return ['', ''];
-};
-
-export const isGateway = (labels: { [key: string]: string }): boolean => {
-  const ingress = getGatewayLabels(serverConfig.istioLabels.ingressGatewayLabel);
-  const egress = getGatewayLabels(serverConfig.istioLabels.egressGatewayLabel);
-  return (
-    labels &&
-    ((ingress[0] in labels && labels[ingress[0]] === ingress[1]) ||
-      (egress[0] in labels && labels[egress[0]] === egress[1]) ||
-      isK8sGateway(labels))
-  );
-};
-
-export const isK8sGateway = (labels: { [key: string]: string }): boolean => {
-  return labels && serverConfig.istioLabels.k8sGatewayLabelName in labels;
-};
-
 export const isWaypoint = (labels: { [key: string]: string }): boolean => {
   return (
     labels &&

--- a/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/frontend/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,7 +1,8 @@
-import { filterByLabel, isGateway, isK8sGateway } from '../LabelFilterHelper';
+import { filterByLabel } from '../LabelFilterHelper';
 import { AppListItem } from '../../types/AppList';
 import { AppHealth, WorkloadHealth, ServiceHealth } from '../../types/Health';
 import { WorkloadListItem } from '../../types/Workload';
+import { InstanceType } from 'types/Common';
 import { ServiceListItem } from '../../types/ServiceList';
 import { setServerConfig } from '../../config/ServerConfig';
 import { serverRateConfig } from '../../types/ErrorRate/__testData__/ErrorRateConfig';
@@ -30,10 +31,12 @@ const emptySvcHealth = new ServiceHealth(
 const appList: AppListItem[] = [
   {
     namespace: 'bookinfo',
+    instanceType: InstanceType.App,
     health: emptyAppHealth,
     name: 'ratings',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'ratings', service: 'ratings', version: 'v1' },
     istioReferences: []
   },
@@ -41,8 +44,10 @@ const appList: AppListItem[] = [
     namespace: 'bookinfo',
     health: emptyAppHealth,
     name: 'productpage',
+    instanceType: InstanceType.App,
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'productpage', service: 'productpage', version: 'v1' },
     istioReferences: []
   },
@@ -50,8 +55,10 @@ const appList: AppListItem[] = [
     namespace: 'bookinfo',
     health: emptyAppHealth,
     name: 'details',
+    instanceType: InstanceType.App,
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'details', service: 'details', version: 'v1' },
     istioReferences: []
   },
@@ -59,8 +66,10 @@ const appList: AppListItem[] = [
     namespace: 'bookinfo',
     health: emptyAppHealth,
     name: 'reviews',
+    instanceType: InstanceType.App,
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
     istioReferences: []
   }
@@ -74,10 +83,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'details', version: 'v1' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   },
   {
@@ -87,10 +98,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'productpage', version: 'v1' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   },
   {
@@ -100,10 +113,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'ratings', version: 'v1' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   },
   {
@@ -113,10 +128,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'reviews', version: 'v1' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   },
   {
@@ -126,10 +143,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'reviews', version: 'v2' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   },
   {
@@ -139,10 +158,12 @@ const workloadList: WorkloadListItem[] = [
     type: 'Deployment',
     istioSidecar: false,
     isAmbient: false,
+    isGateway: false,
     labels: { app: 'reviews', version: 'v3' },
     appLabel: true,
     versionLabel: true,
     istioReferences: [],
+    instanceType: InstanceType.Workload,
     notCoveredAuthPolicy: false
   }
 ];
@@ -152,6 +173,7 @@ const serviceList: ServiceListItem[] = [
     namespace: 'bookinfo',
     health: emptySvcHealth,
     name: 'details',
+    instanceType: InstanceType.Service,
     istioSidecar: false,
     isAmbient: false,
     labels: { app: 'details', service: 'details' },
@@ -165,6 +187,7 @@ const serviceList: ServiceListItem[] = [
     namespace: 'bookinfo',
     health: emptySvcHealth,
     name: 'reviews',
+    instanceType: InstanceType.Service,
     istioSidecar: false,
     isAmbient: false,
     labels: { app: 'reviews', service: 'reviews' },
@@ -178,6 +201,7 @@ const serviceList: ServiceListItem[] = [
     namespace: 'bookinfo',
     health: emptySvcHealth,
     name: 'ratings',
+    instanceType: InstanceType.Service,
     istioSidecar: false,
     isAmbient: false,
     labels: { app: 'ratings', service: 'ratings' },
@@ -191,6 +215,7 @@ const serviceList: ServiceListItem[] = [
     namespace: 'bookinfo',
     health: emptySvcHealth,
     name: 'productpage',
+    instanceType: InstanceType.Service,
     istioSidecar: false,
     isAmbient: false,
     labels: { app: 'productpage', service: 'productpage' },
@@ -218,10 +243,12 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
+        instanceType: InstanceType.App,
         health: emptyAppHealth,
         name: 'details',
         istioSidecar: false,
         isAmbient: false,
+        isGateway: false,
         labels: { app: 'details', service: 'details', version: 'v1' },
         istioReferences: []
       }
@@ -233,10 +260,12 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
+        instanceType: InstanceType.App,
         health: emptyAppHealth,
         name: 'reviews',
         istioSidecar: false,
         isAmbient: false,
+        isGateway: false,
         labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
         istioReferences: []
       }
@@ -253,11 +282,13 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
+        instanceType: InstanceType.Workload,
         health: emptyWorkHealth,
         name: 'reviews-v1',
         type: 'Deployment',
         istioSidecar: false,
         isAmbient: false,
+        isGateway: false,
         labels: { app: 'reviews', version: 'v1' },
         appLabel: true,
         versionLabel: true,
@@ -266,11 +297,13 @@ describe('LabelFilter', () => {
       },
       {
         namespace: 'bookinfo',
+        instanceType: InstanceType.Workload,
         health: emptyWorkHealth,
         name: 'reviews-v2',
         type: 'Deployment',
         istioSidecar: false,
         isAmbient: false,
+        isGateway: false,
         labels: { app: 'reviews', version: 'v2' },
         appLabel: true,
         versionLabel: true,
@@ -279,11 +312,13 @@ describe('LabelFilter', () => {
       },
       {
         namespace: 'bookinfo',
+        instanceType: InstanceType.Workload,
         health: emptyWorkHealth,
         name: 'reviews-v3',
         type: 'Deployment',
         istioSidecar: false,
         isAmbient: false,
+        isGateway: false,
         labels: { app: 'reviews', version: 'v3' },
         appLabel: true,
         versionLabel: true,
@@ -305,6 +340,7 @@ describe('LabelFilter', () => {
         namespace: 'bookinfo',
         health: emptySvcHealth,
         name: 'details',
+        instanceType: InstanceType.Service,
         istioSidecar: false,
         isAmbient: false,
         labels: { app: 'details', service: 'details' },
@@ -320,40 +356,5 @@ describe('LabelFilter', () => {
         serviceRegistry: 'Kubernetes'
       }
     ]);
-  });
-
-  it('check is Ingress/Egress Gateway when false', () => {
-    const result = isGateway({ istio: 'wrong' });
-    expect(result).toBeFalsy();
-  });
-
-  it('check is Ingress Gateway when true', () => {
-    const result = isGateway({ istio: 'ingressgateway' });
-    expect(result).toBeTruthy();
-  });
-
-  it('check is Egress Gateway when true', () => {
-    const result = isGateway({ istio: 'egressgateway' });
-    expect(result).toBeTruthy();
-  });
-
-  it('check is Gateway (K8s) when true', () => {
-    const result = isGateway({ 'gateway.networking.k8s.io/gateway-name': 'gateway-istio' });
-    expect(result).toBeTruthy();
-  });
-
-  it('check is Gateway (K8s) when false', () => {
-    const result = isGateway({ 'gateway.networking.k8s.io/wrong-gateway-name': 'gateway-istio' });
-    expect(result).toBeFalsy();
-  });
-
-  it('check is K8s Gateway when true', () => {
-    const result = isK8sGateway({ 'gateway.networking.k8s.io/gateway-name': 'gateway-istio' });
-    expect(result).toBeTruthy();
-  });
-
-  it('check is K8s Gateway when false', () => {
-    const result = isK8sGateway({ 'gateway.networking.k8s.io/wrong-gateway-name': 'gateway-istio' });
-    expect(result).toBeFalsy();
   });
 });

--- a/frontend/src/pages/AppList/AppListClass.tsx
+++ b/frontend/src/pages/AppList/AppListClass.tsx
@@ -1,14 +1,17 @@
 import { AppList, AppListItem } from '../../types/AppList';
 import { sortIstioReferences } from './FiltersAndSorts';
 import { AppHealth } from '../../types/Health';
+import { InstanceType } from 'types/Common';
 
 export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {
   if (data.applications) {
     return data.applications.map(app => ({
       namespace: app.namespace,
       name: app.name,
+      instanceType: InstanceType.App,
       istioSidecar: app.istioSidecar,
       isAmbient: app.isAmbient,
+      isGateway: app.isGateway,
       health: AppHealth.fromJson(app.namespace, app.name, app.health, {
         rateInterval: rateInterval,
         hasSidecar: app.istioSidecar,

--- a/frontend/src/pages/AppList/FiltersAndSorts.ts
+++ b/frontend/src/pages/AppList/FiltersAndSorts.ts
@@ -11,13 +11,13 @@ import {
   filterByHealth,
   labelFilter
 } from '../../components/Filters/CommonFilters';
-import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
 import { istioConfigTypeFilter } from '../IstioConfigList/FiltersAndSorts';
 import { ObjectReference } from '../../types/IstioObjects';
 import { serverConfig } from 'config';
 import { getGVKTypeString, istioTypesToGVKString } from '../../utils/IstioConfigUtils';
+import { hasMissingSidecar } from 'components/VirtualList/Config';
 
 export const sortFields: SortField<AppListItem>[] = [
   {

--- a/frontend/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -4,7 +4,7 @@ import { ServerList } from './GatewayForm/ServerList';
 import { MAX_PORT, Server, ServerForm, ServerTLSSettings, MIN_PORT } from '../../types/IstioObjects';
 import { isValid } from 'utils/Common';
 import { areValidHosts } from './GatewayForm/ServerBuilder';
-import { serverConfig } from '../../config';
+import { defaultGatewayLabel, defaultGatewayLabelValue } from 'config/Constants';
 
 type Props = {
   gateway: GatewayState;
@@ -24,7 +24,7 @@ export const initGateway = (): GatewayState => ({
   addWorkloadSelector: false,
   gatewayServers: [],
   serversForm: [],
-  workloadSelectorLabels: serverConfig.istioLabels.ingressGatewayLabel,
+  workloadSelectorLabels: `${defaultGatewayLabel}=${defaultGatewayLabelValue}`,
   workloadSelectorValid: true
 });
 

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -67,9 +67,11 @@ export const ServiceDescription: React.FC<ServiceInfoDescriptionProps> = (props:
           }
 
           workloads.push({
+            namespace: wk.namespace,
             workloadName: wk.name,
             istioSidecar: wk.istioSidecar,
             isAmbient: wk.isAmbient,
+            isGateway: wk.isGateway,
             serviceAccountNames: wk.serviceAccountNames,
             labels: wk.labels ?? {}
           });

--- a/frontend/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/frontend/src/pages/ServiceList/FiltersAndSorts.ts
@@ -10,7 +10,6 @@ import {
   getFilterSelectedValues,
   filterByHealth
 } from '../../components/Filters/CommonFilters';
-import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
 import { calculateErrorRate } from '../../types/ErrorRate';
@@ -46,14 +45,7 @@ export const sortFields: SortField<ServiceListItem>[] = [
     isNumeric: false,
     param: 'is',
     compare: (a: ServiceListItem, b: ServiceListItem): number => {
-      // First sort by missing sidecar
-      const aSC = hasMissingSidecar(a) ? 1 : 0;
-      const bSC = hasMissingSidecar(b) ? 1 : 0;
-      if (aSC !== bSC) {
-        return aSC - bSC;
-      }
-
-      // Second by Details
+      // First by Details
       const iRefA = a.istioReferences;
       const iRefB = b.istioReferences;
       const cmpRefs = compareObjectReferences(iRefA, iRefB);

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import * as ServiceListFilters from './FiltersAndSorts';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
 import { ServiceList, ServiceListItem } from '../../types/ServiceList';
-import { DurationInSeconds } from '../../types/Common';
+import { DurationInSeconds, InstanceType } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { namespaceEquals } from '../../utils/Common';
@@ -117,6 +117,7 @@ class ServiceListPageComponent extends FilterComponent.Component<
     if (data.services) {
       return data.services.map(service => ({
         name: service.name,
+        instanceType: InstanceType.Service,
         istioSidecar: service.istioSidecar,
         isAmbient: service.isAmbient,
         namespace: service.namespace,

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -19,7 +19,6 @@ import { location, router, URLParam } from '../../app/History';
 import { MiniGraphCard } from '../../components/CytoscapeGraph/MiniGraphCard';
 import { IstioConfigCard } from '../../components/IstioConfigCard/IstioConfigCard';
 import { MiniGraphCardPF } from 'pages/GraphPF/MiniGraphCardPF';
-import { isGateway } from '../../helpers/LabelFilterHelper';
 import { getGVKTypeString, stringToGVK } from '../../utils/IstioConfigUtils';
 
 type WorkloadInfoProps = {
@@ -170,7 +169,7 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
           checks: []
         };
 
-        if (!isIstioNamespace(this.props.namespace) && !isGateway(this.props.workload?.labels || {})) {
+        if (!isIstioNamespace(this.props.namespace) && !workload.isGateway) {
           if (!isWaypoint) {
             if (
               (!pod.istioContainers || pod.istioContainers.length === 0) &&

--- a/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -7,6 +7,7 @@ import {
   ToggleType
 } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
+import { hasMissingSidecar } from 'components/VirtualList/Config';
 import { SortField } from '../../types/SortFilters';
 import { hasHealth } from '../../types/Health';
 import {
@@ -18,7 +19,6 @@ import {
   getPresenceFilterValue,
   filterByHealth
 } from '../../components/Filters/CommonFilters';
-import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 import { filterByLabel } from '../../helpers/LabelFilterHelper';
 import { calculateErrorRate } from '../../types/ErrorRate';

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import * as WorkloadListFilters from './FiltersAndSorts';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
 import { WorkloadListItem, ClusterWorkloadsResponse } from '../../types/Workload';
-import { DurationInSeconds } from '../../types/Common';
+import { InstanceType, DurationInSeconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { namespaceEquals } from '../../utils/Common';
@@ -119,11 +119,13 @@ class WorkloadListPageComponent extends FilterComponent.Component<
         cluster: deployment.cluster,
         namespace: deployment.namespace,
         name: deployment.name,
+        instanceType: InstanceType.Workload,
         type: deployment.type,
         appLabel: deployment.appLabel,
         versionLabel: deployment.versionLabel,
         istioSidecar: deployment.istioSidecar,
         isAmbient: deployment.isAmbient,
+        isGateway: deployment.isGateway,
         additionalDetailSample: deployment.additionalDetailSample,
         health: WorkloadHealth.fromJson(deployment.namespace, deployment.name, deployment.health, {
           rateInterval: this.props.duration,

--- a/frontend/src/types/App.ts
+++ b/frontend/src/types/App.ts
@@ -1,5 +1,6 @@
 import { Namespace } from './Namespace';
 import { Runtime } from './Workload';
+import { InstanceType } from 'types/Common';
 import { AppHealthResponse } from '../types/Health';
 
 export type AppId = {
@@ -10,8 +11,10 @@ export type AppId = {
 
 export interface AppWorkload {
   isAmbient: boolean;
+  isGateway: boolean;
   istioSidecar: boolean;
   labels: { [key: string]: string };
+  namespace: string;
   serviceAccountNames: string[];
   workloadName: string;
 }
@@ -19,6 +22,7 @@ export interface AppWorkload {
 export interface App {
   cluster?: string;
   health: AppHealthResponse;
+  instanceType: InstanceType.App;
   isAmbient: boolean;
   name: string;
   namespace: Namespace;

--- a/frontend/src/types/AppList.ts
+++ b/frontend/src/types/AppList.ts
@@ -1,5 +1,6 @@
 import { AppHealth } from './Health';
 import { ObjectReference } from './IstioObjects';
+import { InstanceType } from 'types/Common';
 
 export interface AppList {
   applications: AppListItem[];
@@ -9,7 +10,9 @@ export interface AppList {
 export interface AppListItem {
   cluster?: string;
   health: AppHealth;
+  instanceType: InstanceType.App;
   isAmbient: boolean;
+  isGateway: boolean;
   istioReferences: ObjectReference[];
   istioSidecar: boolean;
   labels: { [key: string]: string };

--- a/frontend/src/types/Common.ts
+++ b/frontend/src/types/Common.ts
@@ -113,3 +113,11 @@ export const isEqualTimeRange = (t1: TimeRange, t2: TimeRange): boolean => {
 
   return true;
 };
+
+// InstanceType is either an App, Workload, or Service. It represents one of the three
+// different pages that Kiali shows lists for other than Istio config.
+export enum InstanceType {
+  App = 'app',
+  Service = 'service',
+  Workload = 'workload'
+}

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -7,11 +7,8 @@ export type IstioLabelKey =
   | 'ambientWaypointLabel'
   | 'ambientWaypointLabelValue'
   | 'appLabelName'
-  | 'egressGatewayLabel'
-  | 'ingressGatewayLabel'
   | 'injectionLabelName'
   | 'injectionLabelRev'
-  | 'k8sGatewayLabelName'
   | 'versionLabelName';
 
 interface DeploymentConfig {

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -47,9 +47,11 @@ interface EndpointAddress {
 export interface WorkloadOverview {
   createdAt: string;
   isAmbient: boolean;
+  isGateway: boolean;
   istioSidecar: boolean;
   labels?: { [key: string]: string };
   name: string;
+  namespace: string;
   resourceVersion: string;
   serviceAccountNames: string[];
   type: string;

--- a/frontend/src/types/ServiceList.ts
+++ b/frontend/src/types/ServiceList.ts
@@ -1,3 +1,4 @@
+import { InstanceType } from 'types/Common';
 import { ServiceHealth } from './Health';
 import { Validations, ObjectValidation, ObjectReference } from './IstioObjects';
 import { AdditionalItem } from './Workload';
@@ -23,6 +24,7 @@ export interface ServiceOverview {
 }
 
 export interface ServiceListItem extends ServiceOverview {
+  instanceType: InstanceType.Service;
   namespace: string;
   validation?: ObjectValidation;
 }

--- a/frontend/src/types/Workload.ts
+++ b/frontend/src/types/Workload.ts
@@ -1,5 +1,6 @@
 import { WorkloadHealth, WorkloadHealthResponse } from './Health';
 import { ObjectReference, Pod, Service, Validations } from './IstioObjects';
+import { InstanceType } from 'types/Common';
 
 export type WorkloadId = {
   namespace: string;
@@ -14,11 +15,14 @@ export interface Workload {
   cluster?: string;
   createdAt: string;
   health?: WorkloadHealthResponse;
+  instanceType: InstanceType.Workload;
   isAmbient: boolean;
+  isGateway: boolean;
   istioInjectionAnnotation?: boolean;
   istioSidecar: boolean;
   labels: { [key: string]: string };
   name: string;
+  namespace: string;
   pods: Pod[];
   replicas: Number;
   resourceVersion: string;
@@ -37,9 +41,12 @@ export const emptyWorkload: Workload = {
   availableReplicas: 0,
   createdAt: '',
   isAmbient: false,
+  isGateway: false,
   istioSidecar: true, // true until proven otherwise
   labels: {},
   name: '',
+  namespace: '',
+  instanceType: InstanceType.Workload,
   pods: [],
   replicas: 0,
   resourceVersion: '',
@@ -67,7 +74,9 @@ export interface WorkloadListItem {
   appLabel: boolean;
   cluster?: string;
   health: WorkloadHealth;
+  instanceType: InstanceType.Workload;
   isAmbient: boolean;
+  isGateway: boolean;
   istioReferences: ObjectReference[];
   istioSidecar: boolean;
   labels: { [key: string]: string };

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -90,11 +90,8 @@ export const healthConfig = {
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',
-    egressGatewayLabel: 'istio=egressgateway',
-    ingressGatewayLabel: 'istio=ingressgateway',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
-    k8sGatewayLabelName: 'gateway.networking.k8s.io/gateway-name',
     versionLabelName: 'version'
   },
   prometheus: {

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -241,10 +241,8 @@
               "Components": []
             },
             "ConfigMapName": "",
-            "EgressGatewayNamespace": "",
             "EnvoyAdminLocalPort": 15000,
             "GatewayAPIClasses": [],
-            "IngressGatewayNamespace": "",
             "IstioAPIEnabled": true,
             "IstioIdentityDomain": "svc.cluster.local",
             "IstioInjectionAnnotation": "sidecar.istio.io/inject",

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -57,6 +57,8 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 	istioStatus, err := gi.IstioStatusGetter.GetStatus(ctx)
 	if errors.IsForbidden(err) {
 		return nil, err
+	} else if err != nil {
+		err = fmt.Errorf("when checking the health status of components in the mesh, an error occurred. Please correct the error then try again. Error: %w", err)
 	}
 	mesh.CheckError(err)
 

--- a/models/app.go
+++ b/models/app.go
@@ -50,6 +50,11 @@ type AppListItem struct {
 	// example: true
 	IsAmbient bool `json:"isAmbient"`
 
+	// Define if Labels related to this Workload contains any Gateway label
+	// required: true
+	// example: true
+	IsGateway bool `json:"isGateway"`
+
 	// Labels for App
 	Labels map[string]string `json:"labels"`
 

--- a/models/pod.go
+++ b/models/pod.go
@@ -12,9 +12,11 @@ import (
 // Pods alias for list of Pod structs
 type Pods []*Pod
 
-const AmbientAnnotation = "ambient.istio.io/redirection"
-const AmbientAnnotationEnabled = "enabled"
-const IstioProxy = "istio-proxy"
+const (
+	AmbientAnnotation        = "ambient.istio.io/redirection"
+	AmbientAnnotationEnabled = "enabled"
+	IstioProxy               = "istio-proxy"
+)
 
 // Pod holds a subset of v1.Pod data that is meaningful in Kiali
 type Pod struct {

--- a/models/workload.go
+++ b/models/workload.go
@@ -523,8 +523,15 @@ func (workload *Workload) IsGateway() bool {
 	}
 
 	// gateway-api
+	// This is the old gateway-api label that was removed in 1.24.
 	// If this label exists then it's a gateway
 	if _, ok := workload.Labels["istio.io/gateway-name"]; ok {
+		return true
+	}
+
+	// This is the new gateway-api label that was added in 1.24
+	// The value distinguishes gateways from waypoints.
+	if workload.Labels["gateway.istio.io/managed"] == "istio.io-gateway-controller" {
 		return true
 	}
 

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -226,11 +226,23 @@ func TestIsGatewayLabelsToWorkload(t *testing.T) {
 			},
 			ShouldBeGateway: true,
 		},
-		"gateway-api created gateway should be a gateway": {
+		"gateway-api created gateway with old label should be a gateway": {
 			Labels: map[string]string{
 				"istio.io/gateway-name": "gateway",
 			},
 			ShouldBeGateway: true,
+		},
+		"gateway-api created gateway with new label should be a gateway": {
+			Labels: map[string]string{
+				"gateway.istio.io/managed": "istio.io-gateway-controller",
+			},
+			ShouldBeGateway: true,
+		},
+		"gateway-api created gateway with new label but with waypoint value should not be a gateway": {
+			Labels: map[string]string{
+				"gateway.istio.io/managed": "istio.io-mesh-controller",
+			},
+			ShouldBeGateway: false,
 		},
 		"gateway with istio ingress label should be a gateway": {
 			Labels: map[string]string{

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -6,6 +6,7 @@ import (
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,8 @@ func TestParseDeploymentToWorkload(t *testing.T) {
 	config.Set(cfg)
 
 	w := Workload{}
-	w.ParseDeployment(fakeDeployment())
+	d := fakeDeployment()
+	w.ParseDeployment(d)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -48,6 +50,11 @@ func TestParseDeploymentToWorkload(t *testing.T) {
 	assert.Equal("value-annot-2", w.AdditionalDetails[0].Value)
 	assert.Equal("Annotation 1", w.AdditionalDetails[1].Title)
 	assert.Equal("value-annot-1", w.AdditionalDetails[1].Value)
+	// TODO: The parsing is actually clobbering the Deployment.Annotations if Template.Annotations
+	// is set but fixing it may cause unintended side effects so putting this test after the rest.
+	d.Spec.Template.Annotations = map[string]string{"food": "pizza", "drink": "soda"}
+	w.ParseDeployment(d)
+	assert.Equal(w.TemplateAnnotations, d.Spec.Template.Annotations)
 }
 
 func TestParseReplicaSetToWorkload(t *testing.T) {
@@ -187,39 +194,72 @@ func TestParsePodWithoutLabelsToWorkload(t *testing.T) {
 }
 
 func TestIsGatewayLabelsToWorkload(t *testing.T) {
-	assert := assert.New(t)
-	config.Set(config.NewConfig())
-
-	w := Workload{}
-	w.Type = "Deployment"
-	w.Labels = map[string]string{
-		"istio":   "ingressgateway",
-		"version": "v1",
+	cases := map[string]struct {
+		Labels              map[string]string
+		ShouldBeGateway     bool
+		TemplateAnnotations map[string]string
+	}{
+		"istioctl created egress gateway should be a gateway": {
+			Labels: map[string]string{
+				"operator.istio.io/component": "EgressGateways",
+				"version":                     "v1",
+			},
+			ShouldBeGateway: true,
+		},
+		"istioctl created ingress gateway should be a gateway": {
+			Labels: map[string]string{
+				"operator.istio.io/component": "IngressGateways",
+				"version":                     "v1",
+			},
+			ShouldBeGateway: true,
+		},
+		"gateway with bad label should not be a gateway": {
+			Labels: map[string]string{
+				"operator.istio.io/component": "EgressGateway",
+				"istio-system":                "ingressgateway",
+			},
+			ShouldBeGateway: false,
+		},
+		"gateway-injection created gateway should be a gateway": {
+			TemplateAnnotations: map[string]string{
+				"inject.istio.io/templates": "gateway",
+			},
+			ShouldBeGateway: true,
+		},
+		"gateway-api created gateway should be a gateway": {
+			Labels: map[string]string{
+				"istio.io/gateway-name": "gateway",
+			},
+			ShouldBeGateway: true,
+		},
+		"gateway with istio ingress label should be a gateway": {
+			Labels: map[string]string{
+				"istio": "ingressgateway",
+			},
+			ShouldBeGateway: true,
+		},
+		"gateway with istio egress label should be a gateway": {
+			Labels: map[string]string{
+				"istio": "egressgateway",
+			},
+			ShouldBeGateway: true,
+		},
+		"no labels and no annotations should not be a gateway": {
+			ShouldBeGateway: false,
+		},
 	}
-	assert.True(w.IsGateway())
 
-	w = Workload{}
-	w.Type = "Deployment"
-	w.Labels = map[string]string{
-		"operator.istio.io/component": "EgressGateways",
-		"version":                     "v1",
-	}
-	assert.True(w.IsGateway())
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 
-	w = Workload{}
-	w.Type = "Deployment"
-	w.Labels = map[string]string{
-		"operator.istio.io/component": "EgressGateway",
-		"istio-system":                "ingressgateway",
-	}
-	assert.False(w.IsGateway())
+			w := Workload{}
+			w.Labels = tc.Labels
+			w.TemplateAnnotations = tc.TemplateAnnotations
 
-	w = Workload{}
-	w.Type = "Deployment"
-	w.Labels = map[string]string{
-		"gateway.networking.k8s.io/gateway-name": "gateway",
+			require.Equal(tc.ShouldBeGateway, w.IsGateway())
+		})
 	}
-	assert.True(w.IsGateway())
 }
 
 func fakeDeployment() *apps_v1.Deployment {


### PR DESCRIPTION
### Describe the change

If a user specifies `istio.component_status`, then that will be used exclusively for the istio status checks. If a user doesn't specify `istio.component_status`, then Kiali will look for gateway workloads across all namespaces. Since we look for gateway workloads across namespaces, this PR also removes the gateway related Kiali config options. It also moves the logic for determining if a workload is a gateway or not to the backend whereas before it was duplicated in both the frontend and the backend. This PR also changes ingress gateways to be "not core" in the istio status health checks. Now when you deploy Kiali without creating an ingress/egress gateway, it will no longer complain at you in the masthead.

### Steps to test the PR

#### Test gateway autodetection
1. Deploy Istio + Kiali
2. Create a gateway with gateway-injection:
    ```
    kubectl create namespace istio-ingress
    helm install istio-ingressgateway istio/gateway -n istio-ingress
    ```
3. Ensure Kiali doesn't have a "missing sidecar" badge for the gateway workload.
4. Create a gateway with gateway-api
    ```
    kubectl create namespace istio-ingress
    kubectl apply -f - <<EOF
    apiVersion: gateway.networking.k8s.io/v1
    kind: Gateway
    metadata:
      name: gateway
      namespace: istio-ingress
    spec:
      gatewayClassName: istio
      listeners:
      - name: default
        hostname: "*.example.com"
        port: 80
        protocol: HTTP
        allowedRoutes:
          namespaces:
            from: All
    EOF
    ```
5. Ensure Kiali doesn't have a "missing sidecar" badge for the gateway workload.

#### Test specifying `component_status`
1. Deploy Istio + Kiali
2. Set istio component status to something wrong:
    ```
      istio:
        component_status
          components:
          - app_label: nonexistantgateway
            is_core: false
            is_proxy: true
            namespace: doesnotexist
    ```
3. Masthead should show a warning just for what you've set.

#### Test deploying Istio without gateways doesn't show warning

1. Deploy Sail + Kiali. Use this PR to easily deploy Kiali + sail: https://github.com/kiali/kiali/pull/7876. Then rebuild/reload kiali with this PR.
2. Ensure no warnings in masthead

### Automation testing

Included unit tests.

### Issue reference

#7882 
