### PR TITLE
Enable the release schedule in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Release
 
 on:
-  #schedule:
+  schedule:
   # Every Monday at 07:00 (UTC)
-  #- cron: "00 7 * * MON"
+  - cron: "00 7 * * MON"
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type'     
+        description: 'Release type'
         required: true
         type: choice
         options:


### PR DESCRIPTION
### Describe the change

Now that we have tested the new release GitHub Action and confirmed it works properly, it is time to enable the automated release schedule.

### Steps to test the PR

Verify that the github action is correct.

### Automation testing

N/A
