### PR TITLE
Fix data race in `store.Items()`

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -143,6 +143,18 @@ func TestItemsReturnsWholeMap(t *testing.T) {
 	require.Equal(99, contents["key2"])
 }
 
+func TestItemsReturnsCopy(t *testing.T) {
+	require := require.New(t)
+
+	testStore := store.New[string, int]()
+	testStore.Replace(map[string]int{"key1": 42, "key2": 99})
+
+	contents := testStore.Items()
+	contents["key1"] = 52
+
+	require.Equal(42, testStore.Items()["key1"])
+}
+
 func TestDeleteKey(t *testing.T) {
 	require := require.New(t)
 

--- a/store/threadsafe_store.go
+++ b/store/threadsafe_store.go
@@ -1,9 +1,9 @@
 package store
 
 import (
+	"maps"
+	"slices"
 	"sync"
-
-	"golang.org/x/exp/maps"
 )
 
 // threadSafeStore implements the Store interface and is safe for concurrent use.
@@ -25,10 +25,11 @@ func (s *threadSafeStore[K, V]) Get(key K) (V, bool) {
 	return v, found
 }
 
+// Items returns a copy of all items in the store.
 func (s *threadSafeStore[K, V]) Items() map[K]V {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s.data
+	return maps.Clone(s.data)
 }
 
 // Replace replaces the contents of the store with the given map.
@@ -63,7 +64,7 @@ func (s *threadSafeStore[K, V]) Remove(key K) {
 func (s *threadSafeStore[K, V]) Keys() []K {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return maps.Keys(s.data)
+	return slices.Collect(maps.Keys(s.data))
 }
 
 func (s *threadSafeStore[K, V]) Version() uint {


### PR DESCRIPTION
`store.Items()` was returning the underlying `data` rather than a copy.

### Steps to test the PR

N/A

### Automation testing

Included unit tests.
