### PR TITLE
Bump istio version for sail hack script

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -72,7 +72,7 @@ kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.1
   namespace: istio-system
   updateStrategy:
     type: InPlace


### PR DESCRIPTION
### Describe the change

Bump Istio version in Sail hack script. 
The current version is giving an error: 

```
2024-12-16T08:03:52Z	ERROR	ctrlr.istio	Reconciler error	{"Istio": "default", "reconcileID": "1c69c321-72c3-4ac2-8154-b8acd6529183", "error": "failed to apply profile: failed to get values from profile [\"default\"]: failed to read profile file /var/lib/sail-operator/resources/v1.23.0/profiles/default.yaml: open /var/lib/sail-operator/resources/v1.23.0/profiles/default.yaml: no such file or directory"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224
```

Even this is supposed to be a compatible version:

`The Istio "default" is invalid: spec.version: Unsupported value: "v1.24.0": supported values: "v1.24.1", "v1.23.3", "v1.23.0", "v1.22.6", "v1.22.4"`

### Steps to test the PR

Run `hack/istio/install-istio-via-sail.sh`
Installation must succeed. 

### Automation testing

N/A

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
