### PR TITLE
Add insecure skip verify option to OpenShift auth

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -103,7 +103,7 @@ func httpClientWithPool(conf *config.Config, restConfig rest.Config, systemPool 
 		}
 		tlsConfig.RootCAs = pool
 	} else {
-		log.Trace("Insecure connection to oAuth server.")
+		log.Debug("Insecure connection to oAuth server.")
 	}
 
 	return &http.Client{

--- a/config/config.go
+++ b/config/config.go
@@ -395,7 +395,8 @@ type AuthConfig struct {
 
 // OpenShiftConfig contains specific configuration for authentication when on OpenShift
 type OpenShiftConfig struct {
-	CAFile string `yaml:"ca_file,omitempty"`
+	CAFile                string `yaml:"ca_file,omitempty"`
+	InsecureSkipVerifyTLS bool   `yaml:"insecure_skip_verify_tls,omitempty"`
 }
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider
@@ -677,6 +678,9 @@ func NewConfig() (c *Config) {
 				IssuerUri:               "",
 				Scopes:                  []string{"openid", "profile", "email"},
 				UsernameClaim:           "sub",
+			},
+			OpenShift: OpenShiftConfig{
+				InsecureSkipVerifyTLS: false,
 			},
 		},
 		CustomDashboards: dashboards.GetBuiltInMonitoringDashboards(),


### PR DESCRIPTION
### Describe the change

Adds an option to the `openshift` auth strategy to skip tls verification for testing purposes only. This is only used when communicating to the OAuth server during token exchange.

### Steps to test the PR

This doesn't test the feature directly but it's the easiest way to test this:

1. Deploy Kiali on openshift
2. Set logger to trace level
3. Login to Kiali
4. Get kiali logs and look for "insecure connection" `kubectl logs <kiali-pod> -n <kiali-ns> | grep -i insecure connection`
