### PR TITLE
Add ambient logs cypress tests

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -90,6 +90,7 @@ When('user sees mesh side panel', () => {
 });
 
 When('user {string} mesh display option {string}', (action: string, option: string) => {
+  cy.intercept('GET', '**/api/mesh/graph*').as('graphCall');
   switch (option.toLowerCase()) {
     case 'gateways':
       option = 'filterGateways';
@@ -101,6 +102,7 @@ When('user {string} mesh display option {string}', (action: string, option: stri
 
   if (action === 'enables') {
     cy.get('div#graph-display-menu').find(`input#${option}`).check();
+    cy.wait('@graphCall');
   } else {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -90,7 +90,6 @@ When('user sees mesh side panel', () => {
 });
 
 When('user {string} mesh display option {string}', (action: string, option: string) => {
-  cy.intercept('GET', '**/api/mesh/graph*').as('graphCall');
   switch (option.toLowerCase()) {
     case 'gateways':
       option = 'filterGateways';
@@ -102,7 +101,6 @@ When('user {string} mesh display option {string}', (action: string, option: stri
 
   if (action === 'enables') {
     cy.get('div#graph-display-menu').find(`input#${option}`).check();
-    cy.wait('@graphCall');
   } else {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -90,6 +90,16 @@ Then('the log pane should only show log lines not containing {string}', (filterT
     });
 });
 
+Then('the log pane should show log lines containing {string}', (filterText: string) => {
+  cy.get('#logsText')
+    .find('p')
+    .then(lines => {
+      const linesArray = lines.toArray();
+      const found = linesArray.some(line => line.innerText.includes(filterText));
+      assert.isTrue(found);
+    });
+});
+
 Then(
   'the log pane should show at most {int} lines of logs of each selected container',
   (numberOfLinesPerContainer: number) => {

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -67,7 +67,7 @@ Then('I should see the {string} container listed', (containerName: string) => {
 });
 
 Then('the {string} container should be checked', (containerName: string) => {
-  cy.get('[data-test=workload-logs-pod-containers]').find(`input#container-${containerName}`).should('be.checked');
+  cy.get('[data-test=workload-logs-pod-containers]').find(`input#${containerName}`).should('be.checked');
 });
 
 Then('I should see some {string} pod selected in the pod selector', (podNamePrefix: string) => {

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -52,8 +52,6 @@ When('I select only the {string} container', (containerName: string) => {
 
 When('I select the {string} container', (containerName: string) => {
   cy.get('[data-test=workload-logs-pod-containers]').within(() => {
-    cy.get('[type=checkbox]').uncheck();
-
     cy.get(`input#${containerName}`).check();
   });
 });

--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -50,6 +50,14 @@ When('I select only the {string} container', (containerName: string) => {
   });
 });
 
+When('I select the {string} container', (containerName: string) => {
+  cy.get('[data-test=workload-logs-pod-containers]').within(() => {
+    cy.get('[type=checkbox]').uncheck();
+
+    cy.get(`input#${containerName}`).check();
+  });
+});
+
 When('I enable visualization of spans', () => {
   cy.get('#trace-limit-dropdown-toggle').should('not.exist');
   cy.get('[data-test=workload-logs-pod-containers]').within(() => {

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -60,7 +60,7 @@ Feature: Kiali Mesh page
     And user selects mesh node with label "bookinfo-gateway"
     Then user sees "bookinfo-gateway" node side panel
 
-  @waypoint
+  @waypoint-tracing
   @bookinfo-app
   Scenario: User enables waypoints
     When user opens display menu

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -60,7 +60,7 @@ Feature: Kiali Mesh page
     And user selects mesh node with label "bookinfo-gateway"
     Then user sees "bookinfo-gateway" node side panel
 
-  @ambient
+  @waypoint
   @bookinfo-app
   Scenario: User enables waypoints
     When user opens display menu
@@ -84,7 +84,7 @@ Feature: Kiali Mesh page
     And user sees 1 "dataplane" nodes on the "west" cluster
     And user sees 1 "istiod" nodes on the "east" cluster
     And user sees the istiod node connected to the dataplane nodes
-  
+
   @multi-cluster
   @multi-primary
   Scenario: Multi-primary: see one dataplane and one controlplane for each cluster and an edge between each.

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -53,6 +53,7 @@ Feature: Workload logs tab
     When I go to the Logs tab of the workload detail page
     Then I should see the "ztunnel" container listed
     And I should see the "ratings" container listed
+    And I select the "ztunnel-ratings" container
     And the "ztunnel-ratings" container should be checked
     And the "container-ratings" container should be checked
     And I should see some "ratings-v1" pod selected in the pod selector
@@ -65,6 +66,7 @@ Feature: Workload logs tab
     When I go to the Logs tab of the workload detail page
     Then I should see the "waypoint" container listed
     And I should see the "ratings" container listed
+    And I select the "waypoint-ratings" container
     And the "waypoint-ratings" container should be checked
     And the "container-ratings" container should be checked
     And I should see some "ratings-v1" pod selected in the pod selector

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -46,6 +46,31 @@ Feature: Workload logs tab
     Then the log pane should only show logs for the "ratings" container
 
   @bookinfo-app
+  @ambient
+  @waypoint
+  Scenario: The logs tab should show the ztunnel logs for a pod
+    Given I am on the "ratings-v1" workload detail page of the "bookinfo" namespace
+    When I go to the Logs tab of the workload detail page
+    Then I should see the "ztunnel" container listed
+    And I should see the "ratings" container listed
+    And the "ztunnel" container should be checked
+    And the "ratings" container should be checked
+    And I should see some "ratings-v1" pod selected in the pod selector
+    Then the log pane should show log lines containing "ztunnel"
+
+  @bookinfo-app
+  @waypoint
+  Scenario: The logs tab should show the waypoint logs for a pod
+    Given I am on the "ratings-v1" workload detail page of the "bookinfo" namespace
+    When I go to the Logs tab of the workload detail page
+    Then I should see the "waypoint" container listed
+    And I should see the "ratings" container listed
+    And the "waypoint" container should be checked
+    And the "ratings" container should be checked
+    And I should see some "ratings-v1" pod selected in the pod selector
+    Then the log pane should show log lines containing "envoy://internal_client_address/"
+
+  @bookinfo-app
   @tracing
   @waypoint-tracing
   Scenario: The log pane of the logs tab should show spans

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -17,8 +17,8 @@ Feature: Workload logs tab
     When I go to the Logs tab of the workload detail page
     Then I should see the "sidecar-proxy" container listed
     And I should see the "ratings" container listed
-    And the "sidecar-proxy" container should be checked
-    And the "ratings" container should be checked
+    And the "container-sidecar-proxy" container should be checked
+    And the "container-ratings" container should be checked
     And I should see some "ratings-v1" pod selected in the pod selector
 
   @bookinfo-app
@@ -53,8 +53,8 @@ Feature: Workload logs tab
     When I go to the Logs tab of the workload detail page
     Then I should see the "ztunnel" container listed
     And I should see the "ratings" container listed
-    And the "ztunnel" container should be checked
-    And the "ratings" container should be checked
+    And the "ztunnel-ratings" container should be checked
+    And the "container-ratings" container should be checked
     And I should see some "ratings-v1" pod selected in the pod selector
     Then the log pane should show log lines containing "ztunnel"
 
@@ -65,8 +65,8 @@ Feature: Workload logs tab
     When I go to the Logs tab of the workload detail page
     Then I should see the "waypoint" container listed
     And I should see the "ratings" container listed
-    And the "waypoint" container should be checked
-    And the "ratings" container should be checked
+    And the "waypoint-ratings" container should be checked
+    And the "container-ratings" container should be checked
     And I should see some "ratings-v1" pod selected in the pod selector
     Then the log pane should show log lines containing "envoy://internal_client_address/"
 


### PR DESCRIPTION
### Describe the change

Include cypress logs for ambient logs correlation.

Also, it adds the mesh Ambient test to the @waypoint-tracing tests, because they are executed at the end, so it give it some time to be available. waypoint-tracing tests were just for tracing, because they also need some time to have traces generated once the waypoint is created, but as they include a non tracing test now, the tag might be renamed.

### Steps to test the PR

- Install Istio Ambient, Kiali, bookinfo
- Add bookinfo to Ambient mesh with waypoint
- run cypress:  `yarn cypress:ambient` or `yarn cypress:waypoint` 

Or, ci test passes

### Automation testing

e2e test

### Issue reference
Ref. https://github.com/kiali/kiali/pull/8103
