### PR TITLE
[Mesh Page] Kiali resource usage metrics

### DIFF
--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -167,6 +167,8 @@ const conf = {
         `api/namespaces/${namespace}/pods/${pod}/config_dump/${resource}`,
       podZtunnelConfig: (namespace: string, pod: string) =>
         `api/namespaces/${namespace}/pods/${pod}/config_dump_ztunnel`,
+      resourceUsageMetrics: (namespace: string, workload: string) =>
+        `api/namespaces/${namespace}/${workload}/usage_metrics`,
       serverConfig: `api/config`,
       service: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}`,
       serviceGraphElements: (namespace: string, service: string) =>

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -195,8 +195,7 @@ const conf = {
       workloadDashboard: (namespace: string, workload: string) =>
         `api/namespaces/${namespace}/workloads/${workload}/dashboard`,
       ztunnelDashboard: (namespace: string, controlPlane: string) =>
-        `api/namespaces/${namespace}/ztunnel/${controlPlane}/dashboard`,
-      ztunnelMetrics: (namespace: string, workload: string) => `api/namespaces/${namespace}/ztunnel/${workload}/metrics`
+        `api/namespaces/${namespace}/ztunnel/${controlPlane}/dashboard`
     }
   },
   /** Graph configurations */

--- a/frontend/src/pages/Mesh/target/TargetPanel.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanel.tsx
@@ -27,7 +27,7 @@ import { meshWideMTLSStatusSelector, minTLSVersionSelector } from 'store/Selecto
 import { TargetPanelDataPlane } from './TargetPanelDataPlane';
 import { TargetPanelControlPlane } from './TargetPanelControlPlane';
 import { useKialiTranslation } from 'utils/I18nUtils';
-import { TargetPanelZtunnel } from './TargetPanelZtunnel';
+import { TargetPanelMetrics } from './TargetPanelMetrics';
 
 type ReduxProps = {
   kiosk: string;
@@ -153,8 +153,9 @@ export const TargetPanelComponent: React.FC<TargetPanelProps> = (props: TargetPa
               />
             );
           case MeshInfraType.ZTUNNEL:
+          case MeshInfraType.KIALI:
             return (
-              <TargetPanelZtunnel
+              <TargetPanelMetrics
                 duration={props.duration}
                 istioAPIEnabled={props.istioAPIEnabled}
                 kiosk={props.kiosk}

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -233,6 +233,7 @@ export const renderNodeLink = (meshData: MeshNodeData, style?: string): React.Re
       break;
     case MeshInfraType.WAYPOINT:
     case MeshInfraType.ZTUNNEL:
+    case MeshInfraType.KIALI:
       link = `/namespaces/${encodeURIComponent(meshData.namespace)}/workloads/${encodeURIComponent(
         meshData.infraName
       )}`;

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -50,7 +50,13 @@ import { ComponentStatus, IstiodResourceThresholds } from '../types/IstioStatus'
 import { TracingInfo, TracingResponse, TracingSingleResponse } from '../types/TracingInfo';
 import { ControlPlane, MeshDefinition, MeshQuery } from '../types/Mesh';
 import { DashboardQuery, IstioMetricsOptions, MetricsStatsQuery } from '../types/MetricsOptions';
-import { IstioMetricsMap, MetricsPerNamespace, MetricsStatsResult, ZtunnelMetricsMap } from '../types/Metrics';
+import {
+  IstioMetricsMap,
+  MetricsPerNamespace,
+  MetricsStatsResult,
+  ResourceUsageMetricsMap,
+  ZtunnelMetricsMap
+} from '../types/Metrics';
 import { Namespace } from '../types/Namespace';
 import { KialiCrippledFeatures, ServerConfig } from '../types/ServerConfig';
 import { StatusState } from '../types/StatusState';
@@ -255,6 +261,26 @@ export const getZtunnelMetrics = (
   return newRequest<Readonly<ZtunnelMetricsMap>>(
     HTTP_VERBS.GET,
     urls.ztunnelMetrics(namespace, workload),
+    queryParams,
+    {}
+  );
+};
+
+export const getResourceUsageMetrics = (
+  namespace: string,
+  workload: string,
+  params: IstioMetricsOptions,
+  cluster?: string
+): Promise<ApiResponse<Readonly<ResourceUsageMetricsMap>>> => {
+  const queryParams: QueryParams<IstioMetricsOptions> = { ...params };
+
+  if (cluster) {
+    queryParams.clusterName = cluster;
+  }
+
+  return newRequest<Readonly<ResourceUsageMetricsMap>>(
+    HTTP_VERBS.GET,
+    urls.resourceUsageMetrics(namespace, workload),
     queryParams,
     {}
   );

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -50,13 +50,7 @@ import { ComponentStatus, IstiodResourceThresholds } from '../types/IstioStatus'
 import { TracingInfo, TracingResponse, TracingSingleResponse } from '../types/TracingInfo';
 import { ControlPlane, MeshDefinition, MeshQuery } from '../types/Mesh';
 import { DashboardQuery, IstioMetricsOptions, MetricsStatsQuery } from '../types/MetricsOptions';
-import {
-  IstioMetricsMap,
-  MetricsPerNamespace,
-  MetricsStatsResult,
-  ResourceUsageMetricsMap,
-  ZtunnelMetricsMap
-} from '../types/Metrics';
+import { IstioMetricsMap, MetricsPerNamespace, MetricsStatsResult, ResourceUsageMetricsMap } from '../types/Metrics';
 import { Namespace } from '../types/Namespace';
 import { KialiCrippledFeatures, ServerConfig } from '../types/ServerConfig';
 import { StatusState } from '../types/StatusState';
@@ -241,26 +235,6 @@ export const getControlPlaneMetrics = (
   return newRequest<Readonly<IstioMetricsMap>>(
     HTTP_VERBS.GET,
     urls.controlPlaneMetrics(namespace, controlPlane),
-    queryParams,
-    {}
-  );
-};
-
-export const getZtunnelMetrics = (
-  namespace: string,
-  workload: string,
-  params: IstioMetricsOptions,
-  cluster?: string
-): Promise<ApiResponse<Readonly<ZtunnelMetricsMap>>> => {
-  const queryParams: QueryParams<IstioMetricsOptions> = { ...params };
-
-  if (cluster) {
-    queryParams.clusterName = cluster;
-  }
-
-  return newRequest<Readonly<ZtunnelMetricsMap>>(
-    HTTP_VERBS.GET,
-    urls.ztunnelMetrics(namespace, workload),
     queryParams,
     {}
   );

--- a/frontend/src/types/Metrics.ts
+++ b/frontend/src/types/Metrics.ts
@@ -25,6 +25,11 @@ export type ZtunnelMetricsMap = {
   ztunnel_workload_manager?: Metric[];
 };
 
+export type ResourceUsageMetricsMap = {
+  cpu_usage?: Metric[];
+  memory_usage?: Metric[];
+};
+
 export type MetricsPerNamespace = { [key: string]: IstioMetricsMap };
 
 export type IstioMetricsMap = {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -228,50 +228,6 @@ func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 	}
 }
 
-// ZtunnelMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
-func ZtunnelMetrics(promSupplier promClientSupplier) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-
-		vars := mux.Vars(r)
-		namespace := vars["namespace"]
-		cluster := clusterNameFromQuery(r.URL.Query())
-
-		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
-		if metricsService == nil {
-			// any returned value nil means error & response already written
-			return
-		}
-		oldestNs := GetOldestNamespace(namespaceInfo)
-
-		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
-
-		err := extractIstioMetricsQueryParams(r, &params, oldestNs)
-		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		if namespace != config.Get().IstioNamespace {
-			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
-			return
-		}
-
-		metrics := make(models.MetricsMap)
-
-		ztunnelMetrics, err := metricsService.GetZtunnelMetrics(params)
-		if err != nil {
-			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
-			return
-		}
-
-		for k, v := range ztunnelMetrics {
-			metrics[k] = v
-		}
-
-		RespondWithJSON(w, http.StatusOK, metrics)
-	}
-}
-
 // ResourceUsageMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
 func ResourceUsageMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -272,6 +272,51 @@ func ZtunnelMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 	}
 }
 
+// ResourceUsageMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
+func ResourceUsageMetrics(promSupplier promClientSupplier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		vars := mux.Vars(r)
+		namespace := vars["namespace"]
+		app := vars["app"]
+		cluster := clusterNameFromQuery(r.URL.Query())
+
+		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
+		if metricsService == nil {
+			// any returned value nil means error & response already written
+			return
+		}
+		oldestNs := GetOldestNamespace(namespaceInfo)
+
+		params := models.IstioMetricsQuery{App: app, Cluster: cluster, Namespace: namespace}
+
+		err := extractIstioMetricsQueryParams(r, &params, oldestNs)
+		if err != nil {
+			RespondWithError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if namespace != config.Get().IstioNamespace {
+			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
+			return
+		}
+
+		metrics := make(models.MetricsMap)
+
+		ztunnelMetrics, err := metricsService.GetResourceMetrics(params)
+		if err != nil {
+			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+
+		for k, v := range ztunnelMetrics {
+			metrics[k] = v
+		}
+
+		RespondWithJSON(w, http.StatusOK, metrics)
+	}
+}
+
 // NamespaceMetrics is the API handler to fetch metrics to be displayed, related to all
 // services in the namespace
 func NamespaceMetrics(promSupplier promClientSupplier) http.HandlerFunc {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -874,27 +874,6 @@ func NewRoutes(
 			handlers.ControlPlaneMetrics(handlers.DefaultPromClientSupplier),
 			true,
 		},
-		// swagger:route GET /namespaces/{namespace}/ztunnel/{workload}/metrics ztunnel metrics
-		// ---
-		// Endpoint to fetch metrics to be displayed, related to a single control plane
-		//
-		//     Produces:
-		//     - application/json
-		//
-		//     Schemes: http, https
-		//
-		// responses:
-		//      400: badRequestError
-		//      503: serviceUnavailableError
-		//      200: metricsResponse
-		//
-		{
-			"ZtunnelMetrics",
-			"GET",
-			"/api/namespaces/{namespace}/ztunnel/{workload}/metrics",
-			handlers.ZtunnelMetrics(handlers.DefaultPromClientSupplier),
-			true,
-		},
 		// swagger:route GET /namespaces/{namespace}/{workload}/usage_metrics resource usage metrics
 		// ---
 		// Endpoint to fetch metrics to be displayed, related to cpu and memory usage

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -895,6 +895,27 @@ func NewRoutes(
 			handlers.ZtunnelMetrics(handlers.DefaultPromClientSupplier),
 			true,
 		},
+		// swagger:route GET /namespaces/{namespace}/{workload}/usage_metrics resource usage metrics
+		// ---
+		// Endpoint to fetch metrics to be displayed, related to cpu and memory usage
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      400: badRequestError
+		//      503: serviceUnavailableError
+		//      200: metricsResponse
+		//
+		{
+			"UsageMetrics",
+			"GET",
+			"/api/namespaces/{namespace}/{app}/usage_metrics",
+			handlers.ResourceUsageMetrics(handlers.DefaultPromClientSupplier),
+			true,
+		},
 		// swagger:route GET /namespaces/{namespace}/services/{service}/dashboard services serviceDashboard
 		// ---
 		// Endpoint to fetch dashboard to be displayed, related to a single service


### PR DESCRIPTION
### Describe the change

Show Resource usage for Kiali in the Mesh page: 
![image](https://github.com/user-attachments/assets/feadac5f-9360-4e3b-9096-e08030cf9576)

Added a Kiali link to the workload

### Steps to test the PR

- Install Istio
- Install Kiali
- Go to the Mesh Page
- Click in the Kiali node
- See the metrics 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #8196 
