### PR TITLE
[Tempo] Add helm installation method to hack script

### DIFF
--- a/hack/istio/tempo/helm.yaml
+++ b/hack/istio/tempo/helm.yaml
@@ -1,0 +1,33 @@
+storage:
+  trace:
+    backend: s3
+    s3:
+      access_key: 'minio'
+      secret_key: 'minio123'
+      bucket: 'tempo-data'
+      endpoint: 'minio:9000'
+      insecure: true
+#MinIO storage configuration
+minio:
+  enabled: true
+  mode: standalone
+  rootUser: minio
+  rootPassword: minio123
+  buckets:
+  # Default Tempo storage bucket
+  - name: tempo-data
+    policy: none
+    purge: false
+traces:
+  otlp:
+    grpc:
+      enabled: true
+    http:
+      enabled: true
+  zipkin:
+    enabled: true
+  jaeger:
+    thriftHttp:
+      enabled: false
+  opencensus:
+    enabled: false

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -15,6 +15,7 @@ DELETE_TEMPO="false"
 INSTALL_BOOKINFO="true"
 INSTALL_ISTIO="true"
 INSTALL_KIALI="false"
+METHOD="operator"
 ONLY_TEMPO="false"
 SECURE_DISTRIBUTOR="false"
 TEMPO_NS="tempo"
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       INSTALL_KIALI="$2"
       shift;shift
       ;;
+    -im|--install-method)
+      METHOD="$2"
+      shift;shift
+      ;;
     -ot|--only-tempo)
       ONLY_TEMPO="$2"
       shift;shift
@@ -74,6 +79,9 @@ Valid command line arguments:
        If istio should be installed. true by default.
   -ik|--install-kiali:
        If Kiali should be installed. false by default.
+  -im|--install-method:
+       If using "operator" or "helm". "operator" by default. Helm installation has other properties and uses a more updated version of Tempo.
+       The recommendation resources for using helm in minikube:
   -ot|--only-tempo:
        Install only tempo. false by default.
   -sd|--secure-distributor:
@@ -100,6 +108,11 @@ if [ "$?" = "0" ]; then
   echo "The cluster client executable is found here: ${CLIENT_EXE}"
 else
   echo "You must install the cluster client ${CLIENT_EXE_NAME} in your PATH before you can continue"
+  exit 1
+fi
+
+if [ "${METHOD}" != "operator" ] && [ "${METHOD}" != "helm" ]; then
+  echo "method should be 'operator' or 'helm'"
   exit 1
 fi
 
@@ -141,10 +154,14 @@ install_tempo() {
     --from-literal=access_key_id="minio" \
     --from-literal=access_key_secret="minio123"
 
-  if [ "${SECURE_DISTRIBUTOR}" == "true" ]; then
-    # Create ca and cert for tls for the distributor
-    echo -e "Creating ca and cert for tls for the distributor \n"
-    subj="
+  if [ "${METHOD}" == "operator" ]; then
+
+    echo -e "Installing Tempo with the operator \n"
+
+    if [ "${SECURE_DISTRIBUTOR}" == "true" ]; then
+      # Create ca and cert for tls for the distributor
+      echo -e "Creating ca and cert for tls for the distributor \n"
+      subj="
 C=ES
 ST=ST
 O=AR
@@ -156,9 +173,9 @@ emailAddress=not@mail
     openssl req -x509 -sha256 -nodes -newkey rsa:2048 -subj "$(echo -n "$subj" | tr "\n" "/")" -keyout /tmp/tls.key -out /tmp/service-ca.crt
     ${CLIENT_EXE} -n ${TEMPO_NS} create configmap tempo-ca --from-file=/tmp/service-ca.crt
     ${CLIENT_EXE} create secret tls tempo-cert -n ${TEMPO_NS} --key="/tmp/tls.key" --cert="/tmp/service-ca.crt"
-  # Install TempoStack CR
-  echo -e "Installing tempo with tls enabled \n"
-  ${CLIENT_EXE} apply -n ${TEMPO_NS} -f - <<EOF
+    # Install TempoStack CR
+    echo -e "Installing tempo with tls enabled \n"
+    ${CLIENT_EXE} apply -n ${TEMPO_NS} -f - <<EOF
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoStack
 metadata:
@@ -183,10 +200,10 @@ spec:
       jaegerQuery:
         enabled: false
 EOF
-  else
-    # Install TempoStack CR
-    echo -e "Installing tempo \n"
-    ${CLIENT_EXE} apply -n ${TEMPO_NS} -f - <<EOF
+    else
+      # Install TempoStack CR
+      echo -e "Installing tempo \n"
+      ${CLIENT_EXE} apply -n ${TEMPO_NS} -f - <<EOF
 apiVersion: tempo.grafana.com/v1alpha1
 kind: TempoStack
 metadata:
@@ -207,6 +224,14 @@ spec:
       jaegerQuery:
         enabled: false
 EOF
+    fi
+
+  else
+    echo -e "Installing Tempo with Helm Charts \n"
+    helm repo add grafana https://grafana.github.io/helm-charts
+    helm repo update
+    helm install tempo-cr grafana/tempo-distributed -n tempo -f ${SCRIPT_DIR}/helm.yaml
+
   fi
 }
 

--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -19,6 +19,7 @@ METHOD="operator"
 ONLY_TEMPO="false"
 SECURE_DISTRIBUTOR="false"
 TEMPO_NS="tempo"
+TEMPO_PORT="3200"
 
 # process command line args
 while [[ $# -gt 0 ]]; do
@@ -228,6 +229,7 @@ EOF
 
   else
     echo -e "Installing Tempo with Helm Charts \n"
+    TEMPO_PORT="3100"
     helm repo add grafana https://grafana.github.io/helm-charts
     helm repo update
     helm install tempo-cr grafana/tempo-distributed -n tempo -f ${SCRIPT_DIR}/helm.yaml
@@ -288,7 +290,7 @@ else
     echo -e "Installation finished. \n"
     if [ "${IS_OPENSHIFT}" != "true" ]; then
       echo "If you want to access Tempo from outside the cluster on your local machine, You can port forward the services with:
-  ./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -pt 3200:3200 -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-cr-query-frontend -ts tempo-cr-query-frontend -tn tempo
+  ./run-kiali.sh -pg 13000:3000 -pp 19090:9090 -pt 3200:${TEMPO_PORT} -app 8080 -es false -iu http://127.0.0.1:15014 -tr tempo-cr-query-frontend -ts tempo-cr-query-frontend -tn tempo
 
   To configure Kiali to use this, set the external_services.tracing section with the following settings:
   tracing:


### PR DESCRIPTION
### Describe the change

Tempo has different installations method. Helm supports a more up to date version of Tempo. That changes will make easier to test new changes.

### Steps to test the PR

- `minikube start` (minikube might require more resources, like `minikube start --memory=16384 --cpus=4`, how to know? If any of the pods can't start, that might be a reason) 
- `hack/istio/tempo/install-tempo-env.sh -c kubectl -im helm`
- Install Kiali

See traces in any Trace tab: 

![image](https://github.com/user-attachments/assets/18c07e87-a73c-43a6-9110-1d332f13fe24)


### Automation testing

N/A

### Issue reference

Ref. #7903 
