### PR TITLE
[ui] apply new "infoStyle" where applicable

### DIFF
--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -16,6 +16,7 @@ import { isMultiCluster } from '../../config';
 import { Workload } from '../../types/Workload';
 import { hasMissingSidecar } from 'components/VirtualList/Config';
 import { healthIndicatorStyle } from 'styles/HealthStyle';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxProps = {
   kiosk: string;
@@ -54,10 +55,6 @@ const containerStyle = kialiStyle({
 
 const itemStyle = kialiStyle({
   paddingBottom: '0.25rem'
-});
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
 });
 
 export const renderWaypoint = (bgsize?: string): React.ReactNode => {

--- a/frontend/src/components/IstioWizards/WizardHelp.tsx
+++ b/frontend/src/components/IstioWizards/WizardHelp.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
+import { infoStyle } from 'styles/InfoStyle';
 
 const importantTooltip = kialiStyle({
   fontWeight: 700

--- a/frontend/src/components/Label/Labels.tsx
+++ b/frontend/src/components/Label/Labels.tsx
@@ -3,6 +3,7 @@ import { Label } from './Label';
 import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from '../../config/KialiIcon';
+import { infoStyleProps } from 'styles/InfoStyle';
 
 const SHOW_MORE_TRESHOLD = 2;
 
@@ -18,8 +19,8 @@ const linkStyle = kialiStyle({
   fontSize: '0.8rem'
 });
 
-const infoStyle = kialiStyle({
-  marginLeft: '0.25rem',
+const labelInfoStyle = kialiStyle({
+  ...infoStyleProps,
   marginBottom: '0.125rem'
 });
 
@@ -76,7 +77,7 @@ export const Labels: React.FC<LabelsProps> = (props: LabelsProps) => {
       position={TooltipPosition.auto}
       content={<div style={{ textAlign: 'left' }}>{props.tooltipMessage}</div>}
     >
-      <KialiIcon.Info className={infoStyle} />
+      <KialiIcon.Info className={labelInfoStyle} />
     </Tooltip>
   ) : undefined;
 

--- a/frontend/src/components/Link/IstioObjectLink.tsx
+++ b/frontend/src/components/Link/IstioObjectLink.tsx
@@ -11,9 +11,13 @@ import { connect } from 'react-redux';
 import { isParentKiosk, kioskContextMenuAction } from '../Kiosk/KioskActions';
 import { GroupVersionKind } from '../../types/IstioObjects';
 import { getGVKTypeString, kindToStringIncludeK8s } from '../../utils/IstioConfigUtils';
+import { infoStyleProps } from 'styles/InfoStyle';
 
-const infoStyle = kialiStyle({
-  margin: '0 0 -0.125rem 0.5rem'
+const objectInfoStyle = kialiStyle({
+  ...infoStyleProps,
+  marginBottom: '-0.125rem',
+  marginRight: '0',
+  marginTop: '0'
 });
 
 type ReduxProps = {
@@ -90,7 +94,7 @@ export const ReferenceIstioObjectLink: React.FC<ReferenceIstioObjectProps> = (pr
 
       {showTooltip && (
         <Tooltip position={TooltipPosition.right} content={<div style={{ textAlign: 'left' }}>{tooltipMsg}</div>}>
-          <KialiIcon.Info className={infoStyle} />
+          <KialiIcon.Info className={objectInfoStyle} />
         </Tooltip>
       )}
     </>

--- a/frontend/src/components/MetricsOptions/MetricsReporter.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsReporter.tsx
@@ -6,6 +6,7 @@ import { Reporter, Direction } from '../../types/MetricsOptions';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
+import { infoStyleProps } from 'styles/InfoStyle';
 
 interface Props {
   direction: Direction;
@@ -13,8 +14,11 @@ interface Props {
   reporter: Reporter;
 }
 
-const infoStyle = kialiStyle({
-  margin: '0 0.25rem 0.125rem 0.25rem'
+const metricsReporterInfoStyle = kialiStyle({
+  ...infoStyleProps,
+  marginBottom: '0.125rem',
+  marginRight: '0.25rem',
+  marginTop: '0'
 });
 
 export class MetricsReporter extends React.Component<Props> {
@@ -83,7 +87,7 @@ export class MetricsReporter extends React.Component<Props> {
         />
 
         <Tooltip content={<div style={{ textAlign: 'left' }}>{this.reportTooltip}</div>} position={TooltipPosition.top}>
-          <KialiIcon.Info className={infoStyle} />
+          <KialiIcon.Info className={metricsReporterInfoStyle} />
         </Tooltip>
       </span>
     );

--- a/frontend/src/components/MissingAuthPolicy/MissingAuthPolicy.tsx
+++ b/frontend/src/components/MissingAuthPolicy/MissingAuthPolicy.tsx
@@ -4,7 +4,7 @@ import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { isIstioNamespace } from 'config/ServerConfig';
 import { icons } from 'config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from 'styles/StyleUtils';
+import { infoStyle } from 'styles/InfoStyle';
 
 type MissingAuthPolicyProps = {
   text?: string;
@@ -15,10 +15,6 @@ type MissingAuthPolicyProps = {
   namespace: string;
   className?: string;
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
 
 export const MissingAuthPolicy: React.FC<MissingAuthPolicyProps> = ({
   text = 'Missing Authorization Policy',

--- a/frontend/src/components/MissingLabel/MissingLabel.tsx
+++ b/frontend/src/components/MissingLabel/MissingLabel.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { icons, serverConfig } from '../../config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from 'styles/StyleUtils';
 import { PFBadge } from '../Pf/PfBadges';
+import { infoStyle } from 'styles/InfoStyle';
 
 type MissingLabelProps = {
   className?: string;
@@ -11,10 +11,6 @@ type MissingLabelProps = {
   missingVersion: boolean;
   tooltip: boolean;
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
 
 export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelProps) => {
   const appLabel = serverConfig.istioLabels.appLabelName;

--- a/frontend/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/frontend/src/components/MissingSidecar/MissingSidecar.tsx
@@ -4,7 +4,7 @@ import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { serverConfig } from 'config/ServerConfig';
 import { icons } from 'config';
 import { KialiIcon } from '../../config/KialiIcon';
-import { kialiStyle } from 'styles/StyleUtils';
+import { infoStyle } from 'styles/InfoStyle';
 
 type MissingSidecarProps = {
   className?: string;
@@ -17,10 +17,6 @@ type MissingSidecarProps = {
   texttooltip?: string;
   tooltip?: boolean;
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
 
 export const MissingSidecar: React.FC<MissingSidecarProps> = ({
   textmesh = 'Out of mesh',

--- a/frontend/src/components/Overview/TLSInfo.tsx
+++ b/frontend/src/components/Overview/TLSInfo.tsx
@@ -1,16 +1,13 @@
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 import * as React from 'react';
+import { infoStyle } from 'styles/InfoStyle';
 import { kialiStyle } from 'styles/StyleUtils';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 type Props = {
   version?: string;
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.25rem'
-});
 
 const lockIconStyle = kialiStyle({ marginLeft: '0.25rem' });
 

--- a/frontend/src/components/TracingIntegration/TracesDisplayOptions.tsx
+++ b/frontend/src/components/TracingIntegration/TracesDisplayOptions.tsx
@@ -9,10 +9,11 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
-import { itemInfoStyle, itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
+import { itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
 import { HistoryManager, URLParam } from 'app/History';
 import { KialiIcon } from 'config/KialiIcon';
 import { TraceLimit } from 'components/Metrics/TraceLimit';
+import { infoStyle } from 'styles/InfoStyle';
 
 export interface QuerySettings {
   errorsOnly: boolean;
@@ -141,7 +142,7 @@ export class TracesDisplayOptions extends React.Component<Props, State> {
               </div>
             }
           >
-            <KialiIcon.Info className={itemInfoStyle} />
+            <KialiIcon.Info className={infoStyle} />
           </Tooltip>
         </div>
 

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -45,9 +45,13 @@ import { Td } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 import { hasMissingSidecar } from './Config';
 import { InstanceType } from 'types/Common';
+import { infoStyleProps } from 'styles/InfoStyle';
 
-const infoStyle = kialiStyle({
-  margin: '0 0 -0.125rem 0.5rem'
+const rendererInfoStyle = kialiStyle({
+  ...infoStyleProps,
+  marginBottom: '-0.125rem',
+  marginRight: '0',
+  marginTop: '0'
 });
 
 // Links
@@ -163,7 +167,7 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
               position={TooltipPosition.top}
               content="Layer 7 service Mesh capabilities in Istio Ambient"
             >
-              <KialiIcon.Info className={infoStyle} />
+              <KialiIcon.Info className={rendererInfoStyle} />
             </Tooltip>
           </li>
         )}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -33,6 +33,7 @@ import { GraphFindOptions } from './GraphFindOptions';
 import { location, HistoryManager, URLParam } from '../../../app/History';
 import { isValid } from 'utils/Common';
 import { serverConfig } from '../../../config';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxStateProps = {
   edgeLabels: EdgeLabelMode[];
@@ -96,6 +97,14 @@ const gridStyle = kialiStyle({
 
 const graphFindStyle = kialiStyle({
   marginRight: '0.75rem',
+  $nest: {
+    '& > .pf-v5-c-form__group-control': {
+      display: 'flex'
+    }
+  }
+});
+
+const graphHideStyle = kialiStyle({
   $nest: {
     '& > .pf-v5-c-form__group-control': {
       display: 'flex'
@@ -376,7 +385,7 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
             </GridItem>
 
             <GridItem span={1}>
-              <FormGroup className={graphFindStyle}>
+              <FormGroup className={graphHideStyle}>
                 <GraphFindOptions kind="hide" onSelect={this.updateHideOption} />
                 {this.props.hideValue && (
                   <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
@@ -402,7 +411,7 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </GraphHelpFind>
         ) : (
@@ -413,7 +422,7 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </Tooltip>
         )}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -37,6 +37,7 @@ import { elems, SelectAnd, SelectExp, selectOr, SelectOr, setObserved } from 'he
 import { descendents } from 'helpers/GraphHelpers';
 import { isArray } from 'lodash';
 import { graphLayout, LayoutType } from 'pages/GraphPF/GraphPF';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxStateProps = {
   edgeLabels: EdgeLabelMode[];
@@ -99,6 +100,14 @@ const gridStyle = kialiStyle({
 
 const graphFindStyle = kialiStyle({
   marginRight: '0.75rem',
+  $nest: {
+    '& > .pf-v5-c-form__group-control': {
+      display: 'flex'
+    }
+  }
+});
+
+const graphHideStyle = kialiStyle({
   $nest: {
     '& > .pf-v5-c-form__group-control': {
       display: 'flex'
@@ -365,7 +374,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
             </GridItem>
 
             <GridItem span={1}>
-              <FormGroup className={graphFindStyle}>
+              <FormGroup className={graphHideStyle}>
                 <GraphFindOptions kind="hide" onSelect={this.updateHideOption} />
                 {this.props.hideValue && (
                   <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
@@ -391,7 +400,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </GraphHelpFind>
         ) : (
@@ -402,7 +411,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </Tooltip>
         )}

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -24,7 +24,6 @@ import {
 import { KialiIcon } from 'config/KialiIcon';
 import {
   containerStyle,
-  itemInfoStyle,
   itemStyleWithInfo,
   itemStyleWithoutInfo,
   menuStyle,
@@ -36,6 +35,7 @@ import { KialiDispatch } from 'types/Redux';
 import { KialiCrippledFeatures } from 'types/ServerConfig';
 import { getCrippledFeatures } from 'services/Api';
 import { serverConfig } from '../../../config';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxStateProps = {
   boxByCluster: boolean;
@@ -742,7 +742,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
                 </div>
               }
             >
-              <KialiIcon.Info className={itemInfoStyle} />
+              <KialiIcon.Info className={infoStyle} />
             </Tooltip>
           </div>
 
@@ -771,7 +771,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
                   content={edgeLabelOption.tooltip}
                 >
                   <KialiIcon.Info
-                    className={edgeLabelOption.iconClassName ?? itemInfoStyle}
+                    className={edgeLabelOption.iconClassName ?? infoStyle}
                     color={edgeLabelOption.iconColor}
                   />
                 </Tooltip>
@@ -807,7 +807,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
                           content={rtOption.tooltip}
                         >
                           <KialiIcon.Info
-                            className={edgeLabelOption.iconClassName ?? itemInfoStyle}
+                            className={edgeLabelOption.iconClassName ?? infoStyle}
                             color={edgeLabelOption.iconColor}
                           />
                         </Tooltip>
@@ -847,7 +847,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
                           content={throughputOption.tooltip}
                         >
                           <KialiIcon.Info
-                            className={throughputOption.iconClassName ?? itemInfoStyle}
+                            className={throughputOption.iconClassName ?? infoStyle}
                             color={throughputOption.iconColor}
                           />
                         </Tooltip>
@@ -875,7 +875,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
 
               {item.tooltip && (
                 <Tooltip key={`tooltip_${item.id}`} position={TooltipPosition.right} content={item.tooltip}>
-                  <KialiIcon.Info className={item.iconClassName ?? itemInfoStyle} color={item.iconColor} />
+                  <KialiIcon.Info className={item.iconClassName ?? infoStyle} color={item.iconColor} />
                 </Tooltip>
               )}
 
@@ -907,7 +907,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
                           content={scoringOption.tooltip}
                         >
                           <KialiIcon.Info
-                            className={scoringOption.iconClassName ?? itemInfoStyle}
+                            className={scoringOption.iconClassName ?? infoStyle}
                             color={scoringOption.iconColor}
                           />
                         </Tooltip>
@@ -935,7 +935,7 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
 
               {item.tooltip && (
                 <Tooltip key={`tooltip_${item.id}`} position={TooltipPosition.right} content={item.tooltip}>
-                  <KialiIcon.Info className={item.iconClassName ?? itemInfoStyle} color={item.iconColor} />
+                  <KialiIcon.Info className={item.iconClassName ?? infoStyle} color={item.iconColor} />
                 </Tooltip>
               )}
             </div>

--- a/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
@@ -24,13 +24,13 @@ import {
 import { KialiIcon } from 'config/KialiIcon';
 import {
   containerStyle,
-  itemInfoStyle,
   itemStyleWithInfo,
   itemStyleWithoutInfo,
   menuStyle,
   menuEntryStyle
 } from 'styles/DropdownStyles';
 import { serverConfig } from 'config';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxDispatchProps = {
   setTrafficRates: (trafficRates: TrafficRate[]) => void;
@@ -257,7 +257,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                     position={TooltipPosition.right}
                     content={trafficRateOption.tooltip}
                   >
-                    <KialiIcon.Info className={itemInfoStyle} />
+                    <KialiIcon.Info className={infoStyle} />
                   </Tooltip>
                 )}
 
@@ -287,7 +287,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             position={TooltipPosition.right}
                             content={ambientOption.tooltip}
                           >
-                            <KialiIcon.Info className={itemInfoStyle} />
+                            <KialiIcon.Info className={infoStyle} />
                           </Tooltip>
                         )}
                       </div>
@@ -321,7 +321,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             position={TooltipPosition.right}
                             content={grpcOption.tooltip}
                           >
-                            <KialiIcon.Info className={itemInfoStyle} />
+                            <KialiIcon.Info className={infoStyle} />
                           </Tooltip>
                         )}
                       </div>
@@ -356,7 +356,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             position={TooltipPosition.right}
                             content={httpOption.tooltip}
                           >
-                            <KialiIcon.Info className={itemInfoStyle} />
+                            <KialiIcon.Info className={infoStyle} />
                           </Tooltip>
                         )}
                       </div>
@@ -390,7 +390,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             position={TooltipPosition.right}
                             content={tcpOption.tooltip}
                           >
-                            <KialiIcon.Info className={itemInfoStyle} />
+                            <KialiIcon.Info className={infoStyle} />
                           </Tooltip>
                         )}
                       </div>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -32,6 +32,7 @@ import { PFColors } from '../../../components/Pf/PfColors';
 import { GetIstioObjectUrl } from '../../../components/Link/IstioObjectLink';
 import { homeCluster, isMultiCluster, serverConfig } from '../../../config';
 import { CLUSTER_DEFAULT } from 'types/Graph';
+import { infoStyle } from 'styles/InfoStyle';
 
 interface IstioConfigOverviewProps {
   cluster?: string;
@@ -50,10 +51,6 @@ interface IstioConfigOverviewProps {
 
 const iconStyle = kialiStyle({
   display: 'inline-block'
-});
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
 });
 
 const warnStyle = kialiStyle({

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -10,7 +10,7 @@ interface Props {
   checks?: ObjectCheck[];
 }
 
-const infoStyle = kialiStyle({
+const statusInfoStyle = kialiStyle({
   verticalAlign: '-0.125em !important'
 });
 
@@ -54,7 +54,7 @@ export class IstioStatusMessageList extends React.Component<Props> {
                     <FlexItem>{check.code}</FlexItem>
                     <Tooltip content={check.message} position={TooltipPosition.right}>
                       <div className="iconInfo">
-                        <KialiIcon.Info className={infoStyle} />
+                        <KialiIcon.Info className={statusInfoStyle} />
                       </div>
                     </Tooltip>
                   </Flex>

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlaneMetrics.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlaneMetrics.tsx
@@ -8,7 +8,7 @@ import { KialiIcon } from 'config/KialiIcon';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
 import { useKialiTranslation } from 'utils/I18nUtils';
 import { Datapoint, Metric } from 'types/Metrics';
-import { kialiStyle } from 'styles/StyleUtils';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ControlPlaneProps = {
   istiodContainerCpu?: Metric[];
@@ -18,10 +18,6 @@ type ControlPlaneProps = {
   istiodResourceThresholds?: IstiodResourceThresholds;
   pilotLatency?: Metric[];
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.25rem'
-});
 
 const showMetrics = (metrics: Metric[] | undefined): boolean => {
   // show metrics if metrics exists and some values at least are not zero

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlaneStatus.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlaneStatus.tsx
@@ -4,16 +4,12 @@ import * as React from 'react';
 import { OutboundTrafficPolicy } from 'types/IstioObjects';
 import { useKialiTranslation } from 'utils/I18nUtils';
 import { ControlPlaneMetricsMap } from 'types/Metrics';
-import { kialiStyle } from 'styles/StyleUtils';
+import { infoStyle } from 'styles/InfoStyle';
 
 type Props = {
   controlPlaneMetrics?: ControlPlaneMetricsMap;
   outboundTrafficPolicy?: OutboundTrafficPolicy;
 };
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.25rem'
-});
 
 export const TargetPanelControlPlaneStatus: React.FC<Props> = (props: Props) => {
   const { t } = useKialiTranslation();

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -35,6 +35,7 @@ import { MeshToolbarActions } from 'actions/MeshToolbarActions';
 import { MeshFindOptions } from './MeshFindOptions';
 import { MeshHelpFind } from '../MeshHelpFind';
 import { LayoutType, meshLayout } from '../Mesh';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ReduxStateProps = {
   findValue: string;
@@ -87,6 +88,14 @@ const gridStyle = kialiStyle({
 
 const meshFindStyle = kialiStyle({
   marginRight: '0.75rem',
+  $nest: {
+    '& > .pf-v5-c-form__group-control': {
+      display: 'flex'
+    }
+  }
+});
+
+const meshHideStyle = kialiStyle({
   $nest: {
     '& > .pf-v5-c-form__group-control': {
       display: 'flex'
@@ -297,7 +306,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
             </GridItem>
 
             <GridItem span={1}>
-              <FormGroup className={meshFindStyle}>
+              <FormGroup className={meshHideStyle}>
                 <MeshFindOptions kind="hide" onSelect={this.updateHideOption} />
                 {this.props.hideValue && (
                   <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
@@ -323,7 +332,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </MeshHelpFind>
         ) : (
@@ -334,7 +343,7 @@ export class MeshFindComponent extends React.Component<MeshFindProps, MeshFindSt
               className={findHideHelpStyle}
               onClick={this.toggleFindHelp}
             >
-              <KialiIcon.Info />
+              <KialiIcon.Info className={infoStyle} />
             </Button>
           </Tooltip>
         )}

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -13,6 +13,7 @@ import { HealthIndicator } from '../../components/Health/HealthIndicator';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { DetailDescription } from '../../components/DetailDescription/DetailDescription';
 import { AmbientLabel, tooltipMsgType } from '../../components/Ambient/AmbientLabel';
+import { infoStyleProps } from 'styles/InfoStyle';
 
 interface ServiceInfoDescriptionProps {
   namespace: string;
@@ -35,7 +36,7 @@ const iconStyle = kialiStyle({
 });
 
 const infoStyle = kialiStyle({
-  marginLeft: '0.5rem',
+  ...infoStyleProps,
   verticalAlign: '-0.125rem'
 });
 

--- a/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -5,6 +5,7 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { Gateway, ObjectCheck, ObjectValidation, VirtualService } from '../../types/IstioObjects';
 import { ValidationList } from '../../components/Validations/ValidationList';
 import { KialiIcon } from '../../config/KialiIcon';
+import { infoStyle } from 'styles/InfoStyle';
 
 type ServiceNetworkProps = {
   gateways: Gateway[];
@@ -26,10 +27,6 @@ const resourceListStyle = kialiStyle({
       fontWeight: 700
     }
   }
-});
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.25rem'
 });
 
 export const ServiceNetwork: React.FC<ServiceNetworkProps> = (props: ServiceNetworkProps) => {

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -20,6 +20,7 @@ import { DetailDescription } from '../../components/DetailDescription/DetailDesc
 import { isWaypoint } from '../../helpers/LabelFilterHelper';
 import { AmbientLabel, tooltipMsgType } from '../../components/Ambient/AmbientLabel';
 import { validationKey } from '../../types/IstioConfigList';
+import { infoStyleProps } from 'styles/InfoStyle';
 
 type WorkloadDescriptionProps = {
   health?: H.Health;
@@ -43,7 +44,7 @@ const iconStyle = kialiStyle({
 });
 
 const infoStyle = kialiStyle({
-  marginLeft: '0.5rem',
+  ...infoStyleProps,
   verticalAlign: '-0.125rem'
 });
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPods.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPods.tsx
@@ -20,6 +20,7 @@ import { LocalTime } from '../../components/Time/LocalTime';
 import { Labels } from '../../components/Label/Labels';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { SimpleTable } from 'components/Table/SimpleTable';
+import { infoStyle } from 'styles/InfoStyle';
 
 type WorkloadPodsProps = {
   namespace: string;
@@ -42,10 +43,6 @@ const resourceListStyle = kialiStyle({
       fontWeight: 700
     }
   }
-});
-
-const infoStyle = kialiStyle({
-  marginLeft: '0.5rem'
 });
 
 const iconStyle = kialiStyle({

--- a/frontend/src/styles/DropdownStyles.ts
+++ b/frontend/src/styles/DropdownStyles.ts
@@ -41,10 +41,6 @@ export const itemStyleWithInfo = kialiStyle({
   padding: '0.375rem 0 0.375rem 1rem'
 });
 
-export const itemInfoStyle = kialiStyle({
-  marginLeft: '0.375rem'
-});
-
 export const groupMenuStyle = kialiStyle({
   textAlign: 'left'
 });


### PR DESCRIPTION
This is a follow-on to kiali7769, which introduced new global "infoStyle" for info icons. This PR applies the styling across the UI.

Testing:
@ferhoyos , I've clicked around to, I think, all of the affected places and it looks consistent to me.  In some cases the margin is slightly reduced and in others it is slightly increased.  If necessary we could adjust it globally in either direction. In a couple of places (like the "hide" inputs) I needed to remove some rightMargin so that we didn't combine rightMarging of the component with leftMargin of the info icon.