### PR TITLE
run integration tests on different istio versions

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -48,6 +48,8 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.istio_minor_version_offset }}" ]]; then
           OFFSET="${{ github.event.inputs.istio_minor_version_offset }}"
+          # Convert to absolute value - we want a positive offset, though some people might find it more intuitive to say "-1" offset for the previous version
+          OFFSET=$(( OFFSET < 0 ? -OFFSET : OFFSET ))
         else
           case "${{ github.event.schedule }}" in
             "0 2 * * *") OFFSET=0 ;;

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -3,24 +3,23 @@ name: Test Istio Version
 on:
   schedule:
   # These are in UTC time.
-  # If you change any of these, you must also change the switch statment in the determine-istio-version-to-use task.
+  # If you change any of these, you must also change the case statment in the determine-istio-version-to-use task.
   - cron: '0 2 * * *'
   - cron: '0 4 * * *'
-  - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       istio_version:
-        description: "The version of Istio to test with. Format is either #.#.# or #.#-dev. If specified, this overrides istio_minor_version_offset."
+        description: "istio_version: The version of Istio to test with. Format is either #.#.# or #.#-dev. If specified, this overrides istio_minor_version_offset."
         required: false
         default: ""
         type: string
       istio_minor_version_offset:
-        description: "If istio_version is not set, the latest Istio minor version is tested. To test the previous minor version, set offset to 1 (i.e. 1 minor version prior to the latest minor version). This setting is ignored if istio_version is set."
+        description: "istio_minor_version_offset: If istio_version is not set, by default the latest Istio minor version is tested. To test the previous minor version, set this offset to 1 (i.e. 1 minor version prior to the latest minor version). Set it to 2 for two minor versions previous to the latest. This setting is ignored if istio_version is set."
         required: false
         default: 0
         type: number
       branch_to_test:
-        description: "The branch to build and test."
+        description: "branch_to_test: The branch to build and test."
         required: true
         default: "master"
         type: string
@@ -45,9 +44,8 @@ jobs:
             OFFSET=$(( OFFSET < 0 ? -OFFSET : OFFSET ))
           else
             case "${{ github.event.schedule }}" in
-              "0 2 * * *") OFFSET=0 ;;
-              "0 4 * * *") OFFSET=1 ;;
-              "0 6 * * *") OFFSET=2 ;;
+              "0 2 * * *") OFFSET=1 ;;
+              "0 4 * * *") OFFSET=2 ;;
               *) echo "Invalid schedule or unknown trigger! Cannot determine Istio version." && exit 1 ;;
             esac
           fi

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -1,12 +1,24 @@
 name: Test Istio Version
 
 on:
+  schedule:
+  # These are in UTC time.
+  # If you change any of these, you must also change the switch statment in the determine-istio-version-to-use task.
+  - cron: '0 2 * * *'
+  - cron: '0 4 * * *'
+  - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       istio_version:
-        description: "The version of Istio to test with. Format is either #.#.# or #.#-dev"
-        required: true
+        description: "The version of Istio to test with. Format is either #.#.# or #.#-dev. If specified, this overrides istio_minor_version_offset."
+        required: false
+        default: ""
         type: string
+      istio_minor_version_offset:
+        description: "If istio_version is not set, the latest Istio minor version is tested. To test the previous minor version, set offset to 1 (i.e. 1 minor version prior to the latest minor version). This setting is ignored if istio_version is set."
+        required: false
+        default: 0
+        type: number
       branch_to_test:
         description: "The branch to build and test."
         required: true
@@ -20,12 +32,36 @@ jobs:
     outputs:
       target-branch: ${{ inputs.branch_to_test }}
       build-branch: ${{ inputs.branch_to_test }}
-      istio-version: ${{ inputs.istio_version }}
+      istio-version: ${{ steps.determine-istio-version-to-use.outputs.istio-version }}
     steps:
-      # The initialize job gathers variables for later use in jobs.
-      - run: echo "target-branch -> ${{ inputs.branch_to_test }}"
-      - run: echo "build-branch -> ${{ inputs.branch_to_test }}"
-      - run: echo "istio-version -> ${{ inputs.istio_version }}"
+    # The initialize job gathers variables for later use in jobs.
+    - name: Determine Istio Version to use
+      id: determine-istio-version-to-use
+      run: |
+        if [ -z "${{ github.event.inputs.istio_version }}" ]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.istio_minor_version_offset }}" ]]; then
+            OFFSET="${{ github.event.inputs.istio_minor_version_offset }}"
+            # Convert to absolute value - we want a positive offset, though some people might find it more intuitive to say "-1" offset for the previous version
+            OFFSET=$(( OFFSET < 0 ? -OFFSET : OFFSET ))
+          else
+            case "${{ github.event.schedule }}" in
+              "0 2 * * *") OFFSET=0 ;;
+              "0 4 * * *") OFFSET=1 ;;
+              "0 6 * * *") OFFSET=2 ;;
+              *) echo "Invalid schedule or unknown trigger! Cannot determine Istio version." && exit 1 ;;
+            esac
+          fi
+          LATEST_ISTIO_VERSIONS="$(curl -s https://api.github.com/repos/istio/istio/releases | jq -r '.[].tag_name' | sort -rV | awk -F. '!seen[$1"."$2]++' | head -n $((OFFSET + 1)))"
+          ISTIO_VERSION=$(echo "${LATEST_ISTIO_VERSIONS}" | tail -n 1)
+          echo "The latest Istio versions are:"
+          echo "${LATEST_ISTIO_VERSIONS}"
+          echo "The Istio minor version offset is [${OFFSET}], thus the Istio version to be used in the tests will be: ${ISTIO_VERSION}"
+        else
+          ISTIO_VERSION="${{ github.event.inputs.istio_version }}"
+        fi
+        echo "istio-version=${ISTIO_VERSION}" | tee -a "$GITHUB_OUTPUT"
+    - run: echo "target-branch -> ${{ inputs.branch_to_test }}"
+    - run: echo "build-branch -> ${{ inputs.branch_to_test }}"
 
   build_backend:
     name: Build backend
@@ -51,6 +87,15 @@ jobs:
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
 
+  integration_tests_backend_multicluster_external_controlplane:
+    name: Run backend multicluster external-controlplane integration tests
+    uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
   integration_tests_frontend:
     name: Run frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend.yml
@@ -60,9 +105,36 @@ jobs:
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
 
-  integration_tests_frontend_multicluster:
-    name: Run frontend multicluster integration tests
-    uses: ./.github/workflows/integration-tests-frontend-multicluster.yml
+  integration_tests_frontend_multicluster_primary_remote:
+    name: Run frontend multicluster primary-remote integration tests
+    uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
+  integration_tests_frontend_multicluster_multi_primary:
+    name: Run frontend multicluster multi-primary integration tests
+    uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
+  integration_tests_frontend_ambient:
+    name: Run Ambient frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend-ambient.yml
+    needs: [initialize, build_backend, build_frontend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
+      istio_version: ${{ needs.initialize.outputs.istio-version }}
+
+  integration_tests_frontend_tempo:
+    name: Run tracing frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend-tempo.yml
     needs: [initialize, build_backend, build_frontend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}


### PR DESCRIPTION
This runs all integration tests 2 times nightly - at 2am it runs with the minor version previous to the latest version; at 4am it runs with the minor version that is 2 previous versions back.

So if the latest version of Istio is 1.25.4 and the previous two minor versions are 1.24.8 and 1.23.0 then those last two are run at 2am and 4am respectively.

You can alternatively run this CI action manually - you can either give a specific Istio version to test with (e.g. "1.24.2") or you can specify an offset to the latest minor version. If you give an offset of "1" it will run with the Istio minor version previous to the current minor version. "2" will use the version before that one, and so on. You can opt to specify negative offsets if you find that more intuitive - it doesn't matter. "-1" offset is the same as "1" offset - its the first minor version prior to the latest. Same with "-2" and "2" - its the second minor version prior to the latest.