### PR TITLE
[ambient] handle gateway-to-ambient traffic in the graph

### DIFF
--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -62,10 +62,11 @@ func (a ResponseTimeAppender) AppendGraph(trafficMap graph.TrafficMap, globalInf
 		graph.CheckError(err)
 	}
 
-	a.appendGraph(trafficMap, namespaceInfo.Namespace, globalInfo.PromClient)
+	a.appendGraph(trafficMap, a.Namespaces[namespaceInfo.Namespace], globalInfo.PromClient)
 }
 
-func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace string, client *prometheus.Client) {
+func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespaceInfo graph.NamespaceInfo, client *prometheus.Client) {
+	namespace := namespaceInfo.Name
 	// create map to quickly look up responseTime
 	responseTimeMap := make(map[string]float64)
 	duration := a.Namespaces[namespace].Duration
@@ -77,8 +78,25 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 		// query prometheus for the responseTime info in two queries:
 		groupBy := "source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol"
 
+		// 0) Incoming: Ambient only: query source telemetry, typically from a non-waypoint ingress gateway, that will likely not have overlapping dest or waypoint telem for the traffic (that traffic will be picked up in query #2)
+		if namespaceInfo.IsAmbient {
+			query := fmt.Sprintf(`sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_service_namespace="%s"}[%vs])) by (%s) / sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_service_namespace="%s"}[%vs])) by (%s) > 0`,
+				"istio_request_duration_milliseconds_sum",
+				namespace,
+				namespace,
+				int(duration.Seconds()), // range duration for the query
+				groupBy,
+				"istio_request_duration_milliseconds_count",
+				namespace,
+				namespace,
+				int(duration.Seconds()), // range duration for the query
+				groupBy)
+			incomingVector := promQuery(query, time.Unix(a.QueryTime, 0), client.GetContext(), client.API(), a)
+			a.populateResponseTimeMap(responseTimeMap, &incomingVector)
+		}
+
 		// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic
-		// note - the query order is important as both queries may have overlapping results for edges within
+		// note - the order of the next two queries is important as both queries may have overlapping results for edges within
 		//        the namespace.  This query uses destination proxy and so must come first.
 		query := fmt.Sprintf(`sum(rate(%s{%s,destination_service_namespace="%s"}[%vs])) by (%s) / sum(rate(%s{%s,destination_service_namespace="%s"}[%vs])) by (%s) > 0`,
 			"istio_request_duration_milliseconds_sum",
@@ -114,6 +132,19 @@ func (a ResponseTimeAppender) appendGraph(trafficMap graph.TrafficMap, namespace
 
 		// query prometheus for the responseTime info in two queries:
 		groupBy := "le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol"
+
+		// 0) Incoming: Ambient only: query source telemetry, typically from a non-waypoint ingress gateway, that will likely not have overlapping dest or waypoint telem for the traffic (that traffic will be picked up in query #2)
+		if namespaceInfo.IsAmbient {
+			query := fmt.Sprintf(`histogram_quantile(%.2f, sum(rate(%s{reporter="source",source_workload_namespace!="%s",destination_service_namespace="%s"}[%vs])) by (%s)) > 0`,
+				quantile,
+				"istio_request_duration_milliseconds_bucket",
+				namespace,
+				namespace,
+				int(duration.Seconds()), // range duration for the query
+				groupBy)
+			incomingVector := promQuery(query, time.Unix(a.QueryTime, 0), client.GetContext(), client.API(), a)
+			a.populateResponseTimeMap(responseTimeMap, &incomingVector)
+		}
 
 		// 1) Incoming: query destination telemetry to capture namespace services' incoming traffic
 		// note - the query order is important as both queries may have overlapping results for edges within

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -14,8 +14,11 @@ import (
 func TestResponseTimeP95(t *testing.T) {
 	assert := assert.New(t)
 
-	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=~"destination|waypoint",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
-	q0m0 := model.Metric{
+	q0 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter="source",source_workload_namespace!="bookinfo",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
+	v0 := model.Vector{}
+
+	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=~"destination|waypoint",destination_service_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
+	q1m0 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "istio-system",
 		"source_workload":                "ingressgateway-unknown",
@@ -30,100 +33,6 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_service":  "productpage",
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
-	q0m1 := model.Metric{
-		"source_cluster":                 config.DefaultClusterID,
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_cluster":            config.DefaultClusterID,
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v1",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v1",
-		"request_protocol":               "http"}
-	q0m2 := model.Metric{
-		"source_cluster":                 config.DefaultClusterID,
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_cluster":            config.DefaultClusterID,
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v2",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v2",
-		"request_protocol":               "http"}
-	q0m3 := model.Metric{
-		"source_cluster":                 config.DefaultClusterID,
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "reviews-v1",
-		"source_canonical_service":       "reviews",
-		"source_canonical_revision":      "v1",
-		"destination_cluster":            config.DefaultClusterID,
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "ratings.bookinfo.svc.cluster.local",
-		"destination_service_name":       "ratings",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "ratings-v1",
-		"destination_canonical_service":  "ratings",
-		"destination_canonical_revision": "v1",
-		"request_protocol":               "http"}
-	q0m4 := model.Metric{
-		"source_cluster":                 config.DefaultClusterID,
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "reviews-v2",
-		"source_canonical_service":       "reviews",
-		"source_canonical_revision":      "v2",
-		"destination_cluster":            config.DefaultClusterID,
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "ratings.bookinfo.svc.cluster.local",
-		"destination_service_name":       "ratings",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "ratings-v1",
-		"destination_canonical_service":  "ratings",
-		"destination_canonical_revision": "v1",
-		"request_protocol":               "http"}
-	v0 := model.Vector{
-		&model.Sample{
-			Metric: q0m0,
-			Value:  0.010},
-		&model.Sample{
-			Metric: q0m1,
-			Value:  0.020},
-		&model.Sample{
-			Metric: q0m2,
-			Value:  0.020},
-		&model.Sample{
-			Metric: q0m3,
-			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
-		&model.Sample{
-			Metric: q0m4,
-			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
-	}
-
-	q1 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=~"source|waypoint",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
-	q1m0 := model.Metric{
-		"source_cluster":                 config.DefaultClusterID,
-		"source_workload_namespace":      "bookinfo",
-		"source_workload":                "productpage-v1",
-		"source_canonical_service":       "productpage",
-		"source_canonical_revision":      "v1",
-		"destination_cluster":            config.DefaultClusterID,
-		"destination_service_namespace":  "bookinfo",
-		"destination_service":            "reviews.bookinfo.svc.cluster.local",
-		"destination_service_name":       "reviews",
-		"destination_workload_namespace": "bookinfo",
-		"destination_workload":           "reviews-v1",
-		"destination_canonical_service":  "reviews",
-		"destination_canonical_revision": "v1",
-		"request_protocol":               "http"}
 	q1m1 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
@@ -135,11 +44,26 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_service":            "reviews.bookinfo.svc.cluster.local",
 		"destination_service_name":       "reviews",
 		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http"}
+	q1m2 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
 		"destination_workload":           "reviews-v2",
 		"destination_canonical_service":  "reviews",
 		"destination_canonical_revision": "v2",
 		"request_protocol":               "http"}
-	q1m2 := model.Metric{
+	q1m3 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v1",
@@ -154,7 +78,86 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_service":  "ratings",
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
-	q1m3 := model.Metric{
+	q1m4 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "reviews-v2",
+		"source_canonical_service":       "reviews",
+		"source_canonical_revision":      "v2",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
+		"destination_service_name":       "ratings",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "ratings-v1",
+		"destination_canonical_service":  "ratings",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http"}
+	v1 := model.Vector{
+		&model.Sample{
+			Metric: q1m0,
+			Value:  0.010},
+		&model.Sample{
+			Metric: q1m1,
+			Value:  0.020},
+		&model.Sample{
+			Metric: q1m2,
+			Value:  0.020},
+		&model.Sample{
+			Metric: q1m3,
+			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
+		&model.Sample{
+			Metric: q1m4,
+			Value:  0.030}, // same edge reported by outgoing (q1), this > value should be preferred
+	}
+
+	q2 := `round(histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=~"source|waypoint",source_workload_namespace="bookinfo"}[60s])) by (le,source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol)) > 0,0.001)`
+	q2m0 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v1",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http"}
+	q2m1 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "productpage-v1",
+		"source_canonical_service":       "productpage",
+		"source_canonical_revision":      "v1",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "reviews.bookinfo.svc.cluster.local",
+		"destination_service_name":       "reviews",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "reviews-v2",
+		"destination_canonical_service":  "reviews",
+		"destination_canonical_revision": "v2",
+		"request_protocol":               "http"}
+	q2m2 := model.Metric{
+		"source_cluster":                 config.DefaultClusterID,
+		"source_workload_namespace":      "bookinfo",
+		"source_workload":                "reviews-v1",
+		"source_canonical_service":       "reviews",
+		"source_canonical_revision":      "v1",
+		"destination_cluster":            config.DefaultClusterID,
+		"destination_service_namespace":  "bookinfo",
+		"destination_service":            "ratings.bookinfo.svc.cluster.local",
+		"destination_service_name":       "ratings",
+		"destination_workload_namespace": "bookinfo",
+		"destination_workload":           "ratings-v1",
+		"destination_canonical_service":  "ratings",
+		"destination_canonical_revision": "v1",
+		"request_protocol":               "http"}
+	q2m3 := model.Metric{
 		"source_cluster":                 config.DefaultClusterID,
 		"source_workload_namespace":      "bookinfo",
 		"source_workload":                "reviews-v2",
@@ -170,18 +173,18 @@ func TestResponseTimeP95(t *testing.T) {
 		"destination_canonical_revision": "v1",
 		"request_protocol":               "http"}
 
-	v1 := model.Vector{
+	v2 := model.Vector{
 		&model.Sample{
-			Metric: q1m0,
+			Metric: q2m0,
 			Value:  0.020},
 		&model.Sample{
-			Metric: q1m1,
+			Metric: q2m1,
 			Value:  0.020},
 		&model.Sample{
-			Metric: q1m2,
+			Metric: q2m2,
 			Value:  0.040}, // same edge reported by incoming (q0), this > value should get ignored
 		&model.Sample{
-			Metric: q1m3,
+			Metric: q2m3,
 			Value:  0.040}, // same edge reported by incoming (q0), this > value should get ignored
 	}
 
@@ -192,6 +195,7 @@ func TestResponseTimeP95(t *testing.T) {
 	}
 	mockQuery(api, q0, &v0)
 	mockQuery(api, q1, &v1)
+	mockQuery(api, q2, &v2)
 
 	trafficMap := responseTimeTestTraffic()
 	ingressID, _, _ := graph.Id(config.DefaultClusterID, "istio-system", "", "istio-system", "ingressgateway-unknown", "ingressgateway", graph.Unknown, graph.GraphTypeVersionedApp)
@@ -207,8 +211,9 @@ func TestResponseTimeP95(t *testing.T) {
 		InjectServiceNodes: true,
 		Namespaces: map[string]graph.NamespaceInfo{
 			"bookinfo": {
-				Name:     "bookinfo",
-				Duration: duration,
+				Name:      "bookinfo",
+				Duration:  duration,
+				IsAmbient: true,
 			},
 		},
 		Quantile:  0.95,
@@ -221,7 +226,7 @@ func TestResponseTimeP95(t *testing.T) {
 		},
 	}
 
-	appender.appendGraph(trafficMap, graph.NamespaceInfo{Name: "bookinfo", IsAmbient: false}, client)
+	appender.appendGraph(trafficMap, graph.NamespaceInfo{Name: "bookinfo", IsAmbient: true}, client)
 
 	ingress, ok = trafficMap[ingressID]
 	assert.Equal(true, ok)

--- a/graph/telemetry/istio/appender/response_time_test.go
+++ b/graph/telemetry/istio/appender/response_time_test.go
@@ -221,7 +221,7 @@ func TestResponseTimeP95(t *testing.T) {
 		},
 	}
 
-	appender.appendGraph(trafficMap, "bookinfo", client)
+	appender.appendGraph(trafficMap, graph.NamespaceInfo{Name: "bookinfo", IsAmbient: false}, client)
 
 	ingress, ok = trafficMap[ingressID]
 	assert.Equal(true, ok)
@@ -495,7 +495,7 @@ func TestResponseTimeAvgSkipRates(t *testing.T) {
 		},
 	}
 
-	appender.appendGraph(trafficMap, "bookinfo", client)
+	appender.appendGraph(trafficMap, graph.NamespaceInfo{Name: "bookinfo", IsAmbient: false}, client)
 
 	ingress, ok = trafficMap[ingressID]
 	assert.Equal(true, ok)
@@ -769,7 +769,7 @@ func TestResponseTimeAvg(t *testing.T) {
 		},
 	}
 
-	appender.appendGraph(trafficMap, "bookinfo", client)
+	appender.appendGraph(trafficMap, graph.NamespaceInfo{Name: "bookinfo", IsAmbient: false}, client)
 
 	ingress, ok = trafficMap[ingressID]
 	assert.Equal(true, ok)

--- a/graph/telemetry/istio/util/util.go
+++ b/graph/telemetry/istio/util/util.go
@@ -142,7 +142,7 @@ func AddQueryScope(query string) string {
 	return strings.ReplaceAll(query, "{", scope)
 }
 
-// GetReporter returns the "report=" prom query fragment based on whether the reporter must include waypoint traffic
+// GetReporter returns the "reporter=" prom query fragment based on whether the reporter must include waypoint traffic
 func GetReporter(reporter string, rates graph.RequestedRates) string {
 	if rates.Ambient == graph.AmbientTrafficWaypoint || rates.Ambient == graph.AmbientTrafficTotal {
 		return fmt.Sprintf(`reporter=~"%s|waypoint"`, reporter)

--- a/graph/types.go
+++ b/graph/types.go
@@ -46,9 +46,10 @@ type Edge struct {
 }
 
 type NamespaceInfo struct {
-	Name     string
-	Duration time.Duration
-	IsIstio  bool
+	Name      string
+	Duration  time.Duration
+	IsAmbient bool
+	IsIstio   bool
 }
 
 type NamespaceInfoMap map[string]NamespaceInfo


### PR DESCRIPTION
HTTP traffic from a gateway to an ambient workload travels via HBONE to ztunnel and reports L7 telem only as source proxy. Our ambient handling depends on L7 telem from a waypoint, but there is no waypoint involved. Because there is no waypoint or Destination proxy involved, we were missing this source-reported telemetry. The only way to solve this seems to be adding more queries, specfically to pick up this traffic :-(.

Notes:
- namespace graphs should now be capturing the data as long as the namespace "IsAmbient".
- node graphs should now be capturing the traffic as long as the node's namespace "IsAmbient".
- responseTime should be available on these edges as long as the namespace "IsAmbient".
- aggregate node handling (aka requestClassification/operation nodes) is set as a TODO until it's clear someone needs the support.
- security appender did not add queries for two reasons:
  - it seems HBONE is not setting connection_security or principal attributes, so adding a query to use thattelem is not useful.
  - if the user has TCP traffic selected, we are already able to utilize the information provided by ztunnel.
- throughput appender did not add queries because the default is already using request (i.e. source) telem.

Fixes https://github.com/kiali/kiali/issues/7937
