### PR TITLE
[v2.4] Upgrade go 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiali/kiali
 
-go 1.23.2
+go 1.23.6
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
### Describe the change

Upgrade golang to 1.23.6

### Issue reference

https://issues.redhat.com/browse/OSSM-8745
https://issues.redhat.com/browse/OSSM-8837
