### PR TITLE
Override cy.exec to print full output on failure.

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -225,7 +225,8 @@ Cypress.Commands.add('hasCssVar', { prevSubject: true }, (subject, styleName, cs
 });
 
 // Overrides exec to print out the full output in case of failure.
-// https://github.com/cypress-io/cypress/issues/5470.
+// This is necessary because cypress truncates the output of stdout/stderr.
+// See https://github.com/cypress-io/cypress/issues/5470 for more details.
 Cypress.Commands.overwrite('exec', (originalFn, command, options) => {
   // Don't override when failOnNonZeroExit is false because the caller
   // may be doing something else with the output.

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -223,3 +223,23 @@ Cypress.Commands.add('hasCssVar', { prevSubject: true }, (subject, styleName, cs
       .should('eq', evaluatedStyle);
   });
 });
+
+// Overrides exec to print out the full output in case of failure.
+// https://github.com/cypress-io/cypress/issues/5470.
+Cypress.Commands.overwrite('exec', (originalFn, command, options) => {
+  // Don't override when failOnNonZeroExit is false because the caller
+  // may be doing something else with the output.
+  if (options && !options.failOnNonZeroExit) {
+    return originalFn(command, options);
+  }
+
+  return originalFn(command, { ...options, failOnNonZeroExit: false }).then(result => {
+    if (result.code) {
+      throw new Error(`Execution of "${command}" failed
+      Exit code: ${result.code}
+      Stdout:\n${result.stdout}
+      Stderr:\n${result.stderr}`);
+    }
+    return result;
+  });
+});


### PR DESCRIPTION
### Describe the change

Override cy.exec to print full output on failure

### Steps to test the PR

N/A

### Automation testing

N/A

