### PR TITLE
[dual stack] Support dual stack by being able to display multiple IPs for a service

### DIFF
--- a/business/checkers/virtualservices/route_checker_test.go
+++ b/business/checkers/virtualservices/route_checker_test.go
@@ -42,6 +42,61 @@ func TestServiceMultipleChecks(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
 	assert.Equal(vals[0].Severity, models.WarningSeverity)
 	assert.Equal(vals[0].Path, "spec/http[0]/route[0]/weight")
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTcpRouteUnder100(),
+	}.Check()
+
+	// wrong weight'ed route rule
+	assert.True(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/tcp[0]/route[0]/weight")
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTlsRouteUnder100(),
+	}.Check()
+
+	// wrong weight'ed route rule
+	assert.True(valid)
+	assert.NotEmpty(vals)
+	assert.Len(vals, 1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.route.singleweight", vals[0]))
+	assert.Equal(vals[0].Severity, models.WarningSeverity)
+	assert.Equal(vals[0].Path, "spec/tls[0]/route[0]/weight")
+}
+
+// VirtualService with one route and no weight
+func TestServiceEmptyWeight(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTcpRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+
+	vals, valid = RouteChecker{
+		Namespaces:     []string{"test"},
+		VirtualService: fakeOneTlsRouteNoWeight(),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestVSWithRepeatingSubsets(t *testing.T) {
@@ -92,6 +147,46 @@ func fakeValidVirtualService() *networking_v1.VirtualService {
 
 func fakeOneRouteUnder100() *networking_v1.VirtualService {
 	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTcpRouteUnder100() *networking_v1.VirtualService {
+	virtualService := data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTlsRouteUnder100() *networking_v1.VirtualService {
+	virtualService := data.AddTlsRoutesToVirtualService(data.CreateTlsRoute("reviews", "v1", 45),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddHttpRoutesToVirtualService(data.CreateHttpRouteDestination("reviews", "v1", 0),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTcpRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddTcpRoutesToVirtualService(data.CreateTcpRoute("reviews", "v1", 0),
+		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
+	)
+
+	return virtualService
+}
+
+func fakeOneTlsRouteNoWeight() *networking_v1.VirtualService {
+	virtualService := data.AddTlsRoutesToVirtualService(data.CreateTlsRoute("reviews", "v1", 0),
 		data.CreateEmptyVirtualService("reviews-multiple", "test", []string{"reviews"}),
 	)
 

--- a/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -77,6 +77,8 @@ export const ServiceNetwork: React.FC<ServiceNetworkProps> = (props: ServiceNetw
     return hostnames;
   };
 
+  const service = props.serviceDetails.service;
+  let ips = service.type !== 'External' ? (service.ips ? service.ips : [service.ip]) : [];
   return (
     <Card isCompact={true} id="ServiceNetworkCard">
       <CardHeader>
@@ -89,21 +91,19 @@ export const ServiceNetwork: React.FC<ServiceNetworkProps> = (props: ServiceNetw
           <ul style={{ listStyleType: 'none' }}>
             <li>
               <span>Type</span>
-              {props.serviceDetails.service.type}
+              {service.type}
             </li>
 
-            {props.serviceDetails.service.type !== 'External' && (
+            {ips.map((ip, i) => (
               <li>
-                <span>{props.serviceDetails.service.type !== 'ExternalName' ? 'Service IP' : 'ExternalName'}</span>
-                {props.serviceDetails.service.type !== 'ExternalName'
-                  ? props.serviceDetails.service.ip
-                    ? props.serviceDetails.service.ip
-                    : ''
-                  : props.serviceDetails.service.externalName
-                  ? props.serviceDetails.service.externalName
-                  : ''}
+                <span>
+                  {service.type !== 'ExternalName'
+                    ? `Service ${service.ipFamilies ? service.ipFamilies[i] : 'IP'}`
+                    : 'ExternalName'}
+                </span>
+                {service.type !== 'ExternalName' ? ip : service.externalName ? service.externalName : ''}
               </li>
-            )}
+            ))}
 
             {props.serviceDetails.endpoints && props.serviceDetails.endpoints.length > 0 && (
               <li>
@@ -135,11 +135,11 @@ export const ServiceNetwork: React.FC<ServiceNetworkProps> = (props: ServiceNetw
               </li>
             )}
 
-            {props.serviceDetails.service.ports && props.serviceDetails.service.ports.length > 0 && (
+            {service.ports && service.ports.length > 0 && (
               <li>
                 <span>Ports</span>
                 <div style={{ display: 'inline-block' }}>
-                  {(props.serviceDetails.service.ports ?? []).map((port, i) => {
+                  {(service.ports ?? []).map((port, i) => {
                     return (
                       <div key={`port_${i}`}>
                         <div>

--- a/frontend/src/types/ServiceInfo.ts
+++ b/frontend/src/types/ServiceInfo.ts
@@ -58,6 +58,7 @@ export interface WorkloadOverview {
   type: string;
 }
 
+export type IPFamily = 'IPv4' | 'IPv6';
 export interface Service {
   additionalDetails: AdditionalItem[];
   annotations: { [key: string]: string };
@@ -65,6 +66,8 @@ export interface Service {
   createdAt: string;
   externalName: string;
   ip: string;
+  ips?: string[]; // present in dual stack. ip === ips[0]
+  ipFamilies?: IPFamily[]; // ipFamilies[0] represents ip, ipFamilies[i] represents ips[i]
   labels?: { [key: string]: string };
   name: string;
   namespace: string;

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -48,7 +48,7 @@ export const isK8sGatewayHostValid = (k8sGatewayHost: string): boolean => {
     return false;
   }
 
-  // K8s gateway host must be fqdn but not ip address
+  // K8s gateway host must be fqdn but not ip address (ipv4 or ipv6)
   if (k8sGatewayHost.split('.').length < 2 || k8sGatewayHost.search(ipRegexp) === 0) {
     return false;
   }

--- a/models/service.go
+++ b/models/service.go
@@ -106,20 +106,22 @@ type ServiceDetails struct {
 type (
 	Services []*Service
 	Service  struct {
-		AdditionalDetails []AdditionalItem  `json:"additionalDetails"`
-		Annotations       map[string]string `json:"annotations"`
-		Cluster           string            `json:"cluster"`
-		CreatedAt         string            `json:"createdAt"`
-		ExternalName      string            `json:"externalName"`
-		HealthAnnotations map[string]string `json:"healthAnnotations"`
-		Ip                string            `json:"ip"`
-		Labels            map[string]string `json:"labels"`
-		Name              string            `json:"name"`
-		Namespace         string            `json:"namespace"`
-		Ports             Ports             `json:"ports"`
-		ResourceVersion   string            `json:"resourceVersion"`
-		Selectors         map[string]string `json:"selectors"`
-		Type              string            `json:"type"`
+		AdditionalDetails []AdditionalItem   `json:"additionalDetails"`
+		Annotations       map[string]string  `json:"annotations"`
+		Cluster           string             `json:"cluster"`
+		CreatedAt         string             `json:"createdAt"`
+		ExternalName      string             `json:"externalName"`
+		HealthAnnotations map[string]string  `json:"healthAnnotations"`
+		Ip                string             `json:"ip"`
+		Ips               []string           `json:"ips,omitempty"`
+		IpFamilies        []core_v1.IPFamily `json:"ipFamilies,omitempty"`
+		Labels            map[string]string  `json:"labels"`
+		Name              string             `json:"name"`
+		Namespace         string             `json:"namespace"`
+		Ports             Ports              `json:"ports"`
+		ResourceVersion   string             `json:"resourceVersion"`
+		Selectors         map[string]string  `json:"selectors"`
+		Type              string             `json:"type"`
 	}
 )
 
@@ -157,6 +159,8 @@ func (s *Service) Parse(cluster string, service *core_v1.Service) {
 		s.ExternalName = service.Spec.ExternalName
 		s.HealthAnnotations = GetHealthAnnotation(service.Annotations, GetHealthConfigAnnotation())
 		s.Ip = service.Spec.ClusterIP
+		s.Ips = service.Spec.ClusterIPs
+		s.IpFamilies = service.Spec.IPFamilies
 		s.Labels = service.Labels
 		s.Name = service.Name
 		s.Namespace = service.Namespace


### PR DESCRIPTION
Closes #8004

This parses out more IP information from the core_v1.Service, passes it back to the client, and now Service detail will display the multiple IP familes, as needed.

