### PR TITLE
Added missing tests for KIA1104

### DIFF
--- a/business/checkers/virtualservices/route_checker_test.go
+++ b/business/checkers/virtualservices/route_checker_test.go
@@ -42,6 +42,61 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
 	assert.Equal(vals[0].Severity, models.WarningSeverity)
 	assert.Equal(vals[0].Path, "spec/http[0]/route[0]/weight")
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTcpRouteUnder100(),
+	}.Check()
+
+	// wrong weight'ed route rule
+	assert.True(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/tcp[0]/route[0]/weight")
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTlsRouteUnder100(),
+	}.Check()
+
+	// wrong weight'ed route rule
+	assert.True(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/tls[0]/route[0]/weight")
+}
+
+// VirtualService with one route and no weight
+func TestServiceEmptyWeight(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTcpRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTlsRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestVSWithRepeatingSubsets(t *testing.T) {
@@ -92,6 +147,46 @@ func fakeValidVirtualService() *networking_v1.VirtualService {
 
 func fakeOneRouteUnder100() *networking_v1.VirtualService {
 	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTcpRouteUnder100() *networking_v1.VirtualService {
+	virtualService := data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTlsRouteUnder100() *networking_v1.VirtualService {
+	virtualService := data.AddTlsRoutesToVirtualService(data.CreateTlsRoute("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 0),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTcpRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("reviews", "v1", 0),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTlsRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddTlsRoutesToVirtualService(data.CreateTlsRoute("reviews", "v1", 0),
 		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
 	)
 


### PR DESCRIPTION
### Describe the change

Missing not provided route Weight check for TCP and TLS Route types in VirtualServices while KIA1104 Validations. (HTTP Route was working fine).
This was causing odd 'Warning KIA1104 The weight is assumed to be 100 because there is only one route destination' then VS had empty Weight in TCP and TLS Routes.
Added the missing similar checks in TCP and TLS routes (aligned to HTTP route).

### Steps to test the PR

Create "samples/tcp-echo/tcp-echo-all-v1.yaml"
You will not see a Warning KIA1104 on that VS.
![Screenshot From 2024-12-16 09-39-46](https://github.com/user-attachments/assets/1cb5fdd9-a698-4deb-8f05-f98704e4219f)


### Automation testing

Added unit tests.

### Issue reference
https://github.com/kiali/kiali/issues/8000
