### PR TITLE
Add hack script to create different waypoint proxies scenarios for testing purposes

### DIFF
--- a/hack/istio/ambient/curl-pod.yaml
+++ b/hack/istio/ambient/curl-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl-client
+spec:
+  containers:
+  - name: curl-client
+    image: curlimages/curl
+    command: ["/bin/sh", "-c"]
+    args:
+    - while true; do echo "Calling echo-service..."; curl -s http://echo-service sleep 5; done;

--- a/hack/istio/ambient/echo-service.yaml
+++ b/hack/istio/ambient/echo-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo-server
+  labels:
+    app: echo-server
+spec:
+  containers:
+  - name: echo-server
+    image: ealen/echo-server
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-service
+spec:
+  selector:
+    app: echo-server
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/hack/istio/ambient/install-waypoints.sh
+++ b/hack/istio/ambient/install-waypoints.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+##############################################################################
+# install-waypoins.sh
+#
+# Installs 6 different namespaces with a pod calling a service and a waypoint proxy
+# with different tags in each one to validate different waypoint implementations
+#
+##############################################################################
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case $key in
+    -d|--delete)
+      DELETE="$2"
+      shift;shift
+      ;;
+    -h|--help)
+      cat <<HELPMSG
+Valid command line arguments:
+  -d|--delete: either 'true' or 'false'. If 'true' the waypont namespaces demo will be deleted, not installed.
+  -h|--help: this text
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Go to the main output directory and try to find an Istio there.
+HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+CLIENT_EXE="kubectl"
+OUTPUT_DIR="${OUTPUT_DIR:-${HACK_SCRIPT_DIR}/../../../_output}"
+
+# If we are to delete, remove everything and exit immediately after
+if [ "${DELETE}" == "true" ]; then
+  echo "Deleting Waypoint demos namespaces"
+  ${CLIENT_EXE} delete namespace waypoint-forservice
+  ${CLIENT_EXE} delete namespace waypoint-forworkload
+  ${CLIENT_EXE} delete namespace waypoint-forall
+  ${CLIENT_EXE} delete namespace waypoint-fornone
+  ${CLIENT_EXE} delete namespace waypoint-differentns
+  ${CLIENT_EXE} delete namespace waypoint-override
+  exit 0
+fi
+
+ALL_ISTIOS=$(ls -dt1 ${OUTPUT_DIR}/istio-*)
+if [ "$?" != "0" ]; then
+  ${HACK_SCRIPT_DIR}/../download-istio.sh
+  if [ "$?" != "0" ]; then
+    echo "ERROR: You do not have Istio installed and it cannot be downloaded"
+    exit 1
+  fi
+fi
+# use the Istio release that was last downloaded (that's the -t option to ls)
+ISTIO_DIR=$(ls -dt1 ${OUTPUT_DIR}/istio-* | head -n1)
+
+if [ ! -d "${ISTIO_DIR}" ]; then
+   echo "ERROR: Istio cannot be found at: ${ISTIO_DIR}"
+   exit 1
+fi
+
+echo "Istio is found here: ${ISTIO_DIR}"
+if [[ -x "${ISTIO_DIR}/bin/istioctl" ]]; then
+  echo "istioctl is found here: ${ISTIO_DIR}/bin/istioctl"
+  ISTIOCTL="${ISTIO_DIR}/bin/istioctl"
+  ${ISTIOCTL} version
+else
+  echo "ERROR: istioctl is NOT found at ${ISTIO_DIR}/bin/istioctl"
+  exit 1
+fi
+
+${CLIENT_EXE} create ns waypoint-forservice
+${CLIENT_EXE} create ns waypoint-forworkload
+${CLIENT_EXE} create ns waypoint-forall
+${CLIENT_EXE} create ns waypoint-fornone
+${CLIENT_EXE} create ns waypoint-differentns
+${CLIENT_EXE} create ns waypoint-override
+
+${CLIENT_EXE} label ns waypoint-forservice istio.io/dataplane-mode=ambient
+${CLIENT_EXE} label ns waypoint-forworkload istio.io/dataplane-mode=ambient
+${CLIENT_EXE} label ns waypoint-forall istio.io/dataplane-mode=ambient
+${CLIENT_EXE} label ns waypoint-fornone istio.io/dataplane-mode=ambient
+${CLIENT_EXE} label ns waypoint-differentns istio.io/dataplane-mode=ambient
+${CLIENT_EXE} label ns waypoint-override istio.io/dataplane-mode=ambient
+
+# Create a waypoint for service
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-forservice
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/curl-pod.yaml -n waypoint-forservice
+${ISTIOCTL} waypoint apply -n waypoint-forservice --enroll-namespace
+
+# Create a waypoint for workload and send requests to pod b
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-forworkload
+sleep 15
+# Update with echo-server IP
+POD_IP=$($CLIENT_EXE get pod echo-server -n waypoint-forworkload -o jsonpath="{.status.podIP}")
+echo "Creating client in ns waypoint-forworkload with podIP $POD_IP"
+cat <<NAD | $CLIENT_EXE -n waypoint-forworkload apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl-client
+spec:
+  containers:
+    - name: curl-client
+      image: curlimages/curl
+      command: ["/bin/sh", "-c"]
+      args:
+        - while true; do
+          echo "Calling echo-service...";
+          curl -s http://$POD_IP
+          sleep 5;
+          done;
+NAD
+${ISTIOCTL} waypoint apply -n waypoint-forworkload --name bwaypoint --for workload
+${CLIENT_EXE} label pod -l app=echo-server istio.io/use-waypoint=bwaypoint -n waypoint-forworkload
+
+# Create a waypoint for all
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-forall
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/curl-pod.yaml -n waypoint-forall
+${ISTIOCTL} waypoint apply -n waypoint-forall --name cgw --for all
+${CLIENT_EXE} label namespace waypoint-forall istio.io/use-waypoint=cgw
+
+# Create a waypoint for none (No L7 traffic should be seen)
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-fornone
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/curl-pod.yaml -n waypoint-fornone
+${ISTIOCTL} waypoint apply -n waypoint-fornone --name waypoint --for none
+${CLIENT_EXE} label namespace waypoint-fornone istio.io/use-waypoint=waypoint
+
+# Use a waypoint from another ns
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-differentns
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/curl-pod.yaml -n waypoint-differentns
+${CLIENT_EXE} label namespace waypoint-differentns istio.io/use-waypoint=waypoint
+${CLIENT_EXE} label namespace waypoint-differentns istio.io/use-waypoint-namespace=waypoint-forservice
+
+# Override ns waypoint labeling a service
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/echo-service.yaml -n waypoint-override
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/curl-pod.yaml -n waypoint-override
+${ISTIOCTL} waypoint apply -n waypoint-override --enroll-namespace
+${ISTIOCTL} waypoint apply -n waypoint-override --name use-this
+${CLIENT_EXE} label svc echo-service -n waypoint-override istio.io/use-waypoint=use-this

--- a/hack/istio/ambient/install-waypoints.sh
+++ b/hack/istio/ambient/install-waypoints.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##############################################################################
-# install-waypoins.sh
+# install-waypoints.sh
 #
 # Installs 6 different namespaces with a pod calling a service and a waypoint proxy
 # with different tags in each one to validate different waypoint implementations

--- a/hack/istio/ambient/install-waypoints.sh
+++ b/hack/istio/ambient/install-waypoints.sh
@@ -17,7 +17,7 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
-  -d|--delete: either 'true' or 'false'. If 'true' the waypont namespaces demo will be deleted, not installed.
+  -d|--delete: either 'true' or 'false'. If 'true' the waypoint namespaces demo will be deleted, not installed.
   -h|--help: this text
 HELPMSG
       exit 1


### PR DESCRIPTION
### Describe the change

Add hack script to create different waypoint proxies scenarios for testing purposes.
This PR creates 6 namespaces: 

- waypoint-forservice
- waypoint-forworkload
- waypoint-forall
- waypoint-fornone
- waypoint-fordifferentns
- waypoint-foroverride

![image](https://github.com/user-attachments/assets/f423bd10-b532-43ca-af36-ad969e58d3d7)

The graph seems correct except for: 
- waypoint-fordifferentns It doesn't look to be redirecting the traffic correctly 
- waypoint-forworkload: Points to a service but it is sending the traffic directly to the workload

Ref. https://istio.io/latest/docs/ambient/usage/waypoint/

### Steps to test the PR

Run `hack/istio/ambient/install-waypoints.sh` and the waypoints will be created in the Ambient Mesh, in different namespaces.

### Automation testing

N/A, this hack could be used in the future for testing CI

### Issue reference
Fixes #7499 
