### PR TITLE
[cy] Add cypress test coverage for k8s gw waypoint links

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -100,6 +100,11 @@ Then('the proxy status is {string}', (status: string) => {
   cy.get('[data-label=Status]').get(`.icon-${status}`).should('exist');
 });
 
+Then('the user can see the {string} istio config and badge {string}', (config: string, badge: string) => {
+  cy.get('#IstioConfigCard').should('be.visible').get(`[data-test="${config}"]`).should('exist');
+  cy.get('#IstioConfigCard').should('be.visible').get(`#${badge}`).should('exist');
+});
+
 Then('the proxy status is {string} with {string} details', (status: string, detail: string) => {
   cy.get('[test-data=proxy-status]').get(`.icon-${status}`).should('exist');
   cy.get('[test-data=proxy-status]').trigger('mouseenter');

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -16,7 +16,7 @@ Feature: Kiali Waypoint related features
     And the graph page has enough data
 
   @waypoint
-  Scenario: [Workload details] See the waypoint workload with the correct info
+  Scenario: [Workload list] See the workload list of bookinfo with the correct info
     Given user is at the "workloads" list page
     When user selects the "bookinfo" namespace
     Then the "waypoint" row is visible
@@ -25,6 +25,7 @@ Feature: Kiali Waypoint related features
     And the "Labels" column on the "waypoint" row has the text "gateway.networking.k8s.io/gateway-name=waypoint"
     And the "Type" column on the "waypoint" row has the text "Deployment"
     And the "Details" column on the "waypoint" row has the text "Waypoint Proxy"
+    And the "Details" column on the "waypoint" row has a link ending in "bookinfo/istio/gateway.networking.k8s.io/v1/Gateway/waypoint"
 
   @waypoint
   Scenario: [Workload details - productpage] The workload productpage is enrolled in waypoint
@@ -43,6 +44,7 @@ Feature: Kiali Waypoint related features
     Then the user sees the "L7" badge
     Then the user cannot see the "missing-sidecar" badge for "waypoint" workload in "bookinfo" namespace
     And the proxy status is "info" with "RDS: IGNORED" details
+    And the user can see the "K8sGateway-bookinfo-waypoint" istio config and badge "pfbadge-G"
     And user sees trace information
     When user selects a trace
     Then user sees trace details


### PR DESCRIPTION
### Describe the change

Adding cypress coverage for istio config waypoint link in the workload list and the workload details

### Steps to test the PR

Cy passes (This test are running in the Ambient job), it can also be tested locally with:

- Install istio with Ambient profile  `istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
- Install kiali
- Install bookinfo, add it into the mesh page and create a waypoint  `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
- Run waypoint tests: `yarn cypress run -e TAGS="@waypoint"`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/8077
