### PR TITLE
Mesh page side-panel improvements/fixes

### DIFF
--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -65,9 +65,9 @@ export const shouldRefreshData = (prevProps: TargetPanelCommonProps, nextProps: 
   return (
     // Verify the time of the last request
     prevProps.updateTime !== nextProps.updateTime ||
-    // Check if going from no data to data
+    // Check if going from no target to target
     (!prevProps.target && nextProps.target) ||
-    // Check if the target changed
+    // Check if the target elem changed
     prevProps.target.elem !== nextProps.target.elem
   );
 };

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
@@ -116,8 +116,8 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
   }
 
   render(): React.ReactNode {
-    if (this.state.loading || !this.state.nsInfo) {
-      return this.getLoading();
+    if (!this.state.nsInfo) {
+      return this.state.loading ? this.getLoading() : <></>;
     }
 
     const nsInfo = this.state.nsInfo;

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
@@ -104,7 +104,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
 
   componentDidUpdate(prevProps: TargetPanelDataPlaneNamespaceProps): void {
     const shouldLoad =
-      prevProps.updateTime !== this.props.updateTime || (!prevProps.isExpanded && this.props.isExpanded);
+      this.props.isExpanded && (!prevProps.isExpanded || prevProps.updateTime !== this.props.updateTime);
 
     if (shouldLoad) {
       this.load();
@@ -344,7 +344,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
       .then(result => {
         const nsInfo = result.data;
         if (!nsInfo) {
-          AlertUtils.add(`Failed to find |${namespace}:${cluster}| in GetNamespace() result`);
+          AlertUtils.add(`Failed to find |${cluster}:${namespace}| in GetNamespaceInfo() result`);
           this.setState({ ...defaultState, loading: false });
           return;
         }
@@ -375,7 +375,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
         }
 
         this.setState({ ...defaultState, loading: false });
-        this.handleApiError('Could not fetch namespaces when loading target panel', err);
+        console.debug('Ignore missing namespace when loading target panel, likely deleted.', err);
       });
 
     this.setState({ loading: true });

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -147,8 +147,8 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   }
 
   render(): React.ReactNode {
-    if (this.state.loading || !this.state.nsInfo) {
-      return this.getLoading();
+    if (!this.state.nsInfo) {
+      return this.state.loading ? this.getLoading() : <></>;
     }
 
     const targetNode = this.props.target.elem;

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -102,18 +102,9 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
     const data = targetNode.getData()!;
 
-    // Find the controlplanes nodes and pull out the controlplane
-    // object from infraData. The controlplane object has all the
-    // managed namespaces that is needed by elements on this page.
-    const controlPlanes: ControlPlane[] | undefined = props.target.elem
-      ?.getGraph()
-      .getData()
-      .meshData.elements.nodes?.filter(node => node.data.infraType === MeshInfraType.ISTIOD)
-      .map(node => node.data.infraData);
-
     this.state = {
       ...defaultState,
-      controlPlanes: controlPlanes,
+      controlPlanes: this.getControlPlanes(),
       targetCluster: data.cluster,
       targetNamespace: data.namespace,
       targetNode: targetNode
@@ -287,6 +278,18 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     );
   };
 
+  // Find the controlplanes nodes and pull out the controlplane
+  // object from infraData. The controlplane object has all the
+  // managed namespaces that is needed by elements on this page.
+  private getControlPlanes = (): ControlPlane[] | undefined => {
+    const controlPlanes: ControlPlane[] | undefined = this.props.target.elem
+      ?.getGraph()
+      .getData()
+      .meshData.elements.nodes?.filter(node => node.data.infraType === MeshInfraType.ISTIOD)
+      .map(node => node.data.infraData);
+    return controlPlanes;
+  };
+
   private getNamespaceActions = (): OverviewNamespaceAction[] => {
     // Today actions are fixed, but soon actions may depend of the state of a namespace
     // So we keep this wrapped in a showActions function.
@@ -442,7 +445,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     this.promises
       .registerAll(`promises`, [this.fetchNamespaceInfo(), this.fetchHealthStatus(), this.fetchMetrics()])
       .then(() => {
-        this.setState({ loading: false });
+        this.setState({ controlPlanes: this.getControlPlanes(), loading: false });
       })
       .catch(err => {
         if (err.isCanceled) {


### PR DESCRIPTION
Fixes #8159

Mesh page side-panel improvements/fixes:
- remove error message when dataplane namespace disappears on refresh
  - this was a timing thing, but happened most of the time. No reason to generate an error, now just logs a console debug message
- improve dataplane namespace by fetching data only for expanded rows,this can prevent a lot of fetches when there are a lot of namespaces.
- ensure namespace control planes stay in sync with the mesh topology

Steps to test the PR:
part one
1. As in the #8159, nav to the mesh page and select a dataplane.
2. using kubectl, add a namespace to the dataplane, then start refreshing the mesh page
Ensure that when the mesh page dataplane node label increments that the new namespace also appears in the side panel.
4. delete the namespace and again start refreshing the mesh page
Ensure that when the mesh page dataplane node label decrements that the new namespace is removed from the side panel, with any on-screen errors.

part two
1. On the mesh page select a namespace with control planes
2. as above, add a managed namespace and start refreshing
Ensure that when the mesh page dataplane node label increments that the side panel donut also reflects the change
3. as above, delete the managed namespace and start refreshing
Ensure that when the mesh page dataplane node label decrements that the side panel donut also reflects the change
