### PR TITLE
Fine-tune of config validation cypress test

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -605,7 +605,7 @@ Then(
 
 Then('the AuthorizationPolicy should have a {string}', function (healthStatus: string) {
   waitUntilConfigIsVisible(
-    3,
+    5,
     this.targetAuthorizationPolicy,
     'AuthorizationPolicy',
     this.targetNamespace,
@@ -664,7 +664,7 @@ function waitUntilConfigIsVisible(
         if (retries === 0) {
           throw new Error(`Condition not met after retries`);
         } else {
-          cy.wait(20000);
+          cy.wait(10000);
           waitUntilConfigIsVisible(retries - 1, crdInstanceName, crdName, namespace, healthStatus);
         }
       }
@@ -674,7 +674,7 @@ function waitUntilConfigIsVisible(
 Then(
   'the {string} {string} of the {string} namespace should have a {string}',
   (crdInstanceName: string, crdName: string, namespace: string, healthStatus: string) => {
-    waitUntilConfigIsVisible(3, crdInstanceName, crdName, namespace, healthStatus);
+    waitUntilConfigIsVisible(5, crdInstanceName, crdName, namespace, healthStatus);
   }
 );
 

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -338,9 +338,6 @@ Feature: Kiali Istio Config wizard
     And choosing to delete it
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
-    And viewing the detail for "gatewayapi-1"
-    And user is at the "istio" page
-    And user selects the "bookinfo" namespace
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace
     And the "gatewayapi-1" "K8sGateway" of the "bookinfo" namespace should have a "success"
     When viewing the detail for "gatewayapi-1"


### PR DESCRIPTION
### Describe the change

Increase the retries and reduce the timeout of validation object in cypress test. Doing that we can reduce the time of the test execution in case istio config list page is reconciled earlier.

### Steps to test the PR

Verify that CI tests pass
