### PR TITLE
Add additional options for selecting Gateway API gateway classes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -312,6 +312,7 @@ type IstioConfig struct {
 	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
+	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty"`
 	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
 	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -106,10 +106,15 @@ func Config(conf *config.Config, discovery *istio.Discovery) http.HandlerFunc {
 				return err
 			}
 
+			gatewayAPIClasses, err := layer.IstioConfig.GatewayAPIClasses(conf.KubernetesConfig.ClusterName)
+			if err != nil {
+				return fmt.Errorf("failure while fetching Gateway API classes: %w", err)
+			}
+
 			// @TODO hardcoded home cluster
 			publicConfig.GatewayAPIEnabled = layer.IstioConfig.IsGatewayAPI(conf.KubernetesConfig.ClusterName)
 			publicConfig.AmbientEnabled = layer.IstioConfig.IsAmbientEnabled(conf.KubernetesConfig.ClusterName)
-			publicConfig.GatewayAPIClasses = layer.IstioConfig.GatewayAPIClasses(conf.KubernetesConfig.ClusterName)
+			publicConfig.GatewayAPIClasses = gatewayAPIClasses
 
 			// Fetch the list of all clusters in the mesh
 			// One usage of this data is to cross-link Kiali instances, when possible.

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -379,20 +379,3 @@ func ClusterNameFromIstiod(conf config.Config, k8s ClientInterface) (string, err
 
 	return clusterName, nil
 }
-
-func GatewayAPIClasses(ambientEnabled bool) []config.GatewayAPIClass {
-	result := []config.GatewayAPIClass{}
-	for _, gwClass := range config.Get().ExternalServices.Istio.GatewayAPIClasses {
-		if gwClass.ClassName != "" && gwClass.Name != "" {
-			result = append(result, gwClass)
-		}
-	}
-	if len(result) == 0 {
-		result = append(result, config.GatewayAPIClass{Name: "Istio", ClassName: "istio"})
-		if ambientEnabled {
-			result = append(result, config.GatewayAPIClass{Name: "Waypoint", ClassName: "istio-waypoint"})
-		}
-	}
-
-	return result
-}

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -308,6 +308,7 @@
             "ConfigMapName": "",
             "EnvoyAdminLocalPort": 15000,
             "GatewayAPIClasses": [],
+            "GatewayAPIClassesLabelSelector": "",
             "IstioAPIEnabled": true,
             "IstioIdentityDomain": "svc.cluster.local",
             "IstioInjectionAnnotation": "sidecar.istio.io/inject",


### PR DESCRIPTION
### Describe the change

This adds two new ways for Kiali to find and identify Istio-backed Gateway API gateway classes, providing a nicer setup experience for users:

* Users can now set a `gateway_api_classes_label_selector` configuration field. This takes [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering) targeting gateway API classes. This is usable with the existing `gateway_api_classes` config.
* If neither Gateway API class config field is set, Kiali will load all Gateway API gateway classes that use "istio.io" as a controller. This will work well by default for most deployments.

With either new option,, users do not necessarily have to set gateway class names, decoupling Kiali from gateway class management.

### Steps to test the PR

Build an image and deploy it to a cluster with Istio and gateways + gateway classes already setup. Configure Kiali to match the gateway classes, then verify that gateways pass config validation.

I'll test this in my cluster once reviewers let me know the PR looks functionally okay.

### Automation testing

None - current implementation is lacking tests, and this matches the current implementation.

### Issue reference

Addresses https://github.com/kiali/kiali/issues/8220#issuecomment-2710329177
