### PR TITLE
Use SA to read ztunnel logs

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -123,7 +123,7 @@ func newLayer(
 	temporaryLayer.RegistryStatus = RegistryStatusService{kialiCache: cache}
 	temporaryLayer.TLS = TLSService{discovery: discovery, userClients: userClients, kialiCache: cache, businessLayer: temporaryLayer}
 	temporaryLayer.Svc = SvcService{config: *conf, kialiCache: cache, businessLayer: temporaryLayer, prom: prom, userClients: userClients}
-	temporaryLayer.Workload = *NewWorkloadService(userClients, prom, cache, temporaryLayer, conf, grafana)
+	temporaryLayer.Workload = *NewWorkloadService(userClients, kialiSAClients, prom, cache, temporaryLayer, conf, grafana)
 	temporaryLayer.Validations = NewValidationsService(&temporaryLayer.IstioConfig, cache, &temporaryLayer.Mesh, &temporaryLayer.Namespace, &temporaryLayer.Svc, userClients, &temporaryLayer.Workload)
 
 	temporaryLayer.Tracing = NewTracingService(conf, traceClient, &temporaryLayer.Svc, &temporaryLayer.Workload)


### PR DESCRIPTION
### Describe the change

Use SA to read ztunnel logs. Then, they are filtered by the workload name/namespace, so just the access logs will be shown

### Steps to test the PR

Install Istio Ambient.
Use kiali token strategy. 
Create roles for a test sa just for the bookinfo: 
```
kubectl apply -f https://raw.githubusercontent.com/josunect/yamls/refs/heads/main/roleBookinfo.yaml
kubectl apply -f https://raw.githubusercontent.com/josunect/yamls/refs/heads/main/roleBindingBookinfo.yaml
```

ztunnel logs should be visible when login with a token for the test SA: 
![image](https://github.com/user-attachments/assets/2f51967b-eae7-4ab3-88e1-3eb7e1515c71)

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8033