### PR TITLE
Make sure all inline alerts have correct styles

### DIFF
--- a/frontend/src/app/InitializingScreen.tsx
+++ b/frontend/src/app/InitializingScreen.tsx
@@ -70,7 +70,7 @@ export const InitializingScreen: React.FC<initializingScreenProps> = (props: ini
       <img alt="Kiali Logo" src={theme === Theme.DARK ? kialiLogoDark : kialiLogoLight} width="200" />
       {props.errorMsg ? (
         <div ref={errorDiv} className={defaultErrorStyle}>
-          <Alert variant="danger" title={props.errorMsg} />
+          <Alert variant="danger" isInline={true} title={props.errorMsg} />
           {props.errorDetails ? (
             <>
               <p>

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -56,6 +56,15 @@ const websiteStyle = kialiStyle({
   marginRight: '2rem'
 });
 
+const alertStyle = kialiStyle({
+  marginTop: '1rem',
+  $nest: {
+    '& .pf-v5-c-alert__title': {
+      marginTop: 0
+    }
+  }
+})
+
 export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalProps) => {
   const renderMeshLink = (): React.ReactNode => {
     if (config?.about?.mesh) {
@@ -143,7 +152,7 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
           variant="warning"
           isInline={true}
           title={props.warningMessages[0]}
-          style={{ marginTop: '1rem' }}
+          className={alertStyle}
         />
       )}
 

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -142,7 +142,7 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
         <Alert
           variant="warning"
           isInline={true}
-          title={props.warningMessages[0] || 'An error occurred'}
+          title={props.warningMessages[0]}
           style={{ marginTop: '1rem' }}
         />
       )}

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -63,7 +63,7 @@ const alertStyle = kialiStyle({
       marginTop: 0
     }
   }
-})
+});
 
 export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalProps) => {
   const renderMeshLink = (): React.ReactNode => {
@@ -148,12 +148,7 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
       </TextContent>
 
       {props.warningMessages.length > 0 && (
-        <Alert
-          variant="warning"
-          isInline={true}
-          title={props.warningMessages[0]}
-          className={alertStyle}
-        />
+        <Alert variant="warning" isInline={true} title={props.warningMessages[0]} className={alertStyle} />
       )}
 
       <TextContent className={textContentStyle}>

--- a/frontend/src/components/About/AboutUIModal.tsx
+++ b/frontend/src/components/About/AboutUIModal.tsx
@@ -139,7 +139,12 @@ export const AboutUIModal: React.FC<AboutUIModalProps> = (props: AboutUIModalPro
       </TextContent>
 
       {props.warningMessages.length > 0 && (
-        <Alert variant="warning" title={props.warningMessages[0]} style={{ marginTop: '1rem' }} />
+        <Alert
+          variant="warning"
+          isInline={true}
+          title={props.warningMessages[0] || 'An error occurred'}
+          style={{ marginTop: '1rem' }}
+        />
       )}
 
       <TextContent className={textContentStyle}>

--- a/frontend/src/components/IstioWizards/WizardLabels.tsx
+++ b/frontend/src/components/IstioWizards/WizardLabels.tsx
@@ -247,7 +247,7 @@ export class WizardLabels extends React.Component<Props, State> {
           </Button>
 
           {this.state.validation.length > 0 && (
-            <Alert variant="danger" isInline isExpandable title="An error occurred">
+            <Alert variant="danger" isInline={true} isExpandable title="An error occurred">
               <List isPlain>
                 {this.state.validation.map((message, i) => (
                   <ListItem key={`Message_${i}`}>{message}</ListItem>

--- a/frontend/src/components/IstioWizards/WizardLabels.tsx
+++ b/frontend/src/components/IstioWizards/WizardLabels.tsx
@@ -247,7 +247,7 @@ export class WizardLabels extends React.Component<Props, State> {
           </Button>
 
           {this.state.validation.length > 0 && (
-            <Alert variant="danger" isInline={true} isExpandable title="An error occurred">
+            <Alert variant="danger" isInline isExpandable title="An error occurred">
               <List isPlain>
                 {this.state.validation.map((message, i) => (
                   <ListItem key={`Message_${i}`}>{message}</ListItem>

--- a/frontend/src/components/IstioWizards/WizardLabels.tsx
+++ b/frontend/src/components/IstioWizards/WizardLabels.tsx
@@ -41,11 +41,6 @@ const clearButtonStyle = kialiStyle({
 
 const alertStyle = kialiStyle({
   marginTop: '1rem',
-  $nest: {
-    '& .pf-v5-c-alert__title': {
-      marginTop: 0
-    }
-  }
 })
 
 export class WizardLabels extends React.Component<Props, State> {

--- a/frontend/src/components/IstioWizards/WizardLabels.tsx
+++ b/frontend/src/components/IstioWizards/WizardLabels.tsx
@@ -39,6 +39,15 @@ const clearButtonStyle = kialiStyle({
   marginLeft: '0.5rem'
 });
 
+const alertStyle = kialiStyle({
+  marginTop: '1rem',
+  $nest: {
+    '& .pf-v5-c-alert__title': {
+      marginTop: 0
+    }
+  }
+})
+
 export class WizardLabels extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -247,7 +256,7 @@ export class WizardLabels extends React.Component<Props, State> {
           </Button>
 
           {this.state.validation.length > 0 && (
-            <Alert variant="danger" isInline isExpandable title="An error occurred">
+            <Alert variant="danger" className={alertStyle} isInline isExpandable title="An error occurred">
               <List isPlain>
                 {this.state.validation.map((message, i) => (
                   <ListItem key={`Message_${i}`}>{message}</ListItem>

--- a/frontend/src/components/IstioWizards/WizardLabels.tsx
+++ b/frontend/src/components/IstioWizards/WizardLabels.tsx
@@ -40,8 +40,8 @@ const clearButtonStyle = kialiStyle({
 });
 
 const alertStyle = kialiStyle({
-  marginTop: '1rem',
-})
+  marginTop: '1rem'
+});
 
 export class WizardLabels extends React.Component<Props, State> {
   constructor(props: Props) {

--- a/frontend/src/components/MessageCenter/NotificationList.tsx
+++ b/frontend/src/components/MessageCenter/NotificationList.tsx
@@ -31,7 +31,6 @@ export const NotificationList: React.FC<NotificationListProps> = (props: Notific
           <Alert
             key={`toast_${message.id}`}
             variant={variant}
-            isInline={true}
             title={message.content}
             timeout={true}
             actionClose={<AlertActionCloseButton onClose={() => props.onDismiss(message, true)} />}

--- a/frontend/src/components/MessageCenter/NotificationList.tsx
+++ b/frontend/src/components/MessageCenter/NotificationList.tsx
@@ -31,6 +31,7 @@ export const NotificationList: React.FC<NotificationListProps> = (props: Notific
           <Alert
             key={`toast_${message.id}`}
             variant={variant}
+            isInline={true}
             title={message.content}
             timeout={true}
             actionClose={<AlertActionCloseButton onClose={() => props.onDismiss(message, true)} />}

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -287,6 +287,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                     <ToolbarItem style={{ width: '100%' }}>
                       <Alert
                         style={{ width: '100%' }}
+                        isInline={true}
                         variant={AlertVariant.info}
                         title={this.state.infoMessage}
                         actionClose={<AlertActionCloseButton onClose={() => this.setState({ visibleAlert: false })} />}


### PR DESCRIPTION
### Describe the change

Making sure that Alerts are mimicking,  https://v5-archive.patternfly.org/components/alert  

AboutUIModal.tsx Before and After (margin needs to be changed):
Before:
![image](https://github.com/user-attachments/assets/b63ee1d7-8b44-4b3d-9f3d-806ce980f4fd)
After:
![Screenshot from 2025-01-15 11-17-02](https://github.com/user-attachments/assets/b4410e6e-6af7-47a1-9461-e0e2db066274)


InitializingScreen.tsx
Before:
![Screenshot from 2025-01-13 12-08-32](https://github.com/user-attachments/assets/c6567a4e-2783-4fae-bd0a-702985a3169f)
After:
![Screenshot from 2025-01-13 12-11-06](https://github.com/user-attachments/assets/4ed06a11-8d1d-4e68-94d6-69b0019a9787)

WizardLabels.tsx
Before: 
![Screenshot from 2025-01-13 12-19-58](https://github.com/user-attachments/assets/ccffd244-fcce-48c9-a32c-6b94d4455857)
(No need to make changes other than margin)
After:
![Screenshot from 2025-01-15 11-29-55](https://github.com/user-attachments/assets/783f6b08-3acb-49f5-87dc-4ba7d528d8a0)


NotificationList.tsx
How the alert shows:
![Screenshot from 2025-01-13 15-24-16](https://github.com/user-attachments/assets/351c107b-51c2-4bf9-9507-62655d7a41bb)
Removed the isInLine in the code since toast alerts DO NOT use isInLine alerts

TracesComponent.tsx
Before: 
![Screenshot from 2025-01-14 11-24-39](https://github.com/user-attachments/assets/75aa02c5-8472-447f-8f39-9506c413be0c)
After:
![Screenshot from 2025-01-14 11-28-28](https://github.com/user-attachments/assets/ad44102c-4270-46ac-9a45-268f03d1442a)


Closes #8044 