### PR TITLE
Use transport to check the version

### DIFF
--- a/status/versions.go
+++ b/status/versions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -129,15 +131,30 @@ func tracingVersion(conf *config.Config, homeClusterSAClient kubernetes.ClientIn
 			}
 		} else {
 			// Tempo
+			auth := tracingConfig.Auth
+			if auth.UseKialiToken {
+				auth.Token = homeClusterSAClient.GetToken()
+			}
+			transport, err := httputil.CreateTransport(&auth, &http.Transport{}, 10*time.Second, tracingConfig.CustomHeaders)
+			if err != nil {
+				return nil, err
+			}
+			client := http.Client{Transport: transport, Timeout: 10 * time.Second}
 			if tracingConfig.Provider == config.TempoProvider {
-				body, statusCode, _, err := httputil.HttpGet(fmt.Sprintf("%s/api/status/buildinfo", versionUrl), nil, 10*time.Second, nil, nil)
-				if err != nil || statusCode > 399 {
-					log.Infof("tempo version check failed: url=[%v], code=[%v], err=[%v]", versionUrl, statusCode, err)
+				response, err := client.Get(fmt.Sprintf("%s/api/status/buildinfo", versionUrl))
+
+				if err != nil || response.StatusCode > 399 {
+					log.Infof("tempo version check failed: url=[%v], code=[%v], err=[%v]", versionUrl, response.StatusCode, err)
 				} else {
 					tempoV := new(tempoResponseVersion)
-					err = json.Unmarshal(body, &tempoV)
-					if err == nil {
-						product.Version = tempoV.Version
+					body, err := io.ReadAll(response.Body)
+					if err != nil {
+						log.Infof("Error decoding tempo version response: [%s]", err.Error())
+					} else {
+						err = json.Unmarshal(body, &tempoV)
+						if err == nil {
+							product.Version = tempoV.Version
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Describe the change

Create a client with TLS settings to check the version

### Steps to test the PR

Create a Tempo Stack in OpenShift following: https://medium.com/kialiproject/installing-openshift-service-mesh-3-tp1-with-kiali-and-grafana-tempo-6b76881ceaef

Kiali config: 

```
  tracing:
    enabled: true
    provider: "tempo"
    auth:
      insecure_skip_verify: true
      type: bearer
      token: "sha256..."
    external_url: "https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/north/search"
    internal_url: "https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/north/tempo"
    health_check_url: "https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/north/tempo/api/echo"
    tempo_config: 
      url_format: "jaeger"
```

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8036
