### PR TITLE
Use OCI image for keycloak

### DIFF
--- a/hack/istio/multicluster/setup-keycloak.sh
+++ b/hack/istio/multicluster/setup-keycloak.sh
@@ -75,7 +75,7 @@ KEYCLOAK_HOSTNAME="keycloak-keycloak.${APPS_DOMAIN}"
 echo "Creating keycloak deployment"
 helm upgrade --kube-context "${CLUSTER1_CONTEXT}" --install --wait --timeout 15m \
   --namespace keycloak \
-  --repo https://charts.bitnami.com/bitnami keycloak keycloak \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -111,7 +111,7 @@ EOF
   echo "Creating keycloak deployment"
   helm upgrade --install --wait --timeout 15m \
   --namespace keycloak \
-  --repo https://charts.bitnami.com/bitnami keycloak keycloak \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true


### PR DESCRIPTION
### Describe the change

Use the oci image of the keycloak charts. Necessary as of Nov 18th: https://blog.bitnami.com/2024/10/bitnami-helm-charts-moving-to-oci.html.

### Steps to test the PR

CI passes.
