### PR TITLE
Keycloak tmp fix

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -275,10 +275,6 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 		return &ns, nil
 	}
 
-	if !in.isAccessibleNamespace(models.Namespace{Name: namespace, Cluster: cluster}) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
-	}
-
 	var result models.Namespace
 	if in.clusterIsOpenShift(cluster) {
 		project, err := client.GetProject(ctx, namespace)
@@ -292,6 +288,10 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 			return nil, err
 		}
 		result = models.CastNamespace(*ns, cluster)
+	}
+
+	if !in.isAccessibleNamespace(result) {
+		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
 	}
 
 	// Refresh namespace in cache since we've just fetched it from the API.

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -275,6 +275,10 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 		return &ns, nil
 	}
 
+	if !in.isAccessibleNamespace(models.Namespace{Name: namespace, Cluster: cluster}) {
+		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
+	}
+
 	var result models.Namespace
 	if in.clusterIsOpenShift(cluster) {
 		project, err := client.GetProject(ctx, namespace)
@@ -288,10 +292,6 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 			return nil, err
 		}
 		result = models.CastNamespace(*ns, cluster)
-	}
-
-	if !in.isAccessibleNamespace(result) {
-		return nil, &AccessibleNamespaceError{msg: "Namespace [" + namespace + "] in cluster [" + cluster + "] is not accessible to Kiali"}
 	}
 
 	// Refresh namespace in cache since we've just fetched it from the API.

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -111,7 +111,7 @@ EOF
   echo "Creating keycloak deployment"
   helm upgrade --install --wait --timeout 15m \
   --namespace keycloak \
-   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version 24.3.1 \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true


### PR DESCRIPTION
### Describe the change

The multi cluster multi primary CI is failing because keycloak cannot be accessed with the configured user/password in the latest image (https://github.com/bitnami/charts/blob/main/bitnami/keycloak/CHANGELOG.md#2432-2024-12-20). 
It is not picking the username/password in the helm charts, and it is using the bitnami defaults. 

This change just uses the previous version. 

This is just a temporary fix, that should be reverted to use the latest image once it correctly sets up the bootstrap admin username and password. But I haven't found a way to pass the new variables in helm charts (The way the scripts are doing look correct, regarding the docs https://artifacthub.io/packages/helm/bitnami/keycloak#keycloak-parameters), or it should use a different keycloak image to been able to set up them correctly. 

### Steps to test the PR

CI passes, or run `hack/run-integration-tests.sh --test-suite frontend-multi-primary`


