### PR TITLE
Fixed Service health calculation in ambient, added test

### DIFF
--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -163,3 +163,12 @@ Feature: Kiali Services page
     Then the list is sorted by column "Cluster" in "ascending" order
     When user sorts the list by column "Cluster" in "descending" order
     Then the list is sorted by column "Cluster" in "descending" order
+
+  @ambient
+  Scenario: Filter services table by health
+    And user is at the "services" page
+    When user selects the "bookinfo" namespace
+    And user selects filter "Health"
+    And user filters for health "Healthy"
+    Then user sees "something" in the table
+    And user should only see healthy services in the table

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -706,6 +706,7 @@ export const getClustersAppHealth = async (
             if (namespaceAppHealth[ns][k]) {
               const ah = AppHealth.fromJson(namespaces, k, namespaceAppHealth[ns][k], {
                 rateInterval: duration,
+                // @TODO replace hardcoded values
                 hasSidecar: true,
                 hasAmbient: false
               });
@@ -757,6 +758,7 @@ export const getClustersServiceHealth = async (
             if (namespaceServiceHealth[ns][k]) {
               const sh = ServiceHealth.fromJson(namespaces, k, namespaceServiceHealth[ns][k], {
                 rateInterval: duration,
+                // @TODO replace hardcoded values
                 hasSidecar: true,
                 hasAmbient: false
               });
@@ -806,6 +808,7 @@ export const getClustersWorkloadHealth = async (
             if (namespaceWorkloadHealth[ns][k]) {
               const wh = WorkloadHealth.fromJson(namespaces, k, namespaceWorkloadHealth[ns][k], {
                 rateInterval: duration,
+                // @TODO replace hardcoded values
                 hasSidecar: true,
                 hasAmbient: false
               });

--- a/frontend/src/types/Health.ts
+++ b/frontend/src/types/Health.ts
@@ -381,6 +381,7 @@ export class ServiceHealth extends Health {
     const items: HealthItem[] = [];
     let statusConfig: HealthItemConfig | undefined = undefined;
 
+    // hasAmbient and hasSidecars can be false, but still health requests have info
     if (isRequestHealthNotEmpty(requests)) {
       // Request errors
       const reqError = calculateErrorRate(ns, srv, 'service', requests);
@@ -468,6 +469,7 @@ export class AppHealth extends Health {
     }
 
     // Request errors
+    // hasAmbient and hasSidecars can be false, but still health requests have info
     if (isRequestHealthNotEmpty(requests)) {
       const reqError = calculateErrorRate(ns, app, 'app', requests);
       const reqIn = reqError.errorRatio.inbound.status;
@@ -576,6 +578,7 @@ export class WorkloadHealth extends Health {
     }
 
     // Request errors
+    // hasAmbient and hasSidecars can be false, but still health requests have info
     if (isRequestHealthNotEmpty(requests)) {
       const reqError = calculateErrorRate(ns, workload, 'workload', requests);
       const reqIn = reqError.errorRatio.inbound.status;

--- a/frontend/src/types/Health.ts
+++ b/frontend/src/types/Health.ts
@@ -310,6 +310,15 @@ export const getRequestErrorsSubItem = (thresholdStatus: ThresholdStatus, prefix
   };
 };
 
+export const isRequestHealthNotEmpty = (requests: RequestHealth): boolean => {
+  return (
+    requests &&
+    (Object.keys(requests.inbound).length > 0 ||
+      Object.keys(requests.outbound).length > 0 ||
+      Object.keys(requests.healthAnnotations).length > 0)
+  );
+};
+
 export abstract class Health {
   constructor(public health: HealthConfig) {}
 
@@ -372,7 +381,7 @@ export class ServiceHealth extends Health {
     const items: HealthItem[] = [];
     let statusConfig: HealthItemConfig | undefined = undefined;
 
-    if (ctx.hasSidecar) {
+    if (isRequestHealthNotEmpty(requests)) {
       // Request errors
       const reqError = calculateErrorRate(ns, srv, 'service', requests);
       const reqErrorsText =
@@ -406,7 +415,7 @@ export class ServiceHealth extends Health {
         type: HealthItemType.TRAFFIC_STATUS,
         title: t('Traffic Status'),
         status: NA,
-        text: 'No Istio sidecar'
+        text: NA.name
       });
     }
     return { items, statusConfig };
@@ -459,7 +468,7 @@ export class AppHealth extends Health {
     }
 
     // Request errors
-    if (ctx.hasSidecar) {
+    if (isRequestHealthNotEmpty(requests)) {
       const reqError = calculateErrorRate(ns, app, 'app', requests);
       const reqIn = reqError.errorRatio.inbound.status;
       const reqOut = reqError.errorRatio.outbound.status;
@@ -567,7 +576,7 @@ export class WorkloadHealth extends Health {
     }
 
     // Request errors
-    if (ctx.hasSidecar) {
+    if (isRequestHealthNotEmpty(requests)) {
       const reqError = calculateErrorRate(ns, workload, 'workload', requests);
       const reqIn = reqError.errorRatio.inbound.status;
       const reqOut = reqError.errorRatio.outbound.status;


### PR DESCRIPTION
### Describe the change

Health calculations for Workload, Application and Services in particular was relayed in `hasSidecar` in response, which was not working in Ambient meshes.
But in fact even `hasAmbient` does not cover the cases of 'K8sGateways' which does not have Sidecars in Ambient mode and is not Ambient itself.
So now the health calculation relies on whether there is health information in `requests` field of health response json.

### Steps to test the PR

-   Install Istio Ambient
-   Install Kiali
-   Install bookinfo with:
    `istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true `

-   Modify ratings service to create a validation error:
```
cat <<NAD | kubectl -n bookinfo apply -f -
apiVersion: v1
kind: Service
metadata:
  name: ratings
  labels:
    app: ratings
    service: ratings
spec:
  ports:
  - port: 9081
    name: http
  selector:
    app: ratings
NAD
```

Go to Service List page.
Health information is there.
![Screenshot from 2025-02-25 12-29-19](https://github.com/user-attachments/assets/9f9b4154-00ea-4217-930b-a85a8cc0e6e9)
Go to Service Details, also the Health is shown.
![Screenshot from 2025-02-25 12-29-27](https://github.com/user-attachments/assets/398634a4-88f2-482b-baba-0eab8ca32355)
Overview page select Services. The healthy services number is correct, click on it, the Service List loads with filter added and correct healthy items.
![Screenshot from 2025-02-25 12-29-35](https://github.com/user-attachments/assets/83f0c99b-34f3-44e2-b02a-85ade90a5fa9)




### Automation testing

Added cypress test

### Issue reference

https://github.com/kiali/kiali/issues/8189
