### PR TITLE
[cy] Add test coverage for waypoint tab

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -107,6 +107,27 @@ Then('the proxy status is {string} with {string} details', (status: string, deta
   cy.get(`[data-test=pod-info]`).trigger('mouseleave');
 });
 
+Then('the user goes to the {string} tab', (tab: string) => {
+  openTab(tab);
+});
+
+Then('user goes to the waypoint {string} subtab', (subtab: string) => {
+  cy.get('#waypoint-details').should('be.visible').contains(subtab).click();
+});
+
+Then('validates Services data', () => {
+  cy.get('[data-test="enrolled-data-title"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', 'productpage-v1');
+  cy.get('[role="grid"]').should('be.visible').get('#pfbadge-S').should('exist');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', 'namespace');
+});
+
+Then('validates waypoint Info data', () => {
+  cy.get('[data-test=waypointfor-title]').should('exist').and('contain', 'service');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label=RDS]').and('contain', 'IGNORED');
+});
+
 When('the user validates the Ztunnel tab', () => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -48,6 +48,11 @@ Feature: Kiali Waypoint related features
     Then user sees trace details
     When the user looks for the bootstrap tab
     Then the user sees bootstrap expected information
+    When the user goes to the "Waypoint" tab
+    Then user goes to the waypoint "Services" subtab
+    And validates Services data
+    Then user goes to the waypoint "Info" subtab
+    And validates waypoint Info data
 
   @waypoint
     Scenario: [Workload details - ztunnel] The workload details for a ztunnel are valid

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -254,7 +254,6 @@
   "n/a": "n/a",
   "name": "name",
   "Name": "名称",
-  "namespace": "namespace",
   "Namespace": "命名空间",
   "Namespace Label": "命名空间标签",
   "Namespace: {{namespace}}": "Namespace: {{namespace}}",

--- a/frontend/src/components/Ambient/WaypointConfig.tsx
+++ b/frontend/src/components/Ambient/WaypointConfig.tsx
@@ -155,7 +155,12 @@ export const WaypointConfig: React.FC<WaypointConfigProps> = (props: WaypointCon
         <CardBody>
           <div className={fullHeightStyle}>
             <div style={{ marginBottom: '1.25rem' }}>
-              <Title headingLevel="h5" size={TitleSizes.md} style={{ marginBottom: '1em' }}>
+              <Title
+                headingLevel="h5"
+                size={TitleSizes.md}
+                style={{ marginBottom: '1em' }}
+                data-test="waypointfor-title"
+              >
                 Waypoint for: {waypointFor}
               </Title>
               {showProxyStatus(props.workload)}

--- a/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
@@ -70,7 +70,7 @@ const columns: SortableCompareTh<WorkloadInfo>[] = [
     compare: (a, b) => a.name.localeCompare(b.name)
   },
   {
-    title: t('namespace'),
+    title: t('Namespace'),
     sortable: true,
     compare: (a, b) => a.namespace.localeCompare(b.namespace)
   },
@@ -139,7 +139,7 @@ export const WaypointWorkloadsTable: React.FC<WaypointWorkloadsProps> = (props: 
   return (
     <>
       <div>
-        <Title headingLevel="h5" size={TitleSizes.lg}>
+        <Title headingLevel="h5" size={TitleSizes.lg} data-test="enrolled-data-title">
           {t('List of enrolled')} {props.type}s {labeledBy}
         </Title>
       </div>


### PR DESCRIPTION
### Describe the change

Cypress tests for the waypoint tab

### Steps to test the PR

Cy passes (This test are running in the Ambient job), it can also be tested locally with:
`yarn cypress run -e TAGS="@waypoint"`

### Automation testing

e2e tests

### Issue reference

Ref. https://github.com/kiali/kiali/pull/8009
