### PR TITLE
we only test ambient when on Istio 1.23 and above

### DIFF
--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -125,6 +125,7 @@ jobs:
     name: Run Ambient frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-ambient.yml
     needs: [initialize, build_backend, build_frontend]
+    if: ${{ needs.initialize.outputs.istio-version >= '1.23' }}
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}


### PR DESCRIPTION
I tested on my fork and I see the ambient test skipped when testing 1.22.7. This is what it will look like when ambient tests are skipped on the earlier istio versions:

![image](https://github.com/user-attachments/assets/3d922b47-7b80-495c-8fa8-bef9908ecb6d)

I also tested on my fork with Istio 1.23 and as expected, all green. So this PR is good to go.

![image](https://github.com/user-attachments/assets/183f6086-ede2-4634-8439-ecc7d5d6896b)

