### PR TITLE
Handle URL in kiosk for time duration modal

### DIFF
--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Form, FormGroup, Modal, ModalVariant, TooltipPosition } from '@patternfly/react-core';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
-import { HistoryManager, URLParam } from '../../app/History';
+import { HistoryManager, location, URLParam } from '../../app/History';
 import { useKialiDispatch, useKialiSelector } from '../../hooks/redux';
 import { DurationInSeconds, IntervalInMilliseconds, TimeRange } from '../../types/Common';
 import { DurationDropdownComponent } from '../Dropdown/DurationDropdown';
@@ -26,9 +26,58 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
   const reduxRefreshInterval = useKialiSelector(state => state.userSettings.refreshInterval);
   const reduxTimeRange = useKialiSelector(state => state.userSettings.timeRange);
 
-  const [duration, setDuration] = React.useState(reduxDuration);
-  const [refreshInterval, setRefreshInterval] = React.useState(reduxRefreshInterval);
-  const [timeRange, setTimeRange] = React.useState(reduxTimeRange);
+  const urlParams = new URLSearchParams(location.getSearch());
+  const urlDuration = HistoryManager.getDuration(urlParams);
+  const urlRefresh = HistoryManager.getNumericParam(URLParam.REFRESH_INTERVAL, urlParams);
+  const urlTimeRange = HistoryManager.getNumericParam(URLParam.RANGE_DURATION, urlParams);
+  const urlFrom = HistoryManager.getNumericParam(URLParam.FROM, urlParams);
+  const urlTo = HistoryManager.getNumericParam(URLParam.TO, urlParams);
+
+  const getInitDuration = (): number => {
+    if (!props.customDuration && urlDuration) {
+      return urlDuration;
+    }
+    return reduxDuration;
+  };
+
+  const getInitRefresh = (): number => {
+    if (urlRefresh) {
+      return urlRefresh;
+    }
+    return reduxRefreshInterval;
+  };
+
+  const getUrlTimeRange = (): TimeRange => ({
+    ...(urlTimeRange != null && { rangeDuration: urlTimeRange }),
+    ...(urlFrom != null && { from: urlFrom }),
+    ...(urlTo != null && { to: urlTo })
+  });
+
+  const getInitTimeRange = (): TimeRange => {
+    const tm = getUrlTimeRange();
+
+    if (!tm.rangeDuration && !tm.from && !tm.to && props.customDuration) {
+      return reduxTimeRange;
+    }
+
+    return tm;
+  };
+
+  const [duration, setDuration] = React.useState(getInitDuration());
+  const [refreshInterval, setRefreshInterval] = React.useState(getInitRefresh());
+  const [timeRange, setTimeRange] = React.useState(getInitTimeRange());
+
+  React.useEffect(() => {
+    if (urlDuration !== undefined) {
+      dispatch(UserSettingsActions.setDuration(urlDuration));
+    }
+    if (urlRefresh !== undefined) {
+      dispatch(UserSettingsActions.setRefreshInterval(urlRefresh));
+    }
+    if (getUrlTimeRange() !== undefined) {
+      dispatch(UserSettingsActions.setTimeRange(getUrlTimeRange()));
+    }
+  }, []);
 
   const handleCancel = (): void => {
     // reset the dialog
@@ -44,11 +93,23 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
 
   const handleConfirm = (): void => {
     dispatch(UserSettingsActions.setRefreshInterval(refreshInterval));
+    HistoryManager.setParam(URLParam.REFRESH_INTERVAL, String(refreshInterval));
 
     if (!props.customDuration) {
       dispatch(UserSettingsActions.setDuration(duration));
+      HistoryManager.setParam(URLParam.DURATION, String(duration));
       kioskDurationAction(duration);
     } else {
+      timeRange.rangeDuration
+        ? HistoryManager.setParam(URLParam.RANGE_DURATION, String(timeRange.rangeDuration))
+        : HistoryManager.deleteParam(URLParam.RANGE_DURATION);
+      timeRange.from
+        ? HistoryManager.setParam(URLParam.FROM, String(timeRange.from))
+        : HistoryManager.deleteParam(URLParam.FROM);
+      timeRange.to
+        ? HistoryManager.setParam(URLParam.TO, String(timeRange.to))
+        : HistoryManager.deleteParam(URLParam.TO);
+
       dispatch(UserSettingsActions.setTimeRange(timeRange));
       kioskTimeRangeAction(timeRange);
     }

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -28,51 +28,51 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
   const reduxRefreshInterval = useKialiSelector(state => state.userSettings.refreshInterval);
   const reduxTimeRange = useKialiSelector(state => state.userSettings.timeRange);
 
-  const urlParams = new URLSearchParams(location.getSearch());
-  const urlDuration = HistoryManager.getDuration(urlParams);
-  const urlRefresh = HistoryManager.getNumericParam(URLParam.REFRESH_INTERVAL, urlParams);
-  const urlTimeRange = HistoryManager.getNumericParam(URLParam.RANGE_DURATION, urlParams);
-  const urlFrom = HistoryManager.getNumericParam(URLParam.FROM, urlParams);
-  const urlTo = HistoryManager.getNumericParam(URLParam.TO, urlParams);
-
-  const getInitDuration = (): number => {
-    if (!props.customDuration && urlDuration) {
-      return toValidDuration(urlDuration);
-    }
-    return reduxDuration;
-  };
-
-  const getInitRefresh = (): number => {
-    if (urlRefresh) {
-      // Validate value
-      if (urlRefresh === 0 || config.toolbar.refreshInterval[urlRefresh]) {
-        return urlRefresh;
-      }
-    }
-    return reduxRefreshInterval;
-  };
-
-  const getUrlTimeRange = (): TimeRange => ({
-    ...(urlTimeRange != null && { rangeDuration: urlTimeRange }),
-    ...(urlFrom != null && { from: urlFrom }),
-    ...(urlTo != null && { to: urlTo })
-  });
-
-  const getInitTimeRange = (): TimeRange => {
-    const tm = getUrlTimeRange();
-
-    if (!tm.rangeDuration && !tm.from && !tm.to && props.customDuration) {
-      return reduxTimeRange;
-    }
-
-    return tm;
-  };
-
-  const [duration, setDuration] = React.useState(0);
-  const [refreshInterval, setRefreshInterval] = React.useState(0);
+  const [duration, setDuration] = React.useState<number>(0);
+  const [refreshInterval, setRefreshInterval] = React.useState<number>(0);
   const [timeRange, setTimeRange] = React.useState<TimeRange>({});
 
   React.useEffect(() => {
+    const urlParams = new URLSearchParams(location.getSearch());
+    const urlDuration = HistoryManager.getDuration(urlParams);
+    const urlRefresh = HistoryManager.getNumericParam(URLParam.REFRESH_INTERVAL, urlParams);
+    const urlTimeRange = HistoryManager.getNumericParam(URLParam.RANGE_DURATION, urlParams);
+    const urlFrom = HistoryManager.getNumericParam(URLParam.FROM, urlParams);
+    const urlTo = HistoryManager.getNumericParam(URLParam.TO, urlParams);
+
+    const getInitDuration = (): number => {
+      if (!props.customDuration && urlDuration) {
+        return toValidDuration(urlDuration);
+      }
+      return reduxDuration;
+    };
+
+    const getInitRefresh = (): number => {
+      if (urlRefresh) {
+        // Validate value
+        if (urlRefresh === 0 || config.toolbar.refreshInterval[urlRefresh]) {
+          return urlRefresh;
+        }
+      }
+      return reduxRefreshInterval;
+    };
+
+    const getUrlTimeRange = (): TimeRange => ({
+      ...(urlTimeRange != null && { rangeDuration: urlTimeRange }),
+      ...(urlFrom != null && { from: urlFrom }),
+      ...(urlTo != null && { to: urlTo })
+    });
+
+    const getInitTimeRange = (): TimeRange => {
+      const tm = getUrlTimeRange();
+
+      if (!tm.rangeDuration && !tm.from && !tm.to && props.customDuration) {
+        return reduxTimeRange;
+      }
+
+      return tm;
+    };
+
     setDuration(getInitDuration());
     setRefreshInterval(getInitRefresh());
     setTimeRange(getInitTimeRange());
@@ -80,10 +80,12 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
     if (urlDuration !== undefined) {
       dispatch(UserSettingsActions.setDuration(urlDuration));
     }
+
     // Update just when valid
     if (urlRefresh !== undefined && (urlRefresh === 0 || config.toolbar.refreshInterval[urlRefresh])) {
       dispatch(UserSettingsActions.setRefreshInterval(urlRefresh));
     }
+
     if (getUrlTimeRange() !== undefined) {
       dispatch(UserSettingsActions.setTimeRange(getUrlTimeRange()));
     }

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -9,6 +9,8 @@ import { RefreshComponent } from '../Refresh/Refresh';
 import { TimeRangeComp } from './TimeRangeComponent';
 import { kioskDurationAction, kioskTimeRangeAction } from '../Kiosk/KioskActions';
 import { useKialiTranslation } from 'utils/I18nUtils';
+import { toValidDuration } from '../../config/ServerConfig';
+import { config } from '../../config';
 
 interface Props {
   customDuration: boolean;
@@ -35,14 +37,17 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
 
   const getInitDuration = (): number => {
     if (!props.customDuration && urlDuration) {
-      return urlDuration;
+      return toValidDuration(urlDuration);
     }
     return reduxDuration;
   };
 
   const getInitRefresh = (): number => {
     if (urlRefresh) {
-      return urlRefresh;
+      // Validate value
+      if (urlRefresh === 0 || config.toolbar.refreshInterval[urlRefresh]) {
+        return urlRefresh;
+      }
     }
     return reduxRefreshInterval;
   };
@@ -63,15 +68,20 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
     return tm;
   };
 
-  const [duration, setDuration] = React.useState(getInitDuration());
-  const [refreshInterval, setRefreshInterval] = React.useState(getInitRefresh());
-  const [timeRange, setTimeRange] = React.useState(getInitTimeRange());
+  const [duration, setDuration] = React.useState(0);
+  const [refreshInterval, setRefreshInterval] = React.useState(0);
+  const [timeRange, setTimeRange] = React.useState<TimeRange>({});
 
   React.useEffect(() => {
+    setDuration(getInitDuration());
+    setRefreshInterval(getInitRefresh());
+    setTimeRange(getInitTimeRange());
+
     if (urlDuration !== undefined) {
       dispatch(UserSettingsActions.setDuration(urlDuration));
     }
-    if (urlRefresh !== undefined) {
+    // Update just when valid
+    if (urlRefresh !== undefined && (urlRefresh === 0 || config.toolbar.refreshInterval[urlRefresh])) {
       dispatch(UserSettingsActions.setRefreshInterval(urlRefresh));
     }
     if (getUrlTimeRange() !== undefined) {

--- a/frontend/src/components/Time/TimeDurationModal.tsx
+++ b/frontend/src/components/Time/TimeDurationModal.tsx
@@ -77,6 +77,7 @@ export const TimeDurationModal: React.FC<Props> = (props: Props) => {
     if (getUrlTimeRange() !== undefined) {
       dispatch(UserSettingsActions.setTimeRange(getUrlTimeRange()));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleCancel = (): void => {


### PR DESCRIPTION
### Describe the change

Handle URL in kiosk for time duration modal

### Steps to test the PR

Go to: http://localhost:3000/console/namespaces/bookinfo/workloads/productpage-v1?duration=604800&refresh=30000&kiosk=true&tab=logs&rangeDuration=604800

Make sure that the selector is: 
![image](https://github.com/user-attachments/assets/c948ee37-fd80-4008-b001-1523f7a3bde4)

Also in the modal: 
![image](https://github.com/user-attachments/assets/72413a0f-2092-4a1e-a61b-9031b7630ad2)

Update the modal data: 
![image](https://github.com/user-attachments/assets/14e08f74-79ab-4022-86a1-b394ff976460)

Make sure it changes in the URL. 

Note: For Overview & Traffic, the duration parameter is used. For the other tabs, rangeDuration. Where rangeDuration is used, the "to" and "from" parameters can also be used:

http://localhost:3000/console/namespaces/bookinfo/workloads/productpage-v1?duration=604800&refresh=60000&kiosk=true&tab=traces&from=1733912384867&to=1733912700115

![image](https://github.com/user-attachments/assets/b5705ad7-3331-42ff-8491-107e18bb23eb)


### Automation testing

I think this will be validated in OSSMC tests (Can be done in a follow up PR)

### Issue reference

Fixes https://github.com/kiali/kiali/issues/7958
