### PR TITLE
Remove duplicates in summary panel node service links

### DIFF
--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -240,7 +240,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {this.renderBadgeSummary(nodeData)}
             {nodeData.isWaypoint && renderWaypointLabel('sm')}
             {shouldRenderDestsList && <div>{destsList}</div>}
-            {shouldRenderSvcList && <div>{servicesList}</div>}
+            {shouldRenderSvcList && <div key={Date.now()}>{servicesList}</div>}
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}
             {shouldRenderApp && <div>{renderBadgedLink(nodeData, NodeType.APP)}</div>}
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}


### PR DESCRIPTION
### Describe the change

Create a unique key in the list to force the recreation of the services list to avoid duplicates.
With no fix: 
![image](https://github.com/user-attachments/assets/7e00f868-27e0-471f-90c3-77029c1c09b4)

Click in the workloads for review generate service links duplicates.

### Steps to test the PR

1. Install Kiali
2. Install bookinfo
3. Click in the different workload versions from reviews
4. Validate the links are not duplicated

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
