### PR TITLE
[OSSMC] View in tracing integration with the tracing UI

### DIFF
--- a/frontend/src/actions/__tests__/JaegerActions.test.ts
+++ b/frontend/src/actions/__tests__/JaegerActions.test.ts
@@ -7,7 +7,7 @@ describe('JaegerActions', () => {
       enabled: true,
       integration: true,
       url: 'jaeger-query-istio-system.127.0.0.1.nip.io',
-      internal_url: '',
+      internalURL: '',
       namespaceSelector: true,
       provider: 'jaeger',
       whiteListIstioSystem: ['jaeger-query']

--- a/frontend/src/actions/__tests__/JaegerActions.test.ts
+++ b/frontend/src/actions/__tests__/JaegerActions.test.ts
@@ -7,6 +7,7 @@ describe('JaegerActions', () => {
       enabled: true,
       integration: true,
       url: 'jaeger-query-istio-system.127.0.0.1.nip.io',
+      internal_url: '',
       namespaceSelector: true,
       provider: 'jaeger',
       whiteListIstioSystem: ['jaeger-query']

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -79,7 +79,7 @@ export const kioskRefreshAction = (refreshInterval: IntervalInMilliseconds): voi
   sendParentMessage(showInParent);
 };
 
-export const kioskTracingAction = (url: string, traceID?: string): void => {
+export const kioskTracingAction = (url?: string, traceID?: string): void => {
   const showInParent = `/tracing/namespaces?trace=${traceID}&url=${url}`;
   sendParentMessage(showInParent);
 };

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -13,14 +13,14 @@ export const kioskGraphAction = (
   duration: DurationInSeconds,
   refreshInterval: IntervalInMilliseconds,
   targetPage: string
-) => {
-  let showInParent = '/graph/namespaces?namespaces=' + namespace;
+): void => {
+  let showInParent = `/graph/namespaces?namespaces=${namespace}`;
   if (healthStatus === HEALTHY.name) {
     showInParent += '&graphFind=healthy';
   } else {
     showInParent += '&graphFind=!healthy';
   }
-  showInParent += '&duration=' + duration + '&refresh=' + refreshInterval;
+  showInParent += `&duration=${duration}&refresh=${refreshInterval}`;
   switch (targetPage) {
     case 'applications':
       showInParent += '&graphType=versionedApp';
@@ -35,13 +35,13 @@ export const kioskGraphAction = (
   sendParentMessage(showInParent);
 };
 
-export const kioskContextMenuAction = (href: string) => {
+export const kioskContextMenuAction = (href: string): void => {
   const showInParent = href;
   sendParentMessage(showInParent);
 };
 
-export const kioskIstioConfigAction = (namespace: string) => {
-  const showInParent = '/istio?namespaces=' + namespace;
+export const kioskIstioConfigAction = (namespace: string): void => {
+  const showInParent = `/istio?namespaces=${namespace}`;
   sendParentMessage(showInParent);
 };
 
@@ -50,32 +50,37 @@ export const kioskOverviewAction = (
   namespace: string,
   duration: DurationInSeconds,
   refreshInterval: IntervalInMilliseconds
-) => {
+): void => {
   let showInParent = 'overview';
   switch (showType) {
     case Show.GRAPH:
-      showInParent = '/graph/namespaces?namespaces=' + namespace;
+      showInParent = `/graph/namespaces?namespaces=${namespace}`;
       break;
     case Show.ISTIO_CONFIG:
-      showInParent = '/istio?namespaces=' + namespace;
+      showInParent = `/istio?namespaces=${namespace}`;
       break;
   }
-  showInParent += '&duration=' + duration + '&refresh=' + refreshInterval;
+  showInParent += `&duration=${duration}&refresh=${refreshInterval}`;
   sendParentMessage(showInParent);
 };
 
-export const kioskDurationAction = (duration: DurationInSeconds) => {
-  const showInParent = 'duration=' + duration;
+export const kioskDurationAction = (duration: DurationInSeconds): void => {
+  const showInParent = `duration=${duration}`;
   sendParentMessage(showInParent);
 };
 
-export const kioskTimeRangeAction = (timeRange: TimeRange) => {
-  const showInParent = 'timeRange=' + JSON.stringify(timeRange);
+export const kioskTimeRangeAction = (timeRange: TimeRange): void => {
+  const showInParent = `timeRange=${JSON.stringify(timeRange)}`;
   sendParentMessage(showInParent);
 };
 
-export const kioskRefreshAction = (refreshInterval: IntervalInMilliseconds) => {
-  const showInParent = 'refresh=' + refreshInterval;
+export const kioskRefreshAction = (refreshInterval: IntervalInMilliseconds): void => {
+  const showInParent = `refresh=${refreshInterval}`;
+  sendParentMessage(showInParent);
+};
+
+export const kioskTracingAction = (namespace: string, workload: string, traceID?: string): void => {
+  const showInParent = `/tracing/namespaces?namespaces=${namespace}&workload${workload}&trace=${traceID}`;
   sendParentMessage(showInParent);
 };
 

--- a/frontend/src/components/Kiosk/KioskActions.ts
+++ b/frontend/src/components/Kiosk/KioskActions.ts
@@ -79,8 +79,8 @@ export const kioskRefreshAction = (refreshInterval: IntervalInMilliseconds): voi
   sendParentMessage(showInParent);
 };
 
-export const kioskTracingAction = (namespace: string, workload: string, traceID?: string): void => {
-  const showInParent = `/tracing/namespaces?namespaces=${namespace}&workload${workload}&trace=${traceID}`;
+export const kioskTracingAction = (url: string, traceID?: string): void => {
+  const showInParent = `/tracing/namespaces?trace=${traceID}&url=${url}`;
   sendParentMessage(showInParent);
 };
 

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -44,9 +44,11 @@ import { TracingUrlProvider } from 'types/Tracing';
 import { GetTracingUrlProvider } from 'utils/tracing/UrlProviders';
 import { ExternalServiceInfo } from 'types/StatusState';
 import { retrieveTimeRange } from '../Time/TimeRangeHelper';
+import { isParentKiosk, kioskTracingAction } from '../Kiosk/KioskActions';
 
 type ReduxProps = {
   externalServices: ExternalServiceInfo[];
+  kiosk: string;
   namespaceSelector: boolean;
   provider?: string;
   selectedTrace?: JaegerTrace;
@@ -318,6 +320,15 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                           rel="noopener noreferrer"
                           style={{ marginLeft: '10px' }}
                           data-test="view-in-tracing"
+                          onClick={() => {
+                            if (isParentKiosk(this.props.kiosk)) {
+                              kioskTracingAction(
+                                this.props.namespace,
+                                this.props.target,
+                                this.props.selectedTrace?.traceID
+                              );
+                            }
+                          }}
                         >
                           View in Tracing <ExternalLinkAltIcon />
                         </a>
@@ -394,6 +405,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
 const mapStateToProps = (state: KialiAppState): ReduxProps => {
   return {
     externalServices: state.statusState.externalServices,
+    kiosk: state.globalState.kiosk,
     namespaceSelector: state.tracingState.info ? state.tracingState.info.namespaceSelector : true,
     provider: state.tracingState.info?.provider,
     selectedTrace: state.tracingState.selectedTrace,

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -320,13 +320,12 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                           rel="noopener noreferrer"
                           style={{ marginLeft: '10px' }}
                           data-test="view-in-tracing"
-                          onClick={() => {
+                          onClick={e => {
                             if (isParentKiosk(this.props.kiosk)) {
-                              kioskTracingAction(
-                                this.props.namespace,
-                                this.props.target,
-                                this.props.selectedTrace?.traceID
-                              );
+                              e.preventDefault();
+                              kioskTracingAction(tracingURL);
+                            } else {
+                              window.open(tracingURL, '_blank');
                             }
                           }}
                         >

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -250,13 +250,12 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
     GetTracingUrlProvider(this.props.externalServices, this.props.provider);
 
   private getTracingUrl = (): string | undefined => {
-    if (!this.urlProvider || !this.state.targetApp) {
+    if (!this.urlProvider || !this.state.targetApp || !this.urlProvider.HomeUrl()) {
       return undefined;
     }
     const range = retrieveTimeRange();
     // Convert any time range (like duration) to bounded from/to
     const boundsMillis = guardTimeRange(range, durationToBounds, b => b);
-
     return this.urlProvider.AppSearchUrl(
       this.state.targetApp,
       boundsMillis,
@@ -311,7 +310,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                   <ToolbarItem style={{ marginLeft: 'auto' }}>
                     {/*Blank item used as a separator do shift the following ToolbarItems to the right*/}
                   </ToolbarItem>
-                  {tracingURL && (
+                  {(tracingURL || isParentKiosk(this.props.kiosk)) && (
                     <ToolbarItem>
                       <Tooltip content={<>Open Chart in {this.props.provider} UI</>}>
                         <a

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
@@ -25,7 +25,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { responseFlags } from 'utils/ResponseFlags';
 import { renderMetricsComparison } from './StatsComparison';
 import { router } from 'app/History';
-import { isParentKiosk, kioskContextMenuAction } from '../../Kiosk/KioskActions';
+import { isParentKiosk, kioskContextMenuAction, kioskTracingAction } from '../../Kiosk/KioskActions';
 import { TracingUrlProvider } from 'types/Tracing';
 import { KialiIcon } from 'config/KialiIcon';
 import { SimpleTable, SortableTh } from 'components/Table/SimpleTable';
@@ -338,7 +338,14 @@ class SpanTableComponent extends React.Component<Props, State> {
               More span details <KialiIcon.ExternalLink className={linkIconStyle} />
             </span>
           ),
-          onClick: () => window.open(spanLink, '_blank')
+          onClick: e => {
+            if (parentKiosk) {
+              e.preventDefault();
+              kioskTracingAction(spanLink, this.props.traceID);
+            } else {
+              window.open(spanLink, '_blank');
+            }
+          }
         }
       ];
     }

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
@@ -325,7 +325,7 @@ class SpanTableComponent extends React.Component<Props, State> {
 
     let tracingActions: IAction[] = [];
 
-    if (this.props.externalURLProvider) {
+    if (this.props.externalURLProvider || parentKiosk) {
       const spanLink = this.props.externalURLProvider?.SpanUrl(item);
       tracingActions = [
         {

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -207,6 +207,9 @@ class TraceDetailsComponent extends React.Component<Props, State> {
           externalURL={this.props.tracingURLProvider?.TraceUrl(trace)}
           graphURL={this.getGraphURL(trace.traceID)}
           comparisonURL={comparisonLink}
+          traceId={trace.traceID}
+          namespace={this.props.namespace}
+          target={this.props.target}
         />
         <CardBody>
           <Grid style={{ marginTop: '1.25rem' }}>

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -208,8 +208,6 @@ class TraceDetailsComponent extends React.Component<Props, State> {
           graphURL={this.getGraphURL(trace.traceID)}
           comparisonURL={comparisonLink}
           traceId={trace.traceID}
-          namespace={this.props.namespace}
-          target={this.props.target}
         />
         <CardBody>
           <Grid style={{ marginTop: '1.25rem' }}>

--- a/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
@@ -27,6 +27,7 @@ type Props = ReduxProps & {
   externalURL?: string;
   formattedTrace: FormattedTraceInfo;
   graphURL: string;
+  traceId?: string;
 };
 
 const TracingTraceTitleComponent: React.FC<Props> = (props: Props) => {
@@ -54,9 +55,10 @@ const TracingTraceTitleComponent: React.FC<Props> = (props: Props) => {
     links.push(
       <DropdownItem
         key="view_in_tracing"
-        onClick={() => {
+        onClick={e => {
           if (isParentKiosk(props.kiosk)) {
-            kioskTracingAction('', '', '');
+            e.preventDefault();
+            kioskTracingAction(props.externalURL ? props.externalURL : '', props.traceId);
           } else {
             window.open(props.externalURL, '_blank');
           }
@@ -67,7 +69,7 @@ const TracingTraceTitleComponent: React.FC<Props> = (props: Props) => {
     );
   }
 
-  if (props.comparisonURL) {
+  if (props.comparisonURL && !isParentKiosk(props.kiosk)) {
     links.push(
       <DropdownItem key="compare_with_similar_traces" onClick={() => window.open(props.comparisonURL, '_blank')}>
         {t('Compare with similar traces')} <ExternalLinkAltIcon />

--- a/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
@@ -51,7 +51,7 @@ const TracingTraceTitleComponent: React.FC<Props> = (props: Props) => {
     </DropdownItem>
   ];
 
-  if (props.externalURL) {
+  if (props.externalURL || isParentKiosk(props.kiosk)) {
     links.push(
       <DropdownItem
         key="view_in_tracing"

--- a/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TracingTraceTitle.tsx
@@ -12,7 +12,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { FormattedTraceInfo, fullIDStyle } from './FormattedTraceInfo';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
-import { isParentKiosk, kioskContextMenuAction } from '../../Kiosk/KioskActions';
+import { isParentKiosk, kioskContextMenuAction, kioskTracingAction } from '../../Kiosk/KioskActions';
 import { KialiIcon } from 'config/KialiIcon';
 import { kebabToggleStyle } from 'styles/DropdownStyles';
 import { useKialiTranslation } from 'utils/I18nUtils';
@@ -52,7 +52,16 @@ const TracingTraceTitleComponent: React.FC<Props> = (props: Props) => {
 
   if (props.externalURL) {
     links.push(
-      <DropdownItem key="view_in_tracing" onClick={() => window.open(props.externalURL, '_blank')}>
+      <DropdownItem
+        key="view_in_tracing"
+        onClick={() => {
+          if (isParentKiosk(props.kiosk)) {
+            kioskTracingAction('', '', '');
+          } else {
+            window.open(props.externalURL, '_blank');
+          }
+        }}
+      >
         {t('View in Tracing')} <ExternalLinkAltIcon />
       </DropdownItem>
     );

--- a/frontend/src/reducers/__tests__/TracingStateReducer.test.ts
+++ b/frontend/src/reducers/__tests__/TracingStateReducer.test.ts
@@ -5,6 +5,7 @@ const initialState: TracingState = {
   info: {
     enabled: false,
     integration: false,
+    internal_url: '',
     url: '',
     namespaceSelector: true,
     provider: 'jaeger',
@@ -30,6 +31,7 @@ describe('TracingState reducer', () => {
           url: url,
           enabled: true,
           integration: true,
+          internal_url: '',
           namespaceSelector: true,
           provider: 'jaeger',
           whiteListIstioSystem: []

--- a/frontend/src/reducers/__tests__/TracingStateReducer.test.ts
+++ b/frontend/src/reducers/__tests__/TracingStateReducer.test.ts
@@ -5,7 +5,7 @@ const initialState: TracingState = {
   info: {
     enabled: false,
     integration: false,
-    internal_url: '',
+    internalURL: '',
     url: '',
     namespaceSelector: true,
     provider: 'jaeger',
@@ -31,7 +31,7 @@ describe('TracingState reducer', () => {
           url: url,
           enabled: true,
           integration: true,
-          internal_url: '',
+          internalURL: '',
           namespaceSelector: true,
           provider: 'jaeger',
           whiteListIstioSystem: []

--- a/frontend/src/types/TracingInfo.ts
+++ b/frontend/src/types/TracingInfo.ts
@@ -7,6 +7,7 @@ import { Target } from './MetricsOptions';
 export interface TracingInfo {
   enabled: boolean;
   integration: boolean;
+  internal_url: string;
   namespaceSelector: boolean;
   provider: string;
   url: string;

--- a/frontend/src/types/TracingInfo.ts
+++ b/frontend/src/types/TracingInfo.ts
@@ -7,7 +7,7 @@ import { Target } from './MetricsOptions';
 export interface TracingInfo {
   enabled: boolean;
   integration: boolean;
-  internal_url: string;
+  internalURL: string;
   namespaceSelector: boolean;
   provider: string;
   url: string;

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -23,6 +23,7 @@ func GetTracingInfo(w http.ResponseWriter, r *http.Request) {
 		info = models.TracingInfo{
 			Enabled:              true,
 			Integration:          tracingConfig.InternalURL != "",
+			InternalURL:          tracingConfig.InternalURL,
 			Provider:             string(tracingConfig.Provider),
 			TempoConfig:          tracingConfig.TempoConfig,
 			URL:                  tracingConfig.ExternalURL,

--- a/models/tracing.go
+++ b/models/tracing.go
@@ -13,6 +13,7 @@ const (
 type TracingInfo struct {
 	Enabled              bool               `json:"enabled"`
 	Integration          bool               `json:"integration"`
+	InternalURL          string             `json:"internalURL"`
 	Provider             string             `json:"provider"`
 	TempoConfig          config.TempoConfig `json:"tempoConfig"`
 	URL                  string             `json:"url"`


### PR DESCRIPTION
### Describe the change

- Add a new parent kiosk action for tracing.
See https://github.com/kiali/openshift-servicemesh-plugin/pull/428
- Lint 

### Steps to test the PR
See https://github.com/kiali/openshift-servicemesh-plugin/pull/428 

### Automation testing


### Issue reference
Ref. https://github.com/kiali/kiali/issues/7904
