### PR TITLE
Added filter namespaces per cluster in Graph Validations

### DIFF
--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -39,6 +39,8 @@ import { edgesIn, edgesOut, elems, leafNodes, select } from 'helpers/GraphHelper
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { panelHeadingStyle, panelStyle } from './SummaryPanelStyle';
 import { ApiResponse } from 'types/Api';
+import { store } from '../../store/ConfigStore';
+import { namespacesPerCluster } from '../../utils/Common';
 
 type SummaryPanelGraphMetricsState = {
   grpcReceivedIn: Datapoint[];
@@ -782,9 +784,11 @@ export class SummaryPanelGraph extends React.Component<SummaryPanelPropType, Sum
   };
 
   private updateValidations = (): void => {
-    const namespacesAsString = this.props.namespaces.map(ns => ns.name).join(',');
     const promises = Object.keys(serverConfig.clusters).map(cluster =>
-      API.getConfigValidations(namespacesAsString, cluster)
+      API.getConfigValidations(
+        namespacesPerCluster(this.props.namespaces, store.getState().namespaces.items, cluster).join(','),
+        cluster
+      )
     );
     this.validationSummaryPromises
       .registerAll('validationSummary', promises)

--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -40,7 +40,7 @@ import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { panelHeadingStyle, panelStyle } from './SummaryPanelStyle';
 import { ApiResponse } from 'types/Api';
 import { store } from '../../store/ConfigStore';
-import { namespacesPerCluster } from '../../utils/Common';
+import { namespacesForCluster } from '../../utils/Common';
 
 type SummaryPanelGraphMetricsState = {
   grpcReceivedIn: Datapoint[];
@@ -786,7 +786,7 @@ export class SummaryPanelGraph extends React.Component<SummaryPanelPropType, Sum
   private updateValidations = (): void => {
     const promises = Object.keys(serverConfig.clusters).map(cluster =>
       API.getConfigValidations(
-        namespacesPerCluster(this.props.namespaces, store.getState().namespaces.items, cluster).join(','),
+        namespacesForCluster(this.props.namespaces, store.getState().namespaces.items, cluster).join(','),
         cluster
       )
     );

--- a/frontend/src/utils/Common.ts
+++ b/frontend/src/utils/Common.ts
@@ -17,12 +17,21 @@ export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => b
 export const namespaceEquals = (ns1: Namespace[], ns2: Namespace[]): boolean =>
   arrayEquals(ns1, ns2, (n1, n2) => n1.name === n2.name);
 
-export const namespacesPerCluster = (
+/**
+ * Returns a list of namespace names that are both active and belong to the specified cluster.
+ * If the full list of namespaces is not provided, return the names of active namespaces directly.
+ *
+ * @param activeNss - List of currently active namespaces.
+ * @param allNss - Full list of namespaces (optional). This is needed to figure out namespaces per cluster.
+ * @param cluster - Target cluster to filter namespaces by.
+ */
+export const namespacesForCluster = (
   activeNss: Namespace[],
   allNss: Namespace[] | undefined,
   cluster: string
 ): string[] => {
   const activeNames = new Set(activeNss.map(ns => ns.name));
+  // If allNss is not provided, return the names of active namespaces directly
   if (!allNss) {
     return activeNss.map(ns => ns.name);
   }

--- a/frontend/src/utils/Common.ts
+++ b/frontend/src/utils/Common.ts
@@ -17,6 +17,22 @@ export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => b
 export const namespaceEquals = (ns1: Namespace[], ns2: Namespace[]): boolean =>
   arrayEquals(ns1, ns2, (n1, n2) => n1.name === n2.name);
 
+export const namespacesPerCluster = (
+  activeNss: Namespace[],
+  allNss: Namespace[] | undefined,
+  cluster: string
+): string[] => {
+  const activeNames = new Set(activeNss.map(ns => ns.name));
+  if (!allNss) {
+    return activeNss.map(ns => ns.name);
+  }
+
+  // filter allNss for namespaces that match the selected active names and the cluster
+  return removeDuplicatesArray(
+    allNss.filter(ns => activeNames.has(ns.name) && ns.cluster === cluster).map(ns => ns.name)
+  );
+};
+
 export function groupBy<T>(items: T[], key: keyof T): { [key: string]: T[] } {
   return items.reduce(
     (result, item) => ({

--- a/frontend/src/utils/__tests__/Common.test.ts
+++ b/frontend/src/utils/__tests__/Common.test.ts
@@ -1,4 +1,4 @@
-import { namespacesPerCluster, removeDuplicatesArray, groupBy } from '../Common';
+import { removeDuplicatesArray, groupBy, namespacesForCluster } from '../Common';
 import { Namespace } from '../../types/Namespace';
 
 const arrayDuplicates = ['bookinfo', 'default', 'bookinfo'];
@@ -25,7 +25,7 @@ describe('Active namespaces per cluster', () => {
     ];
     const cluster = 'east';
 
-    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    const result = namespacesForCluster(activeNss, allNss, cluster);
     expect(result).toEqual([]);
   });
 
@@ -39,7 +39,7 @@ describe('Active namespaces per cluster', () => {
     ];
     const cluster = 'east';
 
-    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    const result = namespacesForCluster(activeNss, allNss, cluster);
     expect(result).toEqual(['namespace1', 'namespace4']);
   });
 
@@ -51,7 +51,7 @@ describe('Active namespaces per cluster', () => {
     ];
     const cluster = 'east';
 
-    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    const result = namespacesForCluster(activeNss, allNss, cluster);
     expect(result).toEqual([]);
   });
 
@@ -64,7 +64,7 @@ describe('Active namespaces per cluster', () => {
     ];
     const cluster = 'east';
 
-    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    const result = namespacesForCluster(activeNss, allNss, cluster);
     expect(result).toEqual([]);
   });
 
@@ -76,7 +76,7 @@ describe('Active namespaces per cluster', () => {
     ];
     const cluster = 'east';
 
-    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    const result = namespacesForCluster(activeNss, allNss, cluster);
     expect(result).toEqual(['namespace1']);
   });
 });

--- a/frontend/src/utils/__tests__/Common.test.ts
+++ b/frontend/src/utils/__tests__/Common.test.ts
@@ -1,4 +1,5 @@
-import { removeDuplicatesArray, groupBy } from '../Common';
+import { namespacesPerCluster, removeDuplicatesArray, groupBy } from '../Common';
+import { Namespace } from '../../types/Namespace';
 
 const arrayDuplicates = ['bookinfo', 'default', 'bookinfo'];
 const arrayNoDuplicates = ['bookinfo', 'default'];
@@ -12,6 +13,71 @@ describe('Unique elements in Array', () => {
   it('should return the same array', () => {
     expect(removeDuplicatesArray(arrayNoDuplicates)).toEqual(arrayNoDuplicates);
     expect(removeDuplicatesArray(arrayNoDuplicates).length).toEqual(arrayNoDuplicates.length);
+  });
+});
+
+describe('Active namespaces per cluster', () => {
+  test('should return an empty array when activeNss is empty', () => {
+    const activeNss: Namespace[] = [];
+    const allNss: Namespace[] = [
+      { name: 'namespace1', cluster: 'east' },
+      { name: 'namespace2', cluster: 'west' }
+    ];
+    const cluster = 'east';
+
+    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    expect(result).toEqual([]);
+  });
+
+  test('should return matching namespaces by cluster', () => {
+    const activeNss: Namespace[] = [{ name: 'namespace1' }, { name: 'namespace2' }, { name: 'namespace4' }];
+    const allNss: Namespace[] = [
+      { name: 'namespace1', cluster: 'east' },
+      { name: 'namespace2', cluster: 'west' },
+      { name: 'namespace3', cluster: 'east' },
+      { name: 'namespace4', cluster: 'east' }
+    ];
+    const cluster = 'east';
+
+    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    expect(result).toEqual(['namespace1', 'namespace4']);
+  });
+
+  test('should return an empty array if no namespaces match the cluster', () => {
+    const activeNss: Namespace[] = [{ name: 'namespace1' }, { name: 'namespace2' }];
+    const allNss: Namespace[] = [
+      { name: 'namespace1', cluster: 'west' },
+      { name: 'namespace2', cluster: 'west' }
+    ];
+    const cluster = 'east';
+
+    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    expect(result).toEqual([]);
+  });
+
+  test('should handle namespaces with missing cluster properties', () => {
+    const activeNss: Namespace[] = [{ name: 'namespace1' }, { name: 'namespace2' }];
+    const allNss: Namespace[] = [
+      { name: 'namespace1', cluster: undefined },
+      { name: 'namespace2', cluster: undefined },
+      { name: 'namespace3', cluster: undefined }
+    ];
+    const cluster = 'east';
+
+    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    expect(result).toEqual([]);
+  });
+
+  test('should return matching namespaces when labels are present', () => {
+    const activeNss: Namespace[] = [{ name: 'namespace1' }, { name: 'namespace2' }];
+    const allNss: Namespace[] = [
+      { name: 'namespace1', cluster: 'east', annotations: { key: 'value' }, labels: { key: 'value' } },
+      { name: 'namespace2', cluster: 'west', annotations: { key: 'value2' }, labels: { key: 'value2' } }
+    ];
+    const cluster = 'east';
+
+    const result = namespacesPerCluster(activeNss, allNss, cluster);
+    expect(result).toEqual(['namespace1']);
   });
 });
 


### PR DESCRIPTION
### Describe the change

In multicluster installation, in Graph pages when all namespaces are selected, Kiali UI sends `validations` request to backend per cluster with all namespaces sent as a param.
So those namespaces which exist in 'east' and are requested for 'west', cause 500 errors in response.
Fixed the frontend by adding filter namespaces per cluster in Graph Validations queries.

### Steps to test the PR

1.  Install istio and kiali in multi-primary (This is probable happening in primary remote)
2.  Create a namepsace in the west cluster
3.  Go to the traffic graph
4.  Select all the namespaces


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/8081
