### PR TITLE
Add ability to specify custom CA to Openshift Auth

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -22,6 +23,13 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
+)
+
+const (
+	// OAuthServerCAFile is a certificate bundle used to connect to the oAuth server.
+	// This is for cases when the authentication server is using TLS with a self-signed
+	// certificate.
+	OAuthServerCAFile = "/kiali-cabundle/oauth-server-ca.crt"
 )
 
 const (
@@ -57,7 +65,7 @@ type OpenshiftOAuthService struct {
 	conf           *config.Config
 	kialiSAClients map[string]kubernetes.ClientInterface
 	oAuthConfigs   map[string]*oAuthConfig
-	systemCertPool *x509.CertPool
+	certPool       *x509.CertPool
 }
 
 // Structure that's returned by the openshift oauth authorization server.
@@ -112,10 +120,34 @@ func httpClientWithPool(conf *config.Config, restConfig rest.Config, systemPool 
 	}, nil
 }
 
+// Returns a new cert Pool with the system certs appended as well as
+// any custom CA if it exists.
+func newCertPool(oAuthServerCAFilePath string) *x509.CertPool {
+	// Adding system certs in case the idp does not use the same cert as the oAuth server.
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Errorf("While initializing openshift auth, unable to read system certs: %s", err)
+	}
+
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+
+	if b, err := os.ReadFile(oAuthServerCAFilePath); err == nil {
+		if ok := pool.AppendCertsFromPEM(b); !ok {
+			log.Errorf("Unable to append oAuth server CA to cert pool. Ensure that your CA bundle file: '%s' is formatted correctly as a PEM encoded block", oAuthServerCAFilePath)
+		}
+	} else if !os.IsNotExist(err) {
+		log.Errorf("Unable to read oAuth server CA from bundle file '%s': %s", oAuthServerCAFilePath, err)
+	}
+
+	return pool
+}
+
 // NewOpenshiftOAuthService creates a new OpenshiftOAuthService.
 // It will try to autodiscover the OAuth server configuration from each cluster.
 // It also assumes that you've created an OAuthClient for Kiali in each cluster.
-func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAClients map[string]kubernetes.ClientInterface, clientFactory kubernetes.ClientFactory) (*OpenshiftOAuthService, error) {
+func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAClients map[string]kubernetes.ClientInterface, clientFactory kubernetes.ClientFactory, oAuthServerCustomCAFilePath string) (*OpenshiftOAuthService, error) {
 	oAuthConfigs := make(map[string]*oAuthConfig)
 
 	// Creating a single context for all the clusters.
@@ -126,11 +158,7 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 	ctx, cancel = context.WithDeadline(ctx, oneMinuteFromNow)
 	defer cancel()
 
-	// Adding system certs in case the idp does not use the same cert as the oauth server.
-	systemCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		log.Errorf("While initializing openshift auth, unable to read system certs: %s", err)
-	}
+	pool := newCertPool(oAuthServerCustomCAFilePath)
 
 	// TODO: We could parallelize this to potentially speed up the process.
 	for cluster, client := range kialiSAClients {
@@ -148,7 +176,7 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 		}
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.GetToken()))
 
-		httpClient, err := httpClientWithPool(conf, *client.ClusterInfo().ClientConfig, systemCertPool)
+		httpClient, err := httpClientWithPool(conf, *client.ClusterInfo().ClientConfig, pool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create http client for fetching oauth server metadata from kube api server [%s], error: %s", url, err)
 		}
@@ -214,7 +242,7 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 		conf:           conf,
 		kialiSAClients: kialiSAClients,
 		oAuthConfigs:   oAuthConfigs,
-		systemCertPool: systemCertPool,
+		certPool:       pool,
 	}, nil
 }
 
@@ -225,7 +253,7 @@ func (in *OpenshiftOAuthService) Exchange(ctx context.Context, code string, veri
 		return nil, fmt.Errorf("could not get ServiceAccount client for cluster [%s]", cluster)
 	}
 
-	httpClient, err := httpClientWithPool(in.conf, *client.ClusterInfo().ClientConfig, in.systemCertPool)
+	httpClient, err := httpClientWithPool(in.conf, *client.ClusterInfo().ClientConfig, in.certPool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http client for oauth consumption, error: %s", err)
 	}

--- a/business/openshift_oauth_internal_test.go
+++ b/business/openshift_oauth_internal_test.go
@@ -166,10 +166,10 @@ func TestExchangeUsesSystemPoolAndRestTLS(t *testing.T) {
 						},
 					}},
 				},
-				systemCertPool: x509.NewCertPool(),
+				certPool: x509.NewCertPool(),
 			}
 			if tc.systemPoolCert != nil {
-				svc.systemCertPool.AddCert(tc.systemPoolCert)
+				svc.certPool.AddCert(tc.systemPoolCert)
 			}
 
 			_, err := svc.Exchange(context.Background(), "anycode", "anyverify", conf.KubernetesConfig.ClusterName)

--- a/business/openshift_oauth_test.go
+++ b/business/openshift_oauth_test.go
@@ -3,8 +3,11 @@ package business_test
 import (
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	osoauth_v1 "github.com/openshift/api/oauth/v1"
@@ -18,26 +21,40 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
+func fakeOAuthServerWithTLS(t *testing.T) *httptest.Server {
+	t.Helper()
+	var addr string
+	server := httptest.NewTLSServer(handleOAuthRequest(&addr))
+	addr = server.URL
+	t.Cleanup(server.Close)
+	return server
+}
+
 func fakeOAuthMetadataServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	// This is known after we create the server.
 	// Probably another way of doing this but this works too.
-	addr := ""
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var addr string
+	server := httptest.NewServer(handleOAuthRequest(&addr))
+	addr = server.URL
+	t.Cleanup(server.Close)
+	return server
+}
+
+// Pointer to a string so it can be updated later when the server is started.
+func handleOAuthRequest(addr *string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		oAuthResponse := &business.OAuthAuthorizationServer{
-			AuthorizationEndpoint: addr + "/oauth/authorize",
-			Issuer:                addr,
-			TokenEndpoint:         addr + "/oauth/token",
+			AuthorizationEndpoint: *addr + "/oauth/authorize",
+			Issuer:                *addr,
+			TokenEndpoint:         *addr + "/oauth/token",
 		}
 		b, err := json.Marshal(oAuthResponse)
 		if err != nil {
 			panic("unable to marshal json response for fake oAuthMetadataServer")
 		}
 		_, _ = w.Write(b)
-	}))
-	addr = server.URL
-	t.Cleanup(server.Close)
-	return server
+	})
 }
 
 func TestNewOpenshiftOAuthService(t *testing.T) {
@@ -76,7 +93,7 @@ func TestNewOpenshiftOAuthService(t *testing.T) {
 			clients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: client}
 			clientFactory := kubetest.NewFakeClientFactory(conf, clients)
 
-			_, err := business.NewOpenshiftOAuthService(context.TODO(), conf, clients, clientFactory)
+			_, err := business.NewOpenshiftOAuthService(context.Background(), conf, clients, clientFactory, business.OAuthServerCAFile)
 			if tc.expectErr {
 				require.Error(err)
 			} else {
@@ -110,6 +127,41 @@ func TestNewOAuthMixedClusters(t *testing.T) {
 	openshift.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
 	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
 
-	_, err := business.NewOpenshiftOAuthService(context.TODO(), conf, clients, clientFactory)
+	_, err := business.NewOpenshiftOAuthService(context.Background(), conf, clients, clientFactory, business.OAuthServerCAFile)
+	require.NoError(err)
+}
+
+func TestNewWithCustomOAuthCASucceeds(t *testing.T) {
+	require := require.New(t)
+	metadataServer := fakeOAuthServerWithTLS(t)
+
+	caFilePath := path.Join(t.TempDir(), "oauth-server-ca.crt")
+	file, err := os.OpenFile(caFilePath, os.O_WRONLY|os.O_CREATE, 0o644)
+	require.NoError(err)
+	t.Cleanup(func() { file.Close() })
+
+	require.NoError(pem.Encode(file, &pem.Block{
+		Bytes: metadataServer.Certificate().Raw,
+		Type:  "CERTIFICATE",
+	}))
+
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "openshift"
+
+	openshift := kubetest.NewFakeK8sClient(&osoauth_v1.OAuthClient{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "kiali-istio-system",
+		},
+		RedirectURIs: []string{"http://localhost:20001/kiali"},
+	})
+	openshift.OpenShift = true
+	clients := map[string]kubernetes.ClientInterface{
+		"openshift": openshift,
+	}
+
+	openshift.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	_, err = business.NewOpenshiftOAuthService(context.Background(), conf, clients, clientFactory, caFilePath)
 	require.NoError(err)
 }

--- a/handlers/authentication/openshift_auth_controller.go
+++ b/handlers/authentication/openshift_auth_controller.go
@@ -60,7 +60,7 @@ func extractClusterName(r *http.Request, conf *config.Config) string {
 // The OAuth service created inside the constructor will make a request to the OpenShift OAuth server
 // to gather OAuth metadata.
 func NewOpenshiftAuthController(conf *config.Config, clientFactory kubernetes.ClientFactory) (*OpenshiftAuthController, error) {
-	openshiftOAuthService, err := business.NewOpenshiftOAuthService(context.TODO(), conf, clientFactory.GetSAClients(), clientFactory)
+	openshiftOAuthService, err := business.NewOpenshiftOAuthService(context.TODO(), conf, clientFactory.GetSAClients(), clientFactory, business.OAuthServerCAFile)
 	if err != nil {
 		log.Errorf("Error creating OpenshiftOAuthService: %v", err)
 		return nil, err


### PR DESCRIPTION
### Describe the change

Add ability to specify custom CA configmap for openshift auth at `/kiali-cabundle/oauth-server-ca.crt`.

### Steps to test the PR

N/A.

### Automation testing

Unit tests included.

Docs PR: https://github.com/kiali/kiali.io/pull/838
Operator PR: https://github.com/kiali/kiali-operator/pull/853