### PR TITLE
Workload logs for k8s native sidecar.

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -52,6 +52,7 @@ type WorkloadDetailsPageProps = ReduxProps & {
 
 export const tabName = 'tab';
 export const defaultTab = 'info';
+export const istioProxyName = 'istio-proxy';
 
 const paramToTab: { [key: string]: number } = {
   info: 0,
@@ -315,14 +316,14 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
       workload.pods.forEach(pod => {
         if (pod.istioContainers && pod.istioContainers.length > 0) {
           hasIstioSidecars = true;
-        } else if (pod.istioInitContainers && pod.istioInitContainers.some(cont => cont.name === 'istio-proxy')) {
+        } else if (pod.istioInitContainers && pod.istioInitContainers.some(cont => cont.name === istioProxyName)) {
           hasIstioSidecars = true;
         } else {
           // Ztunnel doesn't have Envoy
           hasIstioSidecars =
             hasIstioSidecars ||
             (!!pod.containers &&
-              pod.containers.some(cont => cont.name === 'istio-proxy' && workload.ambient !== 'ztunnel'));
+              pod.containers.some(cont => cont.name === istioProxyName && workload.ambient !== 'ztunnel'));
         }
       });
     }

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -59,6 +59,7 @@ import { TRACE_LIMIT_DEFAULT } from 'components/Metrics/TraceLimit';
 import { TraceSpansLimit } from 'components/Metrics/TraceSpansLimit';
 import { infoStyle } from 'styles/IconStyle';
 import { WaypointInfo } from '../../types/Workload';
+import { istioProxyName } from './WorkloadDetailsPage';
 
 const appContainerColors = [PFColors.Blue200, PFColors.Blue300, PFColors.Blue400, PFColors.Blue100];
 const proxyContainerColor = PFColors.Gold300;
@@ -1128,6 +1129,8 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     // sort containers by name, consistently positioning proxy container first.
     let containers = [...(pod.istioContainers ?? [])];
     containers.push(...(pod.containers ?? []));
+    // k8s native sidecars are listed within istioInitContainers
+    containers.push(...(pod.istioInitContainers?.filter(cont => cont.name === istioProxyName) ?? []));
 
     containers = containers.sort((c1, c2) => {
       if (c1.isProxy !== c2.isProxy) {


### PR DESCRIPTION
### Describe the change

Added support of K8s Native Sidecars logs in Workload Logs tab.

### Steps to test the PR
Install Istio in native sidecars mode `./hack/istio/install-istio-via-istioctl.sh -c kubectl --native-sidecars true`
Install bookinfo.
Bookinfo's Workload details page Logs tab.
Make sure "sidecar-proxy" checkbox exists and works, loads the logs.


### Automation testing
n/a

### Issue reference
https://github.com/kiali/kiali/issues/7909
