### PR TITLE
Use the same kind node image criteria for all hack scripts

### DIFF
--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -18,6 +18,8 @@ if [ "${HACK_ENV_DONE:-}" == "true" ]; then
   return 0
 fi
 
+set -u
+
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
 switch_cluster() {
@@ -130,6 +132,9 @@ MANAGE_MINIKUBE="${MANAGE_MINIKUBE:-true}"
 # If true and client exe is kubectl, then two kind instances will be installed/uninstalled by these scripts
 MANAGE_KIND="${MANAGE_KIND:-false}"
 
+# Image of the kind cluster
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-}"
+
 # Minikube options - these are ignored if MANAGE_MINIKUBE is false
 MINIKUBE_DRIVER="kvm2"
 MINIKUBE_CPU=""
@@ -142,12 +147,16 @@ KEYCLOAK_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD:-keycloak-password}"
 KEYCLOAK_KUBE_CLIENT_SECRET="${KEYCLOAK_KUBE_CLIENT_SECRET:-kube-client-secret}"
 KIALI_USER_PASSWORD="${KIALI_USER_PASSWORD:-kiali}"
 
+# Path to a Kiali server helm charts tarball
+KIALI_SERVER_HELM_CHARTS="${KIALI_SERVER_HELM_CHARTS:-}"
+
 # Some settings that can be configured when helm installing the two Kiali instances.
 KIALI1_WEB_FQDN="${KIALI1_WEB_FQDN:-}"
 KIALI1_WEB_SCHEMA="${KIALI1_WEB_SCHEMA:-}"
 KIALI2_WEB_FQDN="${KIALI2_WEB_FQDN:-}"
 KIALI2_WEB_SCHEMA="${KIALI2_WEB_SCHEMA:-}"
 
+# If true the local dev image of Kiali will be built and used in the Kiali deployment
 KIALI_BUILD_DEV_IMAGE="${KIALI_BUILD_DEV_IMAGE:-false}"
 
 # process command line args

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -129,23 +129,6 @@ fi
 # Start up two kind instances if requested
 if [ "${MANAGE_KIND}" == "true" ]; then
   echo "Starting kind instances"
-  
-  # If a specific version of Istio hasn't been provided, try and guess the right one
-  # based on the Kiali branch being tested (TARGET_BRANCH) and the compatibility matrices:
-  # https://kiali.io/docs/installation/installation-guide/prerequisites/
-  # https://istio.io/latest/docs/releases/supported-releases/
-  if [ "${TARGET_BRANCH:-""}" == "v1.48" ]; then
-    ISTIO_VERSION="1.13.0"
-  else
-    ISTIO_VERSION=""
-  fi
-
-  KIND_NODE_IMAGE=""
-  if [ "${ISTIO_VERSION}" == "1.13.0" ]; then
-    KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
-  else
-    KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
-  fi
 
   if [ "${KIALI_AUTH_STRATEGY}" == "openid" ]; then
     "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" create-ca
@@ -163,10 +146,10 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     "${SCRIPT_DIR}"/../../start-kind.sh \
       --name "${CLUSTER1_NAME}" \
       --load-balancer-range "${lb_range_start}-${lb_range_end}" \
-      --image "${KIND_NODE_IMAGE}" \
       --enable-keycloak true \
       --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}" \
-      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube
+      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube \
+      --image "${KIND_NODE_IMAGE}"
 
     "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" -kip "${KEYCLOAK_ADDRESS}" deploy
 
@@ -174,10 +157,10 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     "${SCRIPT_DIR}"/../../start-kind.sh \
       --name "${CLUSTER2_NAME}" \
       --load-balancer-range "255.85-255.98" \
-      --image "${KIND_NODE_IMAGE}" \
       --enable-keycloak true \
       --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}" \
-      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube
+      --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube \
+      --image "${KIND_NODE_IMAGE}"
   else
     echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
     "${SCRIPT_DIR}"/../../start-kind.sh \

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -23,23 +23,6 @@ fi
 # Start up two kind instances if requested
 if [ "${MANAGE_KIND}" == "true" ]; then
   echo "Starting kind instances"
-  
-  # If a specific version of Istio hasn't been provided, try and guess the right one
-  # based on the Kiali branch being tested (TARGET_BRANCH) and the compatibility matrices:
-  # https://kiali.io/docs/installation/installation-guide/prerequisites/
-  # https://istio.io/latest/docs/releases/supported-releases/
-  if [ "${TARGET_BRANCH:-""}" == "v1.48" ]; then
-    ISTIO_VERSION="1.13.0"
-  else
-    ISTIO_VERSION=""
-  fi
-
-  KIND_NODE_IMAGE=""
-  if [ "${ISTIO_VERSION}" == "1.13.0" ]; then
-    KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
-  else
-    KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
-  fi
 
   echo "==== START KIND FOR CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
   "${SCRIPT_DIR}"/../../start-kind.sh --name "${CLUSTER1_NAME}" --load-balancer-range "255.70-255.84" --image "${KIND_NODE_IMAGE}"

--- a/hack/istio/multicluster/setup-external-controlplane.sh
+++ b/hack/istio/multicluster/setup-external-controlplane.sh
@@ -41,10 +41,10 @@ install_bookinfo() {
 }
 
 if ! kind get clusters -q | grep -q "${EXTERNAL_CLUSTER_NAME}" ; then
-    ./hack/start-kind.sh --load-balancer-range 255.70-255.84 -n "${EXTERNAL_CLUSTER_NAME}" -eir false -i "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+    ./hack/start-kind.sh --load-balancer-range 255.70-255.84 -n "${EXTERNAL_CLUSTER_NAME}" -eir false --image "${KIND_NODE_IMAGE}"
 fi
 if ! kind get clusters -q | grep -q "${REMOTE_CLUSTER_NAME}" ; then
-    ./hack/start-kind.sh --load-balancer-range 255.85-255.98 -n "${REMOTE_CLUSTER_NAME}" -eir false -i "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+    ./hack/start-kind.sh --load-balancer-range 255.85-255.98 -n "${REMOTE_CLUSTER_NAME}" -eir false --image "${KIND_NODE_IMAGE}"
 fi
 
 # Following: https://istio.io/latest/docs/setup/install/external-controlplane/

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -369,7 +369,7 @@ setup_kind_multicluster() {
     mkdir -p "${certs_dir}"/keycloak
   fi
 
-  if [[ -n "${KIND_NODE_IMAGE}" ]]; then
+  if [ -n "${KIND_NODE_IMAGE}" ]; then
     local kind_node_image="--kind-node-image ${KIND_NODE_IMAGE}"
   fi
 

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -93,11 +93,7 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # https://kiali.io/docs/installation/installation-guide/prerequisites/
 # https://istio.io/latest/docs/releases/supported-releases/
 if [ -z "${ISTIO_VERSION}" ]; then
-  if [ "${TARGET_BRANCH}" == "v1.48" ]; then
-    ISTIO_VERSION="1.12.0"
-  elif [ "${TARGET_BRANCH}" == "v1.57" ]; then
-    ISTIO_VERSION="1.14.0"
-  elif [ "${TARGET_BRANCH}" == "v1.65" ]; then
+  if [ "${TARGET_BRANCH}" == "v1.65" ]; then
     ISTIO_VERSION="1.16.0"
   elif [ "${TARGET_BRANCH}" == "v1.73" ]; then
     ISTIO_VERSION="1.18.0"
@@ -105,7 +101,7 @@ if [ -z "${ISTIO_VERSION}" ]; then
 fi
 
 KIND_NODE_IMAGE=""
-if [ "${ISTIO_VERSION}" == "1.12.0" -o "${ISTIO_VERSION}" == "1.14.0" -o "${ISTIO_VERSION}" == "1.16.0" ]; then
+if [ "${ISTIO_VERSION}" == "1.16.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 elif [ "${ISTIO_VERSION}" == "v1.18.0" ]; then
   KIND_NODE_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
@@ -373,6 +369,10 @@ setup_kind_multicluster() {
     mkdir -p "${certs_dir}"/keycloak
   fi
 
+  if [[ -n "${KIND_NODE_IMAGE}" ]]; then
+    local kind_node_image="--kind-node-image ${KIND_NODE_IMAGE}"
+  fi
+
   local cluster1_context
   local cluster2_context
   local cluster1_name
@@ -384,7 +384,8 @@ setup_kind_multicluster() {
       --certs-dir "${certs_dir}" \
       -dorp docker \
       --istio-dir "${istio_dir}" \
-      ${hub_arg:-}
+      ${kind_node_image:-}
+      ${hub_arg:-} \
 
     cluster1_context="kind-east"
     cluster2_context="kind-west"
@@ -393,7 +394,7 @@ setup_kind_multicluster() {
     kubectl rollout status deployment prometheus -n istio-system --context kind-east
     kubectl rollout status deployment prometheus -n istio-system --context kind-west
   elif [ "${MULTICLUSTER}" == "${PRIMARY_REMOTE}" ]; then
-    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --kiali-enabled false --manage-kind true -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${hub_arg:-}
+    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --kiali-enabled false --manage-kind true -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${kind_node_image:-} ${hub_arg:-}
     cluster1_context="kind-east"
     cluster2_context="kind-west"
     cluster1_name="east"
@@ -401,7 +402,7 @@ setup_kind_multicluster() {
     kubectl rollout status deployment prometheus -n istio-system --context kind-east
     kubectl rollout status deployment prometheus -n istio-system --context kind-west
   elif [ "${MULTICLUSTER}" == "${EXTERNAL_CONTROLPLANE}" ]; then
-    "${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh
+    "${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh ${kind_node_image:-}
     cluster1_context="kind-controlplane"
     cluster2_context="kind-dataplane"
     cluster1_name="controlplane"

--- a/hack/start-kind.sh
+++ b/hack/start-kind.sh
@@ -209,7 +209,7 @@ fi
 start_kind() {
   # Due to: https://github.com/kubernetes-sigs/kind/issues/1449#issuecomment-1612648982 we need two nodes.
   infomsg "Kind cluster to be created with name [${NAME}]"
-  NODE_IMAGE_LINE=${IMAGE:+image: ${IMAGE}}
+  KIND_NODE_IMAGE=${IMAGE:+image: ${IMAGE}}
   cat <<EOF | ${KIND_EXE} create cluster --name "${NAME}" --config -
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -218,10 +218,10 @@ networking:
 $(echo_keycloak_kubeadm_config)
 nodes:
   - role: control-plane
-    ${NODE_IMAGE_LINE}
+    ${KIND_NODE_IMAGE}
 $(echo_keycloak_mount)
   - role: worker
-    ${NODE_IMAGE_LINE}
+    ${KIND_NODE_IMAGE}
 $(echo_image_registry_cluster_config)
 EOF
 }


### PR DESCRIPTION
### Describe the Change

Currently, the Kind node image is defined in multiple hack scripts according to different criteria (sometimes it is hardcoded, sometimes the latest version is used, and sometimes it is not). This PR centralizes the criteria for determining the Kind node image to be used based on the Istio version. It also ensures that the latest Kind node image is used for the latest Istio version (e.g., multicluster scripts were installing kind 1.27 which is not supported by the latest Istio version 1.24.0)

### Steps to Test the PR

- Verify that the hack scripts use the latest Kind version with the `master` branch.
- Check that specific Kind versions are used for previous Istio versions.

### Automation Testing

N/A

