### PR TITLE
Update integration tests for Tempo

### DIFF
--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -112,11 +112,11 @@ func assertSpans(spans []model.TracingSpan, statusCode int, err error, require *
 		require.NotNil(spans)
 		if len(spans) > 0 {
 			require.NotNil(spans[0].TraceID)
-			require.NotNil(spans[0].References[0].TraceID)
-			require.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
 			// References in Tempo are converted from the SpanTraceId, which is not available from the /api/search in Tempo
 			if tracing.Provider == "jaeger" {
 				require.NotEmpty(spans[0].References)
+				require.NotNil(spans[0].References[0].TraceID)
+				require.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
 			}
 		}
 	} else {

--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -104,14 +104,19 @@ func assertTraces(traces *model.TracingResponse, statusCode int, err error, requ
 }
 
 func assertSpans(spans []model.TracingSpan, statusCode int, err error, require *require.Assertions) {
+	tracing, _, err := kiali.TracingConfig()
+
 	if statusCode == 200 {
 		require.NoError(err)
 		require.NotNil(spans)
 		if len(spans) > 0 {
 			require.NotNil(spans[0].TraceID)
-			require.NotEmpty(spans[0].References)
 			require.NotNil(spans[0].References[0].TraceID)
 			require.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
+		}
+		// References in Tempo are converted from the SpanTraceId, which is not available from the /api/search in Tempo
+		if tracing.Provider == "jaeger" {
+			require.NotEmpty(spans[0].References)
 		}
 	} else {
 		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))

--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -114,10 +114,10 @@ func assertSpans(spans []model.TracingSpan, statusCode int, err error, require *
 			require.NotNil(spans[0].TraceID)
 			require.NotNil(spans[0].References[0].TraceID)
 			require.Equal(spans[0].TraceID, spans[0].References[0].TraceID)
-		}
-		// References in Tempo are converted from the SpanTraceId, which is not available from the /api/search in Tempo
-		if tracing.Provider == "jaeger" {
-			require.NotEmpty(spans[0].References)
+			// References in Tempo are converted from the SpanTraceId, which is not available from the /api/search in Tempo
+			if tracing.Provider == "jaeger" {
+				require.NotEmpty(spans[0].References)
+			}
 		}
 	} else {
 		require.Fail(fmt.Sprintf("Status code should be '200' but was: %d and error: %s", statusCode, err))

--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -104,7 +104,8 @@ func assertTraces(traces *model.TracingResponse, statusCode int, err error, requ
 }
 
 func assertSpans(spans []model.TracingSpan, statusCode int, err error, require *require.Assertions) {
-	tracing, _, err := kiali.TracingConfig()
+	tracing, _, errTracing := kiali.TracingConfig()
+	require.NoError(errTracing)
 
 	if statusCode == 200 {
 		require.NoError(err)

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -120,7 +120,6 @@ func NewKialiClient() (c *KialiClient) {
 
 func (c *KialiClient) KialiAuthStrategy() (string, error) {
 	body, _, _, err := httpGETWithRetry(c.kialiURL+"/api/auth/info", c.GetAuth(), TIMEOUT, nil, nil)
-	return config.AuthStrategyAnonymous, nil
 	if err == nil {
 		authStrategy := new(AuthStrategy)
 		err = json.Unmarshal(body, &authStrategy)

--- a/tests/integration/utils/kiali/kiali_client.go
+++ b/tests/integration/utils/kiali/kiali_client.go
@@ -120,6 +120,7 @@ func NewKialiClient() (c *KialiClient) {
 
 func (c *KialiClient) KialiAuthStrategy() (string, error) {
 	body, _, _, err := httpGETWithRetry(c.kialiURL+"/api/auth/info", c.GetAuth(), TIMEOUT, nil, nil)
+	return config.AuthStrategyAnonymous, nil
 	if err == nil {
 		authStrategy := new(AuthStrategy)
 		err = json.Unmarshal(body, &authStrategy)
@@ -159,6 +160,18 @@ func (c *KialiClient) GetAuth() *config.Auth {
 func KialiConfig() (*handlers.PublicConfig, int, error) {
 	url := fmt.Sprintf("%s/api/config", client.kialiURL)
 	response := new(handlers.PublicConfig)
+
+	code, err := getRequestAndUnmarshalInto(url, response)
+	if err == nil {
+		return response, code, nil
+	} else {
+		return nil, code, err
+	}
+}
+
+func TracingConfig() (*models.TracingInfo, int, error) {
+	url := fmt.Sprintf("%s/api/tracing", client.kialiURL)
+	response := new(models.TracingInfo)
 
 	code, err := getRequestAndUnmarshalInto(url, response)
 	if err == nil {


### PR DESCRIPTION
### Describe the change

The Tempo query doesn't seem to be able to return the parentSpanId in the query. The parentSpanId is used to create the references array. There is a conversion in the trace data because the trace format from Tempo is different than the Jaeger trace format. 

This shouldn't affect the functionality of the spans api call

### Steps to test the PR

Affected tests: 
- TestServiceSpans
- TestAppSpans
- TestWorkloadSpans

### Automation testing

Updated integration tests

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8112
