### PR TITLE
Make store.Version() threadsafe

### DIFF
--- a/store/fifo_store_test.go
+++ b/store/fifo_store_test.go
@@ -6,15 +6,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/kiali/kiali/util"
 )
 
 func TestSetAndGet(t *testing.T) {
 	require := require.New(t)
 
 	s := New[string, string]()
-	fifoStore := NewFIFOStore[string, string](s, 3, "test")
+	fifoStore := NewFIFOStore(s, 3, "test")
 	fifoStore.Set("foo", "bar")
 	fifoStore.Set("foo2", "bar2")
 	fifoStore.Set("foo3", "bar3")
@@ -39,7 +37,7 @@ func TestUpdate(t *testing.T) {
 	require := require.New(t)
 
 	s := New[string, string]()
-	fifoStore := NewFIFOStore[string, string](s, 3, "test")
+	fifoStore := NewFIFOStore(s, 3, "test")
 	fifoStore.Set("foo", "bar")
 	fifoStore.Set("foo2", "bar2")
 	fifoStore.Set("foo3", "bar3")
@@ -71,22 +69,18 @@ func TestUpdate(t *testing.T) {
 
 func TestExpired(t *testing.T) {
 	require := require.New(t)
+	ms := 1 * time.Millisecond
 
 	store := New[string, string]()
-	fifoStore := NewFIFOStore[string, string](store, 3, "test")
-	expirationStore := NewExpirationStore[string, string](context.Background(), fifoStore, util.AsPtr(10*time.Second), util.AsPtr(10*time.Second))
+	fifoStore := NewFIFOStore(store, 3, "test")
+	expirationStore := NewExpirationStore(context.Background(), fifoStore, &ms, &ms)
 	expirationStore.Set("foo", "bar")
 	expirationStore.Set("foo2", "bar2")
 	expirationStore.Set("foo3", "bar3")
 
 	require.Equal(len(expirationStore.Store.Items()), 3)
 
-	time.Sleep(5 * time.Second)
-	elem, found := expirationStore.Get("foo")
-	require.True(found)
-	require.Equal(elem, "bar")
-
-	time.Sleep(15 * time.Second)
+	time.Sleep(30 * time.Millisecond)
 
 	_, found1 := expirationStore.Get("foo")
 	require.False(found1)
@@ -94,41 +88,13 @@ func TestExpired(t *testing.T) {
 	require.False(found2)
 	_, found3 := expirationStore.Get("foo3")
 	require.False(found3)
-}
-
-func TestExpiredNoCleanup(t *testing.T) {
-	require := require.New(t)
-
-	store := New[string, string]()
-	fifoStore := NewFIFOStore[string, string](store, 3, "test")
-	expirationStore := NewExpirationStore[string, string](context.Background(), fifoStore, util.AsPtr(10*time.Second), util.AsPtr(10*time.Second))
-	expirationStore.Set("foo", "bar")
-	expirationStore.Set("foo2", "bar2")
-	expirationStore.Set("foo3", "bar3")
-
-	require.Equal(len(expirationStore.Store.Items()), 3)
-
-	time.Sleep(5 * time.Second)
-	elem, found := expirationStore.Get("foo")
-	require.True(found)
-	require.Equal(elem, "bar")
-
-	time.Sleep(15 * time.Second)
-
-	_, found1 := expirationStore.Get("foo")
-	require.False(found1)
-	_, found2 := expirationStore.Get("foo2")
-	require.False(found2)
-	_, found3 := expirationStore.Get("foo3")
-	require.False(found3)
-
 }
 
 func TestReplace(t *testing.T) {
 	require := require.New(t)
 
 	s := New[string, string]()
-	fifoStore := NewFIFOStore[string, string](s, 3, "test")
+	fifoStore := NewFIFOStore(s, 3, "test")
 	fifoStore.Set("foo", "bar")
 	fifoStore.Set("foo2", "bar2")
 	fifoStore.Set("foo3", "bar3")

--- a/store/threadsafe_store.go
+++ b/store/threadsafe_store.go
@@ -67,6 +67,8 @@ func (s *threadSafeStore[K, V]) Keys() []K {
 }
 
 func (s *threadSafeStore[K, V]) Version() uint {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	return s.version
 }
 


### PR DESCRIPTION
### Describe the change

Adds a read lock to `store.Version()`. Also removes a duplicated unit test and speeds up another one that was causing tests to be slow.

### Steps to test the PR

`go test -timeout 30s -race -run '^TestVersionIsThreadsafe$' github.com/kiali/kiali/store`

### Automation testing

Unit tests

### Issue reference
https://github.com/kiali/kiali/issues/8207
