### PR TITLE
[hack] when setting up user-monitoring on openshift, be able to connect to Prom insecurely

### DIFF
--- a/hack/use-openshift-prometheus.sh
+++ b/hack/use-openshift-prometheus.sh
@@ -16,6 +16,7 @@ KIALI_CR_NAMESPACE=""
 MESH_LABEL="mymesh"
 NAMESPACES=""
 NETWORK_POLICIES="false"
+PROM_INSECURE="false"
 OC="oc"
 
 # process command line args
@@ -29,6 +30,7 @@ while [[ $# -gt 0 ]]; do
     -n|--namespaces)            NAMESPACES="$2"        ; shift;shift ;;
     -np|--network-policies)     NETWORK_POLICIES="$2"  ; shift;shift ;;
     -oc|--oc)                   OC="$2"                ; shift;shift ;;
+    -pi|--prometheus-insecure)  PROM_INSECURE="$2"     ; shift;shift ;;
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
@@ -39,6 +41,7 @@ Valid command line arguments:
   -n|--namespaces <names>: Space-separated names of namespaces in the mesh (Default: empty)
   -np|--network-policies (true|false) If true, NetworkPolicies will be created (or deleted if --delete is true) to allow for all ingress traffic, including from OpenShift monitoring namespaces labeled with network.openshift.io/policy-group: monitoring (where Prometheus lives) (Default: false)
   -oc|--oc <path>: Cluster client executable name of 'oc' (Default: oc)
+  -pi|--prometheus-insecure (true|false): If Prometheus server certificate is self-signed, you need to set this to "true" to tell Kiali to connect to Prometheus insecurely. (Default: false)
   -h|--help : this message
 HELPMSG
       exit 1
@@ -326,6 +329,7 @@ spec:
   external_services:
     prometheus:
       auth:
+        insecure_skip_verify: ${PROM_INSECURE}
         type: bearer
         use_kiali_token: true
       query_scope:
@@ -335,7 +339,7 @@ spec:
       url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
 EOM
   echo "..."
-  ${OC} patch kiali ${KIALI_CR_NAME} -n ${KIALI_CR_NAMESPACE} --type=merge --patch '{"spec":{"external_services":{"prometheus":{"auth":{"type":"bearer","use_kiali_token": true},"query_scope":{"mesh_id": "'${MESH_LABEL}'"},"thanos_proxy":{"enabled": true},"url":"https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"}}}}'
+  ${OC} patch kiali ${KIALI_CR_NAME} -n ${KIALI_CR_NAMESPACE} --type=merge --patch '{"spec":{"external_services":{"prometheus":{"auth":{"insecure_skip_verify": '${PROM_INSECURE}',"type":"bearer","use_kiali_token": true},"query_scope":{"mesh_id": "'${MESH_LABEL}'"},"thanos_proxy":{"enabled": true},"url":"https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"}}}}'
 }
 
 ########## MAIN


### PR DESCRIPTION
This was thought to be needed when working on https://github.com/kiali/kiali/issues/7954 - however, it doesn't seem to be required. I was getting an "failed to verify cert" error at one point, and this was needed. But I cannot repeat that failure. Leaving this PR open since it could be useful and may be needed under some situations.
