### PR TITLE
[CI] Fix tempo suite flake

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -171,7 +171,8 @@ for addon in ${ADDONS}; do
 
     kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
     kubectl wait pods --all -n opentelemetry-operator-system --for=condition=Ready --timeout=5m
-
+    # Wait 10 seconds until https://github.com/open-telemetry/opentelemetry-operator/issues/3194 is fixed.
+    sleep 10
     kubectl apply -f ${SCRIPT_DIR}/tempo/otel-collector.yaml
   else
     istio_version=$(kubectl get istios default -o jsonpath='{.spec.version}')


### PR DESCRIPTION
### Describe the change

The otel operator does not wait until its webhook is ready before considering itself ready so we must wait a few seconds before trying to create otel resources.

### Steps to test the PR

```
./hack/run-integration-tests.sh --test-suite frontend-tempo --setup-only true
```

### Automation testing

N/A

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
