### PR TITLE
Add the namespace labels for FilterNamespacesWithDiscoverySelectors

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -275,10 +275,6 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 		return &ns, nil
 	}
 
-	if !in.isAccessibleNamespace(models.Namespace{Name: namespace, Cluster: cluster}) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
-	}
-
 	var result models.Namespace
 	if in.clusterIsOpenShift(cluster) {
 		project, err := client.GetProject(ctx, namespace)
@@ -292,6 +288,10 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 			return nil, err
 		}
 		result = models.CastNamespace(*ns, cluster)
+	}
+
+	if !in.isAccessibleNamespace(result) {
+		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
 	}
 
 	// Refresh namespace in cache since we've just fetched it from the API.

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -111,7 +111,7 @@ EOF
   echo "Creating keycloak deployment"
   helm upgrade --install --wait --timeout 15m \
   --namespace keycloak \
-   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version 24.3.1 \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true


### PR DESCRIPTION
### Describe the change
This issue is not always reproducible, but i think it might happen when the namespace is not found in the cache by `GetClusterNamespace`. This method uses `FilterNamespacesWithDiscoverySelectors` but it doesn't always have all the information needed to verify if the namespace is accessible, because the namespaces labels are missing:

![image](https://github.com/user-attachments/assets/9132f233-94f0-4df2-b283-e2f7d31a2361)

### Steps to test the PR

I tested with Ambient, but I think it also might happen in a non Ambient Mesh. 
Install istio, kiali and bookinfo, set the discovery selectors: 

```
deployment:
  cluster_wide_access: true
  discovery_selectors:
    default:
      - matchExpressions:
        - key: istio.io/dataplane-mode
          operator: Exists
      - matchExpressions:    
        - key: istio-injection
          operator: Exists  
```

Go to a workload, metrics and let the refresh button. It needs to wait until the cache is empty to be able to reproduce the error. 
When applied this PR, the error should not happen.
A way to "force" this error, can be commenting the code: 

https://github.com/kiali/kiali/blob/master/business/namespaces.go#L274

And see how it always returns namespace not accessible. 

### Automation testing

N/A

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8025 
