### PR TITLE
Add benchmark test for validations

### DIFF
--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -27,7 +27,7 @@ import (
 var numberOfObjectsFlag int
 
 func init() {
-	flag.IntVar(&numberOfObjectsFlag, "num-objects", 10, "Number of objects to create of variosu kinds in the benchmark setup.")
+	flag.IntVar(&numberOfObjectsFlag, "num-objects", 10, "Number of objects to create of various kinds in the benchmark setup.")
 }
 
 func parseFlags(t testing.TB) {

--- a/business/istio_validations_perf_test.go
+++ b/business/istio_validations_perf_test.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,12 +11,29 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/istio/istiotest"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 )
+
+var numberOfObjectsFlag int
+
+func init() {
+	flag.IntVar(&numberOfObjectsFlag, "num-objects", 10, "Number of objects to create of variosu kinds in the benchmark setup.")
+}
+
+func parseFlags(t testing.TB) {
+	t.Helper()
+	flag.Parse()
+}
 
 func TestGetValidationsPerf(t *testing.T) {
 	assert := assert.New(t)
@@ -86,4 +104,82 @@ func fakeIstioConfigListPerf(numNs, numDr, numVs, numGw int) *models.IstioConfig
 		n++
 	}
 	return &istioConfigList
+}
+
+func BenchmarkValidate(b *testing.B) {
+	parseFlags(b)
+	services := []string{"details.test.svc.cluster.local", "product.test.svc.cluster.local", "product2.test.svc.cluster.local", "customer.test.svc.cluster.local"}
+	conf := config.NewConfig()
+	config.Set(conf)
+	istioConfigList := fakeIstioConfigListPerf(numberOfObjectsFlag, numberOfObjectsFlag, numberOfObjectsFlag, numberOfObjectsFlag)
+	fakeIstioObjects := []runtime.Object{
+		&core_v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+		kubetest.FakeNamespace("wrong"),
+		kubetest.FakeNamespace("istio-system"),
+	}
+	for _, p := range fakeMeshPolicies() {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range fakePolicies() {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range fakeCombinedServices(services, "test") {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range FakeDepSyncedWithRS(conf) {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range fakeNamespaces() {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range FakeRSSyncedWithPods(conf) {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	for _, p := range fakePods().Items {
+		fakeIstioObjects = append(fakeIstioObjects, p.DeepCopyObject())
+	}
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.Gateways)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.DestinationRules)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.VirtualServices)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.ServiceEntries)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.Sidecars)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.WorkloadEntries)...)
+	fakeIstioObjects = append(fakeIstioObjects, kubernetes.ToRuntimeObjects(istioConfigList.RequestAuthentications)...)
+	for i := 0; i < numberOfObjectsFlag; i++ {
+		fakeIstioObjects = append(fakeIstioObjects, data.CreateAuthorizationPolicyWithPrincipals(fmt.Sprintf("name-%d", i), fmt.Sprintf("ns-%d", i), []string{"principal1", "principal2", "principal2"}))
+	}
+	for i := 0; i < numberOfObjectsFlag; i++ {
+		ns := &core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ns-%d", i)}}
+		fakeIstioObjects = append(fakeIstioObjects, ns)
+	}
+	k8s := kubetest.NewFakeK8sClient(fakeIstioObjects...)
+	cache := SetupBusinessLayer(b, k8s, *conf)
+	cache.SetRegistryStatus(map[string]*kubernetes.RegistryStatus{
+		conf.KubernetesConfig.ClusterName: {
+			Services: data.CreateFakeMultiRegistryServices(services, "test", "*"),
+		},
+	})
+
+	k8sclients := make(map[string]kubernetes.ClientInterface)
+	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
+	discovery := &istiotest.FakeDiscovery{
+		MeshReturn: models.Mesh{ControlPlanes: []models.ControlPlane{{Cluster: &models.KubeCluster{IsKialiHome: true}, Config: models.ControlPlaneConfiguration{}}}},
+	}
+	namespace := NewNamespaceService(k8sclients, k8sclients, cache, conf, discovery)
+	mesh := NewMeshService(k8sclients, discovery)
+	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)
+	vs := NewValidationsService(&layer.IstioConfig, cache, &mesh, &namespace, &layer.Svc, k8sclients, &layer.Workload)
+
+	vInfo, err := vs.NewValidationInfo(context.TODO(), []string{conf.KubernetesConfig.ClusterName})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err = vs.Validate(context.TODO(), conf.KubernetesConfig.ClusterName, vInfo)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
@@ -761,7 +762,9 @@ func fakeValidationMeshServiceWithRegistryStatus(t *testing.T, cfg config.Config
 
 	k8sclients := make(map[string]kubernetes.ClientInterface)
 	k8sclients[cfg.KubernetesConfig.ClusterName] = k8s
-	discovery := istio.NewDiscovery(k8sclients, cache, conf)
+	discovery := &istiotest.FakeDiscovery{
+		MeshReturn: models.Mesh{ControlPlanes: []models.ControlPlane{{Cluster: &models.KubeCluster{IsKialiHome: true}, Config: models.ControlPlaneConfiguration{}}}},
+	}
 	namespace := NewNamespaceService(k8sclients, k8sclients, cache, conf, discovery)
 	mesh := NewMeshService(k8sclients, discovery)
 	layer := NewWithBackends(k8sclients, k8sclients, nil, nil)

--- a/business/testing.go
+++ b/business/testing.go
@@ -28,7 +28,7 @@ func setWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 
 // SetupBusinessLayer mocks out some global variables in the business package
 // such as the kiali cache and the prometheus client.
-func SetupBusinessLayer(t *testing.T, k8s kubernetes.ClientInterface, config config.Config) cache.KialiCache {
+func SetupBusinessLayer(t testing.TB, k8s kubernetes.ClientInterface, config config.Config) cache.KialiCache {
 	t.Helper()
 
 	originalClientFactory := clientFactory

--- a/kubernetes/cache/testing.go
+++ b/kubernetes/cache/testing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-func newTestingCache(t *testing.T, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
+func newTestingCache(t testing.TB, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
 	t.Helper()
 	// Disabling Istio API for tests. Otherwise the cache will try and poll the Istio endpoint
 	// when the cache is created.
@@ -36,7 +36,7 @@ func NewTestingCache(t *testing.T, k8s kubernetes.ClientInterface, conf config.C
 }
 
 // NewTestingCacheWithFactory allows you to pass in a custom client factory. Good for testing multicluster.
-func NewTestingCacheWithFactory(t *testing.T, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
+func NewTestingCacheWithFactory(t testing.TB, cf kubernetes.ClientFactory, conf config.Config) KialiCache {
 	t.Helper()
 	return newTestingCache(t, cf, conf)
 }


### PR DESCRIPTION
### Describe the change

Adds a benchmark test for validations.

Example of how to run this:
```
go test -run=XXX -benchmem -cpuprofile cpu.prof -memprofile mem.prof -bench=. github.com/kiali/kiali/business -num-objects 25
```
That produces a cpu and memory profile that you can examine with pprof like:
```
go tool pprof -http=":8080" ~/go/bin/kiali mem.prof
```
or
```
go tool pprof -web mem.prof
```

It's not perfect. Especially the data generation could use some more work but at least it's a start.

### Steps to test the PR

Run the benchmark with the instructions above.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
