### PR TITLE
[v2.6] Cypress - ignore skip empty login form in interop

### DIFF
--- a/frontend/cypress/integration/common/kiali_login.ts
+++ b/frontend/cypress/integration/common/kiali_login.ts
@@ -39,13 +39,6 @@ When('user fill in username and password', () => {
   }
 });
 
-When('user does not fill in username and password', () => {
-  if (auth_strategy === 'openshift') {
-    cy.log('Log in with empty credentials');
-    cy.get('button[type="submit"]').click();
-  }
-});
-
 When('user fills in an invalid username', () => {
   if (auth_strategy === 'openshift') {
     var invalid: string = 'foobar';

--- a/frontend/cypress/integration/featureFiles/kiali_login.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_login.feature
@@ -9,6 +9,7 @@ Feature: Kiali login
     Given user opens base url
     And user clicks my_htpasswd_provider
 
+  @skip-lpinterop
   Scenario: Try to log in without filling the username and password
     And user does not fill in username and password
     Then user sees the "Login is required. Please try again." phrase displayed

--- a/frontend/cypress/integration/featureFiles/kiali_login.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_login.feature
@@ -9,11 +9,6 @@ Feature: Kiali login
     Given user opens base url
     And user clicks my_htpasswd_provider
 
-  @skip-lpinterop
-  Scenario: Try to log in without filling the username and password
-    And user does not fill in username and password
-    Then user sees the "Login is required. Please try again." phrase displayed
-
   Scenario: Try to log in with an invalid username
     And user fills in an invalid username
     Then user sees the "Invalid login or password. Please try again." phrase displayed


### PR DESCRIPTION
When testing OSSM2.6 in interop pipeline, this testcase fails on OCP4.19 since its no longer possible to send empty login form. We skip the test by using tag `@skip-lpinterop`.

![image](https://github.com/user-attachments/assets/f5523d05-bfff-48c1-be0f-113fa490066d)

This should be cherry picked into OSSM 3.0 and eventually removed in master.