### PR TITLE
[hack] don't specify openshift profile, there is no need anymore

### DIFF
--- a/hack/istio/sail/func-sm.sh
+++ b/hack/istio/sail/func-sm.sh
@@ -170,7 +170,7 @@ EOMCNI
   if [ "${istio_yaml_file}" == "" ]; then
     local istio_profile="demo"
     if [ "${IS_OPENSHIFT}" == "true" ]; then
-      istio_profile="openshift"
+      istio_profile="demo" # no need to specify openshift here - the operator will detect we are openshift and apply the openshift platform profile for us in addition to the demo profile values
     fi
 
     # find out where Tempo is


### PR DESCRIPTION
more sail hack script updates. After learning more about profiles, I found out the istio operator will automatically apply the openshift platform profile values for us. Here we now just always set to the demo profile which reduces the pod limits for the istio resources allowing us to more easily run on local laptops