### PR TITLE
Service details validations

### DIFF
--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -48,7 +48,7 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, len(validations) == 0
 	}
 	// Ignoring waypoint Services as auto-generated
-	if config.IsWaypoint(p.Service.Labels) {
+	if config.IsWaypoint(p.Service.Labels) || config.IsGateway(p.Service.Labels, map[string]string{}) {
 		log.Tracef("Skipping Port matching check for waypoint Service %s from Namespace %s", p.Service.Name, p.Service.Namespace)
 		return validations, len(validations) == 0
 	}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -103,7 +103,7 @@ func (in *IstioValidationsService) GetValidationsForService(ctx context.Context,
 		return nil, fmt.Errorf("Service [namespace: %s] [name: %s] doesn't exist for Validations.", namespace, service)
 	}
 
-	return models.IstioValidations(validationsForCluster(in.kialiCache.Validations().Items(), cluster)).FilterBySingleType(schema.GroupVersionKind{Group: "", Version: "", Kind: "service"}, service), nil
+	return validationsForCluster(in.kialiCache.Validations().Items(), cluster).FilterBySingleType(schema.GroupVersionKind{Group: "", Version: "", Kind: "service"}, service), nil
 }
 
 func (in *IstioValidationsService) GetValidationsForWorkload(ctx context.Context, cluster, namespace, workload string) (models.IstioValidations, error) {
@@ -116,7 +116,7 @@ func (in *IstioValidationsService) GetValidationsForWorkload(ctx context.Context
 		return nil, err
 	}
 
-	return models.IstioValidations(validationsForCluster(in.kialiCache.Validations().Items(), cluster)).FilterBySingleType(schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"}, workload), nil
+	return validationsForCluster(in.kialiCache.Validations().Items(), cluster).FilterBySingleType(schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"}, workload), nil
 }
 
 // CreateValidations returns an IstioValidations object with all the checks found when running

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -15,9 +15,11 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
@@ -400,4 +402,89 @@ func TestGetWaypointServices(t *testing.T) {
 	assert.Equal("bookinfo", waypointsList[0].Namespace)
 	assert.Equal(conf.KubernetesConfig.ClusterName, waypointsList[0].Cluster)
 	assert.Len(waypointsList, 1)
+}
+
+func TestGetServiceDetailsValidations(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
+	clients := map[string]kubernetes.ClientInterface{
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
+			kubetest.FakeNamespace("bookinfo"),
+			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
+				Spec: core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9080, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}}},
+			FakeDeploymentWithPort("ratings", 9080),
+		),
+	}
+	clientFactory.SetClients(clients)
+	cache := cache.NewTestingCacheWithFactory(t, clientFactory, *conf)
+	kialiCache = cache
+
+	prom, err := prometheus.NewClient()
+	require.NoError(err)
+
+	promMock := new(prometheustest.PromAPIMock)
+	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
+	prom.Inject(promMock)
+	discovery := istio.NewDiscovery(clients, cache, conf)
+	svc := NewWithBackends(clients, clients, prom, nil).Svc
+	svc.businessLayer.TLS.discovery = discovery
+
+	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
+	require.NoError(err)
+
+	validationKey := models.IstioValidationKey{Cluster: conf.KubernetesConfig.ClusterName,
+		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"}}
+	assert.NotNil(s.Validations[validationKey])
+	assert.NotNil(s.Validations[validationKey].Checks)
+	assert.Equal(len(s.Validations[validationKey].Checks), 0)
+}
+
+func TestGetServiceDetailsValidationErrors(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
+	clients := map[string]kubernetes.ClientInterface{
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
+			kubetest.FakeNamespace("bookinfo"),
+			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
+				Spec: core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}}},
+			FakeDeploymentWithPort("ratings", 9080),
+		),
+	}
+	clientFactory.SetClients(clients)
+	cache := cache.NewTestingCacheWithFactory(t, clientFactory, *conf)
+	kialiCache = cache
+
+	prom, err := prometheus.NewClient()
+	require.NoError(err)
+
+	promMock := new(prometheustest.PromAPIMock)
+	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
+	prom.Inject(promMock)
+	discovery := istio.NewDiscovery(clients, cache, conf)
+	svc := NewWithBackends(clients, clients, prom, nil).Svc
+	svc.businessLayer.TLS.discovery = discovery
+
+	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
+	require.NoError(err)
+
+	validationKey := models.IstioValidationKey{Cluster: conf.KubernetesConfig.ClusterName,
+		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"}}
+	assert.NotNil(s.Validations[validationKey])
+	assert.Equal(1, len(s.Validations[validationKey].Checks))
+	assert.Equal("KIA0701", s.Validations[validationKey].Checks[0].Code)
+	assert.Equal("Deployment exposing same port as Service not found", s.Validations[validationKey].Checks[0].Message)
+	assert.Equal(models.SeverityLevel("warning"), s.Validations[validationKey].Checks[0].Severity)
+	assert.Equal("spec/ports[0]", s.Validations[validationKey].Checks[0].Path)
 }

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -265,7 +265,7 @@ func TestMultiClusterGetServiceDetails(t *testing.T) {
 	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
 	prom.Inject(promMock)
 	svc := NewWithBackends(clients, clients, prom, nil).Svc
-	s, err := svc.GetServiceDetails(context.TODO(), "west", "bookinfo", "ratings-west-cluster", "60s", time.Now())
+	s, err := svc.GetServiceDetails(context.TODO(), "west", "bookinfo", "ratings-west-cluster", "60s", time.Now(), true)
 	require.NoError(err)
 
 	assert.Equal(s.Service.Name, "ratings-west-cluster")

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -952,6 +952,48 @@ func FakeZtunnelPods(conf *config.Config) []core_v1.Pod {
 	}
 }
 
+func FakeDeploymentWithPort(deployment string, port int32) *apps_v1.Deployment {
+	controller := true
+	return &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              fmt.Sprintf("%s-v1-3618568057-dnkjp", deployment),
+			Namespace:         "bookinfo",
+			CreationTimestamp: meta_v1.NewTime(time.Now()),
+			Labels:            map[string]string{"app": deployment},
+			OwnerReferences: []meta_v1.OwnerReference{{
+				Controller: &controller,
+				APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
+				Kind:       kubernetes.ReplicaSets.Kind,
+				Name:       fmt.Sprintf("%s-v1-3618568057-dnkjp", deployment),
+			}},
+			Annotations: kubetest.FakeIstioAnnotations(),
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{
+				MatchLabels: map[string]string{"app": deployment},
+			},
+			Template: core_v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Labels: map[string]string{"app": deployment},
+				},
+				Spec: core_v1.PodSpec{
+					Containers: []core_v1.Container{
+						{
+							Name:  deployment,
+							Image: "docker.io/istio/examples-bookinfo-ratings-v1:1.20.1",
+							Ports: []core_v1.ContainerPort{
+								{
+									ContainerPort: port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func FakeWaypointPod() []core_v1.Pod {
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 	return []core_v1.Pod{

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -163,10 +163,10 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
-	serviceDetails, err := business.Svc.GetServiceDetails(r.Context(), cluster, namespace, service, rateInterval, queryTime)
+	serviceDetails, err := business.Svc.GetServiceDetails(r.Context(), cluster, namespace, service, rateInterval, queryTime, includeValidations)
 	if includeValidations && err == nil {
 		wg.Wait()
-		serviceDetails.Validations = istioConfigValidations
+		serviceDetails.Validations = istioConfigValidations.MergeValidations(serviceDetails.Validations)
 		err = errValidations
 	}
 


### PR DESCRIPTION
### Describe the change

- Include service validations for service details 
- Exclude service validations for gateways (The validation should be done by the Istio config?)
- Move isGateway to config to be used by services/workloads

### Steps to test the PR

- Install Istio Ambient
- Install Kiali
- Install bookinfo with: 
`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true `
- Modify ratings service to create a validation error: 
```
cat <<NAD | kubectl -n bookinfo apply -f -
apiVersion: v1
kind: Service
metadata:
  name: ratings
  labels:
    app: ratings
    service: ratings
spec:
  ports:
  - port: 9081
    name: http
  selector:
    app: ratings
NAD
```

What should we expect? 

- In service list, bookinfo gateway shouldn't have a warning
- In service list, ratings should have a warning
![image](https://github.com/user-attachments/assets/8f91b6ed-84e7-49ab-8436-f3c49c34255a)

- In ratings services details should be a warning
![image](https://github.com/user-attachments/assets/933fd75a-c031-4651-940e-b8ca2bb5ebf2)

- In bookinfo gateway 
![image](https://github.com/user-attachments/assets/6ededc54-3bb1-4a42-a651-3ed43566b955)
service details should not be a warning


### Automation testing

Included unit tests

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8139 
