### PR TITLE
Added WorkloadGroup references from App and Workload lists.

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -116,6 +116,7 @@ func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteri
 		IncludeRequestAuthentications: true,
 		IncludeSidecars:               true,
 		IncludeVirtualServices:        true,
+		IncludeWorkloadGroups:         true,
 	}
 	istioConfigList := &models.IstioConfigList{}
 

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -95,7 +95,7 @@ func (icc IstioConfigCriteria) Include(resource schema.GroupVersionKind) bool {
 	case kubernetes.WorkloadEntries:
 		return icc.IncludeWorkloadEntries && !isWorkloadSelector
 	case kubernetes.WorkloadGroups:
-		return icc.IncludeWorkloadGroups && !isWorkloadSelector
+		return icc.IncludeWorkloadGroups
 	case kubernetes.RequestAuthentications:
 		return icc.IncludeRequestAuthentications
 	case kubernetes.EnvoyFilters:
@@ -337,6 +337,10 @@ func (in *IstioConfigService) getIstioConfigList(ctx context.Context, cluster st
 		istioConfigList.WorkloadGroups, err = kubeCache.GetWorkloadGroups(namespace, criteria.LabelSelector)
 		if err != nil {
 			return nil, err
+		}
+
+		if isWorkloadSelector {
+			istioConfigList.WorkloadGroups = kubernetes.FilterWorkloadGroupsBySelector(workloadSelector, istioConfigList.WorkloadGroups)
 		}
 	}
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -251,6 +251,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		IncludePeerAuthentications:    true,
 		IncludeRequestAuthentications: true,
 		IncludeSidecars:               true,
+		IncludeWorkloadGroups:         true,
 	}
 	var istioConfigMap models.IstioConfigMap
 
@@ -366,6 +367,17 @@ func FilterWorkloadReferences(wSelector string, istioConfigList models.IstioConf
 	efFiltered := kubernetes.FilterEnvoyFiltersBySelector(wSelector, istioConfigList.EnvoyFilters)
 	for _, ef := range efFiltered {
 		ref := models.BuildKey(kubernetes.EnvoyFilters, ef.Name, ef.Namespace, cluster)
+		exist := false
+		for _, r := range wkdReferences {
+			exist = exist || *r == ref
+		}
+		if !exist {
+			wkdReferences = append(wkdReferences, &ref)
+		}
+	}
+	wgFiltered := kubernetes.FilterWorkloadGroupsBySelector(wSelector, istioConfigList.WorkloadGroups)
+	for _, wg := range wgFiltered {
+		ref := models.BuildKey(kubernetes.WorkloadGroups, wg.Name, wg.Namespace, cluster)
 		exist := false
 		for _, r := range wkdReferences {
 			exist = exist || *r == ref

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -50,7 +50,8 @@ const workloadIstioResources = [
   getGVKTypeString(gvkType.PeerAuthentication),
   getGVKTypeString(gvkType.Sidecar),
   getGVKTypeString(gvkType.RequestAuthentication),
-  getGVKTypeString(gvkType.EnvoyFilter)
+  getGVKTypeString(gvkType.EnvoyFilter),
+  getGVKTypeString(gvkType.WorkloadGroup)
 ];
 
 export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState> {

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -304,6 +304,26 @@ func FilterWorkloadEntriesBySelector(selector labels.Selector, allEntries []*net
 	return entries
 }
 
+func FilterWorkloadGroupsBySelector(workloadSelector string, allGroups []*networking_v1.WorkloadGroup) []*networking_v1.WorkloadGroup {
+	var filtered []*networking_v1.WorkloadGroup
+	workloadLabels := mapWorkloadSelector(workloadSelector)
+	for _, wg := range allGroups {
+		wkLabelsS := []string{}
+		if wg.Spec.Template.Labels != nil {
+			apSelector := wg.Spec.Template.Labels
+			for k, v := range apSelector {
+				wkLabelsS = append(wkLabelsS, k+"="+v)
+			}
+		}
+		if resourceSelector, err := labels.Parse(strings.Join(wkLabelsS, ",")); err == nil {
+			if !resourceSelector.Empty() && resourceSelector.Matches(labels.Set(workloadLabels)) {
+				filtered = append(filtered, wg)
+			}
+		}
+	}
+	return filtered
+}
+
 // FilterPodsByService returns a subpart of pod list filtered according service selector
 func FilterPodsByService(s *core_v1.Service, allPods []core_v1.Pod) []core_v1.Pod {
 	if s == nil || allPods == nil {


### PR DESCRIPTION
### Describe the change

Application and Workloads lists got links to WorkloadGroup Istio config.
![Screenshot From 2025-01-13 12-42-38](https://github.com/user-attachments/assets/1efe1c7e-056b-43fa-bc87-af902e737ccc)
![Screenshot From 2025-01-13 12-41-57](https://github.com/user-attachments/assets/29563480-9c43-4f41-b93a-e82f54c17664)

Workload Details got link to WorkloadGroup Istio config:
![Screenshot From 2025-01-13 12-41-36](https://github.com/user-attachments/assets/61180728-af32-4085-baf6-a0469b0ffb07)

### Steps to test the PR

Create WorkloadGroups and manually create WorkloadEntries with Sidecars:
```
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm
  namespace: bookinfo
  labels:
    app: ratings-vm
spec:
  template:
    address: 2.2.2.2
    labels:
      app: ratings-vm
      class: vm
    serviceAccount: bookinfo-ratings
---
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: ratings-vm
  namespace: bookinfo
spec:
  address: 2.2.2.2
  labels:
    class: vm
    app: ratings-vm
    version: v3
  serviceAccount: bookinfo-ratings
  network: vm-us-east
---
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: bookinfo-ratings-vm
  namespace: bookinfo
spec:
  egress:
  - bind: 127.0.0.2
    hosts:
    - ./*
  ingress:
  - defaultEndpoint: 127.0.0.1:9080
    port:
      name: http
      number: 9080
      protocol: HTTP
  workloadSelector:
    labels:
      app: ratings-vm
      class: vm
---
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm2
  namespace: bookinfo
  labels:
    app: ratings-vm2
spec:
  template:
    address: 2.2.2.2
    labels:
      app: ratings-vm2
      class: vm2
    serviceAccount: bookinfo-ratings
---
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: ratings-vm2
  namespace: bookinfo
spec:
  address: 2.2.2.2
  labels:
    class: vm2
    app: ratings-vm2
    version: v4
  serviceAccount: bookinfo-ratings
  network: vm-us-east
---
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: bookinfo-ratings-vm2
  namespace: bookinfo
spec:
  egress:
  - bind: 127.0.0.2
    hosts:
    - ./*
  ingress:
  - defaultEndpoint: 127.0.0.1:9080
    port:
      name: http
      number: 9080
      protocol: HTTP
  workloadSelector:
    labels:
      app: ratings-vm2
      class: vm2
---
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm-no-entry
  namespace: bookinfo
  labels:
    app: ratings-vm-no-entry
spec:
  template:
    address: 2.2.2.2
    labels:
      app: ratings-vm-no-entry
      class: vm3
    serviceAccount: bookinfo-ratings
---
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm-no-entry2
  namespace: bookinfo
spec:
  template:
    address: 2.2.2.2
    serviceAccount: bookinfo-ratings
```

### Automation testing
n/a

### Issue reference
Epic link https://github.com/kiali/kiali/issues/7107
