### PR TITLE
[CI] Fix cypress test failures with Istio 1.24

### DIFF
--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -8,6 +8,8 @@ Given(
   'I am on the logs tab of the {string} workload detail page of the {string} namespace',
   (workload: string, namespace: string) => {
     cy.visit({ url: `/console/namespaces/${namespace}/workloads/${workload}?tab=logs&refresh=0` });
+    cy.get('#metrics_filter_interval_duration-toggle').click();
+    cy.get('#1800').click();
   }
 );
 

--- a/frontend/cypress/integration/featureFiles/traffic_policies_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/traffic_policies_multicluster.feature
@@ -35,16 +35,17 @@ Feature: Manipulate Traffic Policies in the Primary-Remote and Multi-Primary set
     And user selects the "bookinfo" namespace
     Then user should not see the generated Traffic policy objects located in the "east" cluster
 
-  Scenario: Try to create a Traffic Policy in a remote cluster in the Primary-Remote deployment
+  @multi-primary
+  Scenario: Create a Traffic Policy in a remote cluster
     When user deletes a Traffic Policy and the resource is no longer available in any cluster
     And user is at the "overview" page
     And user decides to "create" a Traffic Policy in the "west" "bookinfo"
     And user confirms to "create" the Traffic Policy
-    Then an error message "Could not create traffic policies." is displayed
-    And user is at the "istio" list page
+    Then an info message "Traffic policies created for bookinfo namespace." is displayed
+    When user is at the "istio" list page
     And user selects the "bookinfo" namespace
+    Then user sees the generated Traffic policy objects located in the "west" cluster
     And user should not see the generated Traffic policy objects located in the "east" cluster
-    And user should not see the generated Traffic policy objects located in the "west" cluster
 
   @multi-primary
   Scenario: Update a Traffic Policy scenario in a remote cluster

--- a/frontend/cypress/integration/featureFiles/traffic_policies_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/traffic_policies_multicluster.feature
@@ -4,7 +4,7 @@
 
 Feature: Manipulate Traffic Policies in the Primary-Remote and Multi-Primary setup
   In Primary-Remote setup, user should be able to create, update and delete policies on the local cluster only.
-  In Multi-Primary setup, user should be able to create, update and delete policies on both clusters. 
+  In Multi-Primary setup, user should be able to create, update and delete policies on both clusters.
 
 	Background:
 		Given user is at administrator perspective
@@ -45,18 +45,6 @@ Feature: Manipulate Traffic Policies in the Primary-Remote and Multi-Primary set
     And user selects the "bookinfo" namespace
     And user should not see the generated Traffic policy objects located in the "east" cluster
     And user should not see the generated Traffic policy objects located in the "west" cluster
-
-  @multi-primary
-  Scenario: Create a Traffic Policy in a remote cluster
-    When user deletes a Traffic Policy and the resource is no longer available in any cluster
-    And user is at the "overview" page
-    And user decides to "create" a Traffic Policy in the "west" "bookinfo"
-    And user confirms to "create" the Traffic Policy
-    Then an info message "Traffic policies created for bookinfo namespace." is displayed
-    When user is at the "istio" list page
-    And user selects the "bookinfo" namespace
-    Then user sees the generated Traffic policy objects located in the "west" cluster
-    And user should not see the generated Traffic policy objects located in the "east" cluster
 
   @multi-primary
   Scenario: Update a Traffic Policy scenario in a remote cluster

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -23,7 +23,6 @@ Feature: Kiali Waypoint related features
     And the health column on the "waypoint" row has a health icon
     And the "Labels" column on the "waypoint" row has the text "gateway.istio.io/managed=istio.io-mesh-controller"
     And the "Labels" column on the "waypoint" row has the text "gateway.networking.k8s.io/gateway-name=waypoint"
-    And the "Labels" column on the "waypoint" row has the text "istio.io/gateway-name=waypoint"
     And the "Type" column on the "waypoint" row has the text "Deployment"
     And the "Details" column on the "waypoint" row has the text "Waypoint Proxy"
 

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config_multicluster.feature
@@ -24,24 +24,6 @@ Feature: Kiali Istio Config page
     And user types "foobar" in the "addPortName_0" input
     Then the preview button should be disabled
 
-  Scenario: Try to Create a Gateway in both clusters in the Primary-Remote deployment
-    When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster
-    And user selects the "bookinfo" namespace
-    And user clicks in the "Gateway" Istio config actions
-    And user sees the "Create Gateway" config wizard
-    And user selects "east,west" from the cluster dropdown
-    And user types "bookinfo-gateway-mc" in the "name" input
-    And user adds a server to a server list
-    Then the preview button should be disabled
-    And user types "website.com" in the "hosts_0" input
-    And user types "8080" in the "addPortNumber_0" input
-    And user types "foobar" in the "addPortName_0" input
-    And user previews the configuration
-    And user creates the istio config
-    Then an error message "Could not create Istio networking.istio.io/v1, Kind=Gateway objects" is displayed
-    And the "Gateway" "bookinfo-gateway-mc" should be listed in "east" "bookinfo" namespace
-    And the "Gateway" "bookinfo-gateway-mc" should not be listed in "west" "bookinfo" namespace
-
   @multi-primary
   Scenario: Create a Gateway in both clusters in the Multi-Primary deployment
     When user deletes gateway named "bookinfo-gateway-mc" and the resource is no longer available in any cluster

--- a/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
@@ -113,22 +113,6 @@ Feature: Service Details Wizard: Request Routing
     Then user sees the "Istio Config" table with empty message
 
   @multi-cluster
-  Scenario: Try to create a Request Routing scenario in a remote cluster in the Primary-Remote deployment
-    When user deletes Request Routing named "ratings" and the resource is no longer available in any cluster
-    When user opens the namespace "bookinfo" and the "west" "ratings" service details page
-    And user clicks in the "Request Routing" actions
-    And user sees the "Create Request Routing" wizard
-    And user clicks in the "Request Matching" tab
-    And user adds a route
-    And user previews the configuration
-    And user creates the configuration
-    Then an error message "Could not create Istio config objects." is displayed
-    And user is at the "istio" list page
-    And user selects the "bookinfo" namespace
-    Then user does not see the generated "ratings" objects located in the "west" cluster
-    And user does not see the generated "ratings" objects located in the "east" cluster
-
-  @multi-cluster
   @multi-primary
   Scenario: Create a Request Routing scenario in a remote cluster
     When user deletes Request Routing named "ratings" and the resource is no longer available in any cluster

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -24,7 +24,7 @@ Feature: Workload logs tab
   @bookinfo-app
   Scenario: The log pane of the logs tab should only show the lines with the requested text
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
-    When I type "DEBUG" on the Show text field
+    When I type "INFO" on the Show text field
     Then the log pane should only show log lines containing "DEBUG"
 
   @bookinfo-app

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -25,7 +25,7 @@ Feature: Workload logs tab
   Scenario: The log pane of the logs tab should only show the lines with the requested text
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
     When I type "INFO" on the Show text field
-    Then the log pane should only show log lines containing "DEBUG"
+    Then the log pane should only show log lines containing "INFO"
 
   @bookinfo-app
   Scenario: The log pane of the logs tab should hide the lines with the requested text


### PR DESCRIPTION
### Describe the change

**Ambient tests**
Remove the check looking for the label "istio.io/gateway-name=waypoint" as it was removed in istio 1.24.
This label is not been used in other checks internally, only this change is required.

**Frontend tests**
The image for the bookinfo deployment has been updated. The logs had changed and the just log INFO messages. The "Last 30m" was updated in the logs to be able to see the messages (They are no so frequent as the DEBUG), and also filter by INFO text. (Trying to patch the deployment changing the log level but it doesn't have any effect). 

**Multi primary tests**
The failures are because the tests are trying to create a remote istio config and they expect failure, but now the Istio CRDs are created in the remote cluster so it successful creates the istio config in the remote. 
Talk to @nrfox and this tests are not needed.

### Steps to test the PR

CI passes.
Also, install istio ambient and a waypoint proxy, and check the labels. No "istio.io/gateway-name=waypoint" should be there.

### Automation testing

Update cypress teste

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
