### PR TITLE
[v2.4] be able to configure /api endpoint to require user authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -178,6 +178,7 @@ type Server struct {
 	Port                       int           `yaml:",omitempty"`
 	Profiler                   Profiler      `yaml:"profiler,omitempty"`
 	StaticContentRootDirectory string        `yaml:"static_content_root_directory,omitempty"`
+	RequireAuth                bool          `yaml:"require_auth,omitempty"` // when true, unauthenticated access to api/ endpoint is not allowed
 	WebFQDN                    string        `yaml:"web_fqdn,omitempty"`
 	WebPort                    string        `yaml:"web_port,omitempty"`
 	WebRoot                    string        `yaml:"web_root,omitempty"`
@@ -923,6 +924,7 @@ func NewConfig() (c *Config) {
 				},
 			},
 			Port:                       20001,
+			RequireAuth:                false,
 			StaticContentRootDirectory: "/opt/kiali/console",
 			WebFQDN:                    "",
 			WebRoot:                    "/",

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -81,7 +81,7 @@ func NewRoutes(
 			"GET",
 			"/api",
 			handlers.Root(conf, clientFactory, kialiCache, grafana),
-			false,
+			conf.Server.RequireAuth,
 		},
 		// swagger:route GET /authenticate auth authenticate
 		// ---


### PR DESCRIPTION
When auth.strategy is not anonymous, users can still see the /api endpoint version and config information. This new config allows users to disable that unauthenticated access, requiring users to authenticate with the server in order to see the /api info.

cherry-pick of https://github.com/kiali/kiali/pull/8055