### PR TITLE
Increase timeout of crd validation status cypress tests

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -30,7 +30,7 @@ Then('user sees inbound metrics information', () => {
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
 
   cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'inbound-metrics-component' } })
     // HOCs can match the component name. This filters the HOCs for just the bare component.
@@ -49,7 +49,7 @@ Then('user sees outbound metrics information', () => {
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
 
   cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'outbound-metrics-component' } })
     // HOCs can match the component name. This filters the HOCs for just the bare component.

--- a/frontend/cypress/integration/common/app_details_multicluster-pf.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster-pf.ts
@@ -23,7 +23,7 @@ Then(
 
     openTab(`${metrics} Metrics`);
     cy.wait('@fetchMetrics');
-    cy.waitForReact(1000, '#root');
+    cy.waitForReact();
 
     cy.getReact('IstioMetricsComponent', { props: { 'data-test': `${metrics.toLowerCase()}-metrics-component` } })
       // HOCs can match the component name. This filters the HOCs for just the bare component.

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -622,15 +622,12 @@ const hexToRgb = (hex: string): string => {
 };
 
 function waitUntilConfigIsVisible(
-  attempt: number,
+  retries: number,
   crdInstanceName: string,
   crdName: string,
   namespace: string,
   healthStatus: string
 ): void {
-  if (attempt === 0) {
-    throw new Error(`Condition not met after retries`);
-  }
   cy.request({ method: 'GET', url: `${Cypress.config('baseUrl')}/api/istio/config?refresh=0` });
   cy.get('[data-test="refresh-button"]').click();
   ensureKialiFinishedLoading();
@@ -664,8 +661,12 @@ function waitUntilConfigIsVisible(
     })
     .then(() => {
       if (!found) {
-        cy.wait(10000);
-        waitUntilConfigIsVisible(attempt - 1, crdInstanceName, crdName, namespace, healthStatus);
+        if (retries === 0) {
+          throw new Error(`Condition not met after retries`);
+        } else {
+          cy.wait(20000);
+          waitUntilConfigIsVisible(retries - 1, crdInstanceName, crdName, namespace, healthStatus);
+        }
       }
     });
 }

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -631,7 +631,6 @@ function waitUntilConfigIsVisible(
   if (attempt === 0) {
     throw new Error(`Condition not met after retries`);
   }
-
   cy.request({ method: 'GET', url: `${Cypress.config('baseUrl')}/api/istio/config?refresh=0` });
   cy.get('[data-test="refresh-button"]').click();
   ensureKialiFinishedLoading();
@@ -651,9 +650,14 @@ function waitUntilConfigIsVisible(
               const colorVar = `--pf-v5-global--${healthStatus}-color--100`;
               const statusColor = getComputedStyle(icon[0]).getPropertyValue(colorVar).replace('#', '');
 
-              cy.wrap(icon[0]).should('have.css', 'color', hexToRgb(statusColor));
-
-              found = true;
+              cy.wrap(icon[0])
+                .invoke('css', 'color')
+                .then(iconColor => {
+                  // Convert the status color to RGB format to compare it with the icon color
+                  if (iconColor?.toString() === hexToRgb(statusColor)) {
+                    found = true;
+                  }
+                });
             });
         }
       }

--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -631,6 +631,7 @@ function waitUntilConfigIsVisible(
   if (attempt === 0) {
     throw new Error(`Condition not met after retries`);
   }
+
   cy.request({ method: 'GET', url: `${Cypress.config('baseUrl')}/api/istio/config?refresh=0` });
   cy.get('[data-test="refresh-button"]').click();
   ensureKialiFinishedLoading();
@@ -650,14 +651,9 @@ function waitUntilConfigIsVisible(
               const colorVar = `--pf-v5-global--${healthStatus}-color--100`;
               const statusColor = getComputedStyle(icon[0]).getPropertyValue(colorVar).replace('#', '');
 
-              cy.wrap(icon[0])
-                .invoke('css', 'color')
-                .then(iconColor => {
-                  // Convert the status color to RGB format to compare it with the icon color
-                  if (iconColor.toString() === hexToRgb(statusColor)) {
-                    found = true;
-                  }
-                });
+              cy.wrap(icon[0]).should('have.css', 'color', hexToRgb(statusColor));
+
+              found = true;
             });
         }
       }

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -33,7 +33,7 @@ Then('user sees workload inbound metrics information', () => {
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
 
   cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'inbound-metrics-component' } })
     // HOCs can match the component name. This filters the HOCs for just the bare component.
@@ -52,7 +52,7 @@ Then('user sees workload outbound metrics information', () => {
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
 
   cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'outbound-metrics-component' } })
     // HOCs can match the component name. This filters the HOCs for just the bare component.
@@ -89,7 +89,7 @@ When(
     openTab('Envoy');
     openEnvoyTab(tab);
 
-    cy.waitForReact(1000, '#root');
+    cy.waitForReact();
 
     cy.get('button#filter_select_type-toggle').click();
     cy.contains('div#filter_select_type button', filter).click();
@@ -144,7 +144,7 @@ Then('the user sees the metrics tab', () => {
   openEnvoyTab('Metrics');
 
   cy.wait('@fetchEnvoyMetrics');
-  cy.waitForReact(1000, '#root');
+  cy.waitForReact();
 
   cy.contains('Loading metrics').should('not.exist');
 

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -336,6 +336,10 @@ Feature: Kiali Istio Config wizard
     When user is at the "istio" page
     And viewing the detail for "gatewayapi-2"
     And choosing to delete it
+    And user is at the "istio" page
+    And user selects the "bookinfo" namespace
+    And viewing the detail for "gatewayapi-1"
+    And user is at the "istio" page
     And user selects the "bookinfo" namespace
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace
     And the "gatewayapi-1" "K8sGateway" of the "bookinfo" namespace should have a "success"

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -186,10 +186,8 @@ Cypress.Commands.add('login', (username: string, password: string) => {
     {
       cacheAcrossSpecs: true,
       validate: () => {
-        if (auth_strategy === 'openshift' || auth_strategy === 'openid') {
-          // Make an API request that returns a 200 only when logged in
-          cy.request({ url: '/api/status' }).its('status').should('eq', 200);
-        }
+        // Make an API request that returns a 200 only when logged in
+        cy.request({ url: '/api/status' }).its('status').should('eq', 200);
       }
     }
   );

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -186,15 +186,9 @@ Cypress.Commands.add('login', (username: string, password: string) => {
     {
       cacheAcrossSpecs: true,
       validate: () => {
-        // For some reason validate is needed to preserve the kiali-token-aes cookie.
         if (auth_strategy === 'openshift' || auth_strategy === 'openid') {
-          cy.getCookies()
-            .should('exist')
-            .and('have.length.at.least', 1)
-            .then((cookies: any) => {
-              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-              expect(cookies.some(cookie => cookie.name.startsWith('kiali-token'))).to.be.true;
-            });
+          // Make an API request that returns a 200 only when logged in
+          cy.request({ url: '/api/status' }).its('status').should('eq', 200);
         }
       }
     }


### PR DESCRIPTION
### Describe the change

Increase timeout between retries for crd validation status cypress tests. The current timeout is not enough for the test https://github.com/kiali/kiali/blob/a5bb923eeac18aaad04e926959c5c17a3587ef2a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature#L303

Other changes in this PR that affect Cypress tests:
-  Session validation is modified to fix session lost issues we had in OpenShift CI tests.
- Default `cy.waitForReact()` used for all cases (the #root selector does not exist in OSSMC).

### Steps to test the PR

Verify that CI tests pass.
