### PR TITLE
Update keycloak image and container

### DIFF
--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -111,7 +111,7 @@ EOF
   echo "Creating keycloak deployment"
   helm upgrade --install --wait --timeout 15m \
   --namespace keycloak \
-   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version 24.3.2 \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -111,7 +111,7 @@ EOF
   echo "Creating keycloak deployment"
   helm upgrade --install --wait --timeout 15m \
   --namespace keycloak \
-   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version 24.3.1 \
+   keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
   --reuse-values --values - <<EOF
 auth:
   createAdminUser: true
@@ -119,8 +119,6 @@ auth:
   adminPassword: admin
   managementUser: manager
   managementPassword: manager
-image:
-  tag: 21.1.2-debian-11-r4
 proxyAddressForwarding: true
 postgresql:
   enabled: true


### PR DESCRIPTION
### Describe the change

The admin user/pwd variables of the Keycloak container (21.1.2) doesn't look compatible with the ones updated in the charts in the latest version (24.3.2).
With the defaults, it looks like everything is working, but I just wondering if there is any issue to use that specific container image. 

### Steps to test the PR
`hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`

### Automation testing
The changes are affecting frontend-multi-primary environment

### Issue reference

Fixes #8029 
