### PR TITLE
Use service name, not app

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2718,7 +2718,7 @@ func (in *WorkloadService) streamParsedLogs(cluster, namespace string, names []s
 
 // StreamPodLogs streams pod logs to an HTTP Response given the provided options
 // The workload name is used to get the waypoint workloads when opts.LogType is "waypoint"
-func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace, workload, app, name string, opts *LogOptions, w http.ResponseWriter) error {
+func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace, workload, service, name string, opts *LogOptions, w http.ResponseWriter) error {
 	names := []string{}
 	if opts.LogType == models.LogTypeZtunnel {
 		// First, get ztunnel namespace and containers
@@ -2729,7 +2729,7 @@ func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace
 		nsDstPattern := fmt.Sprintf(`dst\.namespace=("?%s"?)`, namespace)
 		wkSrcPattern := fmt.Sprintf(`src\.workload=("?%s"?)`, name)
 		nsSrcPattern := fmt.Sprintf(`src\.namespace=("?%s"?)`, namespace)
-		svcPattern := fmt.Sprintf(`dst\.service=("?%s.%s.?)`, app, namespace)
+		svcPattern := fmt.Sprintf(`dst\.service=("?%s.%s.?)`, service, namespace)
 
 		// The ztunnel line should include the pod and the namespace
 		fs := filterOpts{
@@ -2754,7 +2754,7 @@ func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace
 			if len(wk.WaypointWorkloads) > 0 {
 				// Waypoint filter by the app name
 				fs := filterOpts{
-					app: *regexp.MustCompile(app),
+					app: *regexp.MustCompile(service),
 				}
 				opts.filter = fs
 				waypoint := wk.WaypointWorkloads[0]

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2643,7 +2643,7 @@ func (in *WorkloadService) streamParsedLogs(cluster, namespace string, names []s
 				continue
 			}
 
-			if opts.LogType == models.LogTypeWaypoint && !opts.filter.app.MatchString(entry.Message) {
+			if opts.LogType == models.LogTypeWaypoint && (opts.filter.app.MatchString("") || !opts.filter.app.MatchString(entry.Message)) {
 				continue
 			}
 
@@ -2757,7 +2757,6 @@ func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace
 					app: *regexp.MustCompile(app),
 				}
 				opts.filter = fs
-				// TODO: Get efective one
 				waypoint := wk.WaypointWorkloads[0]
 				waypointWk, errWaypoint := in.GetWorkload(ctx, WorkloadCriteria{Cluster: waypoint.Cluster, Namespace: waypoint.Namespace, WorkloadName: waypoint.Name, IncludeServices: false})
 				if errWaypoint != nil {

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -55,13 +55,13 @@ type ReduxProps = {
 };
 
 type TracesProps = ReduxProps & {
-  app?: string;
   cluster?: string;
   fromWaypoint: boolean;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   target: string;
   targetKind: TargetKind;
+  waypointServiceFilter?: string;
 };
 
 interface TracesState {
@@ -366,7 +366,6 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                 </Tab>
                 <Tab eventKey={spansDetailsTab} title="Span Details">
                   <SpanDetails
-                    app={this.props.app}
                     namespace={this.props.namespace}
                     target={this.props.target}
                     externalURLProvider={this.urlProvider}
@@ -374,6 +373,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                     traceID={this.props.selectedTrace.traceID}
                     cluster={this.props.cluster ? this.props.cluster : ''}
                     fromWaypoint={this.props.fromWaypoint}
+                    waypointServiceFilter={this.props.waypointServiceFilter}
                   />
                 </Tab>
               </Tabs>

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
@@ -11,7 +11,6 @@ import { ActiveFiltersInfo } from 'types/Filters';
 import { TraceLabels } from './TraceLabels';
 
 interface SpanDetailsProps {
-  app?: string; // This is used to match the span (operationName) as this is different than the workload
   cluster?: string;
   externalURLProvider?: TracingUrlProvider;
   fromWaypoint: boolean;
@@ -19,6 +18,7 @@ interface SpanDetailsProps {
   namespace: string;
   target: string;
   traceID: string;
+  waypointServiceFilter?: string; // This is used to match the span (operationName) as this is different than the workload
 }
 
 export const SpanDetails: React.FC<SpanDetailsProps> = (props: SpanDetailsProps) => {
@@ -44,7 +44,7 @@ export const SpanDetails: React.FC<SpanDetailsProps> = (props: SpanDetailsProps)
             namespace={props.namespace}
             externalURLProvider={props.externalURLProvider}
             cluster={props.cluster}
-            target={props.app ? props.app : props.target}
+            target={props.waypointServiceFilter ? props.waypointServiceFilter : props.target}
             traceID={props.traceID}
             fromWaypoint={props.fromWaypoint}
           />

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -37,6 +37,7 @@ type WorkloadDetailsState = {
   currentTab: string;
   error?: ErrorMsg;
   health?: WorkloadHealth;
+  waypointServiceFilter?: string;
   workload?: Workload;
 };
 
@@ -123,6 +124,10 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
 
     return API.getWorkload(this.props.workloadId.namespace, this.props.workloadId.workload, params, cluster)
       .then(details => {
+        if (details.data.services && details.data.services.length > 0) {
+          this.setState({ waypointServiceFilter: details.data.services[0].name });
+        }
+
         this.setState({
           workload: details.data,
           health: WorkloadHealth.fromJson(
@@ -185,13 +190,13 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
           <Tab title="Logs" eventKey={2} key="Logs" data-test="workload-details-logs-tab">
             {hasPods ? (
               <WorkloadPodLogs
-                app={this.state.workload?.labels['app']}
                 lastRefreshAt={this.props.lastRefreshAt}
                 namespace={this.props.workloadId.namespace}
                 workload={this.props.workloadId.workload}
                 pods={this.state.workload!.pods}
                 cluster={this.state.cluster}
                 waypoints={this.state.workload!.waypointWorkloads}
+                waypointServiceFilter={this.state.waypointServiceFilter}
               />
             ) : (
               <EmptyState variant={EmptyStateVariant.full}>
@@ -245,13 +250,13 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
         tabsArray.push(
           <Tab eventKey={5} title="Traces" key="Traces">
             <TracesComponent
-              app={this.state.workload?.labels['app']}
               lastRefreshAt={this.props.lastRefreshAt}
               namespace={this.props.workloadId.namespace}
               cluster={this.state.cluster}
               target={this.props.workloadId.workload}
               targetKind="workload"
               fromWaypoint={fromWaypoint}
+              waypointServiceFilter={this.state.waypointServiceFilter}
             />
           </Tab>
         );

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -73,11 +73,11 @@ type ReduxProps = {
 };
 
 export type WorkloadPodLogsProps = ReduxProps & {
-  app?: string;
   cluster?: string;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   pods: Pod[];
+  waypointServiceFilter?: string;
   waypoints?: WaypointInfo[];
   workload: string;
 };
@@ -595,7 +595,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
                     >
                       <KialiIcon.Info key={`al-i-ki`} className={checkInfoIcon} color={proxyContainerColor} />
                     </Tooltip>
-                    {this.props.waypoints && (
+                    {this.props.waypoints && this.props.waypoints.length > 0 && (
                       <>
                         <Checkbox
                           id={`waypoint-${c.displayName}`}
@@ -1219,7 +1219,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
         namespace,
         podName,
         this.props.workload,
-        this.props.app,
+        this.props.waypointServiceFilter,
         c.name,
         maxLines,
         sinceTime,
@@ -1237,7 +1237,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             namespace,
             podName,
             this.props.workload,
-            this.props.app,
+            this.props.waypointServiceFilter,
             c.name,
             maxLines,
             sinceTime,

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1069,7 +1069,7 @@ export const getPodLogs = (
   namespace: string,
   name: string,
   workload: string,
-  app?: string,
+  service?: string,
   container?: string,
   maxLines?: number,
   sinceTime?: number,
@@ -1107,8 +1107,8 @@ export const getPodLogs = (
     params.workload = workload;
   }
 
-  if (app) {
-    params.app = app;
+  if (service) {
+    params.service = service;
   }
 
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -278,11 +278,11 @@ export enum LogType {
 }
 
 export interface PodLogsQuery {
-  app?: string;
   container?: string;
   duration?: string;
   logType?: LogType;
   maxLines?: number;
+  service?: string;
   sinceTime?: number;
   workload?: string;
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -314,7 +314,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch pod logs
-	err = business.Workload.StreamPodLogs(r.Context(), cluster, namespace, queryParams.Get("workload"), queryParams.Get("app"), pod, opts, w)
+	err = business.Workload.StreamPodLogs(r.Context(), cluster, namespace, queryParams.Get("workload"), queryParams.Get("service"), pod, opts, w)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return


### PR DESCRIPTION
### Describe the change

- Use service instead of app to filter waypoint logs and traces
- If service filter is empty, don't return the log line
- Don't show the waypoint check if the workload is not enrolled

### Steps to test the PR

- Install Istio Ambient
- Install bookinfo and add it to the mesh 
- Check that there are logs and traces for the workloads

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8180
