### PR TITLE
Fix install testing demos when GATEWAY_HOST was not set

### DIFF
--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -124,7 +124,7 @@ if [ "${DELETE_DEMOS}" != "true" ]; then
   gateway_yaml=""
   if [ "${USE_GATEWAY_API}" == "true" ]; then
     gateway_yaml="${ISTIO_DIR}/samples/bookinfo/gateway-api/bookinfo-gateway.yaml"
-  elif [ -v GATEWAY_HOST ]; then
+  elif ! [ -z "$GATEWAY_HOST" ]; then
     gateway_yaml=$(mktemp)
     cat << EOF > "${gateway_yaml}"
 apiVersion: networking.istio.io/v1
@@ -200,7 +200,7 @@ EOF
     "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_BOOKINFO}
   fi
 
-  if [ -v "${GATEWAY_HOST}" ]; then
+  if [[ -z "$GATEWAY_HOST" && "${USE_GATEWAY_API}" != "true" ]]; then
     # Assume that the '*' is used for hosts if the gateway host is not specified.
     # Some front-end tests have conflicts with the wildcard host in the bookinfo-gateway. Patch it with the host resolved for the traffic generator.
     ISTIO_INGRESS_HOST=$(${CLIENT_EXE} get cm -n bookinfo traffic-generator-config -o jsonpath='{.data.route}' | sed 's|.*//\([^\:]*\).*/.*|\1|')


### PR DESCRIPTION
### Fix for issue
Bookinfo app doesn't work when it is installed by `install-testing-demos.sh` script.

### Describe the change

```
  elif [ -v GATEWAY_HOST ]; then
```
is always true, since `-v` check if a variable [was set, not if it is empty or not](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bash-Conditional-Expressions)
It is always true, since by default, GATEWAY_HOST is an empty string ( https://github.com/kiali/kiali/blob/master/hack/istio/install-testing-demos.sh#L27 )

So when I run `install-testing-demos.sh` without gateway host param, GATEWAY_HOST is an empty string and the script sets
```
    hosts:
    - ""
```
to the Gateway resource which is created in the temp file (e.g. `/tmp/tmp.8LV8qsrLq`R) which is passed and will be used in `./install-bookinfo-demo.sh` script.

However that Gateway is not valid according to istio validation webhook:
```
on is invalid: 2 errors occurred:
	* short names (non FQDN) are not allowed
	* empty domain name not allowed
```
so bookinfo app and traffic generator don't work.

### Fix 
There should be check `-z` instead, which checks whether GATEWAY_HOST is not an empty string (True if the length of string is zero.)
Check that gateway host is not empty:
```
elif ! [ -z "$GATEWAY_HOST" ]; then
```


cypress tests from upstream pipeline after this fix: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/kiali/job/test-jobs/job/kiali-cypress-tests/3356/