### PR TITLE
When performing a layout, reset the graph by default.

### DIFF
--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -110,7 +110,7 @@ export function getLayoutByName(layoutName: string): Layout {
   }
 }
 
-export function graphLayout(controller: Controller, layoutType: LayoutType, reset?: boolean): void {
+export function graphLayout(controller: Controller, layoutType: LayoutType, reset: boolean = true): void {
   if (!controller?.hasGraph()) {
     console.debug('TG: Skip graphLayout, no graph');
     return;

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -86,7 +86,7 @@ export function getLayoutByName(layoutName: string): Layout {
   }
 }
 
-export function meshLayout(controller: Controller, layoutType: LayoutType, reset?: boolean): void {
+export function meshLayout(controller: Controller, layoutType: LayoutType, reset: boolean = true): void {
   if (!controller?.hasGraph()) {
     console.debug('Skip meshLayout, no graph');
     return;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/7935

Layout should probably always also fit to the screen.

[Screencast From 2024-11-18 21-45-13.webm](https://github.com/user-attachments/assets/06fc9885-ec22-466d-b6f8-f502233c0d98)

