### PR TITLE
Cluster reported as unknown in rates for 503 response code requests

### DIFF
--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -177,7 +177,7 @@ func getNamespaceServicesRequestRates(ctx context.Context, api prom_v1.API, name
 // Note that it does not discriminate on "reporter", so rates can be inflated due to duplication, and therefore
 // should be used mainly for calculating ratios (e.g total rates / error rates)
 func getServiceRequestRates(ctx context.Context, api prom_v1.API, namespace, cluster, service string, queryTime time.Time, ratesInterval string) (model.Vector, error) {
-	lbl := fmt.Sprintf(`destination_service_name="%s",destination_service_namespace="%s",destination_cluster="%s"`, service, namespace, cluster)
+	lbl := fmt.Sprintf(`destination_service_name="%s",destination_service_namespace="%s",destination_cluster=~"%s|unknown"`, service, namespace, cluster)
 	in, err := getRequestRatesForLabel(ctx, api, queryTime, lbl, ratesInterval)
 	if err != nil {
 		return model.Vector{}, err


### PR DESCRIPTION
### Describe the change

Using `|unknown` in `getServiceRequestRates` because the metrics report the 503 response code requests as unknown. 
Probably that should be fixed in the Istio telemetry side, but I'm not sure if that is possible and this could serve as a workaround. 

The query done in the graph:
`sum(rate(istio_requests_total{reporter=~"source|waypoint",source_workload_namespace="bookinfo"} [60s])) by (source_cluster,source_workload_namespace,source_workload,source_canonical_service,source_canonical_revision,destination_cluster,destination_service_namespace,destination_service,destination_service_name,destination_workload_namespace,destination_workload,destination_canonical_service,destination_canonical_revision,request_protocol,response_code,grpc_response_status,response_flags) > 0`

Returned the 503 errors:
![image](https://github.com/user-attachments/assets/fde2b14d-20ae-496c-a6d3-6ace138d6464)

The health data returned: 
```
          "healthData": {
            "requests": {
              "inbound": {
                "http": {
                  "200": 0.377,
                  "503": 1.4
                }
              },
              "outbound": {
                "http": {
                  "200": 0.377
                }
              },
              "healthAnnotations": {}
            }
          },
```

That's why it was possible to see the error in the summary panel: 
![image](https://github.com/user-attachments/assets/e40ddf5d-801a-4bd4-802a-f00108fcc102)

The query done for the rate services:
`rate(istio_requests_total{destination_service_name="reviews",destination_service_namespace="bookinfo",destination_cluster="Kubernetes"}[60s]) > 0`

The health data returned: 
```
"requests": {
  "inbound": {
      "http": {
         "200": 0.42222222222222217
       }
      },
   "outbound": {},
    "healthAnnotations": {}
    }
}
```

### Steps to test the PR

- Install Istio and Kiali
- Install bookinfo, create a fault injection with 80% abort percentage.
- Go to the services list. Before this PR is applied: 
![image](https://github.com/user-attachments/assets/5e08847c-d675-4347-ac73-ed8a6893cb37)
![image](https://github.com/user-attachments/assets/41744549-efa4-4ce1-9908-8e12cf0d3193)

- Once the PR is applied:
![image](https://github.com/user-attachments/assets/2db1b7df-6777-4008-815c-0a5e5fe99e18)
![image](https://github.com/user-attachments/assets/f7e9669d-ef81-46d1-aa69-9454974f242b)

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8203 
