### PR TITLE
Update cross-spawn dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -161,8 +161,7 @@
   "resolutions": {
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",
-    "workbox-webpack-plugin": "^7.1.0",
-    "rollup": "^2.79.2"
+    "workbox-webpack-plugin": "^7.1.0"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4879,9 +4879,9 @@ cross-fetch@4.0.0:
     node-fetch "^2.6.12"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
+  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -11364,7 +11364,7 @@ robust-predicates@^3.0.0:
   resolved "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
   integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
-rollup@^2.43.1, rollup@^2.79.2:
+rollup@^2.43.1:
   version "2.79.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.2.tgz#f150e4a5db4b121a21a747d762f701e5e9f49090"
   integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==


### PR DESCRIPTION
### Describe the change

Upgrade `cross-spawn` dependency to version 7.0.5

**Bonus**: Remove `rollup` entry from resolutions, as it is not needed.

### Steps to test the PR

Verify that CI tests pass

### Issue reference

https://issues.redhat.com/browse/OSSM-8365
