### PR TITLE
Change port name in the istio-ingressgateway route

### DIFF
--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -583,7 +583,7 @@ else
   # Do some OpenShift specific things
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     if [ "${ISTIO_INGRESSGATEWAY_ENABLED}" == "true" ]; then
-      ${CLIENT_EXE} -n ${NAMESPACE} expose svc/istio-ingressgateway --port=http2
+      ${CLIENT_EXE} -n ${NAMESPACE} expose svc/istio-ingressgateway --port=http
     else
       echo "Ingressgateway is disabled - the OpenShift Route will not be created"
     fi


### PR DESCRIPTION
### Describe the change

This PR changes the port name in the `istio-ingressgateway` route exposed by the `install-istio` hack script. This port name was recently changed and it was not propagated to this route.

### Steps to test the PR

1. Install OpenShift CRC: ./hack/crc-openshift.sh start
2. Install istio: ./hack/istio/install-istio-via-istioctl.sh
3. Install bookinfo demo with traffic generator: ./hack/istio/install-bookinfo-demo.sh -tg
4. Check that istio-ingressgateway route is working correctly: http://istio-ingressgateway-istio-system.apps-crc.testing/productpage
An optional way to check is installing Kiali and see that there is traffic graph for the bookinfo demo

### Automation testing

N/A

### Issue reference

Fixes #8163 
