### PR TITLE
Added support of listing K8sGateways for Workloads.

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -162,8 +162,7 @@ func (in *AppService) GetClusterAppList(ctx context.Context, criteria AppCriteri
 		for _, wrk := range valueApp.Workloads {
 			joinMap(applabels, wrk.Labels)
 			if criteria.IncludeIstioResources {
-				wSelector := labels.Set(wrk.Labels).AsSelector().String()
-				wkdReferences = append(wkdReferences, FilterWorkloadReferences(wSelector, *istioConfigList, cluster)...)
+				wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, *istioConfigList, cluster)...)
 			}
 		}
 		appItem.Labels = buildFinalLabels(applabels)
@@ -321,8 +320,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 			for _, wrk := range valueApp.Workloads {
 				joinMap(applabels, wrk.Labels)
 				if criteria.IncludeIstioResources {
-					wSelector := labels.Set(wrk.Labels).AsSelector().String()
-					wkdReferences = append(wkdReferences, FilterWorkloadReferences(wSelector, istioConfigList, criteria.Cluster)...)
+					wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, istioConfigList, criteria.Cluster)...)
 				}
 			}
 			appItem.Labels = buildFinalLabels(applabels)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -339,7 +339,7 @@ func (in *IstioValidationsService) GetIstioObjectValidations(ctx context.Context
 		objectCheckers = []checkers.ObjectChecker{
 			checkers.K8sGatewayChecker{Cluster: cluster, K8sGateways: istioConfigList.K8sGateways, GatewayClasses: in.istioConfig.GatewayAPIClasses(cluster)},
 		}
-		referenceChecker = references.K8sGatewayReferences{K8sGateways: istioConfigList.K8sGateways, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes}
+		referenceChecker = references.K8sGatewayReferences{K8sGateways: istioConfigList.K8sGateways, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.K8sGRPCRoutes:
 		grpcRouteChecker := checkers.K8sGRPCRouteChecker{Cluster: cluster, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, grpcRouteChecker}

--- a/business/references/k8s_gateway_references.go
+++ b/business/references/k8s_gateway_references.go
@@ -3,14 +3,16 @@ package references
 import (
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
 
 type K8sGatewayReferences struct {
-	K8sGateways   []*k8s_networking_v1.Gateway
-	K8sHTTPRoutes []*k8s_networking_v1.HTTPRoute
-	K8sGRPCRoutes []*k8s_networking_v1.GRPCRoute
+	K8sGateways           []*k8s_networking_v1.Gateway
+	K8sHTTPRoutes         []*k8s_networking_v1.HTTPRoute
+	K8sGRPCRoutes         []*k8s_networking_v1.GRPCRoute
+	WorkloadsPerNamespace map[string]models.WorkloadList
 }
 
 func (g K8sGatewayReferences) References() models.IstioReferencesMap {
@@ -19,10 +21,23 @@ func (g K8sGatewayReferences) References() models.IstioReferencesMap {
 	for _, gw := range g.K8sGateways {
 		key := models.IstioReferenceKey{Namespace: gw.Namespace, Name: gw.Name, ObjectGVK: kubernetes.K8sGateways}
 		references := &models.IstioReferences{}
+		references.WorkloadReferences = g.getWorkloadReferences(gw)
 		references.ObjectReferences = g.getConfigReferences(gw)
 		result.MergeReferencesMap(models.IstioReferencesMap{key: references})
 	}
 
+	return result
+}
+
+func (g K8sGatewayReferences) getWorkloadReferences(gw *k8s_networking_v1.Gateway) []models.WorkloadReference {
+	result := make([]models.WorkloadReference, 0)
+
+	// Gateway searches Workloads from own namespace and Gateway Label
+	for _, wl := range g.WorkloadsPerNamespace[gw.Namespace].Workloads {
+		if gw.Name == wl.Labels[config.Get().IstioLabels.AmbientWaypointGatewayLabel] {
+			result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: gw.Namespace})
+		}
+	}
 	return result
 }
 

--- a/business/services.go
+++ b/business/services.go
@@ -269,7 +269,7 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 			svcGateways := kubernetes.FilterGatewaysByVirtualServices(istioConfigList.Gateways, svcVirtualServices)
 			svcK8sGRPCRoutes := kubernetes.FilterK8sGRPCRoutesByService(istioConfigList.K8sGRPCRoutes, istioConfigList.K8sReferenceGrants, item.Namespace, item.Name)
 			svcK8sHTTPRoutes := kubernetes.FilterK8sHTTPRoutesByService(istioConfigList.K8sHTTPRoutes, istioConfigList.K8sReferenceGrants, item.Namespace, item.Name)
-			svcK8sGateways := kubernetes.FilterK8sGatewaysByRoutes(istioConfigList.K8sGateways, svcK8sHTTPRoutes, svcK8sGRPCRoutes)
+			svcK8sGateways := append(kubernetes.FilterK8sGatewaysByRoutes(istioConfigList.K8sGateways, svcK8sHTTPRoutes, svcK8sGRPCRoutes), kubernetes.FilterK8sGatewaysByLabel(istioConfigList.K8sGateways, item.Labels[conf.IstioLabels.AmbientWaypointGatewayLabel])...)
 
 			for _, vs := range svcVirtualServices {
 				ref := models.BuildKey(kubernetes.VirtualServices, vs.Name, vs.Namespace, cluster)

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ const (
 	WaypointForNone           = "none"
 	WaypointForService        = "service"
 	WaypointForWorkload       = "workload"
+	WaypointGatewayLabel      = "gateway.networking.k8s.io/gateway-name"
 	WaypointLabel             = "gateway.istio.io/managed"
 	WaypointLabelValue        = "istio.io-mesh-controller"
 	WaypointUseLabel          = "istio.io/use-waypoint"
@@ -357,15 +358,16 @@ func (lt *LoginToken) Obfuscate() {
 
 // IstioLabels holds configuration about the labels required by Istio
 type IstioLabels struct {
-	AmbientNamespaceLabel      string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
-	AmbientNamespaceLabelValue string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
-	AmbientWaypointLabel       string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
-	AmbientWaypointLabelValue  string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
-	AmbientWaypointUseLabel    string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
-	AppLabelName               string `yaml:"app_label_name,omitempty" json:"appLabelName"`
-	InjectionLabelName         string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
-	InjectionLabelRev          string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
-	VersionLabelName           string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
+	AmbientNamespaceLabel       string `yaml:"ambient_namespace_label,omitempty" json:"ambientNamespaceLabel"`
+	AmbientNamespaceLabelValue  string `yaml:"ambient_namespace_label_value,omitempty" json:"ambientNamespaceLabelValue"`
+	AmbientWaypointGatewayLabel string `yaml:"ambient_waypoint_gateway_label,omitempty" json:"ambientWaypointGatewayLabel"`
+	AmbientWaypointLabel        string `yaml:"ambient_waypoint_label,omitempty" json:"ambientWaypointLabel"`
+	AmbientWaypointLabelValue   string `yaml:"ambient_waypoint_label_value,omitempty" json:"ambientWaypointLabelValue"`
+	AmbientWaypointUseLabel     string `yaml:"ambient_waypoint_use_label,omitempty" json:"ambientWaypointUseLabel"`
+	AppLabelName                string `yaml:"app_label_name,omitempty" json:"appLabelName"`
+	InjectionLabelName          string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
+	InjectionLabelRev           string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
+	VersionLabelName            string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
 // AdditionalDisplayItem holds some display-related configuration, like which annotations are to be displayed
@@ -788,15 +790,16 @@ func NewConfig() (c *Config) {
 			},
 		},
 		IstioLabels: IstioLabels{
-			AmbientNamespaceLabel:      "istio.io/dataplane-mode",
-			AmbientNamespaceLabelValue: "ambient",
-			AmbientWaypointLabel:       WaypointLabel,
-			AmbientWaypointLabelValue:  WaypointLabelValue,
-			AmbientWaypointUseLabel:    WaypointUseLabel,
-			AppLabelName:               "app",
-			InjectionLabelName:         "istio-injection",
-			InjectionLabelRev:          "istio.io/rev",
-			VersionLabelName:           "version",
+			AmbientNamespaceLabel:       "istio.io/dataplane-mode",
+			AmbientNamespaceLabelValue:  "ambient",
+			AmbientWaypointGatewayLabel: WaypointGatewayLabel,
+			AmbientWaypointLabel:        WaypointLabel,
+			AmbientWaypointLabelValue:   WaypointLabelValue,
+			AmbientWaypointUseLabel:     WaypointUseLabel,
+			AppLabelName:                "app",
+			InjectionLabelName:          "istio-injection",
+			InjectionLabelRev:           "istio.io/rev",
+			VersionLabelName:            "version",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
 			Clustering: FeatureFlagClustering{

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -80,6 +80,7 @@ const defaultServerConfig: ComputedServerConfig = {
   istioLabels: {
     ambientNamespaceLabel: 'istio.io/dataplane-mode',
     ambientNamespaceLabelValue: 'ambient',
+    ambientWaypointGatewayLabel: 'gateway.networking.k8s.io/gateway-name',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',

--- a/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -209,7 +209,10 @@ class ServiceInfoComponent extends React.Component<Props, ServiceInfoState> {
             this.props.serviceDetails.k8sHTTPRoutes,
             this.props.serviceDetails.k8sGRPCRoutes,
             this.props.serviceDetails.validations,
-            this.props.cluster
+            this.props.cluster,
+            this.props.serviceDetails?.service?.labels
+              ? this.props.serviceDetails.service.labels[serverConfig.istioLabels.ambientWaypointGatewayLabel]
+              : ''
           )
         : [];
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -12,7 +12,7 @@ import { RenderComponentScroll } from '../../components/Nav/Page';
 import { GraphDataSource } from '../../services/GraphDataSource';
 import { DurationInSeconds } from 'types/Common';
 import { isIstioNamespace, serverConfig } from '../../config/ServerConfig';
-import { gvkType, IstioConfigList, toIstioItems } from '../../types/IstioConfigList';
+import { gvkType, IstioConfigList, skipUnrelatedK8sGateways, toIstioItems } from '../../types/IstioConfigList';
 import { WorkloadPods } from './WorkloadPods';
 import { GraphEdgeTapEvent } from '../../components/CytoscapeGraph/CytoscapeGraph';
 import { location, router, URLParam } from '../../app/History';
@@ -46,6 +46,7 @@ const defaultTab = 'pods';
 
 const workloadIstioResources = [
   getGVKTypeString(gvkType.Gateway),
+  getGVKTypeString(gvkType.K8sGateway),
   getGVKTypeString(gvkType.AuthorizationPolicy),
   getGVKTypeString(gvkType.PeerAuthentication),
   getGVKTypeString(gvkType.Sidecar),
@@ -275,9 +276,10 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     const pods = workload?.pods ?? [];
     const workloadEntries = workload?.workloadEntries ?? [];
 
-    const istioConfigItems = this.state.workloadIstioConfig
-      ? toIstioItems(this.state.workloadIstioConfig, workload?.cluster || '')
-      : [];
+    const istioConfigItems = skipUnrelatedK8sGateways(
+      this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig, workload?.cluster || '') : [],
+      this.props.workload?.labels[serverConfig.istioLabels.ambientWaypointGatewayLabel]
+    );
 
     // RenderComponentScroll handles height to provide an inner scroll combined with tabs
     // This height needs to be propagated to minigraph to proper resize in height

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -168,6 +168,7 @@ export const serverRateConfig = {
   istioLabels: {
     ambientNamespaceLabel: 'istio.io/dataplane-mode',
     ambientNamespaceLabelValue: 'ambient',
+    ambientWaypointGatewayLabel: 'gateway.networking.k8s.io/gateway-name',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -388,7 +388,8 @@ export const k8sGwToIstioItems = (
   k8srs: K8sHTTPRoute[],
   k8sgrpcrs: K8sGRPCRoute[],
   validations: Validations,
-  cluster?: string
+  cluster?: string,
+  gatewayLabel?: string
 ): IstioConfigItem[] => {
   const istioItems: IstioConfigItem[] = [];
   const hasValidations = (vKey: string): ObjectValidation => validations.k8sgateway && validations.k8sgateway[vKey];
@@ -415,7 +416,9 @@ export const k8sGwToIstioItems = (
   });
 
   gws.forEach(gw => {
-    if (k8sGateways.has(`${gw.metadata.namespace}/${gw.metadata.name}`)) {
+    // K8s Gateways which are listed in HTTP or GRPC Routes
+    // OR those K8 Gateways which name equals to service's gatewayLabel
+    if (k8sGateways.has(`${gw.metadata.namespace}/${gw.metadata.name}`) || gatewayLabel === gw.metadata.name) {
       const vKey = validationKey(gw.metadata.name, gw.metadata.namespace);
 
       const item = {

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -14,7 +14,7 @@ import {
   K8sResource
 } from './IstioObjects';
 import { ResourcePermissions } from './Permissions';
-import { getGVKTypeString, getIstioObjectGVK } from '../utils/IstioConfigUtils';
+import { getGVKTypeString, getIstioObjectGVK, kindToStringIncludeK8s } from '../utils/IstioConfigUtils';
 import { TypeMeta } from './Kubernetes';
 
 export interface IstioConfigItem extends TypeMeta {
@@ -219,6 +219,23 @@ export const filterByConfigValidation = (unfiltered: IstioConfigItem[], configFi
       filtered.push(item);
     }
     if (filterByWarning && item.validation && item.validation.checks.filter(i => i.severity === 'warning').length > 0) {
+      filtered.push(item);
+    }
+  });
+
+  return filtered;
+};
+
+export const skipUnrelatedK8sGateways = (unfiltered: IstioConfigItem[], gatewayLabel?: string): IstioConfigItem[] => {
+  const filtered: IstioConfigItem[] = [];
+
+  unfiltered.forEach(item => {
+    if (gvkType.K8sGateway === kindToStringIncludeK8s(item.apiVersion, item.kind)) {
+      // keep only those K8 Gateways which name equals to workload's gatewayLabel
+      if (item.name === gatewayLabel) {
+        filtered.push(item);
+      }
+    } else {
       filtered.push(item);
     }
   });

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -4,6 +4,7 @@ import { MeshCluster } from './Mesh';
 export type IstioLabelKey =
   | 'ambientNamespaceLabel'
   | 'ambientNamespaceLabelValue'
+  | 'ambientWaypointGatewayLabel'
   | 'ambientWaypointLabel'
   | 'ambientWaypointLabelValue'
   | 'appLabelName'

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -88,6 +88,7 @@ export const healthConfig = {
   istioLabels: {
     ambientNamespaceLabel: 'istio.io/dataplane-mode',
     ambientNamespaceLabelValue: 'ambient',
+    ambientWaypointGatewayLabel: 'gateway.networking.k8s.io/gateway-name',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
     appLabelName: 'app',

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -219,6 +219,16 @@ func FilterK8sGatewaysByRoutes(allGws []*k8s_networking_v1.Gateway, httpRoutes [
 	return gateways
 }
 
+func FilterK8sGatewaysByLabel(allGws []*k8s_networking_v1.Gateway, gatewayLabel string) []*k8s_networking_v1.Gateway {
+	gateways := []*k8s_networking_v1.Gateway{}
+	for _, gw := range allGws {
+		if gw.Name == gatewayLabel {
+			gateways = append(gateways, gw)
+		}
+	}
+	return gateways
+}
+
 func FilterPodsByController(controllerName string, controllerGVK schema.GroupVersionKind, allPods []core_v1.Pod) []core_v1.Pod {
 	var pods []core_v1.Pod
 	for _, pod := range allPods {


### PR DESCRIPTION
### Describe the change

In K8sGateway Workload details page, list K8s Gateway in Istio config:
![Screenshot From 2025-01-23 15-25-24](https://github.com/user-attachments/assets/874a5285-f21a-4125-bea8-ca1037e05b89)

### Steps to test the PR

Setup ambient environment.
Or in K8s Gateway setup environment create a K8sGateway which will cause Workload generated.
Go to 'waypoint' or any K8s Gateway Workload details.
You will see the Istio Config list not empty, but will show those objects which name matches the `gateway.networking.k8s.io/gateway-name` label of workload.


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/8075
