### PR TITLE
fix: Store theme in localstorage

### DIFF
--- a/frontend/src/components/Nav/Masthead/ThemeSwitch.tsx
+++ b/frontend/src/components/Nav/Masthead/ThemeSwitch.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { KialiAppState } from 'store/Store';
 import { connect } from 'react-redux';
-import { PF_THEME_DARK, Theme } from 'types/Common';
+import { KIALI_THEME, PF_THEME_DARK, Theme } from 'types/Common';
 import { GlobalActions } from 'actions/GlobalActions';
 import { store } from 'store/ConfigStore';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -74,6 +74,7 @@ export const ThemeSwitchComponent: React.FC<ThemeSwitchProps> = (props: ThemeSwi
 
     document.documentElement.classList.toggle(PF_THEME_DARK);
     store.dispatch(GlobalActions.setTheme(theme));
+    localStorage.setItem(KIALI_THEME, theme);
   };
 
   return (

--- a/frontend/src/types/Common.ts
+++ b/frontend/src/types/Common.ts
@@ -17,6 +17,7 @@ export enum HTTP_VERBS {
 }
 
 export const PF_THEME_DARK = 'pf-v5-theme-dark';
+export const KIALI_THEME = 'KIALI_THEME';
 
 export const enum Theme {
   DARK = 'Dark',

--- a/frontend/src/utils/ThemeUtils.ts
+++ b/frontend/src/utils/ThemeUtils.ts
@@ -1,9 +1,11 @@
 import { useKialiSelector } from 'hooks/redux';
 import { store } from 'store/ConfigStore';
-import { Theme } from 'types/Common';
+import { KIALI_THEME, Theme } from 'types/Common';
 
 export const getKialiTheme = (): Theme => {
-  return (store.getState().globalState.theme as Theme) || getDefaultTheme();
+  return (
+    (localStorage.getItem(KIALI_THEME) as Theme) || (store.getState().globalState.theme as Theme) || getDefaultTheme()
+  );
 };
 
 export const useKialiTheme = (): string => {


### PR DESCRIPTION
### Describe the change

Theme is not stored in browser from v1.81(https://github.com/kiali/kiali/blob/v1.81/frontend/src/components/ThemeSwitch/ThemeSwitch.tsx)
localStorage was eliminated in migration

#### Actual Behaviour
[Bug.webm](https://github.com/user-attachments/assets/b66168a5-4c45-4696-a80a-25da52d80ccd)



#### Now
[Fix Theme.webm](https://github.com/user-attachments/assets/9bee0601-eec8-452e-a506-319e111d3ac8)

### Steps to test the PR

Change the theme and refresh the browser. 

### Issue reference

https://github.com/kiali/kiali/issues/8069