### PR TITLE
Fixed filtering WorkloadGroups with empty Spec.Metadata.Labels

### DIFF
--- a/kubernetes/cache/kube_cache.go
+++ b/kubernetes/cache/kube_cache.go
@@ -1650,7 +1650,12 @@ func (c *kubeCache) GetWorkloadGroups(namespace, labelSelector string) ([]*netwo
 
 	var retWG []*networking_v1.WorkloadGroup
 	for _, w := range workloadGroups {
-		if w.Spec.Metadata == nil || w.Spec.Metadata.Labels == nil || selector.Matches(labels.Set(w.Spec.Metadata.Labels)) {
+		// filter workload group by selector
+		// if selector provided, then WG.Spec.Metadata.Labels should exist and match
+		// if no selector provided, take all
+		// here the logic is a bit complicated as the WG.Spec.Metadata.Labels is allowed to be nil in CRD
+		if selector.Empty() ||
+			(!selector.Empty() && w.Spec.Metadata != nil && w.Spec.Metadata.Labels != nil && selector.Matches(labels.Set(w.Spec.Metadata.Labels))) {
 			ww := w.DeepCopy()
 			ww.Kind = kubernetes.WorkloadGroups.Kind
 			ww.APIVersion = kubernetes.WorkloadGroups.GroupVersion().String()


### PR DESCRIPTION
### Describe the change

The filtering by WorkloadGroup Labels were including those WorkloadGroups without Labels, so they were included in all services.
Fixed the filter, added comments.

Before:
![Screenshot From 2025-01-31 16-40-45](https://github.com/user-attachments/assets/565cd289-d90b-481c-8357-171653c5487d)

After:
![Screenshot From 2025-01-31 16-39-14](https://github.com/user-attachments/assets/0fa1f30c-b7e2-4d9e-9140-0d8f76b01336)

### Steps to test the PR
Create objects:
```
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm
spec:
  metadata:
    labels:
      app: ratings-vm
  template:
    serviceAccount: bookinfo-ratings
---
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: ratings-vm
spec:
  address: 2.2.2.2
  labels:
    class: vm
    app: ratings-vm
    version: v3
  serviceAccount: bookinfo-ratings
  network: vm-us-east
---
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: bookinfo-ratings-vm
  namespace: bookinfo
spec:
  egress:
    - bind: 127.0.0.2
      hosts:
        - ./*
  ingress:
    - defaultEndpoint: 127.0.0.1:9080
      port:
        name: http
        number: 9080
        protocol: HTTP
  workloadSelector:
    labels:
      app: ratings-vm
      class: vm
---
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm2
spec:
  metadata:
    labels:
      app: ratings-vm2
  template:
    serviceAccount: bookinfo-ratings
---
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: ratings-vm2
  namespace: bookinfo
spec:
  address: 2.2.2.2
  labels:
    class: vm2
    app: ratings-vm2
    version: v4
  serviceAccount: bookinfo-ratings
  network: vm-us-east
---
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: bookinfo-ratings-vm2
  namespace: bookinfo
spec:
  egress:
    - bind: 127.0.0.2
      hosts:
        - ./*
  ingress:
    - defaultEndpoint: 127.0.0.1:9080
      port:
        name: http
        number: 9080
        protocol: HTTP
  workloadSelector:
    labels:
      app: ratings-vm2
      class: vm2
---
apiVersion: networking.istio.io/v1
kind: WorkloadGroup
metadata:
  name: ratings-vm-no-entry
  namespace: bookinfo
spec:
  template:
    serviceAccount: bookinfo-ratings
```


### Automation testing
n/a