### PR TITLE
[graph] more tweaks to layout/reset

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "react-flexview": "4.0.3",
     "react-i18next": "^11.7.3",
     "react-redux": "7.2.2",
-    "react-resize-detector": "3.4.0",
+    "react-resize-detector": "9.1.1",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
     "react-router-dom-v5-compat": "^6.11.2",

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -326,7 +326,7 @@ const TopologyContent: React.FC<{
       if (layoutInProgress === LayoutType.Resize) {
         setTimeout(() => {
           controller.getGraph().fit(FIT_PADDING);
-        }, 250);
+        }, 500);
       } else {
         controller.getGraph().fit(FIT_PADDING);
       }

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -322,6 +322,8 @@ const TopologyContent: React.FC<{
     }
 
     if (layoutInProgress !== LayoutType.LayoutNoFit) {
+      controller.getGraph().fit(FIT_PADDING);
+
       // On a resize, delay fit to ensure that the canvas size updates before the fit
       if (layoutInProgress === LayoutType.Resize) {
         setTimeout(() => {

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -82,7 +82,7 @@ const DEFAULT_NODE_SIZE = 40;
 const ZOOM_IN = 4 / 3;
 const ZOOM_OUT = 3 / 4;
 
-export const FIT_PADDING = 80;
+export const FIT_PADDING = 90;
 
 export enum LayoutName {
   BreadthFirst = 'BreadthFirst',
@@ -324,13 +324,12 @@ const TopologyContent: React.FC<{
     if (layoutInProgress !== LayoutType.LayoutNoFit) {
       controller.getGraph().fit(FIT_PADDING);
 
-      // On a resize, delay fit to ensure that the canvas size updates before the fit
+      // On a resize, perform a delayed second fit, this one is performed [hopefully] after
+      // the canvas size is updated (which needs to happen in the underlying PFT code)
       if (layoutInProgress === LayoutType.Resize) {
         setTimeout(() => {
           controller.getGraph().fit(FIT_PADDING);
         }, 500);
-      } else {
-        controller.getGraph().fit(FIT_PADDING);
       }
     }
 
@@ -887,6 +886,10 @@ const TopologyContent: React.FC<{
                   // currently unused
                   zoomOutCallback: () => {
                     controller && controller.getGraph().scaleBy(ZOOM_OUT);
+                  },
+                  // currently unused
+                  fitToScreenCallback: () => {
+                    controller.getGraph().fit(80);
                   },
                   resetViewCallback: () => {
                     graphLayout(controller, LayoutType.Layout);

--- a/frontend/src/pages/GraphPF/GraphPF.tsx
+++ b/frontend/src/pages/GraphPF/GraphPF.tsx
@@ -889,7 +889,7 @@ const TopologyContent: React.FC<{
                   },
                   // currently unused
                   fitToScreenCallback: () => {
-                    controller.getGraph().fit(80);
+                    controller.getGraph().fit(FIT_PADDING);
                   },
                   resetViewCallback: () => {
                     graphLayout(controller, LayoutType.Layout);

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -211,13 +211,14 @@ const TopologyContent: React.FC<{
     }
 
     if (layoutInProgress !== LayoutType.LayoutNoFit) {
-      // On a resize, delay fit to ensure that the canvas size updates before the fit
+      controller.getGraph().fit(FIT_PADDING);
+
+      // On a resize, perform a delayed second fit, this one is performed [hopefully] after
+      // the canvas size is updated (which needs to happen in the underlying PFT code)
       if (layoutInProgress === LayoutType.Resize) {
         setTimeout(() => {
           controller.getGraph().fit(FIT_PADDING);
-        }, 250);
-      } else {
-        controller.getGraph().fit(FIT_PADDING);
+        }, 500);
       }
     }
 
@@ -552,6 +553,10 @@ const TopologyContent: React.FC<{
                   // currently unused
                   zoomOutCallback: () => {
                     controller && controller.getGraph().scaleBy(ZOOM_OUT);
+                  },
+                  // currently unused
+                  fitToScreenCallback: () => {
+                    controller.getGraph().fit(80);
                   },
                   resetViewCallback: () => {
                     meshLayout(controller, LayoutType.Layout);

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -556,7 +556,7 @@ const TopologyContent: React.FC<{
                   },
                   // currently unused
                   fitToScreenCallback: () => {
-                    controller.getGraph().fit(80);
+                    controller.getGraph().fit(FIT_PADDING);
                   },
                   resetViewCallback: () => {
                     meshLayout(controller, LayoutType.Layout);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8917,7 +8917,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.11, lodash-es@^4.17.21:
+lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -8982,7 +8982,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10847,15 +10847,12 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-resize-detector@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-3.4.0.tgz#2ccd399958a0efe9b7c52c5db5a13d87e47cd585"
-  integrity sha512-T96I8Iqa1hGWyooeFA2Sl6FdPoMhXWINfEKg2/EJLxhP37+/94VNuyuyz9CRqpmApD83IWRR+lbB3r0ADMoKJg==
+react-resize-detector@9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-9.1.1.tgz#ce13cf55b9b09d9978fc51e0c87bb3639704921e"
+  integrity sha512-siLzop7i4xIvZIACE/PHTvRegA8QRCEt0TfmvJ/qCIFQJ4U+3NuYcF8tNDmDWxfIn+X1eNCyY2rauH4KRxge8w==
   dependencies:
-    lodash "^4.17.11"
-    lodash-es "^4.17.11"
-    prop-types "^15.6.2"
-    resize-observer-polyfill "^1.5.1"
+    lodash "^4.17.21"
 
 react-router-dom-v5-compat@^6.11.2:
   version "6.24.1"
@@ -11235,7 +11232,7 @@ reselect@4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
Closes #7935 (again)

Increase the delay before performing a resize fit.  This seems to be enough in several tries to break it.

Also update react-resize-detector to the highest version prior to dropping support for react 17.

There are still times when PFT seems to just slightly lose its scale, I can't figure how to fix or avoid it.

To test you can just try various things, combining resize, changing layouts, zooming and panning, graph hide, side panel collapse/expand, etc.  Unless something horrible happens it's probably OK, even if it does sort of start laying out slightly too big.