### PR TITLE
Fixes #7722: Cleanup Istio labels in Kiali config

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -770,7 +770,6 @@ func (in *SvcService) GetServiceAppName(ctx context.Context, cluster, namespace,
 		return "", fmt.Errorf("Service [cluster: %s] [namespace: %s] [name: %s] doesn't exist.", cluster, namespace, service)
 	}
 
-	appLabelName := in.config.IstioLabels.AppLabelName
 	app := svc.Selectors[appLabelName]
 	return app, nil
 }

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2165,7 +2165,7 @@ func (in *WorkloadService) GetWorkloadAppName(ctx context.Context, cluster, name
 		return "", err
 	}
 
-	appLabelName := in.config.IstioLabels.AppLabelName
+	// appLabelName := in.config.IstioLabels.AppLabelName
 	app := wkd.Labels[appLabelName]
 	return app, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -346,17 +346,22 @@ func (lt *LoginToken) Obfuscate() {
 }
 
 // IstioLabels holds configuration about the labels required by Istio
-type IstioLabels struct {
-	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
-	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
-	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
-	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
-	AmbientWaypointUseLabel    string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
-	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName         string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
-	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
-	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
+type IstioLabels struct { 
+    AppLabelName       string `yaml:"app_label_name,omitempty" json:"appLabelName"`
+    InjectionLabelName string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
+    InjectionLabelRev  string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
+    VersionLabelName   string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
+
+// Internal constants for fixed Istio labels 
+const (
+    AmbientNamespaceLabel      = "ambient_namespace_label"
+    AmbientNamespaceLabelValue = "ambient_namespace_label_value"
+    AmbientWaypointLabel       = "ambient_waypoint_label"
+    AmbientWaypointLabelValue  = "ambient_waypoint_label_value"
+    AmbientWaypointUseLabel    = "ambient_waypoint_use_label"
+)
+
 
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
 type AdditionalDisplayItem struct {


### PR DESCRIPTION
### Describe the change

This PR cleans up the IstioLables configuration by: 
1. Making static labels to internals constants.
2. Keeping only user-configurable fields in the IstioLables struct.
3. Updating relevent code to reference the new constants. 

### Issue reference
Fixes #7722
Link: https://github.com/kiali/kiali/issues/7722

Problem : 
<img width="407" alt="Screenshot 2024-11-29 102356" src="https://github.com/user-attachments/assets/8824dae9-201e-4c05-bb7a-61d39135350c">

This PR Fixes 
<img width="453" alt="Screenshot 2024-11-28 143718" src="https://github.com/user-attachments/assets/e848fa11-8956-4a25-b843-881e737d92c7">
