### PR TITLE
[2.4] Fix maistra managed namespaces (#8141)

### DIFF
--- a/istio/kubernetes.go
+++ b/istio/kubernetes.go
@@ -80,6 +80,13 @@ func GetLatestPod(pods []*corev1.Pod) *corev1.Pod {
 // it is managed by the default revision.
 // If a namespace is out of the mesh, then the empty string is returned.
 func GetRevision(namespace models.Namespace) string {
+	const maistraMemberOfLabel = "maistra.io/member-of"
+	const maistraIgnoreNamespaceLabel = "maistra.io/ignore-namespace"
+	if _, hasMaistraIgnoreLabel := namespace.Labels[maistraIgnoreNamespaceLabel]; !hasMaistraIgnoreLabel {
+		if memberOf, hasMemberOfLabel := namespace.Labels[maistraMemberOfLabel]; hasMemberOfLabel {
+			return memberOf
+		}
+	}
 	rev, hasRevLabel := namespace.Labels[models.IstioRevisionLabel]
 	injectionEnabled := namespace.Labels[models.IstioInjectionLabel] == models.IstioInjectionEnabledLabelValue
 	// Injection label takes precedence over revision label.

--- a/models/mesh.go
+++ b/models/mesh.go
@@ -25,6 +25,14 @@ const (
 	IstioInjectionEnabledLabelValue = "enabled"
 )
 
+const (
+	maistraOwnerLabel     = "maistra.io/owner"
+	maistraOwnerNameLabel = "maistra.io/owner-name"
+	maistraVersionLabel   = "maistra-version"
+)
+
+var maistraLabels = []string{maistraOwnerLabel, maistraOwnerNameLabel, maistraVersionLabel}
+
 // Mesh is one or more controlplanes (primaries) managing a dataPlane across one or more clusters.
 // There can be multiple primaries on a single cluster when istio revisions are used. A single
 // primary can also manage multiple clusters (primary-remote deployment).
@@ -69,6 +77,10 @@ type ControlPlane struct {
 	// IstiodNamespace is the namespace name of the deployed control plane
 	IstiodNamespace string `json:"istiodNamespace"`
 
+	// Labels are the labels on the istiod deployment.
+	// omitted from the json serialization because they aren't used on the frontend.
+	Labels map[string]string `json:"-"`
+
 	// ManagedClusters are the clusters that this controlplane manages.
 	// This could include the cluster that the controlplane is running on.
 	ManagedClusters []*KubeCluster `json:"managedClusters"`
@@ -103,6 +115,17 @@ type ControlPlane struct {
 
 	// Version is the version of the controlplane.
 	Version *ExternalServiceInfo `json:"version,omitempty"`
+}
+
+// IsMaistra determines if the controlplane is Maistra or not.
+// TODO: Remove this when maistra 2.6 goes out of support.
+func (c ControlPlane) IsMaistra() bool {
+	for _, maistraLabel := range maistraLabels {
+		if _, hasLabel := c.Labels[maistraLabel]; hasLabel {
+			return true
+		}
+	}
+	return false
 }
 
 // ControlPlaneConfiguration is the configuration for the controlPlane and any associated dataPlane.


### PR DESCRIPTION
### Describe the change

Cherry-pick of #8141 to 2.4 branch

### Steps to test the PR

1. Install Maistra 2.6 operator AND the OSSM 3 operator
2. Deploy SMCP
    ```
    kubectl create ns istio-system
    kubectl apply -f - <<EOF
    apiVersion: maistra.io/v2
    kind: ServiceMeshControlPlane
    metadata:
      name: basic
      namespace: istio-system
    spec:
      mode: ClusterWide
      addons:
        grafana:
          enabled: false
        kiali:
          enabled: false
        prometheus:
          enabled: false
      gateways:
        enabled: false
        egress:
          enabled: false
        openshiftRoute:
          enabled: false
      security:
        manageNetworkPolicy: false
        dataPlane:
          mtls: true
        identity:
          type: ThirdParty
      tracing:
        type: None
    EOF
    ```
3. Create bookinfo ns
    ```
    kubectl create ns bookinfo
    ```
4. Add a namespace to SMMR
    ```
    kubectl label ns bookinfo istio-injection=enabled
    ```
5. Deploy bookinfo
    ```
    oc apply -f https://raw.githubusercontent.com/Maistra/istio/maistra-2.6/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
    ```
6. Navigate to mesh page and verify there's an edge from the managed namespace to the maistra istiod.

### Automation testing

Unit tests included

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
