### PR TITLE
update PFT cypress tests with some logic in the cytsoscape cypress  tests

### DIFF
--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -6,6 +6,7 @@ import { Visualization } from '@patternfly/react-topology';
 import { NodeType } from 'types/Graph';
 import { elems } from 'helpers/GraphHelpers';
 import { nodeInfo } from './graph';
+import { GraphDataSource } from 'services/GraphDataSource';
 
 Then('user sees details information for the remote {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
@@ -64,6 +65,11 @@ Then('user sees {string} from a remote {string} cluster in the minigraph', (type
   cy.waitForReact();
   cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
     .should('have.length', '1')
+    .getProps('dataSource')
+    .should((dataSource: GraphDataSource) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(dataSource.isLoading).to.be.false;
+    })
     .then($graph => {
       const { state } = $graph[0];
 
@@ -92,6 +98,11 @@ Given(
     cy.waitForReact();
     cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
       .should('have.length', '1')
+      .getProps('dataSource')
+      .should((dataSource: GraphDataSource) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        expect(dataSource.isLoading).to.be.false;
+      })
       .then($graph => {
         const { props, state } = $graph[0];
 
@@ -134,6 +145,11 @@ When(
     cy.waitForReact();
     cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
       .should('have.length', '1')
+      .getProps('dataSource')
+      .should((dataSource: GraphDataSource) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        expect(dataSource.isLoading).to.be.false;
+      })
       .then($graph => {
         const { props, state } = $graph[0];
 

--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -63,13 +63,8 @@ Then(
 
 Then('user sees {string} from a remote {string} cluster in the minigraph', (type: string, cluster: string) => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
+  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
     .should('have.length', '1')
-    .getProps('dataSource')
-    .should((dataSource: GraphDataSource) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      expect(dataSource.isLoading).to.be.false;
-    })
     .then($graph => {
       const { state } = $graph[0];
 
@@ -96,13 +91,8 @@ Given(
   'the {string} {string} from the {string} cluster is visible in the minigraph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
+    cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
       .should('have.length', '1')
-      .getProps('dataSource')
-      .should((dataSource: GraphDataSource) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        expect(dataSource.isLoading).to.be.false;
-      })
       .then($graph => {
         const { props, state } = $graph[0];
 
@@ -143,13 +133,8 @@ When(
   'user clicks on the {string} {string} from the {string} cluster in the minigraph',
   (name: string, type: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
+    cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
       .should('have.length', '1')
-      .getProps('dataSource')
-      .should((dataSource: GraphDataSource) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        expect(dataSource.isLoading).to.be.false;
-      })
       .then($graph => {
         const { props, state } = $graph[0];
 

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -13,7 +13,7 @@ Then(`user see the {string} link`, link => {
 
 Then('the nodes located in the {string} cluster should be restricted', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -32,13 +32,8 @@ Then('the nodes located in the {string} cluster should be restricted', (cluster:
 
 Then('the nodes on the minigraph located in the {string} cluster should be restricted', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
+  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
     .should('have.length', '1')
-    .getProps('dataSource')
-    .should((dataSource: GraphDataSource) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      expect(dataSource.isLoading).to.be.false;
-    })
     .then($graph => {
       const { state } = $graph[0];
 

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -1,6 +1,7 @@
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { elems } from './graph';
 import { Visualization } from '@patternfly/react-topology';
+import { GraphDataSource } from 'services/GraphDataSource';
 
 Then(`user does not see the {string} link`, link => {
   cy.get('div[role="dialog"]').find(`#${link}`).should('not.exist');
@@ -12,7 +13,7 @@ Then(`user see the {string} link`, link => {
 
 Then('the nodes located in the {string} cluster should be restricted', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -33,6 +34,11 @@ Then('the nodes on the minigraph located in the {string} cluster should be restr
   cy.waitForReact();
   cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
     .should('have.length', '1')
+    .getProps('dataSource')
+    .should((dataSource: GraphDataSource) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(dataSource.isLoading).to.be.false;
+    })
     .then($graph => {
       const { state } = $graph[0];
 

--- a/frontend/cypress/integration/common/authorization.ts
+++ b/frontend/cypress/integration/common/authorization.ts
@@ -13,7 +13,7 @@ Then(`user see the {string} link`, link => {
 
 Then('the nodes located in the {string} cluster should be restricted', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -27,7 +27,7 @@ Then('user sees a minigraph', () => {
 
 Then('user sees the {string} namespace deployed across the east and west clusters', (namespace: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -48,7 +48,7 @@ Then('user sees the {string} namespace deployed across the east and west cluster
 
 Then('nodes in the {string} cluster should contain the cluster name in their links', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -74,7 +74,7 @@ Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -5,6 +5,7 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
+import { GraphDataSource } from 'services/GraphDataSource';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -14,6 +15,11 @@ Then('user sees a minigraph', () => {
   cy.waitForReact();
   cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
     .should('have.length', '1')
+    .getProps('dataSource')
+    .should((dataSource: GraphDataSource) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(dataSource.isLoading).to.be.false;
+    })
     .then($graph => {
       const { state } = $graph[0];
 
@@ -27,7 +33,7 @@ Then('user sees a minigraph', () => {
 
 Then('user sees the {string} namespace deployed across the east and west clusters', (namespace: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -48,7 +54,7 @@ Then('user sees the {string} namespace deployed across the east and west cluster
 
 Then('nodes in the {string} cluster should contain the cluster name in their links', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -74,7 +80,7 @@ Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { isReady: true } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -5,7 +5,6 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
-import { GraphDataSource } from 'services/GraphDataSource';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -13,13 +12,8 @@ Then('user does not see a minigraph', () => {
 
 Then('user sees a minigraph', () => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true } })
+  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
     .should('have.length', '1')
-    .getProps('dataSource')
-    .should((dataSource: GraphDataSource) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      expect(dataSource.isLoading).to.be.false;
-    })
     .then($graph => {
       const { state } = $graph[0];
 

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -27,7 +27,7 @@ Then('user sees a minigraph', () => {
 
 Then('user sees the {string} namespace deployed across the east and west clusters', (namespace: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -48,7 +48,7 @@ Then('user sees the {string} namespace deployed across the east and west cluster
 
 Then('nodes in the {string} cluster should contain the cluster name in their links', (cluster: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -74,7 +74,7 @@ Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_context_menu.ts
+++ b/frontend/cypress/integration/common/graph_context_menu.ts
@@ -7,7 +7,7 @@ import { NodeAttr } from 'types/Graph';
 // Single cluster only.
 When('user opens the context menu of the {string} service node', (svcName: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -30,7 +30,7 @@ When(
   'user opens the context menu of the {string} service node on the {string} cluster',
   (svcName: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_context_menu.ts
+++ b/frontend/cypress/integration/common/graph_context_menu.ts
@@ -6,9 +6,8 @@ import { NodeAttr } from 'types/Graph';
 
 // Single cluster only.
 When('user opens the context menu of the {string} service node', (svcName: string) => {
-  ensureKialiFinishedLoading();
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -30,9 +29,8 @@ When('user opens the context menu of the {string} service node', (svcName: strin
 When(
   'user opens the context menu of the {string} service node on the {string} cluster',
   (svcName: string, cluster: string) => {
-    ensureKialiFinishedLoading();
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { isReady: true } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_context_menu.ts
+++ b/frontend/cypress/integration/common/graph_context_menu.ts
@@ -7,7 +7,7 @@ import { NodeAttr } from 'types/Graph';
 // Single cluster only.
 When('user opens the context menu of the {string} service node', (svcName: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -30,7 +30,7 @@ When(
   'user opens the context menu of the {string} service node on the {string} cluster',
   (svcName: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -139,7 +139,7 @@ Then('the display menu has default settings', () => {
 
 Then('the graph reflects default settings', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -199,7 +199,7 @@ Then('user sees {string} edge labels', (el: string) => {
   }
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -221,7 +221,7 @@ Then('user does not see {string} boxing', (boxByType: string) => {
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -246,7 +246,7 @@ Then('idle edges {string} in the graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -272,7 +272,7 @@ Then('idle nodes {string} in the graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -295,7 +295,7 @@ Then('ranks {string} in the graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -318,7 +318,7 @@ Then('user does not see service nodes', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -340,7 +340,7 @@ Then('security {string} in the graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -397,7 +397,7 @@ Then('the {string} option should {string} and {string}', (option: string, option
 
 Then('only a single cluster box should be visible', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -491,7 +491,7 @@ When('user {string} {string} traffic option', (action: string, option: string) =
 
 Then('{int} edges appear in the graph', (graphEdges: number) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -508,7 +508,7 @@ Then('{int} edges appear in the graph', (graphEdges: number) => {
 
 Then('the {string} node {string} exists', (nodeName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];
@@ -529,7 +529,7 @@ Then('the {string} node {string} exists', (nodeName: string, action: string) => 
 
 Then('the {string} service {string} exists', (serviceName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -139,7 +139,7 @@ Then('the display menu has default settings', () => {
 
 Then('the graph reflects default settings', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -199,7 +199,7 @@ Then('user sees {string} edge labels', (el: string) => {
   }
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -221,7 +221,7 @@ Then('user does not see {string} boxing', (boxByType: string) => {
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -246,8 +246,7 @@ Then('idle edges {string} in the graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
-
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -273,7 +272,7 @@ Then('idle nodes {string} in the graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -296,7 +295,7 @@ Then('ranks {string} in the graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -319,7 +318,7 @@ Then('user does not see service nodes', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -341,7 +340,7 @@ Then('security {string} in the graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -398,7 +397,7 @@ Then('the {string} option should {string} and {string}', (option: string, option
 
 Then('only a single cluster box should be visible', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -492,9 +491,7 @@ When('user {string} {string} traffic option', (action: string, option: string) =
 
 Then('{int} edges appear in the graph', (graphEdges: number) => {
   cy.waitForReact();
-  ensureKialiFinishedLoading();
-
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -511,7 +508,7 @@ Then('{int} edges appear in the graph', (graphEdges: number) => {
 
 Then('the {string} node {string} exists', (nodeName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];
@@ -532,7 +529,7 @@ Then('the {string} node {string} exists', (nodeName: string, action: string) => 
 
 Then('the {string} service {string} exists', (serviceName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -139,7 +139,7 @@ Then('the display menu has default settings', () => {
 
 Then('the graph reflects default settings', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -199,7 +199,7 @@ Then('user sees {string} edge labels', (el: string) => {
   }
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -221,7 +221,7 @@ Then('user does not see {string} boxing', (boxByType: string) => {
   validateInput(`boxBy${boxByType}`, 'does not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -246,7 +246,7 @@ Then('idle edges {string} in the graph', (action: string) => {
   validateInput('filterIdleEdges', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -272,7 +272,7 @@ Then('idle nodes {string} in the graph', (action: string) => {
   validateInput('filterIdleNodes', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -295,7 +295,7 @@ Then('ranks {string} in the graph', (action: string) => {
   validateInput('rank', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -318,7 +318,7 @@ Then('user does not see service nodes', () => {
   validateInput('filterServiceNodes', 'do not appear');
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -340,7 +340,7 @@ Then('security {string} in the graph', (action: string) => {
   validateInput('filterSecurity', action);
 
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -397,7 +397,7 @@ Then('the {string} option should {string} and {string}', (option: string, option
 
 Then('only a single cluster box should be visible', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -491,7 +491,7 @@ When('user {string} {string} traffic option', (action: string, option: string) =
 
 Then('{int} edges appear in the graph', (graphEdges: number) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -508,7 +508,7 @@ Then('{int} edges appear in the graph', (graphEdges: number) => {
 
 Then('the {string} node {string} exists', (nodeName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];
@@ -529,7 +529,7 @@ Then('the {string} node {string} exists', (nodeName: string, action: string) => 
 
 Then('the {string} service {string} exists', (serviceName: string, action: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', 1)
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_find_hide.ts
+++ b/frontend/cypress/integration/common/graph_find_hide.ts
@@ -31,7 +31,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
     }
   ];
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -54,7 +54,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
 
 Then('user sees nothing highlighted on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -85,7 +85,7 @@ When('user hides unhealthy workloads', () => {
 
 Then('user sees no unhealthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -123,7 +123,7 @@ When('user selects the preset hide option {string}', (option: string) => {
 
 Then('user sees no healthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_find_hide.ts
+++ b/frontend/cypress/integration/common/graph_find_hide.ts
@@ -31,7 +31,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
     }
   ];
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -54,7 +54,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
 
 Then('user sees nothing highlighted on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -85,7 +85,7 @@ When('user hides unhealthy workloads', () => {
 
 Then('user sees no unhealthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -123,7 +123,7 @@ When('user selects the preset hide option {string}', (option: string) => {
 
 Then('user sees no healthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_find_hide.ts
+++ b/frontend/cypress/integration/common/graph_find_hide.ts
@@ -31,7 +31,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
     }
   ];
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -54,7 +54,7 @@ Then('user sees unhealthy workloads highlighted on the graph', () => {
 
 Then('user sees nothing highlighted on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -85,7 +85,7 @@ When('user hides unhealthy workloads', () => {
 
 Then('user sees no unhealthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -123,7 +123,7 @@ When('user selects the preset hide option {string}', (option: string) => {
 
 Then('user sees no healthy workloads on the graph', () => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -5,7 +5,7 @@ import { NodeAttr } from 'types/Graph';
 
 When('user clicks the {string} {string} node', (svcName: string, nodeType: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -28,7 +28,7 @@ When(
   'user clicks the edge from {string} {string} to {string} {string}',
   (svcName: string, nodeType: string, destSvcName: string, destNodeType: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];
@@ -164,7 +164,7 @@ When(
   'user clicks the {string} service node in the {string} namespace in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -5,7 +5,7 @@ import { NodeAttr } from 'types/Graph';
 
 When('user clicks the {string} {string} node', (svcName: string, nodeType: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -28,7 +28,7 @@ When(
   'user clicks the edge from {string} {string} to {string} {string}',
   (svcName: string, nodeType: string, destSvcName: string, destNodeType: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { isReady: true } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];
@@ -164,7 +164,7 @@ When(
   'user clicks the {string} service node in the {string} namespace in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { isReady: true } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_side_panel.ts
+++ b/frontend/cypress/integration/common/graph_side_panel.ts
@@ -5,7 +5,7 @@ import { NodeAttr } from 'types/Graph';
 
 When('user clicks the {string} {string} node', (svcName: string, nodeType: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -28,7 +28,7 @@ When(
   'user clicks the edge from {string} {string} to {string} {string}',
   (svcName: string, nodeType: string, destSvcName: string, destNodeType: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];
@@ -164,7 +164,7 @@ When(
   'user clicks the {string} service node in the {string} namespace in the {string} cluster',
   (service: string, namespace: string, cluster: string) => {
     cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
       .should('have.length', '1')
       .then($graph => {
         const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -111,7 +111,7 @@ Then('user does not see graph traffic menu', () => {
 
 Then('user {string} {string} traffic', (action: string, protocol: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -214,7 +214,7 @@ Then('user sees selected graph refresh {string}', (refresh: string) => {
 
 Then('user sees a {string} graph', graphType => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { isReady: true } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -111,7 +111,7 @@ Then('user does not see graph traffic menu', () => {
 
 Then('user {string} {string} traffic', (action: string, protocol: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -214,7 +214,7 @@ Then('user sees selected graph refresh {string}', (refresh: string) => {
 
 Then('user sees a {string} graph', graphType => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -111,7 +111,7 @@ Then('user does not see graph traffic menu', () => {
 
 Then('user {string} {string} traffic', (action: string, protocol: string) => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];
@@ -214,7 +214,7 @@ Then('user sees selected graph refresh {string}', (refresh: string) => {
 
 Then('user sees a {string} graph', graphType => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } })
+  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
     .should('have.length', '1')
     .then($graph => {
       const { state } = $graph[0];

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -42,7 +42,7 @@ const measureLoadTime = (
           });
           if (isGraph) {
             cy.waitForReact();
-            cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } }).should(
+            cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } }).should(
               'have.length',
               '1'
             );

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -42,7 +42,10 @@ const measureLoadTime = (
           });
           if (isGraph) {
             cy.waitForReact();
-            cy.getReact('GraphPageComponent', { state: { isReady: true } }).should('have.length', '1');
+            cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } }).should(
+              'have.length',
+              '1'
+            );
             // @TODO this check fails on jenkins with CPU/Memory error, to find a better solution
             // .getCurrentState().then(state => {const controller = state.graphRefs.getController() as Visualization; assert.isTrue(controller.hasGraph()); });
           } else {

--- a/frontend/cypress/perf/common.ts
+++ b/frontend/cypress/perf/common.ts
@@ -42,7 +42,7 @@ const measureLoadTime = (
           });
           if (isGraph) {
             cy.waitForReact();
-            cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false } } }).should(
+            cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false, isReady: true } } }).should(
               'have.length',
               '1'
             );

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -131,7 +131,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     }
 
     // The parent component supplies the datasource and the target element. Here we protect against a lifecycle issue where the two
-    // can be out of sync. If so, just assume the parent is currently loading until it things get synchronized.
+    // can be out of sync. If so, just assume the parent is currently loading until things get synchronized.
     const isLoading =
       (this.props.workload && this.props.workload?.name !== this.props.dataSource.fetchParameters.node?.workload) ||
       (this.props.serviceDetails &&
@@ -202,7 +202,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
                     elementsChanged: true,
                     errorMessage: !!this.props.dataSource.errorMessage ? this.props.dataSource.errorMessage : undefined,
                     isError: this.props.dataSource.isError,
-                    isLoading: this.props.dataSource.isLoading,
+                    isLoading: isLoading,
                     fetchParams: this.props.dataSource.fetchParameters,
                     timestamp: this.props.dataSource.graphTimestamp
                   }}

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -66,6 +66,7 @@ type MiniGraphCardState = {
   graphData: DecoratedGraphElements;
   graphRefs?: GraphRefs;
   isKebabOpen: boolean;
+  isLoading: boolean;
   isReady: boolean;
   isTimeOptionsOpen: boolean;
 };
@@ -74,8 +75,9 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
   constructor(props: MiniGraphCardProps) {
     super(props);
     this.state = {
-      isReady: false,
       isKebabOpen: false,
+      isLoading: props.dataSource.isLoading,
+      isReady: false,
       isTimeOptionsOpen: false,
       graphData: props.dataSource.graphData
     };
@@ -92,7 +94,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
   }
 
   private refresh = (): void => {
-    this.setState({ graphData: this.props.dataSource.graphData });
+    this.setState({ graphData: this.props.dataSource.graphData, isLoading: this.props.dataSource.isLoading });
   };
 
   render(): React.ReactNode {


### PR DESCRIPTION
In a PR for issue 7256, and the subsequent PR https://github.com/kiali/kiali/pull/7442, we updated cytoscape cypress tests to more reliably wait for the graph to be populated before testing for edges and nodes. Probably due to timing, those changes were not applied to the analogous PFT cypress tests. This PR applies those changes and will hopefully prevent similar flakes.
