### PR TITLE
Set apiVersion of ReferenceGrant to v1beta1

### DIFF
--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -103,7 +103,7 @@ export const dicTypeToGVK: { [key in gvkType]: GroupVersionKind } = {
   [gvkType.K8sGatewayClass]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'GatewayClass' },
   [gvkType.K8sGRPCRoute]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'GRPCRoute' },
   [gvkType.K8sHTTPRoute]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'HTTPRoute' },
-  [gvkType.K8sReferenceGrant]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'ReferenceGrant' },
+  [gvkType.K8sReferenceGrant]: { Group: 'gateway.networking.k8s.io', Version: 'v1beta1', Kind: 'ReferenceGrant' },
   [gvkType.K8sTCPRoute]: { Group: 'gateway.networking.k8s.io', Version: 'v1alpha2', Kind: 'TCPRoute' },
   [gvkType.K8sTLSRoute]: { Group: 'gateway.networking.k8s.io', Version: 'v1alpha2', Kind: 'TLSRoute' },
 

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -71,7 +71,7 @@ var (
 	K8sGatewayClasses  = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayClassType)
 	K8sGRPCRoutes      = K8sNetworkingGroupVersionV1.WithKind(K8sGRPCRouteType)
 	K8sHTTPRoutes      = K8sNetworkingGroupVersionV1.WithKind(K8sHTTPRouteType)
-	K8sReferenceGrants = K8sNetworkingGroupVersionV1.WithKind(K8sReferenceGrantType)
+	K8sReferenceGrants = K8sNetworkingGroupVersionV1Beta1.WithKind(K8sReferenceGrantType)
 	K8sTCPRoutes       = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTCPRouteType)
 	K8sTLSRoutes       = K8sNetworkingGroupVersionV1Alpha2.WithKind(K8sTLSRouteType)
 


### PR DESCRIPTION
### Describe the change

This PR set the apiVersion of ReferenceGrant istio object to `v1beta` when Kiali gets any object of this kind from Kubernetes.

### Steps to test the PR

1. Create a test `ReferenceGrant` istio object using Kiali wizard
2. Click in the created `ReferenceGrant` istio object to access details page
3. Verify that the apiVersion is `v1beta1`:

![image](https://github.com/user-attachments/assets/4af0a2e9-c208-47aa-9ed2-c379af3d4f11)

### Issue reference

Fixes #8133 
