### PR TITLE
[backport 2.4][cypress] Update mesh cypress testing to be flexible (#8114)

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -43,7 +43,27 @@ When('user selects mesh node with label {string}', (label: string) => {
       assert.isTrue(controller.hasGraph());
 
       const { nodes } = elems(controller);
-      const node = nodes.find(n => n.getLabel() === label);
+      const node = nodes.find(n => n.getLabel().toLowerCase() === label.toLowerCase());
+      assert.exists(node);
+
+      const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
+      setSelectedIds([node!.getId()]);
+    });
+});
+
+When('user selects tracing mesh node', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      assert.isTrue(controller.hasGraph());
+
+      const { nodes } = elems(controller);
+      const node = nodes.find(n => n.getLabel().toLowerCase() === 'jaeger' || n.getLabel().toLowerCase() === 'tempo');
       assert.exists(node);
 
       const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
@@ -110,17 +130,17 @@ Then('user sees expected mesh infra', () => {
       assert.isTrue(controller.hasGraph());
 
       const { nodes, edges } = elems(controller);
-      const nodeNames = nodes.map(n => n.getLabel());
-      const nodesLength = nodeNames.some(n => n === 'External Deployments') ? 9 : 8;
+      const nodeNames = nodes.map(n => n.getLabel().toLowerCase());
+      const minNodesLength = nodeNames.some(n => n === 'external deployments') ? 9 : 8;
 
-      assert.equal(nodes.length, nodesLength, 'Unexpected number of infra nodes');
-      assert.equal(edges.length, 5, 'Unexpected number of infra edges');
-      assert.isTrue(nodeNames.some(n => n === 'Data Plane'));
-      assert.isTrue(nodeNames.some(n => n === 'Grafana'));
+      assert.isAtLeast(nodes.length, minNodesLength, 'Unexpected number of infra nodes');
+      assert.isAtLeast(edges.length, 5, 'Unexpected number of infra edges');
+      assert.isTrue(nodeNames.some(n => n === 'data plane'));
+      assert.isTrue(nodeNames.some(n => n === 'grafana'));
       assert.isTrue(nodeNames.some(n => n.startsWith('istiod')));
-      assert.isTrue(nodeNames.some(n => n === 'jaeger' || n === 'Tempo'));
+      assert.isTrue(nodeNames.some(n => n === 'jaeger' || n === 'tempo'));
       assert.isTrue(nodeNames.some(n => n === 'kiali'));
-      assert.isTrue(nodeNames.some(n => n === 'Prometheus'));
+      assert.isTrue(nodeNames.some(n => n === 'prometheus'));
     });
 });
 
@@ -196,5 +216,15 @@ Then('user sees {string} node side panel', (name: string) => {
     .should('be.visible')
     .within(() => {
       cy.contains(name);
+    });
+});
+
+Then('user sees tracing node side panel', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-node')
+    .should('be.visible')
+    .within(() => {
+      cy.contains(new RegExp('jaeger|Jaeger|tempo|Tempo', 'g'));
     });
 });

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -33,9 +33,9 @@ Feature: Kiali Mesh page
     When user selects mesh node with label "Grafana"
     Then user sees "Grafana" node side panel
 
-  Scenario: Jaeger Infra
-    When user selects mesh node with label "jaeger"
-    Then user sees "jaeger" node side panel
+  Scenario: Tracing Infra
+    When user selects tracing mesh node
+    Then user sees tracing node side panel
 
   Scenario: Prometheus Infra
     When user selects mesh node with label "Prometheus"


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/8114 
