### PR TITLE
Update service with no traces

### DIFF
--- a/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
@@ -46,7 +46,7 @@ Feature: Kiali Service Details page for remote cluster
     Then user sees span details
 
   Scenario: Don't see tracing info after selecting a trace
-    And user is at the details page for the "service" "bookinfo/ratings" located in the "east" cluster
+    And user is at the details page for the "service" "bookinfo/productpage" located in the "west" cluster
     Then user see no traces
 
   Scenario: See details for a service, which is not present in the specific cluster.


### PR DESCRIPTION
### Describe the change

The service ratings for the east cluster, which is not supposed to have traffic, has one initial tracing for some reason, causing a CI flake. 
Update the service for one that is not generating traces. 

Verify that the logic is correct: 

![image](https://github.com/user-attachments/assets/629dba04-b4cc-49f2-9e9d-92bef15ad645)

![image](https://github.com/user-attachments/assets/551cade3-7cf5-4ca3-b8a4-bc58fe51da8a)


### Steps to test the PR

CI passes. Also, the tests can be run locally for: 

`hack/run-integration-tests.sh --test-suite frontend-primary-remote --setup-only true`

