### PR TITLE
Do not send a stack trace to the user, limit exposure to the kiali po…

### DIFF
--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -116,7 +116,7 @@ func handlePanic(w http.ResponseWriter) {
 		if code == http.StatusInternalServerError {
 			stack := debug.Stack()
 			log.Errorf("%s: %s", message, stack)
-			RespondWithDetailedError(w, code, message, string(stack))
+			RespondWithDetailedError(w, code, message, "Stack trace available in Kiali logs")
 			return
 		}
 		RespondWithError(w, code, message)


### PR DESCRIPTION
Do not send a stack trace to the user, limit exposure to the kiali pod logs.  The only occurrence of this was in the graph panic handling, from what I can see.

Closes https://issues.redhat.com/browse/OSSM-8374

After the Change:

![Screenshot From 2025-01-09 11-32-45](https://github.com/user-attachments/assets/04f723d7-976e-4ad1-a53d-6650e3a398ea)

Testing this is a bit hard, because it requires a graph error, which is an unexpected condition. I just added a forced Panic in the server's graph gen code to provide the screenshot above.  I think the change clear from the simple code change.
