### PR TITLE
Refactor config handlers

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -983,16 +983,8 @@ func (in *IstioConfigService) CreateIstioConfigDetail(ctx context.Context, clust
 	return istioConfigDetail, nil
 }
 
-func (in *IstioConfigService) IsGatewayAPI(cluster string) bool {
-	return in.userClients[cluster].IsGatewayAPI()
-}
-
 func (in *IstioConfigService) GatewayAPIClasses(cluster string) []config.GatewayAPIClass {
-	return kubernetes.GatewayAPIClasses(in.IsAmbientEnabled(cluster), in.conf)
-}
-
-func (in *IstioConfigService) IsAmbientEnabled(cluster string) bool {
-	return in.kialiCache.IsAmbientEnabled(cluster)
+	return kubernetes.GatewayAPIClasses(in.kialiCache.IsAmbientEnabled(cluster), in.conf)
 }
 
 func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, namespaces []string, cluster string) models.IstioConfigPermissions {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2167,9 +2167,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 }
 
 func (in *WorkloadService) GetZtunnelConfig(cluster, namespace, pod string) *kubernetes.ZtunnelConfigDump {
-
 	return in.cache.GetZtunnelDump(cluster, namespace, pod)
-
 }
 
 // GetWaypoints: Return the list of waypoint workloads.  This looks for all k8s gateways and then tests their labels

--- a/graph/telemetry/istio/appender/service_entry_test.go
+++ b/graph/telemetry/istio/appender/service_entry_test.go
@@ -14,19 +14,12 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 )
-
-type fakeMeshDiscovery struct {
-	mesh models.Mesh
-}
-
-func (fmd *fakeMeshDiscovery) Mesh(ctx context.Context) (*models.Mesh, error) {
-	return &fmd.mesh, nil
-}
 
 func setupBusinessLayer(t *testing.T, meshExportTo []string, istioObjects ...runtime.Object) *business.Layer {
 	conf := config.NewConfig()
@@ -45,8 +38,8 @@ func setupBusinessLayer(t *testing.T, meshExportTo []string, istioObjects ...run
 	k8sclients[config.Get().KubernetesConfig.ClusterName] = k8s
 
 	if len(meshExportTo) != 0 {
-		discovery := &fakeMeshDiscovery{
-			mesh: models.Mesh{
+		discovery := &istiotest.FakeDiscovery{
+			MeshReturn: models.Mesh{
 				ControlPlanes: []models.ControlPlane{{
 					Cluster: &models.KubeCluster{Name: config.DefaultClusterID, IsKialiHome: true},
 					Config: models.ControlPlaneConfiguration{
@@ -223,7 +216,8 @@ func TestServiceEntry(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -342,7 +336,8 @@ func TestServiceEntryExportAll(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -455,7 +450,8 @@ func TestServiceEntryExportNamespaceFound(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -568,7 +564,8 @@ func TestServiceEntryExportDefinitionNamespace(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -681,7 +678,8 @@ func TestServiceEntryMeshExportDefinitionNamespace(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -794,7 +792,8 @@ func TestServiceEntryMeshExportAll(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -907,7 +906,8 @@ func TestServiceEntryExportNamespaceNotFound(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1020,11 +1020,13 @@ func TestKiali7153_1(t *testing.T) {
 			testNamespaceKey: &graph.AccessibleNamespace{
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
-				Name:              "testNamespace"},
+				Name:              "testNamespace",
+			},
 			otherNamespaceKey: &graph.AccessibleNamespace{
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
-				Name:              "otherNamespace"},
+				Name:              "otherNamespace",
+			},
 		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
@@ -1130,7 +1132,8 @@ func TestDisjointMulticlusterEntries(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "namespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1273,7 +1276,8 @@ func TestServiceEntrySameHostMatchNamespace(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1403,7 +1407,8 @@ func TestServiceEntrySameHostNoMatchNamespace(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "otherNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1514,7 +1519,8 @@ func TestServiceEntryMultipleEdges(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1576,7 +1582,8 @@ func TestSEKiali7305(t *testing.T) {
 				Cluster:           config.DefaultClusterID,
 				CreationTimestamp: time.Now(),
 				Name:              "testNamespace",
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
@@ -1673,7 +1680,8 @@ func TestSEKiali7589(t *testing.T) {
 				Cluster:           "cluster2",
 				CreationTimestamp: time.Now(),
 				Name:              namespace,
-			}},
+			},
+		},
 		GraphType: graph.GraphTypeVersionedApp,
 	}
 	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)

--- a/handlers/config_test.go
+++ b/handlers/config_test.go
@@ -1,0 +1,66 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/istio/istiotest"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/prometheus/prometheustest"
+)
+
+type fakePromClient struct {
+	prometheustest.PromClientMock
+}
+
+func (fpc *fakePromClient) GetConfiguration() (prom_v1.ConfigResult, error) {
+	return prom_v1.ConfigResult{}, nil
+}
+
+func (fpc *fakePromClient) GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error) {
+	return prom_v1.RuntimeinfoResult{}, nil
+}
+
+func TestConfigHandler(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	k8s := kubetest.NewFakeK8sClient()
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := &istiotest.FakeDiscovery{}
+
+	prom := &fakePromClient{PromClientMock: prometheustest.PromClientMock{}}
+
+	handler := handlers.WithFakeAuthInfo(conf, handlers.Config(conf, cache, discovery, cf, prom))
+	mr := mux.NewRouter()
+	mr.Handle("/api/config", handler)
+
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	url := ts.URL + "/api/config"
+
+	resp, err := http.Get(url)
+	require.NoError(err)
+
+	actual, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	require.NotEmpty(actual)
+	require.Equal(200, resp.StatusCode, string(actual))
+
+	var confResp handlers.PublicConfig
+	require.NoError(json.Unmarshal(actual, &confResp))
+}

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -153,6 +153,7 @@ func sidecarInjectorConfigMapName(revision string) string {
 }
 
 type MeshDiscovery interface {
+	Clusters() ([]models.KubeCluster, error)
 	Mesh(ctx context.Context) (*models.Mesh, error)
 }
 

--- a/istio/istiotest/fake.go
+++ b/istio/istiotest/fake.go
@@ -8,10 +8,16 @@ import (
 
 // FakeDiscovery implements the MeshDiscovery interface. Useful for testing.
 type FakeDiscovery struct {
+	// ClustersReturn is the return value of Clusters().
+	ClustersReturn []models.KubeCluster
 	// MeshReturn is the return value of Mesh().
 	MeshReturn models.Mesh
 }
 
 func (fmd *FakeDiscovery) Mesh(ctx context.Context) (*models.Mesh, error) {
 	return &fmd.MeshReturn, nil
+}
+
+func (fmd *FakeDiscovery) Clusters() ([]models.KubeCluster, error) {
+	return fmd.ClustersReturn, nil
 }

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -35,11 +35,11 @@ type ClientInterface interface {
 	GetConfiguration() (prom_v1.ConfigResult, error)
 	GetExistingMetricNames(metricNames []string) ([]string, error)
 	GetFlags() (prom_v1.FlagsResult, error)
-	GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error)
-	GetServiceRequestRates(namespace, cluster, service, ratesInterval string, queryTime time.Time) (model.Vector, error)
-	GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error)
-	GetWorkloadRequestRates(namespace, cluster, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetMetricsForLabels(metricNames []string, labels string) ([]string, error)
+	GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error)
+	GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error)
+	GetServiceRequestRates(namespace, cluster, service, ratesInterval string, queryTime time.Time) (model.Vector, error)
+	GetWorkloadRequestRates(namespace, cluster, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 }
 
 // Client for Prometheus API.

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -33,9 +33,11 @@ type ClientInterface interface {
 	GetAllRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetAppRequestRates(namespace, cluster, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetConfiguration() (prom_v1.ConfigResult, error)
+	GetExistingMetricNames(metricNames []string) ([]string, error)
 	GetFlags() (prom_v1.FlagsResult, error)
 	GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetServiceRequestRates(namespace, cluster, service, ratesInterval string, queryTime time.Time) (model.Vector, error)
+	GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error)
 	GetWorkloadRequestRates(namespace, cluster, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetMetricsForLabels(metricNames []string, labels string) ([]string, error)
 }

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -314,6 +314,11 @@ func (o *PromClientMock) GetConfiguration() (prom_v1.ConfigResult, error) {
 	return args.Get(0).(prom_v1.ConfigResult), args.Error(1)
 }
 
+func (o *PromClientMock) GetExistingMetricNames(metricNames []string) ([]string, error) {
+	args := o.Called(metricNames)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (o *PromClientMock) GetFlags() (prom_v1.FlagsResult, error) {
 	args := o.Called()
 	return args.Get(0).(prom_v1.FlagsResult), args.Error(1)
@@ -367,6 +372,11 @@ func (o *PromClientMock) FetchHistogramValues(metricName, labels, grouping, rate
 func (o *PromClientMock) GetMetricsForLabels(metricNames []string, labels string) ([]string, error) {
 	args := o.Called(metricNames, labels)
 	return args.Get(0).([]string), args.Error(1)
+}
+
+func (o *PromClientMock) GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error) {
+	args := o.Called()
+	return args.Get(0).(prom_v1.RuntimeinfoResult), args.Error(1)
 }
 
 func (o *PromClientMock) MockMetric(name string, labels string, q *prometheus.RangeQuery, value float64) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -197,7 +197,7 @@ func NewRoutes(
 			"Config",
 			"GET",
 			"/api/config",
-			handlers.Config(conf, discovery),
+			handlers.Config(conf, kialiCache, discovery, clientFactory, prom),
 			true,
 		},
 		// swagger:route GET /crippled kiali getCrippledFeatures
@@ -216,7 +216,7 @@ func NewRoutes(
 			"Crippled",
 			"GET",
 			"/api/crippled",
-			handlers.CrippledFeatures,
+			handlers.CrippledFeatures(prom),
 			true,
 		},
 		// swagger:route GET /istio/permissions config getPermissions


### PR DESCRIPTION
### Describe the change

Refactors config handlers to use closures instead of global vars.

### Steps to test the PR

N/A

### Automation testing

Covered by existing e2e tests. This PR adds a unit test for the config handler.

### Issue reference

Related to: https://github.com/kiali/kiali/issues/6923
