### PR TITLE
Allow setting trace limit in graph node-side-panel Trace tab

### DIFF
--- a/frontend/src/components/Metrics/TraceLimit.tsx
+++ b/frontend/src/components/Metrics/TraceLimit.tsx
@@ -5,8 +5,6 @@ import { itemStyleWithoutInfo } from 'styles/DropdownStyles';
 import { ToolbarDropdown } from 'components/Dropdown/ToolbarDropdown';
 import { infoStyle } from 'styles/InfoStyle';
 
-export const TRACE_LIMIT_DEFAULT = 100;
-
 type TraceLimitProps = {
   asRadio?: boolean;
   initialLimit?: number;
@@ -14,6 +12,9 @@ type TraceLimitProps = {
   title?: string;
   titleClassName?: string;
 };
+
+export const TRACE_LIMIT_DEFAULT = 100;
+export type TraceLimitOption = 20 | 100 | 500 | 1000;
 
 export const TraceLimit: React.FC<TraceLimitProps> = (props: TraceLimitProps) => {
   const initialLimit = props.initialLimit ?? TRACE_LIMIT_DEFAULT;


### PR DESCRIPTION
For completeness, we should also allow users the ability to set the trace fetch limit in the graph's node-side-panel Traces tab.

As part of this, remove the "use graph refresh" option and just have users manually refresh the traces list, as needed. This simplifies the tab header, given the new dropdown, and I doubt anyone will miss this option. If they do, we can always bring it back.

part-of kiali7769

Test
@josunect , I overlooked this in the original PR, but I think we need the option here as well. You can look at the network requests to ensure the initial request has limit 20, and that new requests are made if the limit changes.