### PR TITLE
Increase logs period for OSSMC

### DIFF
--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -11,15 +11,13 @@ Given(
 
     const changeIntervalDuration = (): void => {
       cy.get('#metrics_filter_interval_duration-toggle').click();
-      cy.get('#10800').click();
+      cy.get('#1800').click();
     };
 
     // In OSSMC, the duration interval is configured using the time duration modal component
     if (Cypress.env('OSSMC')) {
       cy.get('#time_duration').click();
       changeIntervalDuration();
-      cy.get('#drform-metrics-refresh-toggle').click();
-      cy.get('#0').click();
       cy.get('#time-duration-modal').find('button').contains('Confirm').click();
     } else {
       changeIntervalDuration();

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -11,7 +11,7 @@ Given(
 
     const changeIntervalDuration = (): void => {
       cy.get('#metrics_filter_interval_duration-toggle').click();
-      cy.get('#3600').click();
+      cy.get('#10800').click();
     };
 
     // In OSSMC, the duration interval is configured using the time duration modal component

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -12,14 +12,14 @@ Given(
     const changeIntervalDuration = (): void => {
       cy.get('#metrics_filter_interval_duration-toggle').click();
       cy.get('#10800').click();
-      cy.get('#drform-metrics-refresh-toggle').click();
-      cy.get('#60000').click();
     };
 
     // In OSSMC, the duration interval is configured using the time duration modal component
     if (Cypress.env('OSSMC')) {
       cy.get('#time_duration').click();
       changeIntervalDuration();
+      cy.get('#drform-metrics-refresh-toggle').click();
+      cy.get('#60000').click();
       cy.get('#time-duration-modal').find('button').contains('Confirm').click();
     } else {
       changeIntervalDuration();

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -11,7 +11,7 @@ Given(
 
     const changeIntervalDuration = (): void => {
       cy.get('#metrics_filter_interval_duration-toggle').click();
-      cy.get('#1800').click();
+      cy.get('#3600').click();
     };
 
     // In OSSMC, the duration interval is configured using the time duration modal component

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -12,6 +12,8 @@ Given(
     const changeIntervalDuration = (): void => {
       cy.get('#metrics_filter_interval_duration-toggle').click();
       cy.get('#10800').click();
+      cy.get('#drform-metrics-refresh-toggle').click();
+      cy.get('#60000').click();
     };
 
     // In OSSMC, the duration interval is configured using the time duration modal component

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -19,7 +19,7 @@ Given(
       cy.get('#time_duration').click();
       changeIntervalDuration();
       cy.get('#drform-metrics-refresh-toggle').click();
-      cy.get('#60000').click();
+      cy.get('#0').click();
       cy.get('#time-duration-modal').find('button').contains('Confirm').click();
     } else {
       changeIntervalDuration();

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -24,8 +24,8 @@ Feature: Workload logs tab
   @bookinfo-app
   Scenario: The log pane of the logs tab should only show the lines with the requested text
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace
-    When I type "INFO" on the Show text field
-    Then the log pane should only show log lines containing "INFO"
+    When I type "GET" on the Show text field
+    Then the log pane should only show log lines containing "GET"
 
   @bookinfo-app
   Scenario: The log pane of the logs tab should hide the lines with the requested text


### PR DESCRIPTION
### Describe the change
Update time duration for the workload logs cypress test.
The default was 1800 (30 min), but this is not enough for OSSMC. 
The bookinfo demo only writes logs at the initialization, and OSSMC tests take longer than the server tests. 

### Steps to test the PR

Cypress test passing or run `yarn cypress:run`

### Automation testing

**e2e** tests updated

###  Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/410
