### PR TITLE
Adapt some cypress tests to OSSMC

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -55,7 +55,7 @@ Then('user sees span details', () => {
     .eq(1) // take 1st  row
     .find('td')
     .eq(4) // take 5th cell (kebab)
-    .should('be.visible');
+    .should('exist');
 
   cy.get('table')
     .should('be.visible')

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -9,13 +9,19 @@ Given(
   (workload: string, namespace: string) => {
     cy.visit({ url: `/console/namespaces/${namespace}/workloads/${workload}?tab=logs&refresh=0` });
 
+    const changeIntervalDuration = (): void => {
+      cy.get('#metrics_filter_interval_duration-toggle').click();
+      cy.get('#1800').click();
+    };
+
     // In OSSMC, the duration interval is configured using the time duration modal component
     if (Cypress.env('OSSMC')) {
       cy.get('#time_duration').click();
+      changeIntervalDuration();
+      cy.get('#time-duration-modal').find('button').contains('Confirm').click();
+    } else {
+      changeIntervalDuration();
     }
-
-    cy.get('#metrics_filter_interval_duration-toggle').click();
-    cy.get('#1800').click();
   }
 );
 

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -8,6 +8,12 @@ Given(
   'I am on the logs tab of the {string} workload detail page of the {string} namespace',
   (workload: string, namespace: string) => {
     cy.visit({ url: `/console/namespaces/${namespace}/workloads/${workload}?tab=logs&refresh=0` });
+
+    // In OSSMC, the duration interval is configured using the time duration modal component
+    if (Cypress.env('OSSMC')) {
+      cy.get('#time_duration').click();
+    }
+
     cy.get('#metrics_filter_interval_duration-toggle').click();
     cy.get('#1800').click();
   }

--- a/frontend/src/components/Time/TimeDurationIndicator.tsx
+++ b/frontend/src/components/Time/TimeDurationIndicator.tsx
@@ -81,6 +81,7 @@ class TimeDurationIndicatorComponent extends React.PureComponent<Props> {
   render(): React.ReactNode {
     return (
       <Tooltip
+        trigger={'mouseenter'}
         isContentLeftAligned={true}
         maxWidth={'50em'}
         content={

--- a/frontend/src/components/Time/TimeDurationIndicator.tsx
+++ b/frontend/src/components/Time/TimeDurationIndicator.tsx
@@ -26,6 +26,7 @@ type ReduxDispatchProps = {
 
 type Props = ReduxStateProps &
   ReduxDispatchProps & {
+    id?: string;
     isDuration?: boolean;
     onClick?: () => void;
     setDuration: (duration: DurationInSeconds) => void;
@@ -95,7 +96,7 @@ class TimeDurationIndicatorComponent extends React.PureComponent<Props> {
           </>
         }
       >
-        <Button variant="link" isInline={true} onClick={this.props.onClick}>
+        <Button id={this.props.id} variant="link" isInline={true} onClick={this.props.onClick}>
           <KialiIcon.Clock className={infoStyle} />
           {this.timeDurationIndicator()}, {getRefreshIntervalName(this.props.refreshInterval)}
         </Button>

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -72,6 +72,7 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
 
   return (
     <Modal
+      id="time-duration-modal"
       aria-label={t('Time duration')}
       variant={ModalVariant.small}
       width={700}

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -480,8 +480,8 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                           </ToolbarItem>
 
                           <KioskElement>
-                            <ToolbarItem>
-                              <TimeDurationIndicator onClick={this.toggleTimeOptionsVisibility} />
+                            <ToolbarItem style={{ alignSelf: 'center' }}>
+                              <TimeDurationIndicator id="time_duration" onClick={this.toggleTimeOptionsVisibility} />
                             </ToolbarItem>
                           </KioskElement>
                         </ToolbarGroup>


### PR DESCRIPTION
### Describe the change

There are some Cypress tests that need to be adapted for OSSMC:
- In workload logs, the duration interval is configured using the time duration modal.
- One of the span table values is not immediately visible in OSSMC (scrolling is required due to OpenShift overhead). We need to verify that the value exists.

**Bonus:** Center-align the time duration button in workload logs.

![image](https://github.com/user-attachments/assets/aec6290f-2ba6-432c-8cfa-4770b38a12eb)

### Steps to test the PR

Verify that cypress tests pass for OSSMC
