### PR TITLE
Support "canonical" handling of app and version labels

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -509,9 +509,6 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 			ss = nil
 		}
 		appLabelName, _ := in.conf.GetAppLabelName(w.Labels)
-		if strings.Contains(w.Name, "reviews") {
-			log.Infof("appLabelName=%s workload=%s, %v", appLabelName, w.Name, w.Labels)
-		}
 		castAppDetails(appLabelName, allEntities, ss, w, cluster)
 	}
 

--- a/business/apps.go
+++ b/business/apps.go
@@ -470,7 +470,7 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 		return nil, err
 	}
 
-	appNameSelectors := config.Get().GetAppVersionLabelSelectors(appName, "", "")
+	appNameSelectors := config.Get().GetAppVersionLabelSelectors(appName, "")
 	var appNameSelector config.AppVersionLabelSelector
 	for _, appNameSelector = range appNameSelectors {
 		ws, err = in.businessLayer.Workload.fetchWorkloadsFromCluster(ctx, cluster, namespace, appNameSelector.LabelSelector)
@@ -501,7 +501,8 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 		} else {
 			ss = nil
 		}
-		castAppDetails(appNameSelector.AppLabelName, allEntities, ss, w, cluster)
+		appLabelName, _ := in.conf.GetAppLabelName(w.Labels)
+		castAppDetails(appLabelName, allEntities, ss, w, cluster)
 	}
 
 	return allEntities, nil

--- a/business/apps.go
+++ b/business/apps.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
@@ -480,8 +481,15 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 			ws[selectedWorkload.Name] = selectedWorkload
 		}
 	}
+	// return in sorted order, doesn't hurt, may help client, and helps test consistency
+	keys := make([]string, 0, len(ws))
+	for k := range ws {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
 	allEntities := make(namespaceApps)
-	for _, w := range ws {
+	for _, k := range keys {
+		w := ws[k]
 		// WorkloadGroup.Labels can be empty
 		if len(w.Labels) > 0 {
 			// Check if namespace is cached

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -27,9 +27,11 @@ func setupAppService(clients map[string]kubernetes.ClientInterface) *AppService 
 func TestGetAppListFromDeployments(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
+
 	// Auxiliar fake* tests defined in workload_test.go
 	objects := []runtime.Object{
 		kubetest.FakeNamespace("Namespace"),
@@ -65,7 +67,10 @@ func TestGetAppListFromWorkloadGroups(t *testing.T) {
 	require := require.New(t)
 
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
+
 	// Auxiliar fake* tests defined in workload_test.go
 	kubeObjs := []runtime.Object{
 		kubetest.FakeNamespace("Namespace"),
@@ -114,6 +119,8 @@ func TestGetAppFromDeployments(t *testing.T) {
 	require := require.New(t)
 
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	conf.ExternalServices.CustomDashboards.Enabled = false
 	config.Set(conf)
 
@@ -158,6 +165,8 @@ func TestGetAppFromWorkloadGroups(t *testing.T) {
 	require := require.New(t)
 
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	conf.ExternalServices.CustomDashboards.Enabled = false
 	config.Set(conf)
 
@@ -202,6 +211,9 @@ func TestGetAppFromWorkloadGroups(t *testing.T) {
 func TestGetAppListFromReplicaSets(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	// Auxiliar fake* tests defined in workload_test.go
@@ -237,6 +249,8 @@ func TestGetAppFromReplicaSets(t *testing.T) {
 	// otherwise this adds 10s to the test due to an http timeout.
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks

--- a/business/controlplane_monitor_test.go
+++ b/business/controlplane_monitor_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/models"
 )
 
 func TestRegistryServices(t *testing.T) {
@@ -98,7 +97,7 @@ func runningIstiodPod() *core_v1.Pod {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Status: core_v1.PodStatus{
@@ -114,7 +113,7 @@ func fakeIstiodDeployment(cluster string, manageExternal bool) *apps_v1.Deployme
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Spec: apps_v1.DeploymentSpec{
@@ -156,7 +155,7 @@ func TestRefreshIstioCache(t *testing.T) {
 			Name:      "istio",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Data: map[string]string{"mesh": ""},
@@ -228,7 +227,7 @@ func TestPollingPopulatesCache(t *testing.T) {
 			Name:      "istio",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Data: map[string]string{"mesh": ""},

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -566,12 +566,9 @@ func (in *DashboardsService) GetCustomDashboardRefs(namespace, app, version stri
 		if discoveryEnabled == config.DashboardsDiscoveryEnabled ||
 			(discoveryEnabled == config.DashboardsDiscoveryAuto &&
 				len(pods) <= cfg.ExternalServices.CustomDashboards.DiscoveryAutoThreshold) {
-			filters := make(map[string]string)
-			filters[cfg.IstioLabels.AppLabelName] = app
-			if version != "" {
-				filters[cfg.IstioLabels.VersionLabelName] = version
+			for _, appVersionLabelSelector := range cfg.GetAppVersionLabelSelectors(app, version) {
+				runtimes = append(runtimes, in.discoverDashboards(namespace, appVersionLabelSelector.Requirements)...)
 			}
-			runtimes = in.discoverDashboards(namespace, filters)
 		}
 	}
 	return runtimes

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -562,12 +562,18 @@ func (in *DashboardsService) GetCustomDashboardRefs(namespace, app, version stri
 
 	if len(runtimes) == 0 {
 		cfg := config.Get()
+		discoveredRuntimes := map[string]models.Runtime{}
 		discoveryEnabled := cfg.ExternalServices.CustomDashboards.DiscoveryEnabled
 		if discoveryEnabled == config.DashboardsDiscoveryEnabled ||
 			(discoveryEnabled == config.DashboardsDiscoveryAuto &&
 				len(pods) <= cfg.ExternalServices.CustomDashboards.DiscoveryAutoThreshold) {
 			for _, appVersionLabelSelector := range cfg.GetAppVersionLabelSelectors(app, version) {
-				runtimes = append(runtimes, in.discoverDashboards(namespace, appVersionLabelSelector.Requirements)...)
+				for _, discoveredDashboard := range in.discoverDashboards(namespace, appVersionLabelSelector.Requirements) {
+					discoveredRuntimes[discoveredDashboard.Name] = discoveredDashboard
+				}
+			}
+			for _, runtime := range discoveredRuntimes {
+				runtimes = append(runtimes, runtime)
 			}
 		}
 	}

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -215,6 +215,10 @@ func TestDiscoveryMatcherWithComposition(t *testing.T) {
 
 func TestGetCustomDashboardRefs(t *testing.T) {
 	assert := assert.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	service, prom := setupService("my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *fakeDashboard("2")})

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -208,7 +208,7 @@ func (iss *IstioStatusService) getStatusOf(workloads []*models.Workload, cluster
 
 	// Map workloads there by app name
 	for _, workload := range workloads {
-		appLabel := labels.Set(workload.Labels).Get("app")
+		appLabel := labels.Set(workload.Labels).Get(config.IstioAppLabel)
 		if appLabel == "" {
 			continue
 		}

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -46,7 +46,7 @@ func TestGetValidationsPerf(t *testing.T) {
 		}
 	}
 
-	vs := mockCombinedValidationService(t, fakeIstioConfigListPerf(numNs, numDr, numVs, numGw),
+	vs := mockCombinedValidationService(t, conf, fakeIstioConfigListPerf(numNs, numDr, numVs, numGw),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 
 	now := time.Now()

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -117,7 +117,7 @@ func TestGatewayValidationScopesToNamespaceWhenGatewayToNamespaceSet(t *testing.
 			Name:      istioConfigMapName,
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "1-19-0",
+				config.IstioRevisionLabel: "1-19-0",
 			},
 		},
 		Data: map[string]string{"mesh": ""},
@@ -130,7 +130,7 @@ func TestGatewayValidationScopesToNamespaceWhenGatewayToNamespaceSet(t *testing.
 			Name:      istiodDeploymentName,
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "1-19-0",
+				config.IstioRevisionLabel: "1-19-0",
 				"app":                     "istiod",
 			},
 		},
@@ -839,7 +839,7 @@ defaultVirtualServiceExportTo:
 			Name:      "istio",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Data: map[string]string{"mesh": configMapData},

--- a/business/references/destination_rule_references.go
+++ b/business/references/destination_rule_references.go
@@ -51,7 +51,7 @@ func (n DestinationRuleReferences) getServiceReferences(dr *networking_v1.Destin
 
 func (n DestinationRuleReferences) getWorkloadReferences(dr *networking_v1.DestinationRule) []models.WorkloadReference {
 	keys := make(map[string]bool)
-	allWorklaods := make([]models.WorkloadReference, 0)
+	allWorkloads := make([]models.WorkloadReference, 0)
 	result := make([]models.WorkloadReference, 0)
 
 	host := kubernetes.GetHost(dr.Spec.Host, dr.Namespace, n.Namespaces.GetNames())
@@ -88,14 +88,14 @@ func (n DestinationRuleReferences) getWorkloadReferences(dr *networking_v1.Desti
 				wlLabelSet := labels.Set(wl.Labels)
 				if selector.Matches(wlLabelSet) {
 					if subsetSelector.Matches(wlLabelSet) {
-						allWorklaods = append(allWorklaods, models.WorkloadReference{Name: wl.Name, Namespace: localNs})
+						allWorkloads = append(allWorkloads, models.WorkloadReference{Name: wl.Name, Namespace: localNs})
 					}
 				}
 			}
 		}
 	}
 	// filter unique references
-	for _, wl := range allWorklaods {
+	for _, wl := range allWorkloads {
 		if !keys[wl.Name+"/"+wl.Namespace] {
 			result = append(result, wl)
 			keys[wl.Name+"/"+wl.Namespace] = true

--- a/business/references/workloadentry_references_test.go
+++ b/business/references/workloadentry_references_test.go
@@ -13,8 +13,8 @@ import (
 
 func prepareTestForWorkloadEntry(name string) models.IstioReferences {
 	weReferences := WorkloadEntryReferences{
-		WorkloadGroups:  data.CreateWorkloadGroups(*config.NewConfig()),
-		WorkloadEntries: data.CreateWorkloadEntries(*config.NewConfig()),
+		WorkloadGroups:  data.CreateWorkloadGroups(*config.Get()),
+		WorkloadEntries: data.CreateWorkloadEntries(*config.Get()),
 	}
 	return *weReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.WorkloadEntries, Namespace: "Namespace", Name: name}]
 }
@@ -22,6 +22,8 @@ func prepareTestForWorkloadEntry(name string) models.IstioReferences {
 func TestWorkloadEntryReferences(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks

--- a/business/references/workloadgroup_references_test.go
+++ b/business/references/workloadgroup_references_test.go
@@ -13,8 +13,8 @@ import (
 
 func prepareTestForWorkloadGroup(name string) models.IstioReferences {
 	wgReferences := WorkloadGroupReferences{
-		WorkloadGroups:  data.CreateWorkloadGroups(*config.NewConfig()),
-		WorkloadEntries: data.CreateWorkloadEntries(*config.NewConfig()),
+		WorkloadGroups:  data.CreateWorkloadGroups(*config.Get()),
+		WorkloadEntries: data.CreateWorkloadEntries(*config.Get()),
 		WorkloadsPerNamespace: map[string]models.WorkloadList{
 			"Namespace": data.CreateWorkloadList("Namespace",
 				data.CreateWorkloadListItem("ratings-vm", map[string]string{"app": "ratings-vm", "class": "vm", "version": "v3"}),
@@ -29,6 +29,8 @@ func prepareTestForWorkloadGroup(name string) models.IstioReferences {
 func TestWorkloadGroupReferences(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -21,8 +21,13 @@ import (
 // Consolidate fake/mock data used in tests per package
 
 func FakeDeployments(conf config.Config) []apps_v1.Deployment {
-	appLabel := conf.IstioLabels.AppLabelName
-	versionLabel := conf.IstioLabels.VersionLabelName
+	appLabelName := conf.IstioLabels.AppLabelName
+	versionLabelName := conf.IstioLabels.VersionLabelName
+	if appLabelName == "" {
+		appLabelName = "service.istio.io/canonical-name"
+		versionLabelName = "service.istio.io/canonical-revision"
+	}
+
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 	return []apps_v1.Deployment{
 		{
@@ -38,7 +43,7 @@ func FakeDeployments(conf config.Config) []apps_v1.Deployment {
 			Spec: apps_v1.DeploymentSpec{
 				Template: core_v1.PodTemplateSpec{
 					ObjectMeta: meta_v1.ObjectMeta{
-						Labels: map[string]string{appLabel: "httpbin"},
+						Labels: map[string]string{appLabelName: "httpbin"},
 					},
 				},
 			},
@@ -61,7 +66,7 @@ func FakeDeployments(conf config.Config) []apps_v1.Deployment {
 			Spec: apps_v1.DeploymentSpec{
 				Template: core_v1.PodTemplateSpec{
 					ObjectMeta: meta_v1.ObjectMeta{
-						Labels: map[string]string{appLabel: "httpbin", versionLabel: "v2"},
+						Labels: map[string]string{appLabelName: "httpbin", versionLabelName: "v2"},
 					},
 				},
 			},
@@ -1097,16 +1102,21 @@ func FakeCustomControllerRSSyncedWithPods(conf *config.Config) []apps_v1.Replica
 	}
 }
 
-func FakeServices() []core_v1.Service {
+func FakeServices(conf config.Config) []core_v1.Service {
+	appLabelName := conf.IstioLabels.AppLabelName
+	if appLabelName == "" {
+		appLabelName = "service.istio.io/canonical-name"
+	}
+
 	return []core_v1.Service{
 		{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "httpbin",
 				Namespace: "Namespace",
-				Labels:    map[string]string{"app": "httpbin"},
+				Labels:    map[string]string{appLabelName: "httpbin"},
 			},
 			Spec: core_v1.ServiceSpec{
-				Selector: map[string]string{"app": "httpbin"},
+				Selector: map[string]string{appLabelName: "httpbin"},
 			},
 		},
 	}

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -246,8 +246,7 @@ func FakeDuplicatedReplicaSets() []apps_v1.ReplicaSet {
 	}
 }
 
-func FakeReplicationControllers() []core_v1.ReplicationController {
-	conf := config.NewConfig()
+func FakeReplicationControllers(conf *config.Config) []core_v1.ReplicationController {
 	// Enable ReplicationController, those are not fetched by default
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
@@ -327,8 +326,7 @@ func FakeReplicationControllers() []core_v1.ReplicationController {
 	}
 }
 
-func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
-	conf := config.NewConfig()
+func FakeDeploymentConfigs(conf *config.Config) []osapps_v1.DeploymentConfig {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
@@ -407,8 +405,7 @@ func FakeDeploymentConfigs() []osapps_v1.DeploymentConfig {
 	}
 }
 
-func FakeStatefulSets() []apps_v1.StatefulSet {
-	conf := config.NewConfig()
+func FakeStatefulSets(conf *config.Config) []apps_v1.StatefulSet {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
@@ -484,8 +481,7 @@ func FakeStatefulSets() []apps_v1.StatefulSet {
 	}
 }
 
-func FakeDaemonSets() []apps_v1.DaemonSet {
-	conf := config.NewConfig()
+func FakeDaemonSets(conf *config.Config) []apps_v1.DaemonSet {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
@@ -564,9 +560,7 @@ func FakeDaemonSets() []apps_v1.DaemonSet {
 	}
 }
 
-func FakeDuplicatedStatefulSets() []apps_v1.StatefulSet {
-	conf := config.NewConfig()
-
+func FakeDuplicatedStatefulSets(conf *config.Config) []apps_v1.StatefulSet {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -596,9 +590,7 @@ func FakeDuplicatedStatefulSets() []apps_v1.StatefulSet {
 	}
 }
 
-func FakeDepSyncedWithRS() []apps_v1.Deployment {
-	conf := config.NewConfig()
-
+func FakeDepSyncedWithRS(conf *config.Config) []apps_v1.Deployment {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -629,9 +621,7 @@ func FakeDepSyncedWithRS() []apps_v1.Deployment {
 	}
 }
 
-func FakeRSSyncedWithPods() []apps_v1.ReplicaSet {
-	conf := config.NewConfig()
-
+func FakeRSSyncedWithPods(conf *config.Config) []apps_v1.ReplicaSet {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -669,9 +659,7 @@ func FakeRSSyncedWithPods() []apps_v1.ReplicaSet {
 	}
 }
 
-func FakePodsSyncedWithDeployments() []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakePodsSyncedWithDeployments(conf *config.Config) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -705,9 +693,7 @@ func FakePodsSyncedWithDeployments() []core_v1.Pod {
 	}
 }
 
-func FakePodSyncedWithDeployments() *core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakePodSyncedWithDeployments(conf *config.Config) *core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -804,9 +790,7 @@ func FakePodLogsWaypoint() *kubernetes.PodLogs {
 	}
 }
 
-func FakePodsSyncedWithDuplicated() []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakePodsSyncedWithDuplicated(conf *config.Config) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -865,9 +849,7 @@ func FakePodsSyncedWithDuplicated() []core_v1.Pod {
 	}
 }
 
-func FakePodsNoController() []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakePodsNoController(conf *config.Config) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -899,9 +881,7 @@ func FakePodsNoController() []core_v1.Pod {
 	}
 }
 
-func FakePodsFromCustomController() []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakePodsFromCustomController(conf *config.Config) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -935,9 +915,7 @@ func FakePodsFromCustomController() []core_v1.Pod {
 	}
 }
 
-func FakeZtunnelPods() []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakeZtunnelPods(conf *config.Config) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -989,9 +967,7 @@ func FakeWaypointPod() []core_v1.Pod {
 	}
 }
 
-func FakeWaypointNamespaceEnrolledPods(waypoint bool) []core_v1.Pod {
-	conf := config.NewConfig()
-
+func FakeWaypointNamespaceEnrolledPods(conf *config.Config, waypoint bool) []core_v1.Pod {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	waypointLabel := conf.IstioLabels.AmbientWaypointUseLabel
@@ -1032,8 +1008,7 @@ func FakeWaypointNamespaceEnrolledPods(waypoint bool) []core_v1.Pod {
 	}
 }
 
-func FakeWaypointNServiceEnrolledPods() []core_v1.Service {
-	conf := config.NewConfig()
+func FakeWaypointNServiceEnrolledPods(conf *config.Config) []core_v1.Service {
 	waypointLabel := conf.IstioLabels.AmbientWaypointUseLabel
 
 	return []core_v1.Service{
@@ -1048,11 +1023,9 @@ func FakeWaypointNServiceEnrolledPods() []core_v1.Service {
 			},
 		},
 	}
-
 }
 
-func FakeZtunnelDaemonSet() []apps_v1.DaemonSet {
-	conf := config.NewConfig()
+func FakeZtunnelDaemonSet(conf *config.Config) []apps_v1.DaemonSet {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
@@ -1087,9 +1060,7 @@ func FakeZtunnelDaemonSet() []apps_v1.DaemonSet {
 	}
 }
 
-func FakeCustomControllerRSSyncedWithPods() []apps_v1.ReplicaSet {
-	conf := config.NewConfig()
-
+func FakeCustomControllerRSSyncedWithPods(conf *config.Config) []apps_v1.ReplicaSet {
 	appLabel := conf.IstioLabels.AppLabelName
 	versionLabel := conf.IstioLabels.VersionLabelName
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -24,8 +24,8 @@ func FakeDeployments(conf config.Config) []apps_v1.Deployment {
 	appLabelName := conf.IstioLabels.AppLabelName
 	versionLabelName := conf.IstioLabels.VersionLabelName
 	if appLabelName == "" {
-		appLabelName = "service.istio.io/canonical-name"
-		versionLabelName = "service.istio.io/canonical-revision"
+		appLabelName = "app"
+		versionLabelName = "version"
 	}
 
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
@@ -1105,7 +1105,7 @@ func FakeCustomControllerRSSyncedWithPods(conf *config.Config) []apps_v1.Replica
 func FakeServices(conf config.Config) []core_v1.Service {
 	appLabelName := conf.IstioLabels.AppLabelName
 	if appLabelName == "" {
-		appLabelName = "service.istio.io/canonical-name"
+		appLabelName = "app"
 	}
 
 	return []core_v1.Service{

--- a/business/tls.go
+++ b/business/tls.go
@@ -74,7 +74,7 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, cluster string, re
 
 	// Look for enabled if rev label isn't set: https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
 	namespacesForRevision := sliceutil.Filter(namespaces, func(ns models.Namespace) bool {
-		return ns.Labels[models.IstioRevisionLabel] == revision || ns.Labels[models.IstioInjectionLabel] == "enabled"
+		return ns.Labels[config.IstioRevisionLabel] == revision || ns.Labels[models.IstioInjectionLabel] == "enabled"
 	})
 	namespaceNames := sliceutil.Map(namespacesForRevision, func(ns models.Namespace) string {
 		return ns.Name
@@ -203,7 +203,7 @@ func (in *TLSService) hasAutoMTLSEnabled(cluster string, namespace *models.Names
 	}
 
 	// Find the controlplane that is controlling that namespace.
-	rev := namespace.Labels[models.IstioRevisionLabel]
+	rev := namespace.Labels[config.IstioRevisionLabel]
 	if rev == "" {
 		// Assume that if there is no revision label, it is the default revision.
 		rev = models.DefaultRevisionLabel

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -459,8 +459,10 @@ func (in *WorkloadService) GetWorkload(ctx context.Context, criteria WorkloadCri
 	go func() {
 		defer wg.Done()
 		conf := in.config
-		app := workload.Labels[conf.IstioLabels.AppLabelName]
-		version := workload.Labels[conf.IstioLabels.VersionLabelName]
+		appLabelName, _ := conf.GetAppLabelName(workload.Labels)
+		verLabelName, _ := conf.GetVersionLabelName(workload.Labels)
+		app := workload.Labels[appLabelName]
+		version := workload.Labels[verLabelName]
 		runtimes = NewDashboardsService(in.config, in.grafana, ns, workload).GetCustomDashboardRefs(criteria.Namespace, app, version, workload.Pods)
 	}()
 
@@ -2527,7 +2529,7 @@ func (in *WorkloadService) GetWorkloadTracingName(ctx context.Context, cluster, 
 		tracingName.Lookup = workload
 		return tracingName, nil
 	}
-	appLabelName := in.config.IstioLabels.AppLabelName
+	appLabelName, _ := in.config.GetAppLabelName(wkd.Labels)
 	app := wkd.Labels[appLabelName]
 	tracingName.App = app
 	tracingName.Lookup = app

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -54,9 +54,10 @@ func callStreamPodLogs(svc WorkloadService, namespace, workload, app, podName st
 func TestGetWorkloadListFromDeployments(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks
@@ -70,7 +71,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
 	SetupBusinessLayer(t, k8s, *conf)
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false, Cluster: conf.KubernetesConfig.ClusterName}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -96,9 +97,10 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 func TestGetWorkloadListFromWorkloadGroups(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks
@@ -121,7 +123,7 @@ func TestGetWorkloadListFromWorkloadGroups(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
 	SetupBusinessLayer(t, k8s, *conf)
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: true, IncludeHealth: false, Cluster: conf.KubernetesConfig.ClusterName}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -158,8 +160,9 @@ func TestGetWorkloadListFromWorkloadGroups(t *testing.T) {
 func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks
@@ -173,7 +176,7 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
 	SetupBusinessLayer(t, k8s, *conf)
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -199,19 +202,23 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeReplicationControllers() {
+	for _, obj := range FakeReplicationControllers(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 	svc.excludedWorkloads = map[string]bool{}
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
@@ -238,19 +245,23 @@ func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeDeploymentConfigs() {
+	for _, obj := range FakeDeploymentConfigs(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 	svc.excludedWorkloads = map[string]bool{}
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
@@ -277,19 +288,23 @@ func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeStatefulSets() {
+	for _, obj := range FakeStatefulSets(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 	svc.excludedWorkloads = map[string]bool{}
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
@@ -316,12 +331,16 @@ func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 func TestGetWorkloadListFromDaemonSets(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeDaemonSets() {
+	for _, obj := range FakeDaemonSets(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -355,27 +374,31 @@ func TestGetWorkloadListFromDaemonSets(t *testing.T) {
 func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeDepSyncedWithRS() {
+	for _, obj := range FakeDepSyncedWithRS(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakeRSSyncedWithPods() {
+	for _, obj := range FakeRSSyncedWithPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakePodsSyncedWithDeployments() {
+	for _, obj := range FakePodsSyncedWithDeployments(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -393,19 +416,23 @@ func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 func TestGetWorkloadListFromPod(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakePodsNoController() {
+	for _, obj := range FakePodsNoController(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -423,23 +450,27 @@ func TestGetWorkloadListFromPod(t *testing.T) {
 func TestGetWorkloadListFromPods(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeCustomControllerRSSyncedWithPods() {
+	for _, obj := range FakeCustomControllerRSSyncedWithPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakePodsFromCustomController() {
+	for _, obj := range FakePodsFromCustomController(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
@@ -461,17 +492,19 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 	// Disabling CustomDashboards on Workload details testing
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
-	kubernetes.SetConfig(t, *conf)
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
-		&FakeDepSyncedWithRS()[0],
+		&FakeDepSyncedWithRS(conf)[0],
 	}
-	for _, o := range FakeRSSyncedWithPods() {
+	for _, o := range FakeRSSyncedWithPods(conf) {
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, o := range FakePodsSyncedWithDeployments() {
+	for _, o := range FakePodsSyncedWithDeployments(conf) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
@@ -496,6 +529,8 @@ func TestGetWorkloadFromWorkloadGroup(t *testing.T) {
 	// Disabling CustomDashboards on Workload details testing
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks
@@ -553,18 +588,20 @@ func TestGetWorkloadWithInvalidWorkloadType(t *testing.T) {
 	// otherwise this adds 10s to the test due to an http timeout.
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
-		&FakeDepSyncedWithRS()[0],
+		&FakeDepSyncedWithRS(conf)[0],
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeRSSyncedWithPods() {
+	for _, obj := range FakeRSSyncedWithPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakePodsSyncedWithDeployments() {
+	for _, obj := range FakePodsSyncedWithDeployments(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -591,17 +628,19 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	// otherwise this adds 10s to the test due to an http timeout.
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, obj := range FakeCustomControllerRSSyncedWithPods() {
+	for _, obj := range FakeCustomControllerRSSyncedWithPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakePodsFromCustomController() {
+	for _, obj := range FakePodsFromCustomController(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -634,7 +673,7 @@ func TestGetPod(t *testing.T) {
 	require := require.New(t)
 
 	conf := config.NewConfig()
-	k8s := kubetest.NewFakeK8sClient(FakePodSyncedWithDeployments(), &osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}})
+	k8s := kubetest.NewFakeK8sClient(FakePodSyncedWithDeployments(conf), &osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}})
 	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, conf)
 
@@ -828,17 +867,20 @@ func TestGetZtunnelPodLogsProxy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
-		FakePodSyncedWithDeployments(),
+		FakePodSyncedWithDeployments(conf),
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "bookinfo"}},
 	}
-	for _, obj := range FakeZtunnelDaemonSet() {
+	for _, obj := range FakeZtunnelDaemonSet(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakeZtunnelPods() {
+	for _, obj := range FakeZtunnelPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -846,7 +888,7 @@ func TestGetZtunnelPodLogsProxy(t *testing.T) {
 		logs:            FakePodLogsZtunnel().Logs,
 		ClientInterface: kubetest.NewFakeK8sClient(kubeObjs...),
 	}
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, conf)
 
 	maxLines := 2
@@ -942,11 +984,13 @@ func TestDuplicatedControllers(t *testing.T) {
 	// otherwise this adds 10s to the test due to an http timeout.
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	kubernetes.SetConfig(t, *conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
-		FakePodSyncedWithDeployments(),
+		FakePodSyncedWithDeployments(conf),
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
 	for _, obj := range FakeDuplicatedDeployments() {
@@ -957,11 +1001,11 @@ func TestDuplicatedControllers(t *testing.T) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakeDuplicatedStatefulSets() {
+	for _, obj := range FakeDuplicatedStatefulSets(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
-	for _, obj := range FakePodsSyncedWithDuplicated() {
+	for _, obj := range FakePodsSyncedWithDuplicated(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -986,8 +1030,12 @@ func TestDuplicatedControllers(t *testing.T) {
 func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
-	pods := FakePodsSyncedWithDeployments()
+	pods := FakePodsSyncedWithDeployments(conf)
 
 	// Doesn't matter what the type is as long as kiali doesn't recognize it as a workload.
 	owner := &core_v1.ConfigMap{
@@ -1012,11 +1060,11 @@ func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
-	svc := setupWorkloadService(k8s, config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
+	svc := setupWorkloadService(k8s, conf)
 
 	// Disabling CustomDashboards on Workload details testing
-	conf := config.Get()
+	conf = config.Get()
 	conf.ExternalServices.CustomDashboards.Enabled = false
 	config.Set(conf)
 
@@ -1040,9 +1088,12 @@ func TestGetWorkloadListKindsWithSameName(t *testing.T) {
 	// Disabling CustomDashboards on Workload details testing
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
-	rs := FakeRSSyncedWithPods()
-	pods := FakePodsSyncedWithDeployments()
+	rs := FakeRSSyncedWithPods(conf)
+	pods := FakePodsSyncedWithDeployments(conf)
 	pods[0].OwnerReferences[0].APIVersion = kubernetes.ReplicaSets.GroupVersion().String()
 	pods[0].OwnerReferences[0].Kind = kubernetes.ReplicaSets.Kind
 
@@ -1060,7 +1111,7 @@ func TestGetWorkloadListKindsWithSameName(t *testing.T) {
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
@@ -1076,8 +1127,11 @@ func TestGetWorkloadListRSWithoutPrefix(t *testing.T) {
 	// Disabling CustomDashboards on Workload details testing
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
 
-	rs := FakeRSSyncedWithPods()
+	rs := FakeRSSyncedWithPods(conf)
 	// Doesn't matter what the type is as long as kiali doesn't recognize it as a workload.
 	owner := &core_v1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
@@ -1090,7 +1144,7 @@ func TestGetWorkloadListRSWithoutPrefix(t *testing.T) {
 		},
 	}
 	rs[0].OwnerReferences = []v1.OwnerReference{*v1.NewControllerRef(owner, core_v1.SchemeGroupVersion.WithKind(owner.Kind))}
-	pods := FakePodsSyncedWithDeployments()
+	pods := FakePodsSyncedWithDeployments(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
@@ -1106,7 +1160,7 @@ func TestGetWorkloadListRSWithoutPrefix(t *testing.T) {
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	SetupBusinessLayer(t, k8s, *config.NewConfig())
+	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, conf)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
@@ -1124,9 +1178,11 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.CustomDashboards.Enabled = false
 	conf.KubernetesConfig.ClusterName = "east"
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
-	replicaSets := FakeRSSyncedWithPods()
+	replicaSets := FakeRSSyncedWithPods(conf)
 
 	// Doesn't matter what the type is as long as kiali doesn't recognize it as a workload.
 	owner := &core_v1.ConfigMap{
@@ -1144,7 +1200,7 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 		replicaSets[i].OwnerReferences = []v1.OwnerReference{*ref}
 	}
 
-	pods := FakePodsSyncedWithDeployments()
+	pods := FakePodsSyncedWithDeployments(conf)
 
 	// Setup mocks
 	kubeObjs := []runtime.Object{
@@ -1288,7 +1344,7 @@ func TestValidateWaypoint(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(true) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, true) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -1349,7 +1405,7 @@ func TestValidateWaypointNS(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(false) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, false) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -1408,6 +1464,8 @@ func TestValidateWaypointService(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	config.Set(conf)
 
 	// Setup mocks
@@ -1420,12 +1478,12 @@ func TestValidateWaypointService(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(false) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, false) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNServiceEnrolledPods() {
+	for _, obj := range FakeWaypointNServiceEnrolledPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -1489,12 +1547,12 @@ func TestGetWaypointWorkloads(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(true) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, true) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNServiceEnrolledPods() {
+	for _, obj := range FakeWaypointNServiceEnrolledPods(conf) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -1557,7 +1615,7 @@ func TestValidateWaypointProxyStatus(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(true) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, true) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}
@@ -1687,7 +1745,7 @@ func TestGetWorkloadListWithCustomKindThatMatchesCoreKind(t *testing.T) {
 	kubeObjs := []runtime.Object{
 		&osproject_v1.Project{ObjectMeta: v1.ObjectMeta{Name: "Namespace"}},
 	}
-	for _, pod := range FakePodsFromCustomController() {
+	for _, pod := range FakePodsFromCustomController(conf) {
 		p := pod
 		// Setting here a custom type whose Kind matches a core Kube type.
 		p.OwnerReferences[0].APIVersion = "customAPI/v1"

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -926,6 +926,10 @@ func TestGetWaypointPodLogsProxy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
 	// Setup mocks
 	kubeObjs := []runtime.Object{
 		FakePodWithWaypointAndDeployments(),
@@ -936,7 +940,7 @@ func TestGetWaypointPodLogsProxy(t *testing.T) {
 		kubeObjs = append(kubeObjs, &o)
 	}
 
-	for _, obj := range FakeWaypointNamespaceEnrolledPods(true) {
+	for _, obj := range FakeWaypointNamespaceEnrolledPods(conf, true) {
 		o := obj
 		kubeObjs = append(kubeObjs, &o)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1488,7 +1488,9 @@ func (config *Config) GetAppVersionLabelSelectors(app, version string) []AppVers
 	return labelSelectors
 }
 
-// GetAppLabelName returns the app label name found in the labels, and a "found" bool
+// GetAppLabelName returns the app label name found in the labels, and a "found" bool. If
+// multiple app label names exist in the labels, the "canonical" app label name is
+// returned, using the same preference as Istio.
 func (config *Config) GetAppLabelName(labels map[string]string) (string, bool) {
 	for i := 0; i < len(appLabelNames); i++ {
 		appLabelName := appLabelNames[i]
@@ -1499,7 +1501,9 @@ func (config *Config) GetAppLabelName(labels map[string]string) (string, bool) {
 	return "", false
 }
 
-// GetVersionLabelName returns the version label name found in the labels, and a "found" bool
+// GetVersionLabelName returns the version label name found in the labels, and a "found" bool. If
+// multiple version label names exist in the labels, the "canonical" version label name is
+// returned, using the same preference as Istio.
 func (config *Config) GetVersionLabelName(labels map[string]string) (string, bool) {
 	for i := 0; i < len(versionLabelNames); i++ {
 		versionLabelName := versionLabelNames[i]

--- a/config/config.go
+++ b/config/config.go
@@ -1440,9 +1440,11 @@ type AppVersionLabelSelector struct {
 var appLabelNames, versionLabelNames []string
 
 // GetAppVersionLabelSelectors takes an app and/or version value and returns one or
-// more label selectors to be subsequently tried via label selector fetched. In general,
-// the first label selector that returns data is sufficient, and subsequent selectors
-// can be ignored. Only one selector is returned if config.IstioLabels.AppLabelName and
+// more label selectors to be subsequently tried via label selector fetched. Callers
+// should account for the fact that the same object may be labeled in multiple ways, and
+// therefore could be returned by more than one of the returned selectors.
+//
+// Only one selector is returned if config.IstioLabels.AppLabelName and
 // config.IstioLabels.VersionLabelName are set. If they are unset then three selectors will be
 // returned, in this order (the same order of preference used by Istio when setting the
 // canonical values for telemetry, etc):

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,9 @@ const (
 const (
 	AmbientAnnotation         = "ambient.istio.io/redirection"
 	AmbientAnnotationEnabled  = "enabled"
+	IstioAppLabel             = "app"          // we can assume istio components are labeled with "app"
+	IstioRevisionLabel        = "istio.io/rev" // the standard label key used to identify the istio revision.
+	IstioVersionLabel         = "version"      // we can assume istio components are labeled with "version", if versioned
 	Waypoint                  = "waypoint"
 	WaypointFor               = "istio.io/waypoint-for"
 	WaypointForAll            = "all"
@@ -807,7 +810,7 @@ func NewConfig() (c *Config) {
 			AmbientWaypointUseLabel:     WaypointUseLabel,
 			AppLabelName:                "",
 			InjectionLabelName:          "istio-injection",
-			InjectionLabelRev:           "istio.io/rev",
+			InjectionLabelRev:           IstioRevisionLabel,
 			VersionLabelName:            "",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{

--- a/config/config.go
+++ b/config/config.go
@@ -1473,7 +1473,7 @@ func (config *Config) GetAppVersionLabelSelectors(app, version string) []AppVers
 			requirements[appLabelName] = app
 		}
 		if version != "" {
-			requirements[versionLabelName] = app
+			requirements[versionLabelName] = version
 		}
 		labelSelectors[i] = AppVersionLabelSelector{
 			AppLabelName:     appLabelName,

--- a/frontend/cypress/integration/common/app_details_multicluster-pf.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster-pf.ts
@@ -9,7 +9,7 @@ import { NodeType } from 'types/Graph';
 Then('user sees details information for the remote {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
     cy.get('#pfbadge-A').parent().parent().parent().contains(name); // App
-    cy.get('#pfbadge-W').parent().parent().parent().contains(`${name}-v1`); // Workload
+    cy.get('#pfbadge-W').parent().parent().parent().contains(`${name}-v2`); // Workload
     cy.get('#pfbadge-S').parent().parent().parent().contains(name); // Service
 
     clusterParameterExists(true);

--- a/frontend/cypress/integration/common/app_details_multicluster-pf.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster-pf.ts
@@ -9,7 +9,7 @@ import { NodeType } from 'types/Graph';
 Then('user sees details information for the remote {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
     cy.get('#pfbadge-A').parent().parent().parent().contains(name); // App
-    cy.get('#pfbadge-W').parent().parent().parent().contains(`${name}-v2`); // Workload
+    cy.get('#pfbadge-W').parent().parent().parent().contains(`${name}-v1`); // Workload
     cy.get('#pfbadge-S').parent().parent().parent().contains(name); // Service
 
     clusterParameterExists(true);

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -272,14 +272,16 @@ Then(
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`5 app`);
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else {
-      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`).then(r1 => {
+      cy.exec(
+        `kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`
+      ).then(r1 => {
         let appPods = parseInt(r1.stdout);
         cy.exec(
-          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`
         ).then(r2 => {
           appPods += parseInt(r2.stdout);
           cy.exec(
-            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`
           ).then(r3 => {
             appPods += parseInt(r3.stdout);
             cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`)
@@ -289,14 +291,16 @@ Then(
         });
       });
 
-      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`).then(r1 => {
+      cy.exec(
+        `kubectl get pods -n ${ns} -l app --context ${CLUSTER2_CONTEXT} --no-headers | grep Running | wc -l`
+      ).then(r1 => {
         let appPods = parseInt(r1.stdout);
         cy.exec(
-          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | grep Running | wc -l`
         ).then(r2 => {
           appPods += parseInt(r2.stdout);
           cy.exec(
-            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | grep Running | wc -l`
           ).then(r3 => {
             appPods += parseInt(r3.stdout);
             cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`)

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -272,41 +272,39 @@ Then(
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`5 app`);
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else {
-      let appPods = 0;
-      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`).then(result => {
-        appPods = appPods + parseInt(result.stdout);
+      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`).then(r1 => {
+        let appPods = parseInt(r1.stdout);
+        cy.exec(
+          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+        ).then(r2 => {
+          appPods += parseInt(r2.stdout);
+          cy.exec(
+            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+          ).then(r3 => {
+            appPods += parseInt(r3.stdout);
+            cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`)
+              .find('[data-test="overview-type-app"]')
+              .contains(`${appPods} app`);
+          });
+        });
       });
-      cy.exec(
-        `kubectl get pods -n ${ns} -l service.istio.io/canonical-name --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
-      ).then(result => {
-        appPods = appPods + parseInt(result.stdout);
-      });
-      cy.exec(
-        `kubectl get pods -n ${ns} -l app.kubernetes.io/name --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
-      ).then(result => {
-        appPods = appPods + parseInt(result.stdout);
-      });
-      cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`)
-        .find('[data-test="overview-type-app"]')
-        .contains(`${appPods} app`);
 
-      appPods = 0;
-      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`).then(result => {
-        appPods = appPods + parseInt(result.stdout);
+      cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`).then(r1 => {
+        let appPods = parseInt(r1.stdout);
+        cy.exec(
+          `kubectl get pods -n ${ns} -l 'app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+        ).then(r2 => {
+          appPods += parseInt(r2.stdout);
+          cy.exec(
+            `kubectl get pods -n ${ns} -l 'service.istio.io/canonical-name,!app.kubernetes.io/name,!app' --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+          ).then(r3 => {
+            appPods += parseInt(r3.stdout);
+            cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`)
+              .find('[data-test="overview-type-app"]')
+              .contains(`${appPods} app`);
+          });
+        });
       });
-      cy.exec(
-        `kubectl get pods -n ${ns} -l service.istio.io/canonical-name --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
-      ).then(result => {
-        appPods = appPods + parseInt(result.stdout);
-      });
-      cy.exec(
-        `kubectl get pods -n ${ns} -l app.kubernetes.io/name --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
-      ).then(result => {
-        appPods = appPods + parseInt(result.stdout);
-      });
-      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`)
-        .find('[data-test="overview-type-app"]')
-        .contains(`${appPods} app`);
     }
   }
 );

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -272,17 +272,41 @@ Then(
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`5 app`);
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else {
+      let appPods = 0;
       cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`).then(result => {
-        cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`)
-          .find('[data-test="overview-type-app"]')
-          .contains(`${result.stdout} app`);
+        appPods = appPods + parseInt(result.stdout);
       });
+      cy.exec(
+        `kubectl get pods -n ${ns} -l service.istio.io/canonical-name --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+      ).then(result => {
+        appPods = appPods + parseInt(result.stdout);
+      });
+      cy.exec(
+        `kubectl get pods -n ${ns} -l app.kubernetes.io/name --context ${CLUSTER1_CONTEXT} --no-headers | wc -l`
+      ).then(result => {
+        appPods = appPods + parseInt(result.stdout);
+      });
+      cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`)
+        .find('[data-test="overview-type-app"]')
+        .contains(`${appPods} app`);
 
+      appPods = 0;
       cy.exec(`kubectl get pods -n ${ns} -l app --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`).then(result => {
-        cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`)
-          .find('[data-test="overview-type-app"]')
-          .contains(`${result.stdout} app`);
+        appPods = appPods + parseInt(result.stdout);
       });
+      cy.exec(
+        `kubectl get pods -n ${ns} -l service.istio.io/canonical-name --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+      ).then(result => {
+        appPods = appPods + parseInt(result.stdout);
+      });
+      cy.exec(
+        `kubectl get pods -n ${ns} -l app.kubernetes.io/name --context ${CLUSTER2_CONTEXT} --no-headers | wc -l`
+      ).then(result => {
+        appPods = appPods + parseInt(result.stdout);
+      });
+      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`)
+        .find('[data-test="overview-type-app"]')
+        .contains(`${appPods} app`);
     }
   }
 );

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -271,6 +271,9 @@ Then(
     if (ns === 'bookinfo') {
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`5 app`);
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
+    } else if (ns === 'istio-system') {
+      cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`8 app`);
+      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`8 app`);
     } else {
       cy.exec(
         `kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -88,9 +88,9 @@ When(`the list is sorted by {string} desc`, (column: string) => {
     cy.get('tr').then($rows => {
       $rows.each((index, $row) => {
         if (index < $rows.length - 1) {
-          const currentRow = $row.querySelector(`td[data-label="${column}"]`).textContent;
-          const nextRow = $rows[index + 1].querySelector(`td[data-label="${column}"]`).textContent;
-          expect(currentRow.localeCompare(nextRow)).to.be.at.most(0);
+          const currentRow = $row.querySelector(`td[data-label="${column}"]`)?.textContent;
+          const nextRow = $rows[index + 1].querySelector(`td[data-label="${column}"]`)?.textContent;
+          expect(currentRow?.localeCompare(nextRow ?? '')).to.be.at.most(0);
         }
       });
     });
@@ -273,7 +273,7 @@ Then(
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else if (ns === 'istio-system') {
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`8 app`);
-      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`8 app`);
+      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`3 app`);
     } else {
       cy.exec(
         `kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -84,7 +84,7 @@ Then('user should only see workloads with the {string} label', (label: string) =
 Then('user should only see workloads with an app label', () => {
   cy.wait('@refresh');
   cy.get('tbody').within(() => {
-    const regex = new RegExp(`\\bapp=|\\b=service.istio.io/canonical-name=|\\bapp.kubernetes.io/name=`);
+    const regex = new RegExp(`app=|service\.istio\.io\/canonical-name=|app\.kubernetes\.io\/name=`);
 
     cy.get('tr').each($item => {
       cy.wrap($item)
@@ -97,10 +97,10 @@ Then('user should only see workloads with an app label', () => {
   });
 });
 
-Then('user should only see workloads with an version label', () => {
+Then('user should only see workloads with a version label', () => {
   cy.wait('@refresh');
   cy.get('tbody').within(() => {
-    const regex = new RegExp(`\\bversion=|\\b=service.istio.io/canonical-revision=|\\bapp.kubernetes.io/version=`);
+    const regex = new RegExp(`version=|service\.istio\.io\/canonical-revision=|app\.kubernetes\.io\/version=`);
 
     cy.get('tr').each($item => {
       cy.wrap($item)

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -81,6 +81,38 @@ Then('user should only see workloads with the {string} label', (label: string) =
   });
 });
 
+Then('user should only see workloads with an app label', () => {
+  cy.wait('@refresh');
+  cy.get('tbody').within(() => {
+    const regex = new RegExp(`\\bapp=|\\b=service.istio.io/canonical-name=|\\bapp.kubernetes.io/name=`);
+
+    cy.get('tr').each($item => {
+      cy.wrap($item)
+        .find('td')
+        .eq(4)
+        .within(() => {
+          cy.get('span').children().contains(regex);
+        });
+    });
+  });
+});
+
+Then('user should only see workloads with an version label', () => {
+  cy.wait('@refresh');
+  cy.get('tbody').within(() => {
+    const regex = new RegExp(`\\bversion=|\\b=service.istio.io/canonical-revision=|\\bapp.kubernetes.io/version=`);
+
+    cy.get('tr').each($item => {
+      cy.wrap($item)
+        .find('td')
+        .eq(4)
+        .within(() => {
+          cy.get('span').children().contains(regex);
+        });
+    });
+  });
+});
+
 When('user filters for version {string}', (state: string) => {
   activateFilter(state);
 });

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -78,7 +78,7 @@ Feature: Kiali Workloads page
     And user selects filter "App Label"
     And user filters for app label "Present"
     Then user sees "workloads" in workloads table
-    And user should only see workloads with the "app" label
+    And user should only see workloads with an app label
 
   @bookinfo-app
   Scenario: Filter workloads table by Version Label
@@ -86,7 +86,7 @@ Feature: Kiali Workloads page
     And user selects filter "Version Label"
     And user filters for version "Present"
     Then user sees "workloads" in workloads table
-    And user should only see workloads with the "version" label
+    And user should only see workloads with a version label
 
   @bookinfo-app
   Scenario: Filter workloads table by label

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -400,7 +400,7 @@
   "The meshConfig.meshMTLS.minProtocolVersion field specifies the minimum TLS version for the TLS                   connections among Istio workloads. N/A if it was not set.": "The meshConfig.meshMTLS.minProtocolVersion field specifies the minimum TLS version for the TLS                   connections among Istio workloads. N/A if it was not set.",
   "The Side Panel shows details about the currently selected node or edge, otherwise the whole graph.": "侧面板显示有关当前选定节点或边的详细信息，否则显示整个视图。",
   "The Side Panel shows details about the currently selected node or edge, otherwise the whole mesh.": "The Side Panel shows details about the currently selected node or edge, otherwise the whole mesh.",
-  "There are not Workloads with sidecar for this service": "此服务没有具有sidecar的工作负载",
+  "There are no Workloads with sidecar for this service": "There are no Workloads with sidecar for this service",
   "This chart shows cpu consumption for the istiod {{cpuMetricSource}}": "This chart shows cpu consumption for the istiod {{cpuMetricSource}}",
   "This chart shows memory consumption for the istiod {{memoryMetricSource}}": "This chart shows memory consumption for the istiod {{memoryMetricSource}}",
   "This rule is not accessible.": "该规则将无法生效。",

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -169,7 +169,6 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
     const applicationList =
       props.apps && props.apps.length > 0
         ? props.apps
-            .sort((a1: string, a2: string) => (a1 < a2 ? -1 : 1))
             .filter(name => {
               if (name === undefined) {
                 return null;
@@ -321,6 +320,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
       const item = props.health.getWorkloadStatus();
 
       if (item) {
+        item.children?.sort((i1, i2) => (i1.text < i2.text ? -1 : 1));
         return (
           <div>
             {item.text}
@@ -343,15 +343,13 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
           <div>
             <ul id="workload-list" style={{ listStyleType: 'none' }}>
               {props.workloads
-                ? props.workloads
-                    .sort((w1: AppWorkload, w2: AppWorkload) => (w1.workloadName < w2.workloadName ? -1 : 1))
-                    .map((wkd, subIdx) => {
-                      return (
-                        <li key={subIdx} className={itemStyle}>
-                          {renderWorkloadItem(wkd)}
-                        </li>
-                      );
-                    })
+                ? props.workloads.map((wkd, subIdx) => {
+                    return (
+                      <li key={subIdx} className={itemStyle}>
+                        {renderWorkloadItem(wkd)}
+                      </li>
+                    );
+                  })
                 : undefined}
             </ul>
           </div>
@@ -368,9 +366,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
   const serviceList = (): React.ReactNode => {
     const serviceList =
       props.services && props.services.length > 0
-        ? props.services
-            .sort((s1: string, s2: string) => (s1 < s2 ? -1 : 1))
-            .map(name => renderServiceItem(props.namespace, name))
+        ? props.services.map(name => renderServiceItem(props.namespace, name))
         : renderEmptyItem('services');
 
     return [
@@ -381,6 +377,11 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
       </div>
     ];
   };
+
+  props.apps?.sort((a1: string, a2: string) => (a1 < a2 ? -1 : 1));
+  props.services?.sort((s1: string, s2: string) => (s1 < s2 ? -1 : 1));
+  props.waypointWorkloads?.sort((w1: WorkloadInfo, w2: WorkloadInfo) => (w1.name < w2.name ? -1 : 1));
+  props.workloads?.sort((w1: AppWorkload, w2: AppWorkload) => (w1.workloadName < w2.workloadName ? -1 : 1));
 
   return (
     <div className={containerStyle}>

--- a/frontend/src/components/Envoy/EnvoyDetails.tsx
+++ b/frontend/src/components/Envoy/EnvoyDetails.tsx
@@ -32,7 +32,6 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { RenderComponentScroll } from 'components/Nav/Page';
 import { DashboardRef } from 'types/Runtimes';
 import { CustomMetrics } from 'components/Metrics/CustomMetrics';
-import { serverConfig } from 'config';
 import { FilterSelected } from 'components/Filters/StatefulFilters';
 import { location, router } from '../../app/History';
 import {
@@ -42,6 +41,7 @@ import {
 import { istioAceEditorStyle } from 'styles/AceEditorStyle';
 import { Theme, TimeInMilliseconds } from '../../types/Common';
 import { subTabStyle } from 'styles/TabStyles';
+import { getAppLabelName, getVersionLabelName } from 'config/ServerConfig';
 
 const resources: string[] = ['clusters', 'listeners', 'routes', 'bootstrap', 'config', 'metrics'];
 
@@ -291,8 +291,10 @@ class EnvoyDetailsComponent extends React.Component<EnvoyDetailsProps, EnvoyDeta
     const SummaryWriterComp = builder[0];
     const summaryWriter = builder[1];
     const height = this.state.tabHeight - 226;
-    const app = this.props.workload.labels[serverConfig.istioLabels.appLabelName];
-    const version = this.props.workload.labels[serverConfig.istioLabels.versionLabelName];
+    const appLabelName = getAppLabelName(this.props.workload.labels);
+    const verLabelName = getVersionLabelName(this.props.workload.labels);
+    const app = appLabelName ? this.props.workload.labels[appLabelName] : '';
+    const version = verLabelName ? this.props.workload.labels[verLabelName] : '';
     const envoyMetricsDashboardRef = this.getEnvoyMetricsDashboardRef();
     let filteredEnvoyTabs = envoyTabs;
 
@@ -348,15 +350,16 @@ class EnvoyDetailsComponent extends React.Component<EnvoyDetailsProps, EnvoyDeta
                 </div>
               ) : this.showMetrics() && envoyMetricsDashboardRef ? (
                 <CustomMetrics
-                  lastRefreshAt={this.props.lastRefreshAt}
-                  namespace={this.props.namespace}
                   app={app}
-                  version={version}
-                  workload={this.props.workload!.name}
-                  template={envoyMetricsDashboardRef.template}
+                  appLabelName={appLabelName}
+                  data-test="envoy-metrics-component"
                   embedded={true}
                   height={this.state.tabHeight - 40 - 24 + 13}
-                  data-test="envoy-metrics-component"
+                  lastRefreshAt={this.props.lastRefreshAt}
+                  namespace={this.props.namespace}
+                  template={envoyMetricsDashboardRef.template}
+                  version={version}
+                  workload={this.props.workload!.name}
                 />
               ) : (
                 <SummaryWriterComp

--- a/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -37,6 +37,7 @@ import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { renderDisabledDropdownOption } from 'utils/DropdownUtils';
 import { t } from 'utils/I18nUtils';
+import { getAppLabelName, getVersionLabelName } from 'config/ServerConfig';
 
 type ReduxProps = {
   istioAPIEnabled: boolean;
@@ -62,9 +63,6 @@ type Props = ReduxProps & {
   virtualServices: VirtualService[];
   workloads: WorkloadOverview[];
 };
-
-const appLabelName = serverConfig.istioLabels.appLabelName;
-const versionLabelName = serverConfig.istioLabels.versionLabelName;
 
 const ServiceWizardDropdownComponent: React.FC<Props> = (props: Props) => {
   const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
@@ -99,11 +97,9 @@ const ServiceWizardDropdownComponent: React.FC<Props> = (props: Props) => {
   const getValidWorkloads = (): WorkloadOverview[] => {
     return props.workloads.filter(workload => {
       // A workload could skip the version label on this check only when there is a single workload list
-      return (
-        workload.labels &&
-        workload.labels[appLabelName] &&
-        (workload.labels[versionLabelName] || props.workloads.length === 1)
-      );
+      const appLabelName = getAppLabelName(workload.labels);
+      const verLabelName = getVersionLabelName(workload.labels);
+      return workload.labels && appLabelName && (verLabelName || props.workloads.length === 1);
     });
   };
 
@@ -193,8 +189,10 @@ const ServiceWizardDropdownComponent: React.FC<Props> = (props: Props) => {
 
   const hasMeshWorkloads = checkHasMeshWorkloads();
   const toolTipMsgActions = !hasMeshWorkloads
-    ? t('There are not Workloads with sidecar for this service')
-    : `There are not Workloads with ${appLabelName} and ${versionLabelName} labels`;
+    ? t('There are no Workloads with sidecar for this service')
+    : `There are no Workloads with ${serverConfig.istioLabels.appLabelName ?? 'app'} and ${
+        serverConfig.istioLabels.versionLabelName ?? 'version'
+      } labels`;
 
   const validWorkloads = getValidWorkloads();
   const validActions = hasMeshWorkloads && validWorkloads;

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -70,6 +70,7 @@ import { ANYTHING, PRESENCE } from './RequestRouting/MatchBuilder';
 import { t } from 'utils/I18nUtils';
 import { defaultGatewayLabel, defaultGatewayLabelValue } from 'config/Constants';
 import { dicTypeToGVK, gvkType } from '../../types/IstioConfigList';
+import { getAppLabelName } from 'config/ServerConfig';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -931,9 +932,10 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
 
     if (wState.trafficPolicy.peerAuthnSelector.addPeerAuthentication) {
       const peerAuthnLabels: { [key: string]: string } = {};
-      peerAuthnLabels[serverConfig.istioLabels.appLabelName] = wProps.workloads[0].labels![
-        serverConfig.istioLabels.appLabelName
-      ];
+      const appLabelName = getAppLabelName(wProps.workloads[0].labels);
+      if (appLabelName) {
+        peerAuthnLabels[appLabelName] = wProps.workloads[0].labels![appLabelName];
+      }
 
       wizardPA = {
         apiVersion: ISTIO_SECURITY_VERSION,

--- a/frontend/src/components/IstioWizards/WizardActions.ts
+++ b/frontend/src/components/IstioWizards/WizardActions.ts
@@ -70,7 +70,7 @@ import { ANYTHING, PRESENCE } from './RequestRouting/MatchBuilder';
 import { t } from 'utils/I18nUtils';
 import { defaultGatewayLabel, defaultGatewayLabelValue } from 'config/Constants';
 import { dicTypeToGVK, gvkType } from '../../types/IstioConfigList';
-import { getAppLabelName } from 'config/ServerConfig';
+import { getAppLabelName, getVersionLabelName } from 'config/ServerConfig';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -654,15 +654,14 @@ export const buildIstioConfig = (wProps: ServiceWizardProps, wState: ServiceWiza
     const subsets = wProps.workloads
       .filter(workload => {
         // Filter out workloads without version label
-        const versionLabelName = serverConfig.istioLabels.versionLabelName;
-        return workload.labels![versionLabelName];
+        return getVersionLabelName(workload.labels);
       })
       .map(workload => {
         // Using version
-        const versionLabelName = serverConfig.istioLabels.versionLabelName;
-        const versionValue = workload.labels![versionLabelName];
+        const versionLabelName = getVersionLabelName(workload.labels);
+        const versionValue = workload.labels![versionLabelName!];
         const labels: { [key: string]: string } = {};
-        labels[versionLabelName] = versionValue;
+        labels[versionLabelName!] = versionValue;
         // Populate helper table workloadName -> version
         wkdNameVersion[workload.name] = versionValue;
         return {
@@ -1269,13 +1268,18 @@ const getWorkloadsByVersion = (
   workloads: WorkloadOverview[],
   destinationRules: DestinationRule[]
 ): { [key: string]: string } => {
-  const versionLabelName = serverConfig.istioLabels.versionLabelName;
   const wkdVersionName: { [key: string]: string } = {};
-  workloads.forEach(workload => (wkdVersionName[workload.labels![versionLabelName]] = workload.name));
+  workloads.forEach(workload => {
+    const versionLabelName = getVersionLabelName(workload.labels);
+    if (versionLabelName) {
+      wkdVersionName[workload.labels![versionLabelName]] = workload.name;
+    }
+  });
   if (destinationRules.length > 0) {
     destinationRules.forEach(dr => {
       dr.spec.subsets?.forEach(ss => {
-        const version = ss.labels![versionLabelName];
+        const versionLabelName = getVersionLabelName(ss.labels);
+        const version = ss.labels![versionLabelName!];
         wkdVersionName[ss.name] = wkdVersionName[version];
       });
     });

--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -11,7 +11,6 @@ import {
   EmptyStateHeader
 } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
-import { serverConfig } from '../../config/ServerConfig';
 import { router, HistoryManager, URLParam, location } from '../../app/History';
 import * as API from '../../services/Api';
 import { KialiAppState } from '../../store/Store';
@@ -54,12 +53,14 @@ type MetricsState = {
 
 type CustomMetricsProps = {
   app: string;
+  appLabelName?: string;
   embedded?: boolean;
   height?: number;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   template: string;
   version?: string;
+  versionLabelName?: string;
   workload?: string;
   workloadType?: string;
 };
@@ -120,11 +121,11 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
   }
 
   private initOptions = (settings: MetricsSettings): DashboardQuery => {
-    const filters = `${serverConfig.istioLabels.appLabelName}:${this.props.app}`;
+    const filters = this.props.app && this.props.appLabelName ? `${this.props.appLabelName}:${this.props.app}` : '';
 
     const options: DashboardQuery = this.props.version
       ? {
-          labelsFilters: `${filters},${serverConfig.istioLabels.versionLabelName}:${this.props.version}`
+          labelsFilters: `${filters},${this.props.versionLabelName}:${this.props.version}`
         }
       : {
           labelsFilters: filters,

--- a/frontend/src/components/MissingLabel/MissingLabel.tsx
+++ b/frontend/src/components/MissingLabel/MissingLabel.tsx
@@ -23,7 +23,8 @@ export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelPro
       {props.missingApp && (
         <>
           <div>
-            <PFBadge badge={{ badge: appLabel }} isRead={true} style={{ marginRight: 0 }} /> label is missing. <br />
+            <PFBadge badge={{ badge: appLabel ?? 'app' }} isRead={true} style={{ marginRight: 0 }} /> label is missing.{' '}
+            <br />
           </div>
           <div>This workload won't be linked with an application.</div>
         </>
@@ -32,8 +33,8 @@ export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelPro
       {props.missingVersion && (
         <>
           <div>
-            <PFBadge badge={{ badge: versionLabel }} isRead={true} style={{ marginRight: 0 }} /> label is missing.{' '}
-            <br />
+            <PFBadge badge={{ badge: versionLabel ?? 'version' }} isRead={true} style={{ marginRight: 0 }} /> label is
+            missing. <br />
           </div>
           <div>The label is recommended as it affects telemetry.</div>
         </>

--- a/frontend/src/components/MissingLabel/MissingLabel.tsx
+++ b/frontend/src/components/MissingLabel/MissingLabel.tsx
@@ -13,8 +13,8 @@ type MissingLabelProps = {
 };
 
 export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelProps) => {
-  const appLabel = serverConfig.istioLabels.appLabelName;
-  const versionLabel = serverConfig.istioLabels.versionLabelName;
+  const appLabelName = serverConfig.istioLabels.appLabelName ?? 'app'; // just need a value for badge text
+  const versionLabelName = serverConfig.istioLabels.versionLabelName ?? 'version'; // just need a value for badge text
   const icon = icons.istio.missingLabel.icon;
   const color = icons.istio.missingLabel.color;
 
@@ -23,7 +23,7 @@ export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelPro
       {props.missingApp && (
         <>
           <div>
-            <PFBadge badge={{ badge: appLabel ?? 'app' }} isRead={true} style={{ marginRight: 0 }} /> label is missing.{' '}
+            <PFBadge badge={{ badge: appLabelName }} isRead={true} style={{ marginRight: 0 }} /> label is missing.{' '}
             <br />
           </div>
           <div>This workload won't be linked with an application.</div>
@@ -33,8 +33,8 @@ export const MissingLabel: React.FC<MissingLabelProps> = (props: MissingLabelPro
       {props.missingVersion && (
         <>
           <div>
-            <PFBadge badge={{ badge: versionLabel ?? 'version' }} isRead={true} style={{ marginRight: 0 }} /> label is
-            missing. <br />
+            <PFBadge badge={{ badge: versionLabelName }} isRead={true} style={{ marginRight: 0 }} /> label is missing.{' '}
+            <br />
           </div>
           <div>The label is recommended as it affects telemetry.</div>
         </>

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -83,10 +83,10 @@ const defaultServerConfig: ComputedServerConfig = {
     ambientWaypointGatewayLabel: 'gateway.networking.k8s.io/gateway-name',
     ambientWaypointLabel: 'gateway.istio.io/managed',
     ambientWaypointLabelValue: 'istio.io-mesh-controller',
-    appLabelName: 'app',
+    appLabelName: '',
     injectionLabelName: 'istio-injection',
     injectionLabelRev: 'istio.io/rev',
-    versionLabelName: 'version'
+    versionLabelName: ''
   },
   kialiFeatureFlags: {
     disabledFeatures: [],
@@ -142,6 +142,10 @@ let homeCluster = getHomeCluster(serverConfig);
 let isMultiCluster = isMC();
 export { homeCluster, isMultiCluster };
 
+// set when serverConfig is set
+let appLabelNames: string[] = [];
+let versionLabelNames: string[] = [];
+
 export const toValidDuration = (duration: number): number => {
   // Check if valid
   if (serverConfig.durations[duration]) {
@@ -171,6 +175,15 @@ export const setServerConfig = (cfg: ServerConfig): void => {
   if (!serverConfig.ambientEnabled) {
     serverConfig.kialiFeatureFlags.uiDefaults.graph.traffic.ambient = 'none';
   }
+
+  // set the current app and version label name possibilities
+  if (cfg.istioLabels.appLabelName !== '' && cfg.istioLabels.versionLabelName !== '') {
+    appLabelNames = [cfg.istioLabels.appLabelName];
+    versionLabelNames = [cfg.istioLabels.versionLabelName];
+  } else {
+    appLabelNames = ['service.istio.io/canonical-name', 'app.kubernetes.io/name', 'app'];
+    versionLabelNames = ['service.istio.io/canonical-revision', 'app.kubernetes.io/version', 'version'];
+  }
 };
 
 export const isIstioNamespace = (namespace: string): boolean => {
@@ -197,3 +210,19 @@ function isMC(): boolean {
     Object.values(serverConfig.clusters).filter(c => c.accessible).length > 1
   );
 }
+
+// getAppLabelName returns the app label name found in the labels, or undefined
+export const getAppLabelName = (labels?: { [key: string]: string }): string | undefined => {
+  if (labels) {
+    return appLabelNames.find(labelName => labels[labelName] !== undefined);
+  }
+  return undefined;
+};
+
+// getVersionLabelName returns the version label name found in the labels, or undefined
+export const getVersionLabelName = (labels?: { [key: string]: string }): string | undefined => {
+  if (labels) {
+    return versionLabelNames.find(labelName => labels[labelName] !== undefined);
+  }
+  return undefined;
+};

--- a/frontend/src/pages/AppDetails/AppDescription.tsx
+++ b/frontend/src/pages/AppDetails/AppDescription.tsx
@@ -9,6 +9,7 @@ import * as H from '../../types/Health';
 import { HealthIndicator } from '../../components/Health/HealthIndicator';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { AmbientLabel, tooltipMsgType } from '../../components/Ambient/AmbientLabel';
+import { getAppLabelName } from 'config/ServerConfig';
 
 type AppDescriptionProps = {
   app?: App;
@@ -28,8 +29,11 @@ const healthIconStyle = kialiStyle({
 export const AppDescription: React.FC<AppDescriptionProps> = (props: AppDescriptionProps) => {
   const appLabels: { [key: string]: string } = {};
 
-  if (props.app) {
-    appLabels[serverConfig.istioLabels.appLabelName] = props.app.name;
+  if (props.app?.workloads && props.app.workloads.length > 0) {
+    const appLabelName = getAppLabelName(props.app.workloads[0].labels);
+    if (appLabelName) {
+      appLabels[appLabelName] = props.app.name;
+    }
   }
 
   return props.app ? (
@@ -66,7 +70,7 @@ export const AppDescription: React.FC<AppDescriptionProps> = (props: AppDescript
       <CardBody>
         <Labels
           labels={appLabels}
-          tooltipMessage={`Workloads and Services grouped by ${serverConfig.istioLabels.appLabelName} label`}
+          tooltipMessage={`Workloads and Services grouped by ${serverConfig.istioLabels.appLabelName ?? 'app'} label`}
         />
 
         <DetailDescription

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -26,6 +26,7 @@ import { HistoryManager } from 'app/History';
 import { basicTabStyle } from 'styles/TabStyles';
 import { serverConfig } from 'config';
 import { isGVKSupported } from '../../utils/IstioConfigUtils';
+import { getAppLabelName } from 'config/ServerConfig';
 
 type AppDetailsState = {
   app?: App;
@@ -128,6 +129,8 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     const tabs: React.ReactNode[] = [];
 
     if (this.state.app) {
+      const appLabelName =
+        this.state.app.workloads.length > 0 ? getAppLabelName(this.state.app.workloads[0].labels) : undefined;
       this.state.app.runtimes.forEach(runtime => {
         runtime.dashboardRefs.forEach(dashboard => {
           if (dashboard.template !== 'envoy') {
@@ -137,9 +140,10 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
             const tab = (
               <Tab title={dashboard.title} key={`cd-${dashboard.template}`} eventKey={tabKey}>
                 <CustomMetrics
+                  app={this.props.appId.app}
+                  appLabelName={appLabelName}
                   lastRefreshAt={this.props.lastRefreshAt}
                   namespace={this.props.appId.namespace}
-                  app={this.props.appId.app}
                   template={dashboard.template}
                 />
               </Tab>

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Card, CardBody, CardHeader, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ServiceDetailsInfo, WorkloadOverview } from '../../types/ServiceInfo';
 import { AppWorkload } from '../../types/App';
-import { isMultiCluster, serverConfig } from '../../config';
+import { isMultiCluster } from '../../config';
 import { Labels } from '../../components/Label/Labels';
 import { kialiStyle } from 'styles/StyleUtils';
 import { LocalTime } from '../../components/Time/LocalTime';
@@ -16,6 +16,7 @@ import { AmbientLabel, tooltipMsgType } from '../../components/Ambient/AmbientLa
 import { infoStyle } from 'styles/IconStyle';
 import { classes } from 'typestyle';
 import { getIstioObjectGVK } from '../../utils/IstioConfigUtils';
+import { getAppLabelName } from 'config/ServerConfig';
 
 interface ServiceInfoDescriptionProps {
   namespace: string;
@@ -61,10 +62,12 @@ export const ServiceDescription: React.FC<ServiceInfoDescriptionProps> = (props:
         .sort((w1: WorkloadOverview, w2: WorkloadOverview) => (w1.name < w2.name ? -1 : 1))
         .forEach(wk => {
           if (wk.labels) {
-            const appName = wk.labels[serverConfig.istioLabels.appLabelName];
-
-            if (!apps.includes(appName)) {
-              apps.push(appName);
+            const appLabelName = getAppLabelName(wk.labels);
+            if (appLabelName) {
+              const appName = wk.labels[appLabelName];
+              if (!apps.includes(appName)) {
+                apps.push(appName);
+              }
             }
           }
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -10,7 +10,7 @@ import { renderAPILogo, renderRuntimeLogo } from '../../components/Logo/Logos';
 import * as H from '../../types/Health';
 import { KialiIcon } from '../../config/KialiIcon';
 import { HealthIndicator } from '../../components/Health/HealthIndicator';
-import { isMultiCluster, serverConfig } from '../../config';
+import { isMultiCluster } from '../../config';
 import { MissingSidecar } from '../../components/MissingSidecar/MissingSidecar';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 import { MissingLabel } from '../../components/MissingLabel/MissingLabel';
@@ -22,6 +22,7 @@ import { gvkType, validationKey } from '../../types/IstioConfigList';
 import { infoStyle } from 'styles/IconStyle';
 import { classes } from 'typestyle';
 import { renderWaypointSimpleLabel } from '../../components/Ambient/WaypointLabel';
+import { getAppLabelName } from 'config/ServerConfig';
 
 type WorkloadDescriptionProps = {
   health?: H.Health;
@@ -77,8 +78,9 @@ export const WorkloadDescription: React.FC<WorkloadDescriptionProps> = (props: W
   const apps: string[] = [];
   const services: string[] = [];
 
-  if (workload.labels[serverConfig.istioLabels.appLabelName]) {
-    apps.push(workload.labels[serverConfig.istioLabels.appLabelName]);
+  const appLabelName = getAppLabelName(workload.labels);
+  if (appLabelName) {
+    apps.push(workload.labels[appLabelName]);
   }
 
   workload.services?.forEach(s => services.push(s.name));

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -8,7 +8,7 @@ import * as AlertUtils from '../../utils/AlertUtils';
 import { IstioMetrics } from '../../components/Metrics/IstioMetrics';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { CustomMetrics } from '../../components/Metrics/CustomMetrics';
-import { serverConfig } from '../../config/ServerConfig';
+import { getAppLabelName, getVersionLabelName, serverConfig } from '../../config/ServerConfig';
 import { WorkloadPodLogs } from './WorkloadPodLogs';
 import { DurationInSeconds, TimeInMilliseconds } from '../../types/Common';
 import { KialiAppState } from '../../store/Store';
@@ -335,8 +335,10 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
     const tabs: React.ReactNode[] = [];
 
     if (this.state.workload) {
-      const app = this.state.workload.labels[serverConfig.istioLabels.appLabelName];
-      const version = this.state.workload.labels[serverConfig.istioLabels.versionLabelName];
+      const appLabelName = getAppLabelName(this.state.workload.labels);
+      const verLabelName = getVersionLabelName(this.state.workload.labels);
+      const app = appLabelName ? this.state.workload.labels[appLabelName] : undefined;
+      const version = verLabelName ? this.state.workload.labels[verLabelName] : undefined;
       const isLabeled = app && version;
 
       if (isLabeled) {
@@ -350,13 +352,15 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
               const tab = (
                 <Tab key={dashboard.template} title={dashboard.title} eventKey={tabKey}>
                   <CustomMetrics
+                    app={app}
+                    appLabelName={appLabelName}
                     lastRefreshAt={this.props.lastRefreshAt}
                     namespace={this.props.workloadId.namespace}
-                    app={app}
+                    template={dashboard.template}
                     version={version}
+                    versionLabelName={verLabelName}
                     workload={this.state.workload!.name}
                     workloadType={this.state.workload!.gvk.Kind}
-                    template={dashboard.template}
                   />
                 </Tab>
               );

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -405,16 +405,16 @@ func getWorkload(cluster, namespace, workloadName string, gi *graph.GlobalInfo) 
 
 func getAppWorkloads(cluster, namespace, app, version string, gi *graph.GlobalInfo) []models.WorkloadListItem {
 	cfg := config.Get()
-	appLabel := cfg.IstioLabels.AppLabelName
-	versionLabel := cfg.IstioLabels.VersionLabelName
 
 	result := []models.WorkloadListItem{}
 	versionOk := graph.IsOKVersion(version)
 	for _, workload := range getWorkloadList(cluster, namespace, gi).Workloads {
-		if appVal, ok := workload.Labels[appLabel]; ok && app == appVal {
+		appLabelName, appLabelNameFound := cfg.GetAppLabelName(workload.Labels)
+		verLabelName, verLabelNameFound := cfg.GetVersionLabelName(workload.Labels)
+		if appLabelNameFound && workload.Labels[appLabelName] == app {
 			if !versionOk {
 				result = append(result, workload)
-			} else if versionVal, ok := workload.Labels[versionLabel]; ok && version == versionVal {
+			} else if verLabelNameFound && workload.Labels[verLabelName] == version {
 				result = append(result, workload)
 			}
 		}

--- a/graph/telemetry/istio/appender/idle_node.go
+++ b/graph/telemetry/istio/appender/idle_node.go
@@ -75,18 +75,16 @@ func (a IdleNodeAppender) buildIdleNodeTrafficMap(trafficMap graph.TrafficMap, n
 		}
 
 		cfg := config.Get()
-		appLabel := cfg.IstioLabels.AppLabelName
-		versionLabel := cfg.IstioLabels.VersionLabelName
 		if workloadList, ok := workloadLists[cluster]; ok {
 			for _, w := range workloadList.Workloads {
 				labels := w.Labels
 				app := graph.Unknown
 				version := graph.Unknown
-				if v, ok := labels[appLabel]; ok {
-					app = v
+				if appLabelName, found := cfg.GetAppLabelName(labels); found {
+					app = labels[appLabelName]
 				}
-				if v, ok := labels[versionLabel]; ok {
-					version = v
+				if verLabelName, found := cfg.GetVersionLabelName(labels); found {
+					version = labels[verLabelName]
 				}
 				id, nodeType, _ := graph.Id(cluster, "", "", namespace, w.Name, app, version, a.GraphType)
 				if _, found := trafficMap[id]; !found {

--- a/graph/telemetry/istio/appender/labeler.go
+++ b/graph/telemetry/istio/appender/labeler.go
@@ -33,10 +33,6 @@ func (f *LabelerAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *g
 
 // labelNodes puts all k8s labels in the metadata for all nodes.
 func labelNodes(trafficMap graph.TrafficMap, gi *graph.GlobalInfo) {
-	// We need to know the names of the Istio labels for app and version because we do not label the nodes with those.
-	// There is no need to get the Istio label names multiple times, so get them once now.
-	istioLabelNames := config.Get().IstioLabels
-
 	for _, n := range trafficMap {
 		// can't get labels for nodes on the outside or inaccessible nodes, so just go to the next and ignore this one.
 		if b, ok := n.Metadata[graph.IsOutside]; ok && b.(bool) {
@@ -82,8 +78,12 @@ func labelNodes(trafficMap graph.TrafficMap, gi *graph.GlobalInfo) {
 
 		if len(labelsMetadata) > 0 {
 			n.Metadata[graph.Labels] = labelsMetadata
-			delete(n.Metadata[graph.Labels].(graph.LabelsMetadata), istioLabelNames.AppLabelName)
-			delete(n.Metadata[graph.Labels].(graph.LabelsMetadata), istioLabelNames.VersionLabelName)
+			if appLabelName, found := config.Get().GetAppLabelName(labelsMetadata); found {
+				delete(n.Metadata[graph.Labels].(graph.LabelsMetadata), appLabelName)
+			}
+			if verLabelName, found := config.Get().GetVersionLabelName(labelsMetadata); found {
+				delete(n.Metadata[graph.Labels].(graph.LabelsMetadata), verLabelName)
+			}
 		}
 	}
 }

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -42,9 +42,6 @@ func (a WorkloadEntryAppender) AppendGraph(trafficMap graph.TrafficMap, globalIn
 }
 
 func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
-	appLabel := config.Get().IstioLabels.AppLabelName
-	versionLabel := config.Get().IstioLabels.VersionLabelName
-
 	for _, n := range trafficMap {
 		// Skip the check if this node is outside the requested namespace, we limit badging to the requested namespaces
 		if n.Namespace != namespaceInfo.Namespace {
@@ -69,7 +66,9 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 		log.Tracef("WorkloadEntries found: %d", len(istioCfg.WorkloadEntries))
 
 		for _, entry := range istioCfg.WorkloadEntries {
-			if entry.Spec.Labels[appLabel] == n.App && entry.Spec.Labels[versionLabel] == n.Version {
+			appLabelName, appLabelNameFound := config.Get().GetAppLabelName(entry.Spec.Labels)
+			verLabelName, verLabelNameFound := config.Get().GetVersionLabelName(entry.Spec.Labels)
+			if appLabelNameFound && verLabelNameFound && entry.Spec.Labels[appLabelName] == n.App && entry.Spec.Labels[verLabelName] == n.Version {
 				if n.Metadata[graph.HasWorkloadEntry] == nil {
 					n.Metadata[graph.HasWorkloadEntry] = []graph.WEInfo{}
 				}

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -34,6 +34,7 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry"
 	"github.com/kiali/kiali/graph/telemetry/istio/appender"
@@ -366,7 +367,7 @@ func populateTrafficMap(trafficMap graph.TrafficMap, vector *model.Vector, metri
 		ztunnel := false
 		if protocol == graph.TCP.Name {
 			if lApp, appOk := m["app"]; appOk {
-				ztunnel = string(lApp) == "ztunnel"
+				ztunnel = string(lApp) == config.Ztunnel
 			}
 		}
 

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -273,6 +273,8 @@ func TestAppDetailsEndpoint(t *testing.T) {
 	// Disabling CustomDashboards on testing
 	// otherwise this adds 10s to the test due to an http timeout.
 	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
 	conf.ExternalServices.CustomDashboards.Enabled = false
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	kubernetes.SetConfig(t, *conf)

--- a/handlers/apps_test.go
+++ b/handlers/apps_test.go
@@ -287,7 +287,7 @@ func TestAppDetailsEndpoint(t *testing.T) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
-	for _, obj := range business.FakeServices() {
+	for _, obj := range business.FakeServices(*conf) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -50,15 +50,15 @@ func TestWorkloadsEndpoint(t *testing.T) {
 	mockClock()
 
 	kubeObjects := []runtime.Object{kubetest.FakeNamespace("ns")}
-	for _, obj := range business.FakeDepSyncedWithRS() {
+	for _, obj := range business.FakeDepSyncedWithRS(cfg) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
-	for _, obj := range business.FakeRSSyncedWithPods() {
+	for _, obj := range business.FakeRSSyncedWithPods(cfg) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
-	for _, obj := range business.FakePodsSyncedWithDeployments() {
+	for _, obj := range business.FakePodsSyncedWithDeployments(cfg) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -29,8 +29,7 @@ const (
 
 const (
 	istioControlPlaneClustersLabel        = "topology.istio.io/controlPlaneClusters"
-	istiodAppNameLabelKey                 = "app"
-	istiodAppNameLabelValue               = "istiod"
+	istiodAppLabelValue                   = "istiod"
 	istiodClusterIDEnvKey                 = "CLUSTER_ID"
 	istiodExternalEnvKey                  = "EXTERNAL_ISTIOD"
 	istiodScopeGatewayEnvKey              = "PILOT_SCOPE_GATEWAY_TO_NAMESPACE"
@@ -293,7 +292,7 @@ func (in *Discovery) Mesh(ctx context.Context) (*models.Mesh, error) {
 		}
 
 		// If there's an istiod on it, then it's a controlplane cluster. Otherwise it is a remote cluster.
-		istiods, err := kubeCache.GetDeploymentsWithSelector(metav1.NamespaceAll, istiodAppNameLabelKey+"="+istiodAppNameLabelValue)
+		istiods, err := kubeCache.GetDeploymentsWithSelector(metav1.NamespaceAll, config.IstioAppLabel+"="+istiodAppLabelValue)
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +310,7 @@ func (in *Discovery) Mesh(ctx context.Context) (*models.Mesh, error) {
 				Labels:          istiod.Labels,
 				IstiodName:      istiod.Name,
 				IstiodNamespace: istiod.Namespace,
-				Revision:        istiod.Labels[models.IstioRevisionLabel],
+				Revision:        istiod.Labels[config.IstioRevisionLabel],
 			}
 
 			controlPlaneConfig, err := in.getControlPlaneConfiguration(kubeCache, &controlPlane)
@@ -604,7 +603,7 @@ func (in *Discovery) setTags(ctx context.Context, controlPlanes []models.Control
 			tag := models.Tag{
 				Cluster:  cluster,
 				Name:     webhook.Labels[models.IstioTagLabel],
-				Revision: webhook.Labels[models.IstioRevisionLabel],
+				Revision: webhook.Labels[config.IstioRevisionLabel],
 			}
 			key := tag.Cluster + tag.Revision
 			if _, found := tagsByClusterRev[key]; found {

--- a/istio/discovery_internal_test.go
+++ b/istio/discovery_internal_test.go
@@ -104,7 +104,7 @@ func TestIstioConfigMapName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "istio",
 					Namespace: "istio-system",
-					Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+					Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 				},
 				Data: map[string]string{"mesh": ""},
 			},
@@ -115,7 +115,7 @@ func TestIstioConfigMapName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "istio-v1",
 					Namespace: "istio-system",
-					Labels:    map[string]string{models.IstioRevisionLabel: "v1"},
+					Labels:    map[string]string{config.IstioRevisionLabel: "v1"},
 				},
 				Data: map[string]string{"mesh": ""},
 			},
@@ -126,7 +126,7 @@ func TestIstioConfigMapName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "istio",
 					Namespace: "istio-system",
-					Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+					Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 				},
 				Data: map[string]string{"mesh": ""},
 			},
@@ -139,7 +139,7 @@ func TestIstioConfigMapName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "istio-v2",
 					Namespace: "istio-system",
-					Labels:    map[string]string{models.IstioRevisionLabel: "v2"},
+					Labels:    map[string]string{config.IstioRevisionLabel: "v2"},
 				},
 				Data: map[string]string{"mesh": ""},
 			},
@@ -180,7 +180,7 @@ func TestIstioConfigMapName(t *testing.T) {
 			controlPlane := &models.ControlPlane{
 				Cluster:         &models.KubeCluster{Name: conf.KubernetesConfig.ClusterName},
 				IstiodNamespace: "istio-system",
-				Revision:        tc.configMap.Labels[models.IstioRevisionLabel],
+				Revision:        tc.configMap.Labels[config.IstioRevisionLabel],
 			}
 			_, err = discovery.getControlPlaneConfiguration(kubeCache, controlPlane)
 			if tc.expectErr {

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -70,7 +70,7 @@ func fakeIstiodDeployment(cluster string, manageExternal bool) *apps_v1.Deployme
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Spec: apps_v1.DeploymentSpec{
@@ -374,7 +374,7 @@ func TestMesh(t *testing.T) {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 	}
@@ -387,7 +387,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -429,7 +429,7 @@ func TestControlPlaneCertificate(t *testing.T) {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 	}
@@ -442,7 +442,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -585,7 +585,7 @@ func TestMeshResolvesNetwork(t *testing.T) {
 					Namespace: "istio-system",
 					Labels: map[string]string{
 						"app":                     "istiod",
-						models.IstioRevisionLabel: "default",
+						config.IstioRevisionLabel: "default",
 					},
 				},
 			}
@@ -593,7 +593,7 @@ func TestMeshResolvesNetwork(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "istio",
 					Namespace: "istio-system",
-					Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+					Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 				},
 				Data: map[string]string{"mesh": ""},
 			}
@@ -625,7 +625,7 @@ func TestGetMeshMultipleRevisions(t *testing.T) {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "1-18-0",
+				config.IstioRevisionLabel: "1-18-0",
 			},
 		},
 	}
@@ -635,7 +635,7 @@ func TestGetMeshMultipleRevisions(t *testing.T) {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "1-19-0",
+				config.IstioRevisionLabel: "1-19-0",
 			},
 		},
 	}
@@ -649,7 +649,7 @@ trustDomain: cluster.local
 			Name:      "istio-1-18-0",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "1-18-0",
+				config.IstioRevisionLabel: "1-18-0",
 			},
 		},
 		Data: map[string]string{"mesh": configMap_1_18_Data},
@@ -664,7 +664,7 @@ trustDomain: cluster.local
 			Name:      "istio-1-19-0",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "1-19-0",
+				config.IstioRevisionLabel: "1-19-0",
 			},
 		},
 		Data: map[string]string{"mesh": configMap_1_19_Data},
@@ -733,7 +733,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -785,7 +785,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -839,7 +839,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -884,7 +884,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -940,7 +940,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -1025,7 +1025,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -1033,7 +1033,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "external-istiod",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -1216,7 +1216,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "istio",
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+			Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -1248,7 +1248,7 @@ func TestIstiodResourceThresholds(t *testing.T) {
 	conf := config.NewConfig()
 	istiodAppLabels := map[string]string{
 		"app":                     "istiod",
-		models.IstioRevisionLabel: "default",
+		config.IstioRevisionLabel: "default",
 	}
 
 	testCases := map[string]struct {
@@ -1430,7 +1430,7 @@ func TestIstiodResourceThresholds(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "istio",
 						Namespace: "istio-system",
-						Labels:    map[string]string{models.IstioRevisionLabel: "default"},
+						Labels:    map[string]string{config.IstioRevisionLabel: "default"},
 					},
 					Data: map[string]string{"mesh": ""},
 				},
@@ -1495,7 +1495,7 @@ trustDomain: cluster.local
 		ObjectMeta: v1.ObjectMeta{
 			Name:      configMapName,
 			Namespace: "istio-system",
-			Labels:    map[string]string{models.IstioRevisionLabel: revision},
+			Labels:    map[string]string{config.IstioRevisionLabel: revision},
 		},
 		Data: map[string]string{"mesh": configMapData},
 	}
@@ -1529,7 +1529,7 @@ func runningIstiodPod(revision string) *core_v1.Pod {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: revision,
+				config.IstioRevisionLabel: revision,
 			},
 		},
 		Status: core_v1.PodStatus{
@@ -1604,7 +1604,7 @@ func TestCanConnectToUnreachableIstiod(t *testing.T) {
 
 func fakeIstiodWithRevision(cluster string, revision string, manageExternal bool) *apps_v1.Deployment {
 	deployment := fakeIstiodDeployment(cluster, manageExternal)
-	deployment.Labels[models.IstioRevisionLabel] = revision
+	deployment.Labels[config.IstioRevisionLabel] = revision
 	deployment.Name = "istiod-" + revision
 	return deployment
 }
@@ -1657,9 +1657,9 @@ func TestUpdateStatusMultipleHealthyRevs(t *testing.T) {
 	defaultIstiod := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
 	istiod_1_19 := fakeIstiodWithRevision(conf.KubernetesConfig.ClusterName, "1-19-0", false)
 	defaultPod := runningIstiodPod("default")
-	defaultPod.Labels[models.IstioRevisionLabel] = "default"
+	defaultPod.Labels[config.IstioRevisionLabel] = "default"
 	istiod_1_19_pod := runningIstiodPod("1-19-0")
-	istiod_1_19_pod.Labels[models.IstioRevisionLabel] = "1-19-0"
+	istiod_1_19_pod.Labels[config.IstioRevisionLabel] = "1-19-0"
 
 	k8s := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("istio-system"),
@@ -1716,7 +1716,7 @@ func TestDiscoverWithTags(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "istio-revision-tag-default",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 				models.IstioTagLabel:      "default",
 			},
 		},
@@ -1778,7 +1778,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -1812,7 +1812,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "1.23.0"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "1.23.0"}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -1829,7 +1829,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -1848,7 +1848,7 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-prod",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1.23.0",
+							config.IstioRevisionLabel: "1.23.0",
 							models.IstioTagLabel:      "prod",
 						},
 					},
@@ -1858,21 +1858,21 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-dev",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1.22.0",
+							config.IstioRevisionLabel: "1.22.0",
 							models.IstioTagLabel:      "dev",
 						},
 					},
 				}
 				istiod_1_22 := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
 				istiod_1_22.Name = "istiod-1-22-0"
-				istiod_1_22.Labels[models.IstioRevisionLabel] = "1.22.0"
+				istiod_1_22.Labels[config.IstioRevisionLabel] = "1.22.0"
 				istiod_1_23 := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
 				istiod_1_23.Name = "istiod-1-23-0"
-				istiod_1_23.Labels[models.IstioRevisionLabel] = "1.23.0"
+				istiod_1_23.Labels[config.IstioRevisionLabel] = "1.23.0"
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
 						defaultWebhook,
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						tagProd,
 						tagDev,
 						istiod_1_23,
@@ -1900,7 +1900,7 @@ func TestDiscoverWithTags(t *testing.T) {
 					conf.KubernetesConfig.ClusterName: {
 						fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 						defaultWebhook,
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
 						istioConfigMap,
 						FakeCertificateConfigMap("istio-system"),
@@ -1926,7 +1926,7 @@ func TestDiscoverWithTags(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name: "bookinfo",
 								Labels: map[string]string{
-									models.IstioRevisionLabel: "default",
+									config.IstioRevisionLabel: "default",
 									"include":                 "true",
 								},
 							},
@@ -1953,7 +1953,7 @@ func TestDiscoverWithTags(t *testing.T) {
 					conf.KubernetesConfig.ClusterName: {
 						fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 						defaultWebhook,
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
 						fakeIstioConfigMap("default"),
 						FakeCertificateConfigMap("istio-system"),
@@ -1976,7 +1976,7 @@ func TestDiscoverWithTags(t *testing.T) {
 					conf.KubernetesConfig.ClusterName: {
 						fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false),
 						defaultWebhook,
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
 						fakeIstioConfigMap("default"),
 						FakeCertificateConfigMap("istio-system"),
@@ -1993,7 +1993,7 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-prod",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1-23-0",
+							config.IstioRevisionLabel: "1-23-0",
 							models.IstioTagLabel:      "prod",
 						},
 					},
@@ -2002,24 +2002,24 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-canary",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1-24-0",
+							config.IstioRevisionLabel: "1-24-0",
 							models.IstioTagLabel:      "canary",
 						},
 					},
 				}
 				istiod_1_23 := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
-				istiod_1_23.Labels[models.IstioRevisionLabel] = "1-23-0"
+				istiod_1_23.Labels[config.IstioRevisionLabel] = "1-23-0"
 				istiod_1_23.Name = "istiod-1-23-0"
 				istiod_1_24 := fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, false)
-				istiod_1_24.Labels[models.IstioRevisionLabel] = "1-24-0"
+				istiod_1_24.Labels[config.IstioRevisionLabel] = "1-24-0"
 				istiod_1_23.Name = "istiod-1-24-0"
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
 						defaultWebhook,
 						tagProd,
 						tagCanary,
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "travels", Labels: map[string]string{models.IstioRevisionLabel: "canary"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "travels", Labels: map[string]string{config.IstioRevisionLabel: "canary"}}},
 						istiod_1_23,
 						istiod_1_24,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -2044,7 +2044,7 @@ func TestDiscoverWithTags(t *testing.T) {
 				primary := fakeIstiodDeployment("primary", true)
 				return map[string][]runtime.Object{
 					"primary": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						defaultWebhook,
 						primary,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -2052,7 +2052,7 @@ func TestDiscoverWithTags(t *testing.T) {
 						FakeCertificateConfigMap("istio-system"),
 					},
 					"remote": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 						defaultWebhook,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system", Annotations: map[string]string{"topology.istio.io/controlPlaneClusters": "primary"}}},
 						FakeCertificateConfigMap("istio-system"),
@@ -2074,17 +2074,17 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-prod",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1-23-0",
+							config.IstioRevisionLabel: "1-23-0",
 							models.IstioTagLabel:      "prod",
 						},
 					},
 				}
 				primary := fakeIstiodDeployment("primary", true)
-				primary.Labels[models.IstioRevisionLabel] = "1-23-0"
+				primary.Labels[config.IstioRevisionLabel] = "1-23-0"
 				primary.Name = "istiod-1-23-0"
 				return map[string][]runtime.Object{
 					"primary": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						defaultWebhook,
 						tagProd,
 						primary,
@@ -2093,7 +2093,7 @@ func TestDiscoverWithTags(t *testing.T) {
 						FakeCertificateConfigMap("istio-system"),
 					},
 					"remote": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						tagProd,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system", Annotations: map[string]string{"topology.istio.io/controlPlaneClusters": "primary"}}},
 						FakeCertificateConfigMap("istio-system"),
@@ -2115,29 +2115,29 @@ func TestDiscoverWithTags(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-prod",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1-23-0",
+							config.IstioRevisionLabel: "1-23-0",
 							models.IstioTagLabel:      "prod",
 						},
 					},
 				}
 				east := fakeIstiodDeployment("east", true)
-				east.Labels[models.IstioRevisionLabel] = "1-23-0"
+				east.Labels[config.IstioRevisionLabel] = "1-23-0"
 				east.Name = "istiod-1-23-0"
 				tagProdWest := &admissionregistrationv1.MutatingWebhookConfiguration{
 					ObjectMeta: v1.ObjectMeta{
 						Name: "istio-revision-tag-prod",
 						Labels: map[string]string{
-							models.IstioRevisionLabel: "1-23-0",
+							config.IstioRevisionLabel: "1-23-0",
 							models.IstioTagLabel:      "prod",
 						},
 					},
 				}
 				west := fakeIstiodDeployment("west", true)
-				west.Labels[models.IstioRevisionLabel] = "1-23-0"
+				west.Labels[config.IstioRevisionLabel] = "1-23-0"
 				west.Name = "istiod-1-23-0"
 				return map[string][]runtime.Object{
 					"east": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						defaultWebhook,
 						tagProdEast,
 						east,
@@ -2146,7 +2146,7 @@ func TestDiscoverWithTags(t *testing.T) {
 						FakeCertificateConfigMap("istio-system"),
 					},
 					"west": {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 						defaultWebhook,
 						tagProdWest,
 						west,
@@ -2216,7 +2216,7 @@ func TestDiscoverTagsWithoutWebhookPermissions(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "istio-revision-tag-default",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 				models.IstioTagLabel:      "default",
 			},
 		},
@@ -2237,7 +2237,7 @@ func TestDiscoverTagsWithoutWebhookPermissions(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(
 		defaultWebhook,
 		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
-		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "default"}}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "default"}}},
 		istiodDeployment,
 		istioConfigMap,
 		FakeCertificateConfigMap("istio-system"),
@@ -2282,7 +2282,7 @@ func fakeDefaultWebhook() *admissionregistrationv1.MutatingWebhookConfiguration 
 		ObjectMeta: v1.ObjectMeta{
 			Name: "istio-revision-tag-default",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 				models.IstioTagLabel:      "default",
 			},
 		},
@@ -2298,13 +2298,13 @@ func TestDiscoverTagsWithExternalCluster(t *testing.T) {
 	config.Set(conf)
 
 	external := fakeIstiodDeployment("remote", true)
-	external.Labels[models.IstioRevisionLabel] = "1-23-0"
+	external.Labels[config.IstioRevisionLabel] = "1-23-0"
 	external.Name = "istiod-1-23-0"
 	external.Namespace = "external"
 	externalConfigMap := fakeIstioConfigMap("1-23-0")
 	externalConfigMap.Namespace = "external"
 	tagProdRemote := fakeDefaultWebhook()
-	tagProdRemote.Labels[models.IstioRevisionLabel] = "1-23-0"
+	tagProdRemote.Labels[config.IstioRevisionLabel] = "1-23-0"
 	tagProdRemote.Labels[models.IstioTagLabel] = "prod"
 	clients := map[string]kubernetes.ClientInterface{
 		"external": approvingClient(kubetest.NewFakeK8sClient(
@@ -2319,7 +2319,7 @@ func TestDiscoverTagsWithExternalCluster(t *testing.T) {
 			FakeCertificateConfigMap("external"),
 		)),
 		"remote": approvingClient(kubetest.NewFakeK8sClient(
-			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioRevisionLabel: "prod"}}},
+			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioRevisionLabel: "prod"}}},
 			tagProdRemote,
 			&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "external"}},
 		)),
@@ -2347,7 +2347,7 @@ func TestDiscoverTagsWithExternalCluster(t *testing.T) {
 	require.NotEqual(externalControlPlane.Tag.Cluster, externalControlPlane.Cluster.Name)
 	require.Equal(externalControlPlane.Tag.Cluster, externalControlPlane.ID)
 
-	expectedNamespaces := []models.Namespace{{Name: "bookinfo", Cluster: "remote", Labels: map[string]string{models.IstioRevisionLabel: "prod"}, Revision: "prod"}}
+	expectedNamespaces := []models.Namespace{{Name: "bookinfo", Cluster: "remote", Labels: map[string]string{config.IstioRevisionLabel: "prod"}, Revision: "prod"}}
 	require.Equal(expectedNamespaces, externalControlPlane.ManagedNamespaces)
 }
 

--- a/istio/version.go
+++ b/istio/version.go
@@ -153,8 +153,8 @@ func GetVersion(ctx context.Context, conf *config.Config, client kubernetes.Clie
 			// Look for an istio service with the rev label in the control plane namespace.
 			revLabelSelector := labels.Set(
 				map[string]string{
-					"istio.io/rev": revision,
-					"app":          "istiod",
+					config.IstioAppLabel:      istiodAppLabelValue,
+					config.IstioRevisionLabel: revision,
 				},
 			).AsSelector().String()
 			services, err := kubeCache.GetServices(namespace, revLabelSelector)

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -29,7 +29,6 @@ const (
 
 const (
 	kialiCacheMeshKey = "mesh"
-	ztunnelApp        = "ztunnel"
 )
 
 // KialiCache stores both kube objects and non-kube related data such as pods' proxy status.
@@ -269,7 +268,7 @@ func (in *kialiCacheImpl) IsAmbientEnabled(cluster string) bool {
 		}
 
 		selector := map[string]string{
-			"app": ztunnelApp,
+			config.IstioAppLabel: config.Ztunnel,
 		}
 		daemonsets, err := kubeCache.GetDaemonSetsWithSelector(metav1.NamespaceAll, selector)
 		if err != nil {
@@ -301,7 +300,7 @@ func (in *kialiCacheImpl) GetZtunnelPods(cluster string) []v1.Pod {
 
 	}
 	selector := map[string]string{
-		"app": ztunnelApp,
+		config.IstioAppLabel: config.Ztunnel,
 	}
 	daemonsets, err := kubeCache.GetDaemonSetsWithSelector(metav1.NamespaceAll, selector)
 	if err != nil {
@@ -323,7 +322,7 @@ func (in *kialiCacheImpl) GetZtunnelPods(cluster string) []v1.Pod {
 	}
 
 	for _, pod := range dsPods {
-		if strings.Contains(pod.Name, ztunnelApp) {
+		if strings.Contains(pod.Name, config.Ztunnel) {
 			ztunnelPods = append(ztunnelPods, pod)
 		}
 	}

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -131,12 +131,12 @@ func ParseTwoPartHost(host Host) (string, string) {
 }
 
 func HasMatchingWorkloads(service string, workloadList []labels.Set) bool {
-	appLabel := config.Get().IstioLabels.AppLabelName
-
 	// Check Workloads
 	for _, wl := range workloadList {
-		if service == wl.Get(appLabel) {
-			return true
+		if appLabelName, found := config.Get().GetAppLabelName(wl); found {
+			if service == wl.Get(appLabelName) {
+				return true
+			}
 		}
 	}
 

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -48,7 +48,7 @@ func setupMocks(t *testing.T) *mesh.GlobalInfo {
 			Namespace: "istio-system",
 			Labels: map[string]string{
 				"app":                     "istiod",
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Spec: apps_v1.DeploymentSpec{
@@ -94,7 +94,7 @@ trustDomain: cluster.local
 			Name:      "istio",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				models.IstioRevisionLabel: "default",
+				config.IstioRevisionLabel: "default",
 			},
 		},
 		Data: map[string]string{"mesh": configMapData},
@@ -136,7 +136,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 	}
 
 	defaultInjection := map[string]string{models.IstioInjectionLabel: models.IstioInjectionEnabledLabelValue}
-	revLabel := map[string]string{models.IstioRevisionLabel: "default"}
+	revLabel := map[string]string{config.IstioRevisionLabel: "default"}
 	primaryClient := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("istio-system"),
 		kubetest.FakeNamespaceWithLabels("data-plane-1", defaultInjection),

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -196,7 +196,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 				mesh.CheckError(err)
 
 				version := models.DefaultRevisionLabel
-				if rev, ok := wp.Labels[models.IstioRevisionLabel]; ok {
+				if rev, ok := wp.Labels[config.IstioRevisionLabel]; ok {
 					version = rev
 				}
 
@@ -241,24 +241,24 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 			configMap, err := gi.Business.IstioConfig.GetIstioConfigMap(ctx, "", criteria)
 			mesh.CheckError(err)
 
-			for cluster, config := range configMap {
+			for cluster, conf := range configMap {
 				gwNodes := []*mesh.Node{}
-				for _, gw := range config.Gateways {
+				for _, gw := range conf.Gateways {
 					version := models.DefaultRevisionLabel
-					if rev, ok := gw.Labels[models.IstioRevisionLabel]; ok {
+					if rev, ok := gw.Labels[config.IstioRevisionLabel]; ok {
 						version = rev
 					}
 					gwNode, _, err := addInfra(meshMap, mesh.InfraTypeGateway, cluster, gw.Namespace, gw.Name, gw, version, false, "")
 					mesh.CheckError(err)
 					gwNodes = append(gwNodes, gwNode)
 				}
-				for _, gw := range config.K8sGateways {
+				for _, gw := range conf.K8sGateways {
 					// skip waypoints because they are treated independently
 					if strings.Contains(strings.ToLower(string(gw.Spec.GatewayClassName)), "waypoint") {
 						continue
 					}
 					version := models.DefaultRevisionLabel
-					if rev, ok := gw.Labels[models.IstioRevisionLabel]; ok {
+					if rev, ok := gw.Labels[config.IstioRevisionLabel]; ok {
 						version = rev
 					}
 					gwNode, _, err := addInfra(meshMap, mesh.InfraTypeGateway, cluster, gw.Namespace, gw.Name, gw, version, false, "")

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -22,8 +22,10 @@ func HasDRCircuitBreaker(dr *networking_v1.DestinationRule, namespace, serviceNa
 				if version == "" {
 					return true
 				}
-				if versionValue, ok := subset.Labels[cfg.IstioLabels.VersionLabelName]; ok && versionValue == version {
-					return true
+				if verLabelName, found := cfg.GetVersionLabelName(subset.Labels); found {
+					if versionValue, ok := subset.Labels[verLabelName]; ok && versionValue == version {
+						return true
+					}
 				}
 			}
 		}

--- a/models/mesh.go
+++ b/models/mesh.go
@@ -11,8 +11,6 @@ import (
 )
 
 const (
-	// IstioRevisionLabel is the standard label key used to identify the istio revision.
-	IstioRevisionLabel = "istio.io/rev"
 	// IstioTagLabel is the standard label key used on webhooks to identify the tag.
 	IstioTagLabel = "istio.io/tag"
 	// DefaultRevisionLabel is the value for the default revision.

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -83,7 +83,7 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 			namespace.Revision = ""
 		} else if injectionLabel == IstioInjectionEnabledLabelValue {
 			namespace.Revision = DefaultRevisionLabel
-		} else if label, hasLabel := ns.Labels[IstioRevisionLabel]; hasLabel {
+		} else if label, hasLabel := ns.Labels[config.IstioRevisionLabel]; hasLabel {
 			namespace.Revision = label
 		}
 	}

--- a/models/pod.go
+++ b/models/pod.go
@@ -134,8 +134,12 @@ func (pod *Pod) Parse(p *core_v1.Pod) {
 	pod.Status = string(p.Status.Phase)
 	pod.StatusMessage = string(p.Status.Message)
 	pod.StatusReason = string(p.Status.Reason)
-	_, pod.AppLabel = p.Labels[conf.IstioLabels.AppLabelName]
-	_, pod.VersionLabel = p.Labels[conf.IstioLabels.VersionLabelName]
+	if appLabelName, found := conf.GetAppLabelName(p.Labels); found {
+		_, pod.AppLabel = p.Labels[appLabelName]
+	}
+	if verLabelName, found := conf.GetVersionLabelName(p.Labels); found {
+		_, pod.VersionLabel = p.Labels[verLabelName]
+	}
 	pod.ServiceAccountName = p.Spec.ServiceAccountName
 }
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -725,7 +725,7 @@ func (workload *Workload) WaypointFor() string {
 // IsWaypoint return true if the workload is a ztunnel (Based in labels)
 func (workload *Workload) IsZtunnel() bool {
 	for _, pod := range workload.Pods {
-		if pod.Labels["app"] == "ztunnel" {
+		if pod.Labels[config.IstioAppLabel] == config.Ztunnel {
 			return true
 		}
 	}

--- a/models/workload.go
+++ b/models/workload.go
@@ -303,8 +303,12 @@ func (workload *WorkloadListItem) ParseWorkload(w *Workload) {
 		workload.Ambient = "waypoint"
 	}
 	/** Check the labels app and version required by Istio in template Pods*/
-	_, workload.AppLabel = w.Labels[conf.IstioLabels.AppLabelName]
-	_, workload.VersionLabel = w.Labels[conf.IstioLabels.VersionLabelName]
+	if appLabelName, found := conf.GetAppLabelName(w.Labels); found {
+		_, workload.AppLabel = w.Labels[appLabelName]
+	}
+	if verLabelName, found := conf.GetVersionLabelName(w.Labels); found {
+		_, workload.VersionLabel = w.Labels[verLabelName]
+	}
 }
 
 func (workload *Workload) parseObjectMeta(meta *meta_v1.ObjectMeta, tplMeta *meta_v1.ObjectMeta) {
@@ -315,8 +319,12 @@ func (workload *Workload) parseObjectMeta(meta *meta_v1.ObjectMeta, tplMeta *met
 		// TODO: This is not right since the template labels won't match the workload's labels.
 		workload.Labels = tplMeta.Labels
 		/** Check the labels app and version required by Istio in template Pods*/
-		_, workload.AppLabel = tplMeta.Labels[conf.IstioLabels.AppLabelName]
-		_, workload.VersionLabel = tplMeta.Labels[conf.IstioLabels.VersionLabelName]
+		if appLabelName, found := conf.GetAppLabelName(tplMeta.Labels); found {
+			_, workload.AppLabel = tplMeta.Labels[appLabelName]
+		}
+		if verLabelName, found := conf.GetVersionLabelName(tplMeta.Labels); found {
+			_, workload.VersionLabel = tplMeta.Labels[verLabelName]
+		}
 	} else {
 		workload.Labels = map[string]string{}
 	}
@@ -523,8 +531,13 @@ func (workload *Workload) ParseWorkloadGroup(wg *networking_v1.WorkloadGroup, we
 		}
 	}
 	/** Check the labels app and version required by Istio in template Pods*/
-	_, workload.AppLabel = workload.Labels[conf.IstioLabels.AppLabelName]
-	_, workload.VersionLabel = workload.Labels[conf.IstioLabels.VersionLabelName]
+	if appLabelName, found := conf.GetAppLabelName(workload.Labels); found {
+		_, workload.AppLabel = workload.Labels[appLabelName]
+	}
+	if verLabelName, found := conf.GetVersionLabelName(workload.Labels); found {
+		_, workload.VersionLabel = workload.Labels[verLabelName]
+	}
+
 	for _, entry := range wentries {
 		podStatus := core_v1.PodFailed
 		if healthutil.IsWorkloadEntryHealthy(entry) {
@@ -578,8 +591,12 @@ func (workload *Workload) ParsePods(controllerName string, controllerGVK schema.
 	}
 
 	/** Check the labels app and version required by Istio in template Pods*/
-	_, workload.AppLabel = workload.Labels[conf.IstioLabels.AppLabelName]
-	_, workload.VersionLabel = workload.Labels[conf.IstioLabels.VersionLabelName]
+	if appLabelName, found := conf.GetAppLabelName(workload.Labels); found {
+		_, workload.AppLabel = workload.Labels[appLabelName]
+	}
+	if verLabelName, found := conf.GetVersionLabelName(workload.Labels); found {
+		_, workload.VersionLabel = workload.Labels[verLabelName]
+	}
 }
 
 func (workload *Workload) SetPods(pods []core_v1.Pod) {

--- a/tests/integration/tests/applications_test.go
+++ b/tests/integration/tests/applications_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestApplicationsList(t *testing.T) {
 		require.NotNil(app.Labels)
 		require.Equal(kiali.BOOKINFO, app.Namespace)
 		if !strings.Contains(app.Name, "traffic-generator") {
-			require.True(app.IstioSidecar)
+			require.True(app.IstioSidecar, fmt.Sprintf("failed on %s:%s", app.Namespace, app.Name))
 			require.NotNil(app.IstioReferences)
 		}
 	}

--- a/tests/integration/tests/applications_test.go
+++ b/tests/integration/tests/applications_test.go
@@ -21,7 +21,7 @@ func TestApplicationsList(t *testing.T) {
 		require.NotNil(app.Health)
 		require.NotNil(app.Labels)
 		require.Equal(kiali.BOOKINFO, app.Namespace)
-		if !strings.Contains(app.Name, "traffic-generator") {
+		if !strings.Contains(app.Name, "traffic-generator") && !app.IsGateway {
 			require.True(app.IstioSidecar, fmt.Sprintf("failed on %s:%s", app.Namespace, app.Name))
 			require.NotNil(app.IstioReferences)
 		}
@@ -41,7 +41,7 @@ func TestApplicationDetails(t *testing.T) {
 	for _, workload := range app.Workloads {
 		require.NotEmpty(workload.WorkloadName)
 		if !strings.Contains(workload.WorkloadName, "traffic-generator") {
-			require.True(workload.IstioSidecar)
+			require.True(workload.IstioSidecar, fmt.Sprintf("failed on %s:%s", app.Namespace.Name, app.Name))
 		}
 	}
 	require.NotEmpty(app.ServiceNames)


### PR DESCRIPTION
Closes #7603 

Operator PR: https://github.com/kiali/kiali-operator/pull/879

Historically, Kiali supports a single set of app/version label names and the Kiali defaults to the original Istio label names:
`app`,  `version`.
Over time the labeling schemes have evolved, and many users prefer the k8s label names of:
 `app.kubernetes.io/name`, `app.kubernetes.io/version`
And to handle this mixed approach in telemetry, Istio introduced the idea of a canonical app and version, and with it introduced the label names:
 `service.istio.io/canonical-name`,   `service.istio.io/canonical-revision`

When setting the canonical value, the order of preference is:
1. `service.istio.io/canonical-name`, `service.istio.io/canonical-revision`
2. `app.kubernetes.io/name`, `app.kubernetes.io/version`
3. `app`, `version`

What has resulted for many users is a mixed labeling scheme. And as such, Kiali's single scheme, as defined in the Kiali CR, is limiting to those users, where certain objects may be missed.

This PR relieves that limitation by allowing for a mixed scheme by default.  The Kiali CR now defaults to unset values for `istio_labels.app_label_name` and `istio_labels.version_label_name`, and will accept any of the three schemes above.  For users with a consistent scheme, they can still set the CR to their scheme (one of the above, or something custom).

Note that this PR, and therefore Kiali, does not support a mix of app and version label names. For example, if labeling a deployment with `app`, it is assumed that the version label name would be `version`.  Although, it is valid to label the same object with multiple schemes.  The same service could be labeled with both `app=foo` and `app.kubernetes.io/name=foo`.  Note that when determining the app label value used on the service, the canonical order of preference is applied. So, in the [unrecommended] situation where the same service is labeled with both `app=foo` and `app.kubernetes.io/name=bar`, `bar` would be the preferred value.

The crux of the PR is in `config.go`, where we now determine the active label names when the config is set, and a set of utilities that do the handling.  It is now very rare to find in the code a direct access of `config.IstioLabels.AppLabelName`, for example.  In general all access is done via the utilities. On the client, there are analogous utilities found in `ServerConfig.ts`.

To test:
Using the operator and server prs, install kiali and bookinfo.  With the defaults, you will see some different behavior. For example, in overview you may see a higher number of applications listed for istio-system, because we are now picking up apps not labeled with `app`, but with other labeling schemes.  You can play with mixed labeling to convince yourself it is working.  Then, update the CR to set a single scheme.  After the restart you should lose sight of objects not labeled in that way.

Note:
PR also includes a fix to hack/istio/multicluster/install-multi-primary.sh to better handle DORP=podman
