### PR TITLE
Skip validation checkers when there are no config changes

### DIFF
--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -20,7 +20,7 @@ type AuthorizationPolicyChecker struct {
 	ServiceEntries        []*networking_v1.ServiceEntry
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
 	VirtualServices       []*networking_v1.VirtualService
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (a AuthorizationPolicyChecker) Check() models.IstioValidations {

--- a/business/checkers/common/multi_match_selector_checker_test.go
+++ b/business/checkers/common/multi_match_selector_checker_test.go
@@ -27,7 +27,7 @@ func TestTwoSidecarsWithSelector(t *testing.T) {
 				"app": "details",
 			}, data.CreateSidecar("sidecar2", "bookinfo")),
 		},
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assert.Empty(validations)
@@ -42,7 +42,7 @@ func TestTwoSidecarsWithoutSelector(t *testing.T) {
 			data.CreateSidecar("sidecar2", "bookinfo"),
 			data.CreateSidecar("sidecar3", "bookinfo2"),
 		},
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assertMultimatchFailure(t, "generic.multimatch.selectorless", validations, "sidecar1", []string{"sidecar2"})
@@ -59,7 +59,7 @@ func TestTwoSidecarsWithoutSelectorDifferentNamespaces(t *testing.T) {
 			data.CreateSidecar("sidecar1", "bookinfo"),
 			data.CreateSidecar("sidecar2", "bookinfo2"),
 		},
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assert.Empty(validations)
@@ -86,7 +86,7 @@ func TestTwoSidecarsTargetingOneDeployment(t *testing.T) {
 		config.Get().KubernetesConfig.ClusterName,
 		kubernetes.Sidecars,
 		sidecars,
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar1", []string{"sidecar3", "sidecar4"})
@@ -117,7 +117,7 @@ func TestSidecarsCrossNamespaces(t *testing.T) {
 		config.Get().KubernetesConfig.ClusterName,
 		kubernetes.Sidecars,
 		sidecars,
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assertMultimatchFailure(t, "generic.multimatch.selector", validations, "sidecar1", []string{"sidecar2"})
@@ -149,7 +149,7 @@ func TestSidecarsDifferentNamespaces(t *testing.T) {
 		config.Get().KubernetesConfig.ClusterName,
 		kubernetes.Sidecars,
 		sidecars,
-		workloadList(),
+		workloads(),
 	).Check()
 
 	assert.Empty(validations)
@@ -179,12 +179,12 @@ func assertMultimatchFailure(t *testing.T, code string, vals models.IstioValidat
 	}
 }
 
-func workloadList() map[string]models.WorkloadList {
-	wli := []models.WorkloadListItem{
-		data.CreateWorkloadListItem("details-v1", map[string]string{"app": "details", "version": "v1"}),
-		data.CreateWorkloadListItem("details-v2", map[string]string{"app": "details", "version": "v2"}),
-		data.CreateWorkloadListItem("details-v3", map[string]string{"app": "details", "version": "v3"}),
+func workloads() map[string]models.Workloads {
+	workloads := models.Workloads{
+		data.CreateWorkload("details-v1", map[string]string{"app": "details", "version": "v1"}),
+		data.CreateWorkload("details-v2", map[string]string{"app": "details", "version": "v2"}),
+		data.CreateWorkload("details-v3", map[string]string{"app": "details", "version": "v3"}),
 	}
 
-	return data.CreateWorkloadsPerNamespace([]string{"bookinfo", "bookinfo2", "bookinfo3", "bookinfo4"}, wli...)
+	return data.CreateWorkloadsPerNamespace([]string{"bookinfo", "bookinfo2", "bookinfo3", "bookinfo4"}, workloads)
 }

--- a/business/checkers/common/workload_selector_checker.go
+++ b/business/checkers/common/workload_selector_checker.go
@@ -10,11 +10,11 @@ import (
 type GenericNoWorkloadFoundChecker struct {
 	ObjectGVK             schema.GroupVersionKind
 	SelectorLabels        map[string]string
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	Path                  string
 }
 
-func SelectorNoWorkloadFoundChecker(objectGVK schema.GroupVersionKind, selectorLabels map[string]string, workloadsPerNamespace map[string]models.WorkloadList) GenericNoWorkloadFoundChecker {
+func SelectorNoWorkloadFoundChecker(objectGVK schema.GroupVersionKind, selectorLabels map[string]string, workloadsPerNamespace map[string]models.Workloads) GenericNoWorkloadFoundChecker {
 	return GenericNoWorkloadFoundChecker{
 		ObjectGVK:             objectGVK,
 		SelectorLabels:        selectorLabels,
@@ -23,7 +23,7 @@ func SelectorNoWorkloadFoundChecker(objectGVK schema.GroupVersionKind, selectorL
 	}
 }
 
-func WorkloadSelectorNoWorkloadFoundChecker(objectGVK schema.GroupVersionKind, selectorLabels map[string]string, workloadsPerNamespace map[string]models.WorkloadList) GenericNoWorkloadFoundChecker {
+func WorkloadSelectorNoWorkloadFoundChecker(objectGVK schema.GroupVersionKind, selectorLabels map[string]string, workloadsPerNamespace map[string]models.Workloads) GenericNoWorkloadFoundChecker {
 	return GenericNoWorkloadFoundChecker{
 		ObjectGVK:             objectGVK,
 		SelectorLabels:        selectorLabels,
@@ -47,8 +47,8 @@ func (wsc GenericNoWorkloadFoundChecker) Check() ([]*models.IstioCheck, bool) {
 func (wsc GenericNoWorkloadFoundChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
 	selector := labels.SelectorFromSet(labelSelector)
 
-	for _, wls := range wsc.WorkloadsPerNamespace {
-		for _, wl := range wls.Workloads {
+	for _, workloads := range wsc.WorkloadsPerNamespace {
+		for _, wl := range workloads {
 			wlLabelSet := labels.Set(wl.Labels)
 			if selector.Matches(wlLabelSet) {
 				return true

--- a/business/checkers/common/workload_selector_checker_test.go
+++ b/business/checkers/common/workload_selector_checker_test.go
@@ -20,7 +20,7 @@ func TestPresentWorkloads(t *testing.T) {
 			"app":     "details",
 			"version": "v1",
 		},
-		workloadList(),
+		workloads(),
 	).Check()
 
 	// Well configured object
@@ -32,7 +32,7 @@ func TestPresentWorkloads(t *testing.T) {
 		map[string]string{
 			"app": "details",
 		},
-		workloadList(),
+		workloads(),
 	).Check()
 
 	// Well configured object
@@ -51,14 +51,14 @@ func TestWorkloadNotFound(t *testing.T) {
 }
 
 func testFailureWithWorkloadList(assert *assert.Assertions, selector map[string]string) {
-	testFailure(assert, selector, workloadList(), "generic.selector.workloadnotfound")
+	testFailure(assert, selector, workloads(), "generic.selector.workloadnotfound")
 }
 
 func testFailureWithEmptyWorkloadList(assert *assert.Assertions, selector map[string]string) {
-	testFailure(assert, selector, data.CreateWorkloadsPerNamespace([]string{"test"}, models.WorkloadListItem{}), "generic.selector.workloadnotfound")
+	testFailure(assert, selector, data.CreateWorkloadsPerNamespace([]string{"test"}, models.Workloads{}), "generic.selector.workloadnotfound")
 }
 
-func testFailure(assert *assert.Assertions, selector map[string]string, wl map[string]models.WorkloadList, code string) {
+func testFailure(assert *assert.Assertions, selector map[string]string, wl map[string]models.Workloads, code string) {
 	vals, valid := WorkloadSelectorNoWorkloadFoundChecker(
 		kubernetes.Sidecars,
 		selector,

--- a/business/checkers/destinationrules/no_dest_checker.go
+++ b/business/checkers/destinationrules/no_dest_checker.go
@@ -12,7 +12,7 @@ import (
 
 type NoDestinationChecker struct {
 	Namespaces            models.Namespaces
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	DestinationRule       *networking_v1.DestinationRule
 	VirtualServices       []*networking_v1.VirtualService
 	ServiceEntries        []*networking_v1.ServiceEntry
@@ -97,10 +97,10 @@ func (n NoDestinationChecker) hasMatchingWorkload(host kubernetes.Host, subsetLa
 	if len(selectors) != 0 {
 		selector := labels.SelectorFromSet(labels.Set(selectors))
 
-		for _, wl := range n.WorkloadsPerNamespace[localNs].Workloads {
-			wlLabelSet := labels.Set(wl.Labels)
-			if selector.Matches(wlLabelSet) {
-				if subsetSelector.Matches(wlLabelSet) {
+		for _, w := range n.WorkloadsPerNamespace[localNs] {
+			wLabelSet := labels.Set(w.Labels)
+			if selector.Matches(wLabelSet) {
+				if subsetSelector.Matches(wLabelSet) {
 					return true
 				}
 			}
@@ -130,7 +130,7 @@ func (n NoDestinationChecker) hasMatchingService(host kubernetes.Host, itemNames
 
 	if localNs == itemNamespace {
 		// Check Workloads
-		if matches := kubernetes.HasMatchingWorkloads(localSvc, n.WorkloadsPerNamespace[localNs].GetLabels()); matches {
+		if matches := kubernetes.HasMatchingWorkloads(localSvc, models.GetLabels(n.WorkloadsPerNamespace[localNs])); matches {
 			return matches
 		}
 	}

--- a/business/checkers/destinationrules/no_dest_checker_test.go
+++ b/business/checkers/destinationrules/no_dest_checker_test.go
@@ -26,10 +26,10 @@ func TestValidHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
@@ -43,10 +43,10 @@ func TestValidWildcardHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule: data.CreateTestDestinationRule("test-namespace",
@@ -64,10 +64,10 @@ func TestValidMeshWideHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "*.local"),
@@ -84,10 +84,10 @@ func TestValidShortSvcHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace.svc"),
@@ -104,10 +104,10 @@ func TestValidServiceNamespace(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace"),
@@ -128,10 +128,10 @@ func TestValidServiceNamespaceInvalid(t *testing.T) {
 			models.Namespace{Name: "test-namespace"},
 			models.Namespace{Name: "outside-ns"},
 		},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews.not-a-namespace"),
@@ -155,10 +155,10 @@ func TestValidServiceNamespaceCrossNamespace(t *testing.T) {
 			models.Namespace{Name: "test-namespace"},
 			models.Namespace{Name: "outside-ns"},
 		},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"outside-ns": data.CreateWorkloadList("outside-ns",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"outside-ns": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		// using outside-ns namespace in host where the workloads are created. this should not fail
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.outside-ns.svc.cluster.local"),
@@ -178,10 +178,10 @@ func TestNoValidHost(t *testing.T) {
 
 	// reviews is not part of services
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("otherv1", appVersionLabel("other", "v1"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("otherv1", appVersionLabel("other", "v1"))},
 		},
 		RegistryServices: []*kubernetes.RegistryService{{}},
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
@@ -207,10 +207,10 @@ func TestNoValidShortSvcHost(t *testing.T) {
 	// Not valid:
 	// reviews.test-namespace.svc.cluster
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("otherv1", appVersionLabel("other", "v1"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("otherv1", appVersionLabel("other", "v1"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews.test-namespace.svc.cluster"),
@@ -231,9 +231,9 @@ func TestNoMatchingSubset(t *testing.T) {
 
 	// reviews does not have v2 in known services
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateTestDestinationRule("test-namespace", "name", "reviews"),
@@ -274,10 +274,10 @@ func TestNoMatchingSubsetWithMoreLabels(t *testing.T) {
 		data.AddSubsetToDestinationRule(s2, data.CreateEmptyDestinationRule("test-namespace", "name", "reviews")))
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  dr,
@@ -308,10 +308,10 @@ func TestSubsetNotReferenced(t *testing.T) {
 
 	vals, valid := NoDestinationChecker{
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"bookinfo": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  dr,
@@ -340,10 +340,10 @@ func TestSubsetReferenced(t *testing.T) {
 
 	vals, valid := NoDestinationChecker{
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"bookinfo": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  dr,
@@ -376,10 +376,10 @@ func TestSubsetPresentMatchingNotReferenced(t *testing.T) {
 
 	vals, valid := NoDestinationChecker{
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo"}},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"bookinfo": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "bookinfo"),
 		DestinationRule:  dr,
@@ -405,10 +405,10 @@ func TestWronglyReferenced(t *testing.T) {
 
 	vals, valid := NoDestinationChecker{
 		Namespaces: models.Namespaces{models.Namespace{Name: "bookinfo2"}, models.Namespace{Name: "bookinfo"}},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviews", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"bookinfo": {
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviews", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  dr,
@@ -426,10 +426,10 @@ func TestFailCrossNamespaceHost(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		// Intentionally using the same serviceName, but different NS. This SHOULD fail to match the above workloads which are created in test-namespace
 		DestinationRule: data.CreateTestDestinationRule("test-namespace", "name", "reviews.different-ns.svc.cluster.local"),
@@ -644,10 +644,10 @@ func TestNoLabelsInSubset(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateNoLabelsDestinationRule("test-namespace", "name", "reviews"),
@@ -664,10 +664,10 @@ func TestSubsetWithoutLabels(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NoDestinationChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2"))),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2"))},
 		},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 		DestinationRule:  data.CreateNoSubsetLabelsDestinationRule("test-namespace", "name", "reviews"),

--- a/business/checkers/gateway_checker.go
+++ b/business/checkers/gateway_checker.go
@@ -10,7 +10,7 @@ import (
 
 type GatewayChecker struct {
 	Gateways              []*networking_v1.Gateway
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	IsGatewayToNamespace  bool
 	Cluster               string
 }

--- a/business/checkers/gateways/selector_checker.go
+++ b/business/checkers/gateways/selector_checker.go
@@ -8,7 +8,7 @@ import (
 )
 
 type SelectorChecker struct {
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	Gateway               *networking_v1.Gateway
 	IsGatewayToNamespace  bool
 }
@@ -26,12 +26,12 @@ func (s SelectorChecker) Check() ([]*models.IstioCheck, bool) {
 func (s SelectorChecker) hasMatchingWorkload(labelSelector map[string]string) bool {
 	selector := labels.SelectorFromSet(labelSelector)
 
-	for _, wls := range s.WorkloadsPerNamespace {
-		if s.IsGatewayToNamespace && wls.Namespace != s.Gateway.Namespace {
+	for ns, workloads := range s.WorkloadsPerNamespace {
+		if s.IsGatewayToNamespace && ns != s.Gateway.Namespace {
 			continue
 		}
-		for _, wl := range wls.Workloads {
-			wlLabelSet := labels.Set(wl.Labels)
+		for _, w := range workloads {
+			wlLabelSet := labels.Set(w.Labels)
 			if selector.Matches(wlLabelSet) {
 				return true
 			}

--- a/business/checkers/gateways/selector_checker_test.go
+++ b/business/checkers/gateways/selector_checker_test.go
@@ -22,10 +22,10 @@ func TestValidInternalSelector(t *testing.T) {
 
 	vals, valid := SelectorChecker{
 		Gateway: ingress,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("istio-ingressgateway", map[string]string{"istio": "ingressgateway"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("istio-ingressgateway", map[string]string{"istio": "ingressgateway"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -34,10 +34,10 @@ func TestValidInternalSelector(t *testing.T) {
 
 	vals, valid = SelectorChecker{
 		Gateway: egress,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("istio-egressgateway", map[string]string{"istio": "egressgateway"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("istio-egressgateway", map[string]string{"istio": "egressgateway"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -55,10 +55,10 @@ func TestValidNamespaceSelector(t *testing.T) {
 
 	vals, valid := SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -77,10 +77,10 @@ func TestLocalNamespaceSelector(t *testing.T) {
 
 	vals, valid := SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: true,
 	}.Check()
 
@@ -92,10 +92,10 @@ func TestLocalNamespaceSelector(t *testing.T) {
 
 	vals, valid = SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -107,10 +107,10 @@ func TestLocalNamespaceSelector(t *testing.T) {
 
 	vals, valid = SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: true,
 	}.Check()
 
@@ -122,10 +122,10 @@ func TestLocalNamespaceSelector(t *testing.T) {
 
 	vals, valid = SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -143,10 +143,10 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 
 	vals, valid := SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"testproxy": data.CreateWorkloadList(conf.IstioNamespace,
-				data.CreateWorkloadListItem("testproxy", map[string]string{"app": "proxy"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"testproxy": {
+				data.CreateWorkload("testproxy", map[string]string{"app": "proxy"}),
+			}},
 		IsGatewayToNamespace: false,
 	}.Check()
 
@@ -155,11 +155,8 @@ func TestValidIstioNamespaceSelector(t *testing.T) {
 
 	vals, valid = SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": {
-				Namespace: "test",
-				Workloads: []models.WorkloadListItem{},
-			},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {},
 		},
 		IsGatewayToNamespace: false,
 	}.Check()
@@ -178,8 +175,8 @@ func TestMissingSelectorTarget(t *testing.T) {
 
 	vals, valid := SelectorChecker{
 		Gateway: gw,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test"),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {},
 		},
 		IsGatewayToNamespace: false,
 	}.Check()

--- a/business/checkers/no_service_checker.go
+++ b/business/checkers/no_service_checker.go
@@ -12,7 +12,7 @@ import (
 type NoServiceChecker struct {
 	Namespaces            models.Namespaces
 	IstioConfigList       *models.IstioConfigList
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	AuthorizationDetails  *kubernetes.RBACDetails
 	RegistryServices      []*kubernetes.RegistryService
 	PolicyAllowAny        bool
@@ -71,7 +71,7 @@ func runGatewayCheck(virtualService *networking_v1.VirtualService, gatewayNames 
 	return models.IstioValidations{key: validations}
 }
 
-func runDestinationRuleCheck(destinationRule *networking_v1.DestinationRule, workloads map[string]models.WorkloadList,
+func runDestinationRuleCheck(destinationRule *networking_v1.DestinationRule, workloads map[string]models.Workloads,
 	serviceEntries []*networking_v1.ServiceEntry, clusterNamespaces models.Namespaces, registryStatus []*kubernetes.RegistryService, virtualServices []*networking_v1.VirtualService,
 	policyAllowAny bool, cluster string) models.IstioValidations {
 	key, validations := EmptyValidValidation(destinationRule.Name, destinationRule.Namespace, kubernetes.DestinationRules, cluster)

--- a/business/checkers/no_service_checker_test.go
+++ b/business/checkers/no_service_checker_test.go
@@ -31,17 +31,17 @@ func TestAllIstioObjectWithServices(t *testing.T) {
 	assert := assert.New(t)
 
 	vals := NoServiceChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
-				data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
-				data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
-				data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
-				data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2")),
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("detailsv2", appVersionLabel("details", "v2")),
+				data.CreateWorkload("productv1", appVersionLabel("product", "v1")),
+				data.CreateWorkload("productv2", appVersionLabel("product", "v2")),
+				data.CreateWorkload("customerv1", appVersionLabel("customer", "v1")),
+				data.CreateWorkload("customerv2", appVersionLabel("customer", "v2")),
+			}},
 		IstioConfigList:      fakeIstioConfigList(),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 		RegistryServices: append(data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "test"),
@@ -63,15 +63,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 
 	vals := NoServiceChecker{
 		IstioConfigList: fakeIstioConfigList(),
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
-				data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
-				data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2")),
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("detailsv2", appVersionLabel("details", "v2")),
+				data.CreateWorkload("productv1", appVersionLabel("product", "v1")),
+				data.CreateWorkload("productv2", appVersionLabel("product", "v2")),
+			}},
 		AuthorizationDetails: &kubernetes.RBACDetails{},
 		RegistryServices: append(data.CreateFakeRegistryServices("product.test.svc.cluster.local", "test", "."),
 			data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "details.test.svc.cluster.local"}, "test", "*")...),
@@ -86,15 +86,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.nodest.matchingregistry", customerDr.Checks[0]))
 
 	vals = NoServiceChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
-				data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
-				data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2")),
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("detailsv2", appVersionLabel("details", "v2")),
+				data.CreateWorkload("customerv1", appVersionLabel("customer", "v1")),
+				data.CreateWorkload("customerv2", appVersionLabel("customer", "v2")),
+			}},
 		IstioConfigList:      fakeIstioConfigList(),
 		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "details.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
@@ -111,15 +111,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.NoError(validations.ConfirmIstioCheckMessage("virtualservices.nohost.hostnotfound", productVs.Checks[1]))
 
 	vals = NoServiceChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
-				data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
-				data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
-				data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
-				data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2")),
+				data.CreateWorkload("productv1", appVersionLabel("product", "v1")),
+				data.CreateWorkload("productv2", appVersionLabel("product", "v2")),
+				data.CreateWorkload("customerv1", appVersionLabel("customer", "v1")),
+				data.CreateWorkload("customerv2", appVersionLabel("customer", "v2")),
+			}},
 		IstioConfigList:      fakeIstioConfigList(),
 		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"reviews.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},
@@ -129,15 +129,15 @@ func TestDetectObjectWithoutService(t *testing.T) {
 	assert.True(vals[models.IstioValidationKey{ObjectGVK: kubernetes.DestinationRules, Namespace: "test", Name: "customer-dr"}].Valid)
 
 	vals = NoServiceChecker{
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("productv1", appVersionLabel("product", "v1")),
-				data.CreateWorkloadListItem("productv2", appVersionLabel("product", "v2")),
-				data.CreateWorkloadListItem("detailsv1", appVersionLabel("details", "v1")),
-				data.CreateWorkloadListItem("detailsv2", appVersionLabel("details", "v2")),
-				data.CreateWorkloadListItem("customerv1", appVersionLabel("customer", "v1")),
-				data.CreateWorkloadListItem("customerv2", appVersionLabel("customer", "v2"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test": {
+				data.CreateWorkload("productv1", appVersionLabel("product", "v1")),
+				data.CreateWorkload("productv2", appVersionLabel("product", "v2")),
+				data.CreateWorkload("detailsv1", appVersionLabel("details", "v1")),
+				data.CreateWorkload("detailsv2", appVersionLabel("details", "v2")),
+				data.CreateWorkload("customerv1", appVersionLabel("customer", "v1")),
+				data.CreateWorkload("customerv2", appVersionLabel("customer", "v2")),
+			}},
 		IstioConfigList:      fakeIstioConfigList(),
 		RegistryServices:     data.CreateFakeMultiRegistryServices([]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "customer.test.svc.cluster.local"}, "test", "*"),
 		AuthorizationDetails: &kubernetes.RBACDetails{},

--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -13,7 +13,7 @@ import (
 type PeerAuthenticationChecker struct {
 	PeerAuthentications   []*security_v1.PeerAuthentication
 	MTLSDetails           kubernetes.MTLSDetails
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	Cluster               string
 }
 

--- a/business/checkers/request_authentication_checker.go
+++ b/business/checkers/request_authentication_checker.go
@@ -10,7 +10,7 @@ import (
 
 type RequestAuthenticationChecker struct {
 	RequestAuthentications []*security_v1.RequestAuthentication
-	WorkloadsPerNamespace  map[string]models.WorkloadList
+	WorkloadsPerNamespace  map[string]models.Workloads
 	Cluster                string
 }
 

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -13,7 +13,7 @@ type SidecarChecker struct {
 	Sidecars              []*networking_v1.Sidecar
 	ServiceEntries        []*networking_v1.ServiceEntry
 	Namespaces            models.Namespaces
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	RegistryServices      []*kubernetes.RegistryService
 	Cluster               string
 }

--- a/business/checkers/workloads/uncovered_workload_checker.go
+++ b/business/checkers/workloads/uncovered_workload_checker.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UncoveredWorkloadChecker struct {
-	Workload              models.WorkloadListItem
+	Workload              *models.Workload
 	Namespace             string
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
 }

--- a/business/checkers/workloads_checker.go
+++ b/business/checkers/workloads_checker.go
@@ -12,16 +12,16 @@ const WorkloadCheckerType = "workload"
 
 type WorkloadChecker struct {
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	Cluster               string
 }
 
 func (w WorkloadChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	for _, wls := range w.WorkloadsPerNamespace {
-		for _, wl := range wls.Workloads {
-			validations.MergeValidations(w.runChecks(wl, wls.Namespace))
+	for ns, workloads := range w.WorkloadsPerNamespace {
+		for _, wl := range workloads {
+			validations.MergeValidations(w.runChecks(wl, ns))
 		}
 	}
 
@@ -29,7 +29,7 @@ func (w WorkloadChecker) Check() models.IstioValidations {
 }
 
 // runChecks runs all the individual checks for a single workload and appends the result into validations.
-func (w WorkloadChecker) runChecks(workload models.WorkloadListItem, namespace string) models.IstioValidations {
+func (w WorkloadChecker) runChecks(workload *models.Workload, namespace string) models.IstioValidations {
 	wlName := workload.Name
 	key, rrValidation := EmptyValidValidation(wlName, namespace, schema.GroupVersionKind{Group: "", Version: "", Kind: WorkloadCheckerType}, w.Cluster)
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -217,7 +217,8 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 
 	validations := models.IstioValidations{}
 	vInfo.clusterInfo = &validationClusterInfo{
-		cluster: cluster,
+		cluster:          cluster,
+		registryServices: []*kubernetes.RegistryService{},
 	}
 
 	if registryStatus := in.kialiCache.GetRegistryStatus(cluster); registryStatus != nil {
@@ -313,6 +314,11 @@ func getClusterConfigHash(vInfo *validationInfo) string {
 		for _, w := range wl.Workloads {
 			hasher.Write([]byte(w.ResourceVersion))
 		}
+	}
+
+	// loop through the services and gather up their resourceVersions
+	for _, s := range vInfo.clusterInfo.registryServices {
+		hasher.Write([]byte(s.ResourceVersion))
 	}
 
 	// loop through the config and gather up their resourceVersions

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -3,7 +3,6 @@ package business
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"hash"
 	"maps"
@@ -314,12 +313,8 @@ func getClusterConfigHash(vInfo *validationInfo) string {
 	for _, wl := range workloadLists {
 		for _, w := range wl.Workloads {
 			// add to the hash any mutable values used in the checkers
-			if json, err := json.Marshal(w.Labels); err == nil {
-				hasher.Write(json)
-			}
-			if json, err := json.Marshal(w.TemplateLabels); err == nil {
-				hasher.Write(json)
-			}
+			hasher.Write([]byte(fmt.Sprintf("%v", w.Labels)))         // this automatically sorts by map key
+			hasher.Write([]byte(fmt.Sprintf("%v", w.TemplateLabels))) // this automatically sorts by map key
 		}
 	}
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -3,6 +3,7 @@ package business
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"hash"
 	"maps"
@@ -20,7 +21,6 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
-	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
@@ -309,13 +309,16 @@ func toWorkloadMap(workloads models.Workloads) map[string]models.WorkloadList {
 func getClusterConfigHash(vInfo *validationInfo) string {
 	var hasher hash.Hash = sha256.New()
 
-	// loop through the workloads and gather up their specVersions
+	// loop through the workloads and gather up hashes of their relevant checker info
 	workloadLists := vInfo.wlMap[vInfo.clusterInfo.cluster]
 	for _, wl := range workloadLists {
 		for _, w := range wl.Workloads {
-			hasher.Write(w.SpecVersion)
-			if w.Name == "ratings-v1" {
-				log.Infof("validations ratings-v1 SPEC: %x", w.SpecVersion)
+			// add to the hash any mutable values used in the checkers
+			if json, err := json.Marshal(w.Labels); err == nil {
+				hasher.Write(json)
+			}
+			if json, err := json.Marshal(w.TemplateLabels); err == nil {
+				hasher.Write(json)
 			}
 		}
 	}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
@@ -308,11 +309,14 @@ func toWorkloadMap(workloads models.Workloads) map[string]models.WorkloadList {
 func getClusterConfigHash(vInfo *validationInfo) string {
 	var hasher hash.Hash = sha256.New()
 
-	// loop through the workloads and gather up their resourceVersions
+	// loop through the workloads and gather up their specVersions
 	workloadLists := vInfo.wlMap[vInfo.clusterInfo.cluster]
 	for _, wl := range workloadLists {
 		for _, w := range wl.Workloads {
-			hasher.Write([]byte(w.ResourceVersion))
+			hasher.Write(w.SpecVersion)
+			if w.Name == "ratings-v1" {
+				log.Infof("validations ratings-v1 SPEC: %x", w.SpecVersion)
+			}
 		}
 	}
 

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -170,7 +170,12 @@ func BenchmarkValidate(b *testing.B) {
 	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
 	vs := NewValidationsService(&layer.IstioConfig, cache, &mesh, &namespace, &layer.Svc, k8sclients, &layer.Workload)
 
-	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName}, nil)
+	var changeMap ValidationChangeMap
+	if conf.ExternalServices.Istio.ValidationChangeDetectionEnabled {
+		changeMap = ValidationChangeMap{}
+	}
+
+	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -170,7 +170,7 @@ func BenchmarkValidate(b *testing.B) {
 	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
 	vs := NewValidationsService(&layer.IstioConfig, cache, &mesh, &namespace, &layer.Svc, k8sclients, &layer.Workload)
 
-	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName})
+	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -70,9 +70,10 @@ func TestGetValidationsPerf(t *testing.T) {
 	now := time.Now()
 	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
-	validations, err := vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err := vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
 	log.Debugf("Validation Performance test took %f seconds for %d namespaces", time.Since(now).Seconds(), numNs)
+	assert.True(validationPerformed)
 	assert.NotEmpty(validations)
 }
 
@@ -182,7 +183,7 @@ func BenchmarkValidate(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err = vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
+		_, _, err = vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -68,7 +68,7 @@ func TestGetValidationsPerf(t *testing.T) {
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 
 	now := time.Now()
-	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName})
+	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
 	validations, err := vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -65,8 +65,9 @@ func TestGetNamespaceValidations(t *testing.T) {
 	var changeMap = map[string]string{}
 	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	require.NoError(err)
-	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
+	assert.True(validationPerformed)
 	vs.kialiCache.Validations().Replace(validations)
 
 	validations, err = vs.GetValidations(context.TODO(), conf.KubernetesConfig.ClusterName)
@@ -77,8 +78,9 @@ func TestGetNamespaceValidations(t *testing.T) {
 	// simulate a reconcile w/o a config change should skip running the checkers (new vInfo but re-use the changemap)
 	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	require.NoError(err)
-	validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
+	assert.False(validationPerformed)
 	assert.Nil(validations)
 
 	// refresh the config but keep the changeMap, and we should see new validations. (note PeerAuthentication config updates its ResourceVersion)
@@ -86,8 +88,9 @@ func TestGetNamespaceValidations(t *testing.T) {
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	require.NoError(err)
-	validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
+	assert.True(validationPerformed)
 	assert.NotNil(validations)
 }
 
@@ -723,8 +726,9 @@ func TestValidatingSingleObjectUpdatesList(t *testing.T) {
 
 	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
-	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
+	assert.True(validationPerformed)
 	vs.kialiCache.Validations().Replace(validations)
 
 	currentValidations, err := vs.GetValidations(context.Background(), conf.KubernetesConfig.ClusterName)
@@ -740,8 +744,9 @@ func TestValidatingSingleObjectUpdatesList(t *testing.T) {
 	// make sure validations are updated in a cache before retrieving them
 	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
-	validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	validationPerformed, validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
+	assert.True(validationPerformed)
 	vs.kialiCache.Validations().Replace(validations)
 
 	updatedValidations, _, err := vs.ValidateIstioObject(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.VirtualServices, "product-vs")

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -62,7 +62,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, conf, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 
-	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName})
+	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
 	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
@@ -704,7 +704,7 @@ func TestValidatingSingleObjectUpdatesList(t *testing.T) {
 	v, err := vs.userClients[conf.KubernetesConfig.ClusterName].Istio().NetworkingV1().VirtualServices("test").Get(context.Background(), "product-vs", v1.GetOptions{})
 	require.NoError(err)
 
-	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName})
+	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
 	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
@@ -721,7 +721,7 @@ func TestValidatingSingleObjectUpdatesList(t *testing.T) {
 	require.NoError(err)
 
 	// make sure validations are updated in a cache before retrieving them
-	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName})
+	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
 	require.NoError(err)
 	validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -62,7 +62,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, conf, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 
-	var changeMap = map[string]string{}
+	var changeMap = map[string][]byte{}
 	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	require.NoError(err)
 	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
@@ -74,7 +74,9 @@ func TestGetNamespaceValidations(t *testing.T) {
 	require.NotEmpty(validations)
 	assert.True(validations[models.IstioValidationKey{ObjectGVK: kubernetes.VirtualServices, Namespace: "test", Name: "product-vs"}].Valid)
 
-	// reValidating w/o a config change should skip running the checkers
+	// simulate a reconcile w/o a config change should skip running the checkers (new vInfo but re-use the changemap)
+	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
+	require.NoError(err)
 	validations, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
 	require.NoError(err)
 	assert.Nil(validations)

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -62,7 +62,7 @@ func TestGetNamespaceValidations(t *testing.T) {
 	vs := mockCombinedValidationService(t, conf, fakeIstioConfigList(),
 		[]string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"})
 
-	var changeMap = map[string][]byte{}
+	var changeMap = map[string]string{}
 	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
 	require.NoError(err)
 	validations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)

--- a/business/references/auth_policy_references.go
+++ b/business/references/auth_policy_references.go
@@ -18,7 +18,7 @@ type AuthorizationPolicyReferences struct {
 	ServiceEntries        []*networking_v1.ServiceEntry
 	VirtualServices       []*networking_v1.VirtualService
 	RegistryServices      []*kubernetes.RegistryService
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (n AuthorizationPolicyReferences) References() models.IstioReferencesMap {
@@ -96,14 +96,14 @@ func (n AuthorizationPolicyReferences) getWorkloadReferences(ap *security_v1.Aut
 		selector := labels.SelectorFromSet(ap.Spec.Selector.MatchLabels)
 
 		// AuthPolicy searches Workloads from own namespace, or from all namespaces when AuthPolicy is in root namespace
-		for _, wls := range n.WorkloadsPerNamespace {
-			if !config.IsRootNamespace(ap.Namespace) && wls.Namespace != ap.Namespace {
+		for ns, workloads := range n.WorkloadsPerNamespace {
+			if !config.IsRootNamespace(ap.Namespace) && ns != ap.Namespace {
 				continue
 			}
-			for _, wl := range wls.Workloads {
+			for _, wl := range workloads {
 				wlLabelSet := labels.Set(wl.Labels)
 				if selector.Matches(wlLabelSet) {
-					result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: wls.Namespace})
+					result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: ns})
 				}
 			}
 		}

--- a/business/references/auth_policy_references_test.go
+++ b/business/references/auth_policy_references_test.go
@@ -24,11 +24,10 @@ func prepareTestForAuthPolicy(ap *security_v1.AuthorizationPolicy, vs *networkin
 		AuthorizationPolicies: []*security_v1.AuthorizationPolicy{ap},
 		ServiceEntries:        []*networking_v1.ServiceEntry{se},
 		VirtualServices:       []*networking_v1.VirtualService{vs},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"istio-system": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("istiod", map[string]string{"app": "istio-ingressgateway"}),
-			),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"istio-system": {
+				data.CreateWorkload("istiod", map[string]string{"app": "istio-ingressgateway"}),
+			}},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("foo-dev", "istio-system"),
 	}
 	return *drReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.AuthorizationPolicies, Namespace: ap.Namespace, Name: ap.Name}]

--- a/business/references/destination_rule_references.go
+++ b/business/references/destination_rule_references.go
@@ -15,7 +15,7 @@ type DestinationRuleReferences struct {
 	Namespaces            models.Namespaces
 	DestinationRules      []*networking_v1.DestinationRule
 	VirtualServices       []*networking_v1.VirtualService
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 	ServiceEntries        []*networking_v1.ServiceEntry
 	RegistryServices      []*kubernetes.RegistryService
 }
@@ -84,11 +84,11 @@ func (n DestinationRuleReferences) getWorkloadReferences(dr *networking_v1.Desti
 			subsetLabelSet := labels.Set(subset.Labels)
 			subsetSelector := labels.SelectorFromSet(subsetLabelSet)
 
-			for _, wl := range n.WorkloadsPerNamespace[localNs].Workloads {
-				wlLabelSet := labels.Set(wl.Labels)
+			for _, w := range n.WorkloadsPerNamespace[localNs] {
+				wlLabelSet := labels.Set(w.Labels)
 				if selector.Matches(wlLabelSet) {
 					if subsetSelector.Matches(wlLabelSet) {
-						allWorkloads = append(allWorkloads, models.WorkloadReference{Name: wl.Name, Namespace: localNs})
+						allWorkloads = append(allWorkloads, models.WorkloadReference{Name: w.Name, Namespace: localNs})
 					}
 				}
 			}

--- a/business/references/destination_rule_references_test.go
+++ b/business/references/destination_rule_references_test.go
@@ -22,13 +22,13 @@ func prepareTestForDestinationRule(dr *networking_v1.DestinationRule, vs *networ
 		},
 		DestinationRules: []*networking_v1.DestinationRule{dr},
 		VirtualServices:  []*networking_v1.VirtualService{vs},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test-namespace": data.CreateWorkloadList("test-namespace",
-				data.CreateWorkloadListItem("reviewsv1", appVersionLabel("reviews", "v1")),
-				data.CreateWorkloadListItem("reviewsv2", appVersionLabel("reviews", "v2")),
-				data.CreateWorkloadListItem("reviewsv3", appVersionLabel("reviews", "v3")),
-				data.CreateWorkloadListItem("reviewsv4", appVersionLabel("reviews", "v4"))),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"test-namespace": {
+				data.CreateWorkload("reviewsv1", appVersionLabel("reviews", "v1")),
+				data.CreateWorkload("reviewsv2", appVersionLabel("reviews", "v2")),
+				data.CreateWorkload("reviewsv3", appVersionLabel("reviews", "v3")),
+				data.CreateWorkload("reviewsv4", appVersionLabel("reviews", "v4")),
+			}},
 		ServiceEntries:   []*networking_v1.ServiceEntry{fakeServiceEntry()},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("reviews", "test-namespace"),
 	}

--- a/business/references/gateway_references.go
+++ b/business/references/gateway_references.go
@@ -13,7 +13,7 @@ import (
 type GatewayReferences struct {
 	Gateways              []*networking_v1.Gateway
 	VirtualServices       []*networking_v1.VirtualService
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (n GatewayReferences) References() models.IstioReferencesMap {
@@ -38,11 +38,11 @@ func (n GatewayReferences) getWorkloadReferences(gw *networking_v1.Gateway) []mo
 	selector := labels.SelectorFromSet(gw.Spec.Selector)
 
 	// Gateway searches Workloads from all namespace
-	for _, wls := range n.WorkloadsPerNamespace {
-		for _, wl := range wls.Workloads {
+	for ns, workloads := range n.WorkloadsPerNamespace {
+		for _, wl := range workloads {
 			wlLabelSet := labels.Set(wl.Labels)
 			if selector.Matches(wlLabelSet) {
-				result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: wls.Namespace})
+				result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: ns})
 			}
 		}
 	}

--- a/business/references/gateway_references_test.go
+++ b/business/references/gateway_references_test.go
@@ -16,10 +16,10 @@ func prepareTestForGateway(gw *networking_v1.Gateway, vss []*networking_v1.Virtu
 	gwReferences := GatewayReferences{
 		Gateways:        []*networking_v1.Gateway{gw},
 		VirtualServices: vss,
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"test": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("istio-ingressgateway", map[string]string{"istio": "ingressgateway"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"istio-system": {
+				data.CreateWorkload("istio-ingressgateway", map[string]string{"istio": "ingressgateway"}),
+			}},
 	}
 	return *gwReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.Gateways, Namespace: gw.Namespace, Name: gw.Name}]
 }

--- a/business/references/k8s_gateway_references.go
+++ b/business/references/k8s_gateway_references.go
@@ -12,7 +12,7 @@ type K8sGatewayReferences struct {
 	K8sGateways           []*k8s_networking_v1.Gateway
 	K8sHTTPRoutes         []*k8s_networking_v1.HTTPRoute
 	K8sGRPCRoutes         []*k8s_networking_v1.GRPCRoute
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (g K8sGatewayReferences) References() models.IstioReferencesMap {
@@ -33,9 +33,9 @@ func (g K8sGatewayReferences) getWorkloadReferences(gw *k8s_networking_v1.Gatewa
 	result := make([]models.WorkloadReference, 0)
 
 	// Gateway searches Workloads from own namespace and Gateway Label
-	for _, wl := range g.WorkloadsPerNamespace[gw.Namespace].Workloads {
-		if gw.Name == wl.Labels[config.Get().IstioLabels.AmbientWaypointGatewayLabel] {
-			result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: gw.Namespace})
+	for _, w := range g.WorkloadsPerNamespace[gw.Namespace] {
+		if gw.Name == w.Labels[config.Get().IstioLabels.AmbientWaypointGatewayLabel] {
+			result = append(result, models.WorkloadReference{Name: w.Name, Namespace: gw.Namespace})
 		}
 	}
 	return result

--- a/business/references/k8s_gateway_references_test.go
+++ b/business/references/k8s_gateway_references_test.go
@@ -28,12 +28,13 @@ func TestK8sGatewayReferences(t *testing.T) {
 		K8sGateways:   []*k8s_networking_v1.Gateway{gw},
 		K8sHTTPRoutes: []*k8s_networking_v1.HTTPRoute{r1, r2},
 		K8sGRPCRoutes: []*k8s_networking_v1.GRPCRoute{r3, r4},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("bookinfo", map[string]string{conf.IstioLabels.AmbientWaypointGatewayLabel: "bookinfo"})),
-			"test": data.CreateWorkloadList("test",
-				data.CreateWorkloadListItem("test", map[string]string{conf.IstioLabels.AmbientWaypointGatewayLabel: "bookinfo"})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"bookinfo": {
+				data.CreateWorkload("bookinfo", map[string]string{conf.IstioLabels.AmbientWaypointGatewayLabel: "bookinfo"}),
+			},
+			"test": {
+				data.CreateWorkload("test", map[string]string{conf.IstioLabels.AmbientWaypointGatewayLabel: "bookinfo"}),
+			}},
 	}
 
 	references := gatewayReferences.References()

--- a/business/references/peer_auth_references.go
+++ b/business/references/peer_auth_references.go
@@ -13,7 +13,7 @@ import (
 
 type PeerAuthReferences struct {
 	MTLSDetails           kubernetes.MTLSDetails
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (n PeerAuthReferences) References() models.IstioReferencesMap {
@@ -101,10 +101,10 @@ func (n PeerAuthReferences) getWorkloadReferences(pa *security_v1.PeerAuthentica
 		selector := labels.SelectorFromSet(pa.Spec.Selector.MatchLabels)
 
 		// PeerAuth searches Workloads from own namespace
-		for _, wl := range n.WorkloadsPerNamespace[pa.Namespace].Workloads {
-			wlLabelSet := labels.Set(wl.Labels)
+		for _, w := range n.WorkloadsPerNamespace[pa.Namespace] {
+			wlLabelSet := labels.Set(w.Labels)
 			if selector.Matches(wlLabelSet) {
-				result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: pa.Namespace})
+				result = append(result, models.WorkloadReference{Name: w.Name, Namespace: pa.Namespace})
 			}
 		}
 	}

--- a/business/references/peer_auth_references_test.go
+++ b/business/references/peer_auth_references_test.go
@@ -20,11 +20,13 @@ func prepareTestForPeerAuth(pa *security_v1.PeerAuthentication, drs []*networkin
 			DestinationRules:    drs,
 			EnabledAutoMtls:     false,
 		},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"istio-system": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("grafana", map[string]string{"app": "grafana"})),
-			"bookinfo": data.CreateWorkloadList("bookinfo",
-				data.CreateWorkloadListItem("details", map[string]string{"app": "details"})),
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"istio-system": {
+				data.CreateWorkload("grafana", map[string]string{"app": "grafana"}),
+			},
+			"bookinfo": {
+				data.CreateWorkload("details", map[string]string{"app": "details"}),
+			},
 		},
 	}
 	return *drReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.PeerAuthentications, Namespace: pa.Namespace, Name: pa.Name}]

--- a/business/references/sidecar_references.go
+++ b/business/references/sidecar_references.go
@@ -18,7 +18,7 @@ type SidecarReferences struct {
 	Namespaces            models.Namespaces
 	ServiceEntries        []*networking_v1.ServiceEntry
 	RegistryServices      []*kubernetes.RegistryService
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (n SidecarReferences) References() models.IstioReferencesMap {
@@ -106,10 +106,10 @@ func (n SidecarReferences) getWorkloadReferences(sc *networking_v1.Sidecar) []mo
 		selector := labels.SelectorFromSet(sc.Spec.WorkloadSelector.Labels)
 
 		// Sidecar searches Workloads from own namespace
-		for _, wl := range n.WorkloadsPerNamespace[sc.Namespace].Workloads {
-			wlLabelSet := labels.Set(wl.Labels)
+		for _, w := range n.WorkloadsPerNamespace[sc.Namespace] {
+			wlLabelSet := labels.Set(w.Labels)
 			if selector.Matches(wlLabelSet) {
-				result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: sc.Namespace})
+				result = append(result, models.WorkloadReference{Name: w.Name, Namespace: sc.Namespace})
 			}
 		}
 	}

--- a/business/references/sidecar_references_test.go
+++ b/business/references/sidecar_references_test.go
@@ -20,11 +20,10 @@ func prepareTestForSidecar(sc *networking_v1.Sidecar, vs *networking_v1.VirtualS
 		},
 		Sidecars:       []*networking_v1.Sidecar{sc},
 		ServiceEntries: []*networking_v1.ServiceEntry{se},
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"istio-system": data.CreateWorkloadList("istio-system",
-				data.CreateWorkloadListItem("istiod", map[string]string{"app": "istio-ingressgateway"}),
-			),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"istio-system": {
+				data.CreateWorkload("istiod", map[string]string{"app": "istio-ingressgateway"}),
+			}},
 		RegistryServices: data.CreateFakeRegistryServicesLabels("foo-service", "istio-system"),
 	}
 	return *drReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.Sidecars, Namespace: sc.Namespace, Name: sc.Name}]

--- a/business/references/workloadgroup_references.go
+++ b/business/references/workloadgroup_references.go
@@ -12,7 +12,7 @@ import (
 type WorkloadGroupReferences struct {
 	WorkloadGroups        []*networking_v1.WorkloadGroup
 	WorkloadEntries       []*networking_v1.WorkloadEntry
-	WorkloadsPerNamespace map[string]models.WorkloadList
+	WorkloadsPerNamespace map[string]models.Workloads
 }
 
 func (n WorkloadGroupReferences) References() models.IstioReferencesMap {
@@ -33,10 +33,10 @@ func (n WorkloadGroupReferences) getWorkloadReferences(wg *networking_v1.Workloa
 	result := make([]models.WorkloadReference, 0)
 
 	// Searches Workloads from all namespace
-	for _, wls := range n.WorkloadsPerNamespace {
-		for _, wl := range wls.Workloads {
-			if wg.Namespace == wls.Namespace && wg.Name == wl.Name {
-				result = append(result, models.WorkloadReference{Name: wl.Name, Namespace: wls.Namespace})
+	for ns, workloads := range n.WorkloadsPerNamespace {
+		for _, w := range workloads {
+			if wg.Namespace == ns && wg.Name == w.Name {
+				result = append(result, models.WorkloadReference{Name: w.Name, Namespace: ns})
 			}
 		}
 	}

--- a/business/references/workloadgroup_references_test.go
+++ b/business/references/workloadgroup_references_test.go
@@ -15,13 +15,13 @@ func prepareTestForWorkloadGroup(name string) models.IstioReferences {
 	wgReferences := WorkloadGroupReferences{
 		WorkloadGroups:  data.CreateWorkloadGroups(*config.Get()),
 		WorkloadEntries: data.CreateWorkloadEntries(*config.Get()),
-		WorkloadsPerNamespace: map[string]models.WorkloadList{
-			"Namespace": data.CreateWorkloadList("Namespace",
-				data.CreateWorkloadListItem("ratings-vm", map[string]string{"app": "ratings-vm", "class": "vm", "version": "v3"}),
-				data.CreateWorkloadListItem("ratings-vm2", map[string]string{"app": "ratings-vm2", "class": "vm2", "version": "v4"}),
-				data.CreateWorkloadListItem("ratings-vm-no-entry", map[string]string{"app": "ratings-vm-no-entry", "class": "vm3"}),
-				data.CreateWorkloadListItem("ratings-vm-no-labels", map[string]string{})),
-		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			"Namespace": {
+				data.CreateWorkload("ratings-vm", map[string]string{"app": "ratings-vm", "class": "vm", "version": "v3"}),
+				data.CreateWorkload("ratings-vm2", map[string]string{"app": "ratings-vm2", "class": "vm2", "version": "v4"}),
+				data.CreateWorkload("ratings-vm-no-entry", map[string]string{"app": "ratings-vm-no-entry", "class": "vm3"}),
+				data.CreateWorkload("ratings-vm-no-labels", map[string]string{}),
+			}},
 	}
 	return *wgReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.WorkloadGroups, Namespace: "Namespace", Name: name}]
 }

--- a/business/services.go
+++ b/business/services.go
@@ -581,11 +581,12 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 		return nil, err
 	}
 
+	config := config.Get()
 	wo := models.WorkloadOverviews{}
 	isAmbient := len(ws) > 0
 	for _, w := range ws {
 		wi := &models.WorkloadListItem{}
-		wi.ParseWorkload(w)
+		wi.ParseWorkload(w, config)
 		wo = append(wo, wi)
 		// The service is not marked as Ambient if any of the workloads is Ambient
 		if !w.IsAmbient {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1444,7 +1444,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			// Add some precalculated fields useful for validation
 			w.ValidationKey = fmt.Sprintf("%s:%s:%s", w.Cluster, w.Namespace, w.Name)
 
-w.ServiceAccountNames = w.Pods.ServiceAccounts()
+			w.ServiceAccountNames = w.Pods.ServiceAccounts()
 			slices.Sort(w.ServiceAccountNames)
 			w.ValidationVersion = fmt.Sprintf("%v:%v", w.Labels, w.ServiceAccountNames)
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -282,10 +282,9 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		return *workloadList, err
 	}
 
-	config := config.Get()
 	for _, w := range ws {
 		wItem := &models.WorkloadListItem{Health: *models.EmptyWorkloadHealth()}
-		wItem.ParseWorkload(w, config)
+		wItem.ParseWorkload(w, in.config)
 		if istioConfigList, ok := istioConfigMap[cluster]; ok && criteria.IncludeIstioResources {
 			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.config, wItem.Labels, istioConfigList, cluster))
 		}
@@ -1432,7 +1431,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			// Add the Proxy Status to the workload
 			for _, pod := range w.Pods {
 				isWaypoint := w.IsWaypoint()
-				if config.Get().ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
+				if in.config.ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
 					pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name, !isWaypoint)
 				}
 				// Add the Proxy Status to the workload
@@ -2122,7 +2121,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 
 		// Add the Proxy Status to the workload
 		for _, pod := range w.Pods {
-			if config.Get().ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
+			if in.config.ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
 				pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(criteria.Cluster, criteria.Namespace, pod.Name, !isWaypoint)
 			}
 			// If Ambient is enabled for pod, check if has any Waypoint proxy

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1444,6 +1444,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			// Add some precalculated fields useful for validation
 			w.ValidationKey = fmt.Sprintf("%s:%s:%s", w.Cluster, w.Namespace, w.Name)
 
+w.ServiceAccountNames = w.Pods.ServiceAccounts()
 			slices.Sort(w.ServiceAccountNames)
 			w.ValidationVersion = fmt.Sprintf("%v:%v", w.Labels, w.ServiceAccountNames)
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -148,7 +149,7 @@ func (in *WorkloadService) isWorkloadValid(workloadType string) bool {
 }
 
 // @TODO do validations per cluster
-func (in *WorkloadService) getWorkloadValidations(authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.WorkloadList) models.IstioValidations {
+func (in *WorkloadService) getWorkloadValidations(authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads) models.IstioValidations {
 	validations := checkers.WorkloadChecker{
 		AuthorizationPolicies: authpolicies,
 		WorkloadsPerNamespace: workloadsPerNamespace,
@@ -281,9 +282,10 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		return *workloadList, err
 	}
 
+	config := config.Get()
 	for _, w := range ws {
 		wItem := &models.WorkloadListItem{Health: *models.EmptyWorkloadHealth()}
-		wItem.ParseWorkload(w)
+		wItem.ParseWorkload(w, config)
 		if istioConfigList, ok := istioConfigMap[cluster]; ok && criteria.IncludeIstioResources {
 			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.config, wItem.Labels, istioConfigList, cluster))
 		}
@@ -301,8 +303,8 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 	for _, istioConfigList := range istioConfigMap {
 		// @TODO multi cluster validations
 		authpolicies := istioConfigList.AuthorizationPolicies
-		allWorkloads := map[string]models.WorkloadList{}
-		allWorkloads[namespace] = *workloadList
+		allWorkloads := map[string]models.Workloads{}
+		allWorkloads[namespace] = ws
 		validations := in.getWorkloadValidations(authpolicies, allWorkloads)
 		validations.StripIgnoredChecks()
 		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
@@ -1426,19 +1428,25 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			w.SetPods(cPods)
 		}
 
-		// Add the Proxy Status to the workload
-		for _, pod := range w.Pods {
-			isWaypoint := w.IsWaypoint()
-			if config.Get().ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
-				pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name, !isWaypoint)
-			}
-			// Add the Proxy Status to the workload
-			if pod.AmbientEnabled() {
-				w.WaypointWorkloads = in.GetWaypointsForWorkload(ctx, *w, false)
-			}
-		}
-
 		if cnFound {
+			// Add the Proxy Status to the workload
+			for _, pod := range w.Pods {
+				isWaypoint := w.IsWaypoint()
+				if config.Get().ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
+					pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name, !isWaypoint)
+				}
+				// Add the Proxy Status to the workload
+				if pod.AmbientEnabled() {
+					w.WaypointWorkloads = in.GetWaypointsForWorkload(ctx, *w, false)
+				}
+			}
+
+			// Add some precalculated fields useful for validation
+			w.ValidationKey = fmt.Sprintf("%s:%s:%s", w.Cluster, w.Namespace, w.Name)
+
+			slices.Sort(w.ServiceAccountNames)
+			w.ValidationVersion = fmt.Sprintf("%v:%v", w.Labels, w.ServiceAccountNames)
+
 			ws = append(ws, w)
 		}
 	}
@@ -2170,7 +2178,7 @@ func (in *WorkloadService) GetWaypoints(ctx context.Context) models.Workloads {
 		return in.cache.GetWaypointList()
 	}
 
-	waypoints := []*models.Workload{}
+	waypoints := models.Workloads{}
 
 	for cluster := range in.userClients {
 		gateways, err := in.GetAllWorkloads(ctx, cluster, config.GatewayLabel)

--- a/config/config.go
+++ b/config/config.go
@@ -321,10 +321,11 @@ type IstioConfig struct {
 	IstiodPodMonitoringPort           int               `yaml:"istiod_pod_monitoring_port,omitempty"`
 	// IstiodPollingIntervalSeconds is how often in seconds Kiali will poll istiod(s) for
 	// proxy status and registry services. Polling is not performed if IstioAPIEnabled is false.
-	IstiodPollingIntervalSeconds int             `yaml:"istiod_polling_interval_seconds,omitempty"`
-	Registry                     *RegistryConfig `yaml:"registry,omitempty"`
-	RootNamespace                string          `yaml:"root_namespace,omitempty"`
-	UrlServiceVersion            string          `yaml:"url_service_version"`
+	IstiodPollingIntervalSeconds     int             `yaml:"istiod_polling_interval_seconds,omitempty"`
+	Registry                         *RegistryConfig `yaml:"registry,omitempty"`
+	RootNamespace                    string          `yaml:"root_namespace,omitempty"`
+	UrlServiceVersion                string          `yaml:"url_service_version"`
+	ValidationChangeDetectionEnabled bool            `yaml:"validation_hashing_enabled,omitempty"`
 	// ValidationReconcileInterval sets how often Kiali will validate Istio configuration.
 	// Validations cannot be disabled at the moment but you can set this to a long period of time.
 	ValidationReconcileInterval *time.Duration `yaml:"validation_reconcile_interval,omitempty"`
@@ -758,6 +759,7 @@ func NewConfig() (c *Config) {
 				IstiodPollingIntervalSeconds:      20,
 				RootNamespace:                     "istio-system",
 				UrlServiceVersion:                 "",
+				ValidationChangeDetectionEnabled:  true,
 				ValidationReconcileInterval:       util.AsPtr(time.Minute),
 				GatewayAPIClasses:                 []GatewayAPIClass{},
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -325,7 +325,7 @@ type IstioConfig struct {
 	Registry                         *RegistryConfig `yaml:"registry,omitempty"`
 	RootNamespace                    string          `yaml:"root_namespace,omitempty"`
 	UrlServiceVersion                string          `yaml:"url_service_version"`
-	ValidationChangeDetectionEnabled bool            `yaml:"validation_hashing_enabled,omitempty"`
+	ValidationChangeDetectionEnabled bool            `yaml:"validation_change_detection_enabled,omitempty"`
 	// ValidationReconcileInterval sets how often Kiali will validate Istio configuration.
 	// Validations cannot be disabled at the moment but you can set this to a long period of time.
 	ValidationReconcileInterval *time.Duration `yaml:"validation_reconcile_interval,omitempty"`

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -135,7 +135,10 @@ func (r *ValidationsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		// if there have been no config changes for the cluster, just re-use the prior validations
 		if clusterValidations == nil {
+			log.Tracef("No changes for cluster [%s], re-using validations", cluster)
 			clusterValidations = models.IstioValidations(prevValidations).FilterByCluster(cluster)
+		} else {
+			log.Tracef("Config changes found for cluster [%s], updating validations ", cluster)
 		}
 
 		newValidations = newValidations.MergeValidations(clusterValidations)

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -117,9 +117,9 @@ func (r *ValidationsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	version := r.kialiCache.Validations().Version()
 	newValidations := make(models.IstioValidations)
 	prevValidations := r.kialiCache.Validations().Items()
-	var changeMap map[string][]byte
+	var changeMap business.ValidationChangeMap
 	if config.Get().ExternalServices.Istio.ValidationChangeDetectionEnabled {
-		changeMap = r.kialiCache.ValidationHashes().Items()
+		changeMap = r.kialiCache.ValidationConfig().Items()
 	}
 
 	// validation requires cross-cluster service account information.
@@ -152,7 +152,7 @@ func (r *ValidationsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	r.kialiCache.Validations().Replace(newValidations)
-	r.kialiCache.ValidationHashes().Replace(changeMap)
+	r.kialiCache.ValidationConfig().Replace(changeMap)
 
 	return ctrl.Result{}, nil
 }

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -138,10 +138,10 @@ func (r *ValidationsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		// if there have been no config changes for the cluster, just re-use the prior validations
 		if clusterValidations == nil {
-			log.Tracef("No changes for cluster [%s], re-using validations", cluster)
+			log.Tracef("validations: no changes for cluster [%s], re-using", cluster)
 			clusterValidations = models.IstioValidations(prevValidations).FilterByCluster(cluster)
 		} else {
-			log.Tracef("Config changes found for cluster [%s], updating validations ", cluster)
+			log.Tracef("validations: config changes found for cluster [%s], updating", cluster)
 		}
 
 		newValidations = newValidations.MergeValidations(clusterValidations)

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -82,8 +82,8 @@ type KialiCache interface {
 	// Validations caches validations for a cluster/namespace.
 	Validations() store.Store[models.IstioValidationKey, *models.IstioValidation]
 
-	// ValidationHashes stores hash values used for detecting changes in sets of config used for validation
-	ValidationHashes() store.Store[string, []byte]
+	// ValidationWatcher stores values used for detecting changes in config used for validation
+	ValidationConfig() store.Store[string, string]
 
 	// SetClusters sets the list of clusters that the cache knows about.
 	SetClusters([]models.KubeCluster)
@@ -135,7 +135,7 @@ type kialiCacheImpl struct {
 	waypointList models.WaypointStore
 	// validations key'd by the validation key
 	validations      store.Store[models.IstioValidationKey, *models.IstioValidation]
-	validationHashes store.Store[string, []byte]
+	validationConfig store.Store[string, string]
 
 	// Info about the kube clusters that the cache knows about.
 	clusters    []models.KubeCluster
@@ -152,7 +152,7 @@ func NewKialiCache(kialiSAClients map[string]kubernetes.ClientInterface, cfg con
 		conf:                    cfg,
 		kubeCache:               make(map[string]KubeCache),
 		validations:             store.New[models.IstioValidationKey, *models.IstioValidation](),
-		validationHashes:        store.New[string, []byte](),
+		validationConfig:        store.New[string, string](),
 		meshStore:               store.NewExpirationStore(ctx, store.New[string, *models.Mesh](), util.AsPtr(meshExpirationTime), nil),
 		namespaceStore:          store.NewExpirationStore(ctx, store.New[namespacesKey, map[string]models.Namespace](), &namespaceKeyTTL, nil),
 		refreshDuration:         time.Duration(cfg.KubernetesConfig.CacheDuration) * time.Second,
@@ -261,8 +261,8 @@ func (c *kialiCacheImpl) Validations() store.Store[models.IstioValidationKey, *m
 	return c.validations
 }
 
-func (c *kialiCacheImpl) ValidationHashes() store.Store[string, []byte] {
-	return c.validationHashes
+func (c *kialiCacheImpl) ValidationConfig() store.Store[string, string] {
+	return c.validationConfig
 }
 
 // IsAmbientEnabled checks if the istio Ambient profile was enabled

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -252,7 +252,8 @@ type IstioService struct {
 		Port     int    `json:"port"`
 		Protocol string `json:"protocol,omitempty"`
 	} `json:"ports"`
-	Hostname string `json:"hostname"`
+	Hostname        string `json:"hostname"`
+	ResourceVersion string `json:"ResourceVersion"`
 	// ClusterVIPs defined in Istio 1.11.x
 	ClusterVIPs11 map[string]string `json:"cluster-vips,omitempty"`
 	// ClusterVIPs defined in Istio 1.12.x

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -319,6 +319,7 @@
             "Registry": null,
             "RootNamespace": "istio-system",
             "UrlServiceVersion": "",
+            "ValidationChangeDetectionEnabled": true,
             "ValidationReconcileInterval": 60000000000
           }
         }

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -415,6 +415,17 @@ func (iv IstioValidations) FilterByKey(objectGVK schema.GroupVersionKind, name s
 	return fiv
 }
 
+func (iv IstioValidations) FilterByCluster(cluster string) IstioValidations {
+	fiv := IstioValidations{}
+	for k, v := range iv {
+		if v.Cluster == cluster {
+			fiv[k] = v
+		}
+	}
+
+	return fiv
+}
+
 // FilterByTypes takes an input as ObjectTypes, transforms to singular types and filters the validations
 func (iv IstioValidations) FilterByTypes(objectTypes []string) IstioValidations {
 	types := make(map[string]bool, len(objectTypes))

--- a/models/workload.go
+++ b/models/workload.go
@@ -173,7 +173,11 @@ type WorkloadListItem struct {
 	// Names of the waypoint proxy workloads, if any
 	WaypointWorkloads []string `json:"waypointWorkloads"`
 
-	ValidationKey     string
+	// ValidationKey is a pre-calculated key string: "cluster:namespace:name"
+	ValidationKey string
+
+	// ValidationVersion is a pre-calculated string representing the workload "version", basically
+	// the workload information that, if changed, requires re-validation.
 	ValidationVersion string
 }
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -172,6 +172,9 @@ type WorkloadListItem struct {
 
 	// Names of the waypoint proxy workloads, if any
 	WaypointWorkloads []string `json:"waypointWorkloads"`
+
+	ValidationKey     string
+	ValidationVersion string
 }
 
 type WorkloadOverviews []*WorkloadListItem
@@ -278,8 +281,7 @@ type Workloads []*Workload
 
 type WorkloadEntries []*WorkloadEntry
 
-func (workload *WorkloadListItem) ParseWorkload(w *Workload) {
-	conf := config.Get()
+func (workload *WorkloadListItem) ParseWorkload(w *Workload, conf *config.Config) {
 	workload.Name = w.Name
 	workload.Namespace = w.Namespace
 	workload.WorkloadGVK = w.WorkloadGVK
@@ -717,9 +719,9 @@ func (workloads WorkloadOverviews) HasIstioSidecar() bool {
 	return false
 }
 
-func (wl WorkloadList) GetLabels() []labels.Set {
-	wLabels := make([]labels.Set, 0, len(wl.Workloads))
-	for _, w := range wl.Workloads {
+func GetLabels(workloads []*Workload) []labels.Set {
+	wLabels := make([]labels.Set, 0, len(workloads))
+	for _, w := range workloads {
 		wLabels = append(wLabels, labels.Set(w.Labels))
 	}
 	return wLabels

--- a/models/workload.go
+++ b/models/workload.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -172,6 +174,10 @@ type WorkloadListItem struct {
 
 	// Names of the waypoint proxy workloads, if any
 	WaypointWorkloads []string `json:"waypointWorkloads"`
+
+	// SpecVersion is a hash value representing the workload's Spec, to be used for detecting change.
+	// it is set at parse-time.
+	SpecVersion []byte
 }
 
 type WorkloadOverviews []*WorkloadListItem
@@ -285,6 +291,7 @@ func (workload *WorkloadListItem) ParseWorkload(w *Workload) {
 	workload.WorkloadGVK = w.WorkloadGVK
 	workload.CreatedAt = w.CreatedAt
 	workload.ResourceVersion = w.ResourceVersion
+	workload.SpecVersion = w.SpecVersion
 	if w.WorkloadGVK == kubernetes.WorkloadGroups {
 		// For WorkloadGroups IstioSidecar is already calculated while fetching
 		workload.IstioSidecar = w.IstioSidecar
@@ -385,6 +392,10 @@ func (workload *Workload) ParseDeployment(d *apps_v1.Deployment) {
 	}
 	workload.CurrentReplicas = d.Status.Replicas
 	workload.AvailableReplicas = d.Status.AvailableReplicas
+	if json, err := json.Marshal(d.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseReplicaSet(r *apps_v1.ReplicaSet) {
@@ -395,6 +406,10 @@ func (workload *Workload) ParseReplicaSet(r *apps_v1.ReplicaSet) {
 	}
 	workload.CurrentReplicas = r.Status.Replicas
 	workload.AvailableReplicas = r.Status.AvailableReplicas
+	if json, err := json.Marshal(r.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseReplicaSetParent(r *apps_v1.ReplicaSet, workloadName string, workloadGVK schema.GroupVersionKind) {
@@ -409,6 +424,10 @@ func (workload *Workload) ParseReplicaSetParent(r *apps_v1.ReplicaSet, workloadN
 	}
 	workload.CurrentReplicas = r.Status.Replicas
 	workload.AvailableReplicas = r.Status.AvailableReplicas
+	if json, err := json.Marshal(r.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseReplicationController(r *core_v1.ReplicationController) {
@@ -419,6 +438,10 @@ func (workload *Workload) ParseReplicationController(r *core_v1.ReplicationContr
 	}
 	workload.CurrentReplicas = r.Status.Replicas
 	workload.AvailableReplicas = r.Status.AvailableReplicas
+	if json, err := json.Marshal(r.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseDeploymentConfig(dc *osapps_v1.DeploymentConfig) {
@@ -427,6 +450,10 @@ func (workload *Workload) ParseDeploymentConfig(dc *osapps_v1.DeploymentConfig) 
 	workload.DesiredReplicas = dc.Spec.Replicas
 	workload.CurrentReplicas = dc.Status.Replicas
 	workload.AvailableReplicas = dc.Status.AvailableReplicas
+	if json, err := json.Marshal(dc.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseStatefulSet(s *apps_v1.StatefulSet) {
@@ -437,6 +464,10 @@ func (workload *Workload) ParseStatefulSet(s *apps_v1.StatefulSet) {
 	}
 	workload.CurrentReplicas = s.Status.Replicas
 	workload.AvailableReplicas = s.Status.ReadyReplicas
+	if json, err := json.Marshal(s.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParsePod(pod *core_v1.Pod) {
@@ -461,6 +492,10 @@ func (workload *Workload) ParsePod(pod *core_v1.Pod) {
 	// Pod has not concept of replica
 	workload.CurrentReplicas = workload.DesiredReplicas
 	workload.AvailableReplicas = podAvailableReplicas
+	if json, err := json.Marshal(pod.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseJob(job *batch_v1.Job) {
@@ -471,6 +506,10 @@ func (workload *Workload) ParseJob(job *batch_v1.Job) {
 	workload.DesiredReplicas = job.Status.Active + job.Status.Succeeded + job.Status.Failed
 	workload.CurrentReplicas = workload.DesiredReplicas
 	workload.AvailableReplicas = job.Status.Active + job.Status.Succeeded
+	if json, err := json.Marshal(job.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseCronJob(cnjb *batch_v1.CronJob) {
@@ -496,6 +535,10 @@ func (workload *Workload) ParseCronJob(cnjb *batch_v1.CronJob) {
 	workload.DesiredReplicas = workload.CurrentReplicas
 	workload.AvailableReplicas = podAvailableReplicas
 	workload.HealthAnnotations = GetHealthAnnotation(cnjb.Annotations, GetHealthConfigAnnotation())
+	if json, err := json.Marshal(cnjb.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseDaemonSet(ds *apps_v1.DaemonSet) {
@@ -508,6 +551,10 @@ func (workload *Workload) ParseDaemonSet(ds *apps_v1.DaemonSet) {
 	workload.CurrentReplicas = ds.Status.CurrentNumberScheduled
 	workload.AvailableReplicas = ds.Status.NumberAvailable
 	workload.HealthAnnotations = GetHealthAnnotation(ds.Annotations, GetHealthConfigAnnotation())
+	if json, err := json.Marshal(ds.Spec); err == nil {
+		hash := sha256.Sum256(json)
+		workload.SpecVersion = hash[:]
+	}
 }
 
 func (workload *Workload) ParseWorkloadGroup(wg *networking_v1.WorkloadGroup, wentries []*networking_v1.WorkloadEntry, sidecars []*networking_v1.Sidecar) {

--- a/tests/data/policy_data.go
+++ b/tests/data/policy_data.go
@@ -1,6 +1,9 @@
 package data
 
 import (
+	"fmt"
+	"math/rand/v2"
+
 	api_security_v1 "istio.io/api/security/v1"
 	api_security_v1beta1 "istio.io/api/security/v1beta1"
 	api_v1beta1 "istio.io/api/type/v1beta1"
@@ -11,6 +14,7 @@ func CreateEmptyPeerAuthentication(name, namespace string, mtls *api_security_v1
 	pa := security_v1.PeerAuthentication{}
 	pa.Name = name
 	pa.Namespace = namespace
+	pa.ResourceVersion = fmt.Sprintf("%d", rand.Int64())
 	pa.Spec.Mtls = mtls
 	return &pa
 }

--- a/tests/data/workload_data.go
+++ b/tests/data/workload_data.go
@@ -12,10 +12,10 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateWorkloadsPerNamespace(namespaces []string, items ...models.WorkloadListItem) map[string]models.WorkloadList {
-	allWorkloads := map[string]models.WorkloadList{}
+func CreateWorkloadsPerNamespace(namespaces []string, workloads models.Workloads) map[string]models.Workloads {
+	allWorkloads := map[string]models.Workloads{}
 	for _, namespace := range namespaces {
-		allWorkloads[namespace] = CreateWorkloadList(namespace, items...)
+		allWorkloads[namespace] = workloads
 	}
 	return allWorkloads
 }
@@ -25,6 +25,22 @@ func CreateWorkloadList(namespace string, items ...models.WorkloadListItem) mode
 		Namespace: namespace,
 		Workloads: items,
 	}
+}
+
+func CreateWorkload(name string, labels map[string]string) *models.Workload {
+	w := models.Workload{}
+	w.Name = name
+	w.Labels = labels
+
+	if _, found := labels["app"]; found {
+		w.AppLabel = true
+	}
+
+	if _, found := labels["version"]; found {
+		w.VersionLabel = true
+	}
+
+	return &w
 }
 
 func CreateWorkloadListItem(name string, labels map[string]string) models.WorkloadListItem {


### PR DESCRIPTION
Part-of #8007 

The idea here is to generate a hash for config used in validations, using config ResourceVersion where applicable, and otherwise hashing relevant checker information. For example, we can't use Workload ResourceVersion because it changes when status is updated (and so is sensitive to pods coming and going). If the hash does not change at validation Reconcile time, then skip running the checkers.

This solution is something of a trade-off. It avoids the complexity needed for callback-based watchers on config, or other very granular approaches. But each reconcile still needs to gather the related config, and generate the hash. The savings is in being able to avoid running the checkers.  In the data presented in #8007 the checkers accounted for a lot of the validation time, so the hope is that this will be helpful, and push off any need to do something more complicated.

The algorithm works like this:

```
For base config (used for cross-cluster validation)
  generate a hash for the config (basically workload config)

For each cluster:
  generate a hash for the config defined in that cluster (services, all of the istio config)
  if hash is different or there is a base config change
    run checkers for the cluster
    replace previous validations
  else 
    keep previous validations
```

This also introduces a hidden config option to enable or disable this logic (default is enabled). The option is mainly a fail-safe, just in case we find a flaw in the logic that prevents validation re-generation, or somehow ends up adding to resource consumption.

Operator PR: https://github.com/kiali/kiali-operator/pull/885