### PR TITLE
Added missing filter by namespace in Service references.

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -269,7 +269,7 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 			svcGateways := kubernetes.FilterGatewaysByVirtualServices(istioConfigList.Gateways, svcVirtualServices)
 			svcK8sGRPCRoutes := kubernetes.FilterK8sGRPCRoutesByService(istioConfigList.K8sGRPCRoutes, istioConfigList.K8sReferenceGrants, item.Namespace, item.Name)
 			svcK8sHTTPRoutes := kubernetes.FilterK8sHTTPRoutesByService(istioConfigList.K8sHTTPRoutes, istioConfigList.K8sReferenceGrants, item.Namespace, item.Name)
-			svcK8sGateways := append(kubernetes.FilterK8sGatewaysByRoutes(istioConfigList.K8sGateways, svcK8sHTTPRoutes, svcK8sGRPCRoutes), kubernetes.FilterK8sGatewaysByLabel(istioConfigList.K8sGateways, item.Labels[conf.IstioLabels.AmbientWaypointGatewayLabel])...)
+			svcK8sGateways := append(kubernetes.FilterK8sGatewaysByRoutes(istioConfigList.K8sGateways, svcK8sHTTPRoutes, svcK8sGRPCRoutes), kubernetes.FilterK8sGatewaysByLabel(kubernetes.FilterByNamespaceNames(istioConfigList.K8sGateways, []string{item.Namespace}), item.Labels[conf.IstioLabels.AmbientWaypointGatewayLabel])...)
 
 			for _, vs := range svcVirtualServices {
 				ref := models.BuildKey(kubernetes.VirtualServices, vs.Name, vs.Namespace, cluster)


### PR DESCRIPTION
### Describe the change

Filter Waypoint K8s Gateways by namespace fro Service references.

### Steps to test the PR

1. Install Istio in Ambient
2. Install Kiali 
3. Install bookinfo with waypoint: `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`
4. Install travels: `istio/install-travel-agency-demo.sh -c kubectl -ei false -di travel-control,travel-agency,travel-portal -w true` 

### Automation testing
n/a

### Issue reference

https://github.com/kiali/kiali/issues/8101
