### PR TITLE
Fix issue with unary "label:" graph find/hide

### DIFF
--- a/frontend/src/helpers/GraphHelpers.tsx
+++ b/frontend/src/helpers/GraphHelpers.tsx
@@ -88,7 +88,16 @@ export const selectAnd = (elems: GraphElement[], ands: SelectAnd): GraphElement[
 
 export const select = (elems: GraphElement[], exp: SelectExp): GraphElement[] => {
   return elems.filter(e => {
-    const propVal = e.getData()[exp.prop] || '';
+    let propVal = e.getData()[exp.prop];
+
+    switch (exp.op) {
+      case 'falsy':
+        return !propVal;
+      case 'truthy':
+        return !!propVal;
+      default:
+        propVal = propVal ?? '';
+    }
 
     switch (exp.op) {
       case '!=':
@@ -113,10 +122,6 @@ export const select = (elems: GraphElement[], exp: SelectExp): GraphElement[] =>
         return (propVal as string).endsWith(exp.val as string);
       case '^=':
         return (propVal as string).startsWith(exp.val as string);
-      case 'falsy':
-        return !propVal;
-      case 'truthy':
-        return !!propVal;
       default:
         return propVal === exp.val;
     }

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFindPF.tsx
@@ -1191,7 +1191,7 @@ class GraphFindPFComponent extends React.Component<GraphFindProps, GraphFindStat
         // special node operand
         if (field.startsWith('label:')) {
           const safeFieldName = CytoscapeGraphUtils.toSafeCyFieldName(field);
-          return { target: 'node', selector: { prop: safeFieldName, op: isNegation ? '<=' : '>', val: 0 } };
+          return { target: 'node', selector: { prop: safeFieldName, op: isNegation ? 'falsy' : 'truthy' } };
         }
 
         return undefined;


### PR DESCRIPTION
Fixes #8232

Test:
1. deploy bookinfo
2. traffic graph page
3. graph find: `label:service`
4. graph find: `!label:service`

You can supplement with other label-oriented tests.  Note that the active "app" and "version" label names are special, and not applicable to graph find/hide.


