### PR TITLE
[POC] Add local mode

### DIFF
--- a/business/controlplane_monitor.go
+++ b/business/controlplane_monitor.go
@@ -30,7 +30,7 @@ type ControlPlaneMonitor interface {
 	RefreshIstioCache(ctx context.Context) error
 }
 
-func NewControlPlaneMonitor(cache cache.KialiCache, clientFactory kubernetes.ClientFactory, conf *config.Config, discovery *istio.Discovery) *controlPlaneMonitor {
+func NewControlPlaneMonitor(cache cache.KialiCache, clientFactory kubernetes.ClientFactory, conf *config.Config, discovery istio.MeshDiscovery) *controlPlaneMonitor {
 	return &controlPlaneMonitor{
 		cache:           cache,
 		clientFactory:   clientFactory,
@@ -52,7 +52,7 @@ type controlPlaneMonitor struct {
 	// these directly from the client factory rather than passing in a static list.
 	clientFactory   kubernetes.ClientFactory
 	conf            *config.Config
-	discovery       *istio.Discovery
+	discovery       istio.MeshDiscovery
 	pollingInterval time.Duration
 }
 

--- a/business/controlplane_monitor_test.go
+++ b/business/controlplane_monitor_test.go
@@ -17,9 +17,11 @@ import (
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
 )
 
 func TestRegistryServices(t *testing.T) {
@@ -79,7 +81,7 @@ func istiodTestServer(t *testing.T) *httptest.Server {
 			return
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
-			t.Fatalf("Unexpected request path: %s", r.URL.Path)
+			t.Logf("Unexpected request path: %s", r.URL.Path)
 			return
 		}
 		if _, err := w.Write(kubernetes.ReadFile(t, file)); err != nil {
@@ -150,23 +152,10 @@ func TestRefreshIstioCache(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 
-	istioConfigMap := &core_v1.ConfigMap{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "istio",
-			Namespace: "istio-system",
-			Labels: map[string]string{
-				config.IstioRevisionLabel: "default",
-			},
-		},
-		Data: map[string]string{"mesh": ""},
-	}
-
 	k8s := kubetest.NewFakeK8sClient(
 		runningIstiodPod(),
 		fakeIstiodDeployment(conf.KubernetesConfig.ClusterName, true),
 		kubetest.FakeNamespace("istio-system"),
-		istioConfigMap,
-		FakeCertificateConfigMap("istio-system"),
 	)
 	// RefreshIstioCache relies on this being set.
 	k8s.KubeClusterInfo.Name = conf.KubernetesConfig.ClusterName
@@ -181,9 +170,20 @@ func TestRefreshIstioCache(t *testing.T) {
 	k8sclients[conf.KubernetesConfig.ClusterName] = fakeForwarder
 	cf := kubetest.NewFakeClientFactory(conf, k8sclients)
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	discovery := istio.NewDiscovery(k8sclients, cache, conf)
+	discovery := &istiotest.FakeDiscovery{
+		MeshReturn: models.Mesh{
+			ControlPlanes: []models.ControlPlane{{
+				Cluster: &models.KubeCluster{
+					Name: conf.KubernetesConfig.ClusterName,
+				},
+				IstiodName:      "istio",
+				IstiodNamespace: "istio-system",
+				Revision:        "default",
+				Status:          kubernetes.ComponentHealthy,
+			}},
+		},
+	}
 	cpm := NewControlPlaneMonitor(cache, cf, conf, discovery)
-
 	assert.Nil(cache.GetRegistryStatus(conf.KubernetesConfig.ClusterName))
 	err := cpm.RefreshIstioCache(context.TODO())
 	require.NoError(err)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -288,7 +288,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		if istioConfigList, ok := istioConfigMap[cluster]; ok && criteria.IncludeIstioResources {
 			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.conf, wItem.Labels, istioConfigList, cluster))
 		}
-		if criteria.IncludeHealth {
+		if criteria.IncludeHealth && in.conf.ExternalServices.Prometheus.Enabled {
 			wItem.Health, err = in.businessLayer.Health.GetWorkloadHealth(ctx, namespace, cluster, wItem.Name, criteria.RateInterval, criteria.QueryTime, w)
 			if err != nil {
 				log.Errorf("Error fetching Health in namespace %s for workload %s: %s", namespace, wItem.Name, err)
@@ -2167,9 +2167,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 }
 
 func (in *WorkloadService) GetZtunnelConfig(cluster, namespace, pod string) *kubernetes.ZtunnelConfigDump {
-
 	return in.cache.GetZtunnelDump(cluster, namespace, pod)
-
 }
 
 // GetWaypoints: Return the list of waypoint workloads.  This looks for all k8s gateways and then tests their labels

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -1,0 +1,221 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	servercmd "github.com/kiali/kiali/cmd/server"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/util/httputil"
+)
+
+func Run(
+	ctx context.Context,
+	conf *config.Config,
+	version string,
+	commitHash string,
+	goVersion string,
+	staticAssetFS fs.FS,
+	homeClusterContext string,
+	remoteClusterContexts []string,
+	openBrowser bool,
+) (<-chan struct{}, error) {
+	log.Info("Running Kiali in local mode")
+	log.Infof("Loading kubeconfig from file: %s", conf.Deployment.RemoteSecretPath)
+	kubeConfig, err := clientcmd.LoadFromFile(conf.Deployment.RemoteSecretPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read kubeconfig from file: %s", conf.Deployment.RemoteSecretPath)
+	}
+
+	contextNames := slices.Clone(remoteClusterContexts)
+	homeContext := kubeConfig.CurrentContext
+	if homeClusterContext != "" {
+		homeContext = homeClusterContext
+	}
+	contextNames = append(contextNames, homeContext)
+
+	contexts := map[string]*api.Context{}
+	for _, ctx := range contextNames {
+		kubeContext := kubeConfig.Contexts[ctx]
+		if kubeContext == nil {
+			return nil, fmt.Errorf("current context not set in kubeconfig file: %s", conf.Deployment.RemoteSecretPath)
+		}
+		contexts[ctx] = kubeContext
+	}
+	clients := map[string]kubernetes.ClientInterface{}
+	for context, clusterInfo := range contexts {
+		clusterName := clusterInfo.Cluster
+		if override := conf.Deployment.ClusterNameOverrides[clusterInfo.Cluster]; override != "" {
+			clusterName = override
+		}
+		remoteClusterInfo := &kubernetes.RemoteClusterInfo{
+			ClusterName: clusterName,
+			Config:      clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{CurrentContext: context}),
+		}
+		clientConfig, err := remoteClusterInfo.Config.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get client config for remote cluster [%s]. Err: %s", context, err)
+		}
+
+		client, err := kubernetes.NewClientWithRemoteClusterInfoWithClusterName(clientConfig, remoteClusterInfo)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create remote Kiali Service Account client. Err: %s", err)
+		}
+
+		clients[clusterName] = client
+
+		// TODO: Need to set the kube cluster name to the current context otherwise cache won't start.
+		// TODO: Does the cache really need to fail on that condition?
+		if context == homeContext {
+			conf.KubernetesConfig.ClusterName = clusterName
+			config.Set(conf)
+		}
+	}
+
+	cf, err := kubernetes.NewClientFactoryWithSAClients(ctx, *conf, clients)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new client factory")
+	}
+
+	// TODO: pass prom url to port forward instead of setting here?
+
+	log.Info("Port forwarding to Prometheus.")
+	// TODO: Better predict prom
+	if cf.GetSAHomeClusterClient() == nil {
+		log.Info("Home cluster client is nil. Not starting prom.")
+	} else {
+		// if conf.ExternalServices.Prometheus.
+		// Can we run Kiali without prom? Would be nice in some cases.
+		if err := portForwardToProm(ctx, cf.GetSAHomeClusterClient(), conf); err != nil {
+			log.Warningf("Unable to setup port forwarding to prom pods: %s\t Disabling prometheus.", err)
+			conf.ExternalServices.Prometheus.Enabled = false
+			config.Set(conf)
+		}
+		if conf.ExternalServices.Tracing.Enabled {
+			if err := portForwardToTracing(ctx, cf.GetSAHomeClusterClient(), conf); err != nil {
+				log.Warningf("Unable to setup port forwarding to tracing pods: %s", err)
+			}
+		}
+	}
+	log.Info("Running server")
+	stopped := servercmd.Run(ctx, conf, version, commitHash, goVersion, staticAssetFS, cf)
+	log.Info("Server is ready.")
+	if openBrowser {
+		log.Info("Opening Kiali in default browser")
+		if err := openDefaultBrowser(ctx); err != nil {
+			log.Errorf("Unable to open default browser: %s", err)
+		}
+	}
+
+	return stopped, nil
+}
+
+func openDefaultBrowser(ctx context.Context) error {
+	// TODO: Choose port.
+	const kialiURL = "http://localhost:20001"
+	var cmd string
+	switch runtime.GOOS {
+	// TODO: handle windows and mac.
+	default:
+		cmd = "xdg-open"
+	}
+	return exec.CommandContext(ctx, cmd, kialiURL).Start()
+}
+
+func portForwardToTracing(ctx context.Context, localClient kubernetes.ClientInterface, conf *config.Config) error {
+	localPort := httputil.Pool.GetFreePort()
+	conf.ExternalServices.Tracing.InternalURL = fmt.Sprintf("http://127.0.0.1:%d", localPort)
+	config.Set(conf)
+	url, err := url.Parse(conf.ExternalServices.Tracing.InternalURL)
+	if err != nil {
+		return err
+	}
+
+	tracingPods, err := localClient.Kube().CoreV1().Pods("istio-system").List(ctx, metav1.ListOptions{LabelSelector: "app=jaeger"})
+	if err != nil {
+		return err
+	}
+
+	if len(tracingPods.Items) == 0 {
+		return fmt.Errorf("no Tracing pod found in istio-system namespace")
+	}
+
+	log.Info("Port forwarding to tracing pods")
+	pf, err := httputil.NewPortForwarder(
+		localClient.Kube().CoreV1().RESTClient(),
+		localClient.ClusterInfo().ClientConfig,
+		"istio-system",
+		tracingPods.Items[0].Name,
+		"localhost",
+		url.Port()+":16685",
+		io.Discard,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := pf.Start(); err != nil {
+		return err
+	}
+	go func() {
+		defer pf.Stop()
+		<-ctx.Done()
+	}()
+
+	return nil
+}
+
+func portForwardToProm(ctx context.Context, localClient kubernetes.ClientInterface, conf *config.Config) error {
+	localPort := httputil.Pool.GetFreePort()
+	conf.ExternalServices.Prometheus.URL = fmt.Sprintf("http://127.0.0.1:%d", localPort)
+	config.Set(conf)
+	url, err := url.Parse(conf.ExternalServices.Prometheus.URL)
+	if err != nil {
+		return err
+	}
+
+	promPods, err := localClient.Kube().CoreV1().Pods("istio-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus"})
+	if err != nil {
+		return err
+	}
+
+	if len(promPods.Items) == 0 {
+		return fmt.Errorf("no Prometheus pod found in istio-system namespace")
+	}
+
+	log.Info("Port forwarding to prom pods")
+	pf, err := httputil.NewPortForwarder(
+		localClient.Kube().CoreV1().RESTClient(),
+		localClient.ClusterInfo().ClientConfig,
+		"istio-system",
+		promPods.Items[0].Name,
+		"localhost",
+		url.Port()+":9090",
+		io.Discard,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := pf.Start(); err != nil {
+		return err
+	}
+	go func() {
+		defer pf.Stop()
+		<-ctx.Done()
+	}()
+
+	return nil
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"io/fs"
+	"os"
+
+	_ "go.uber.org/automaxprocs"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/controller"
+	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
+	"github.com/kiali/kiali/server"
+	"github.com/kiali/kiali/tracing"
+)
+
+func run(ctx context.Context, conf *config.Config, version string, commitHash string, goVersion string, staticAssetFS fs.FS, clientFactory kubernetes.ClientFactory) <-chan struct{} {
+	log.Info("Initializing Kiali Cache")
+	cache, err := cache.NewKialiCache(clientFactory.GetSAClients(), *conf)
+	if err != nil {
+		log.Fatalf("Error initializing Kiali Cache. Details: %s", err)
+	}
+
+	cache.SetBuildInfo(models.BuildInfo{
+		CommitHash:       commitHash,
+		ContainerVersion: determineContainerVersion(version),
+		GoVersion:        goVersion,
+		Version:          version,
+	})
+
+	discovery := istio.NewDiscovery(clientFactory.GetSAClients(), cache, conf)
+	cpm := business.NewControlPlaneMonitor(cache, clientFactory, conf, discovery)
+
+	if conf.ExternalServices.Istio.IstioAPIEnabled {
+		cpm.PollIstiodForProxyStatus(ctx)
+	}
+
+	// Create shared prometheus client shared by all prometheus requests in the business layer.
+	prom, err := prometheus.NewClient()
+	if err != nil {
+		log.Fatalf("Error creating Prometheus client: %s", err)
+	}
+
+	// Create shared tracing client shared by all tracing requests in the business layer.
+	// Because tracing is not an essential component, we don't want to block startup
+	// of the server if the tracing client fails to initialize. tracing.NewClient will
+	// continue to retry until the client is initialized or the context is cancelled.
+	// Passing in a loader function allows the tracing client to be used once it is
+	// finally initialized.
+	var tracingClient tracing.ClientInterface
+	tracingLoader := func() tracing.ClientInterface {
+		return tracingClient
+	}
+	if conf.ExternalServices.Tracing.Enabled {
+		go func() {
+			client, err := tracing.NewClient(ctx, conf, clientFactory.GetSAHomeClusterClient().GetToken())
+			if err != nil {
+				log.Fatalf("Error creating tracing client: %s", err)
+				return
+			}
+			tracingClient = client
+		}()
+	} else {
+		log.Debug("Tracing is disabled")
+	}
+
+	// Start listening to requests
+	server, err := server.NewServer(cpm, clientFactory, cache, conf, prom, tracingLoader, discovery, staticAssetFS)
+	if err != nil {
+		log.Fatal(err)
+	}
+	server.Start()
+
+	grafana := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
+
+	// Needs to be started after the server so that the cache is started because the controllers use the cache.
+	// Passing nil here because the tracing client is not used for validations and that is all this layer is used for.
+	// Passing the `tracingClient` above would be a race condition since it gets set in a goroutine.
+	layer, err := business.NewLayerWithSAClients(conf, cache, prom, nil, cpm, grafana, discovery, clientFactory.GetSAClients())
+	if err != nil {
+		log.Fatalf("Error creating business layer: %s", err)
+	}
+
+	controllerStopped, err := controller.Start(ctx, conf, clientFactory, cache, &layer.Validations)
+	if err != nil {
+		log.Fatalf("Error creating validations controller: %s", err)
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		// Shutdown internal components
+		<-ctx.Done()
+		log.Info("Shutting down internal components")
+		cache.Stop()
+		server.Stop()
+		// Wait for controller to stop.
+		<-controllerStopped
+		close(stopped)
+	}()
+	return stopped
+}
+
+func Run(ctx context.Context, conf *config.Config, version string, commitHash string, goVersion string, staticAssetFS fs.FS, clientFactory kubernetes.ClientFactory) <-chan struct{} {
+	updateConfigWithIstioInfo(conf)
+
+	// prepare our internal metrics so Prometheus can scrape them
+	internalmetrics.RegisterInternalMetrics()
+
+	return run(ctx, conf, version, commitHash, goVersion, staticAssetFS, clientFactory)
+}
+
+// determineContainerVersion will return the version of the image container.
+// It does this by looking at an ENV defined in the Dockerfile when the image is built.
+// If the ENV is not defined, the version is assumed the same as the given default value.
+func determineContainerVersion(defaultVersion string) string {
+	v := os.Getenv("KIALI_CONTAINER_VERSION")
+	if v == "" {
+		return defaultVersion
+	}
+	return v
+}
+
+// This is used to update the config with information about istio that
+// comes from the environment such as the cluster name.
+func updateConfigWithIstioInfo(conf *config.Config) {
+	homeCluster := conf.KubernetesConfig.ClusterName
+	if homeCluster != "" {
+		// If the cluster name is already set, we don't need to do anything
+		return
+	}
+
+	err := func() error {
+		log.Debug("Cluster name is not set. Attempting to auto-detect the cluster name from the home cluster environment.")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Need to create a temporary client factory here so that we can create a client
+		// to auto-detect the istio cluster name from the environment. There's a bit of a
+		// chicken and egg problem with the client factory because the client factory
+		// uses the cluster id to keep track of all the clients. But in order to create
+		// a client to get the cluster id from the environment, you need to create a client factory.
+		// To get around that we create a temporary client factory here and then set the kiali
+		// config cluster name. We then create the global client factory later in the business
+		// package and that global client factory has the cluster id set properly.
+		cf, err := kubernetes.NewClientFactory(ctx, *conf)
+		if err != nil {
+			return err
+		}
+
+		// Try to auto-detect the cluster name
+		homeCluster, err = kubernetes.ClusterNameFromIstiod(*conf, cf.GetSAHomeClusterClient())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}()
+	if err != nil {
+		log.Warningf("Cannot resolve local cluster name. Err: %s. Falling back to [%s]", err, config.DefaultClusterID)
+		homeCluster = config.DefaultClusterID
+	}
+
+	log.Debugf("Auto-detected the istio cluster name to be [%s]. Updating the kiali config", homeCluster)
+	conf.KubernetesConfig.ClusterName = homeCluster
+	config.Set(conf)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -226,6 +226,7 @@ type PrometheusConfig struct {
 	CacheEnabled    bool              `yaml:"cache_enabled,omitempty"`    // Enable cache for Prometheus queries
 	CacheExpiration int               `yaml:"cache_expiration,omitempty"` // Global cache expiration expressed in seconds
 	CustomHeaders   map[string]string `yaml:"custom_headers,omitempty"`
+	Enabled         bool              `yaml:"enabled,omitempty"`
 	HealthCheckUrl  string            `yaml:"health_check_url,omitempty"`
 	IsCore          bool              `yaml:"is_core,omitempty"`
 	QueryScope      map[string]string `yaml:"query_scope,omitempty"`
@@ -454,7 +455,8 @@ type DeploymentConfig struct {
 	// RemoteSecretPath is used to identify the remote cluster Kiali will connect to as its "local cluster".
 	// This is to support installing Kiali in the control plane, but observing only the data plane in the remote cluster.
 	// Experimental feature. See: https://github.com/kiali/kiali/issues/3002
-	RemoteSecretPath string `yaml:"remote_secret_path,omitempty"`
+	RemoteSecretPath     string            `yaml:"remote_secret_path,omitempty"`
+	ClusterNameOverrides map[string]string `yaml:"cluster_name_overrides",omitempty`
 }
 
 // we need to play games with a custom unmarshaller/marshaller for metav1.LabelSelector because it has no yaml struct tags so
@@ -661,6 +663,13 @@ type Profiler struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 }
 
+type RunMode string
+
+const (
+	RunModeLocal RunMode = "local"
+	RunModeApp   RunMode = "app"
+)
+
 // Config defines full YAML configuration.
 type Config struct {
 	AdditionalDisplayDetails []AdditionalDisplayItem             `yaml:"additional_display_details,omitempty"`
@@ -680,6 +689,7 @@ type Config struct {
 	KubernetesConfig         KubernetesConfig                    `yaml:"kubernetes_config,omitempty"`
 	LoginToken               LoginToken                          `yaml:"login_token,omitempty"`
 	Server                   Server                              `yaml:",omitempty"`
+	RunMode                  RunMode                             `yaml:"runMode,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -773,6 +783,7 @@ func NewConfig() (c *Config) {
 				// Prom Cache expires and it forces to repopulate cache
 				CacheExpiration: 300,
 				CustomHeaders:   map[string]string{},
+				Enabled:         true,
 				QueryScope:      map[string]string{},
 				ThanosProxy: ThanosProxy{
 					Enabled:         false,
@@ -947,6 +958,7 @@ func NewConfig() (c *Config) {
 			WebSchema:                  "",
 			WriteTimeout:               30,
 		},
+		RunMode: RunModeApp,
 	}
 
 	return
@@ -1366,12 +1378,12 @@ func Validate(conf Config) error {
 		return fmt.Errorf("server port is negative: %v", conf.Server.Port)
 	}
 
-	if strings.Contains(conf.Server.StaticContentRootDirectory, "..") {
-		return fmt.Errorf("server static content root directory must not contain '..': %v", conf.Server.StaticContentRootDirectory)
-	}
-	if _, err := os.Stat(conf.Server.StaticContentRootDirectory); os.IsNotExist(err) {
-		return fmt.Errorf("server static content root directory does not exist: %v", conf.Server.StaticContentRootDirectory)
-	}
+	// if strings.Contains(conf.Server.StaticContentRootDirectory, "..") {
+	// 	return fmt.Errorf("server static content root directory must not contain '..': %v", conf.Server.StaticContentRootDirectory)
+	// }
+	// if _, err := os.Stat(conf.Server.StaticContentRootDirectory); os.IsNotExist(err) {
+	// 	return fmt.Errorf("server static content root directory does not exist: %v", conf.Server.StaticContentRootDirectory)
+	// }
 
 	webRoot := conf.Server.WebRoot
 	if !validPathRegEx.MatchString(webRoot) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -43,7 +43,7 @@ func NewScheme() (*runtime.Scheme, error) {
 }
 
 // Start creates and starts all the controllers. They'll get cancelled when the context is cancelled.
-func Start(ctx context.Context, conf *config.Config, cf kubernetes.ClientFactory, kialiCache cache.KialiCache, validationsService *business.IstioValidationsService) error {
+func Start(ctx context.Context, conf *config.Config, cf kubernetes.ClientFactory, kialiCache cache.KialiCache, validationsService *business.IstioValidationsService) (<-chan struct{}, error) {
 	// TODO: Replace with kiali logging but if this isn't set some errors are thrown.
 	ctrl.SetLogger(zap.New())
 
@@ -51,7 +51,7 @@ func Start(ctx context.Context, conf *config.Config, cf kubernetes.ClientFactory
 	log.Debug("Setting up Validations Contoller")
 	scheme, err := NewScheme()
 	if err != nil {
-		return fmt.Errorf("error setting up ValidationsController when creating scheme: %s", err)
+		return nil, fmt.Errorf("error setting up ValidationsController when creating scheme: %s", err)
 	}
 
 	// In the future this could be any cluster and not just home cluster.
@@ -64,7 +64,7 @@ func Start(ctx context.Context, conf *config.Config, cf kubernetes.ClientFactory
 		Scheme:  scheme,
 	})
 	if err != nil {
-		return fmt.Errorf("error setting up ValidationsController when creating manager: %s", err)
+		return nil, fmt.Errorf("error setting up ValidationsController when creating manager: %s", err)
 	}
 
 	var clusters []string
@@ -74,15 +74,17 @@ func Start(ctx context.Context, conf *config.Config, cf kubernetes.ClientFactory
 	}
 
 	if err := NewValidationsController(ctx, clusters, conf, kialiCache, validationsService, mgr); err != nil {
-		return fmt.Errorf("error setting up ValidationsController: %s", err)
+		return nil, fmt.Errorf("error setting up ValidationsController: %s", err)
 	}
 
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
 		if err := mgr.Start(ctx); err != nil {
 			log.Errorf("error starting Validations Controller: %s", err)
 		}
 		log.Debug("Stopped Validations Controller")
 	}()
 
-	return nil
+	return stopped, nil
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://localhost:20001",
   "name": "@kiali/kiali-ui",
   "version": "2.7.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { ServerConfig } from '../types/ServerConfig';
+import { RunMode, ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
 import { MeshCluster } from '../types/Mesh';
 
@@ -130,7 +130,8 @@ const defaultServerConfig: ComputedServerConfig = {
   prometheus: {
     globalScrapeInterval: 15,
     storageTsdbRetention: 21600
-  }
+  },
+  runMode: RunMode.APP
 };
 
 // Overwritten with real server config on user login. Also used for tests.

--- a/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/frontend/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -187,7 +187,8 @@ export const serverRateConfig = {
   istioTelemetryV2: true,
   deployment: {
     viewOnlyMode: false
-  }
+  },
+  runMode: 'app'
 } as ServerConfig;
 
 export const tolerancesDefault = [

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -134,6 +134,12 @@ export interface ToleranceConfig {
  End Health Config
 */
 
+// enum for run mode
+export enum RunMode {
+  LOCAL = 'local',
+  APP = 'app'
+}
+
 export interface ServerConfig {
   ambientEnabled: boolean;
   authStrategy: string;
@@ -154,4 +160,5 @@ export interface ServerConfig {
     globalScrapeInterval?: DurationInSeconds;
     storageTsdbRetention?: DurationInSeconds;
   };
+  runMode: RunMode;
 }

--- a/frontend/src/types/__testData__/HealthConfig.ts
+++ b/frontend/src/types/__testData__/HealthConfig.ts
@@ -104,7 +104,8 @@ export const healthConfig = {
   istioTelemetryV2: true,
   deployment: {
     viewOnlyMode: false
-  }
+  },
+  runMode: 'app'
 } as ServerConfig;
 
 export const tolerancesDefault = [

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -59,6 +59,7 @@ type PublicConfig struct {
 	KialiFeatureFlags   config.KialiFeatureFlags      `json:"kialiFeatureFlags,omitempty"`
 	LogLevel            string                        `json:"logLevel,omitempty"`
 	Prometheus          PrometheusConfig              `json:"prometheus,omitempty"`
+	RunMode             config.RunMode                `json:"runMode,omitempty"`
 }
 
 // Config is a REST http.HandlerFunc serving up the Kiali configuration made public to clients.
@@ -95,6 +96,7 @@ func Config(conf *config.Config, discovery *istio.Discovery) http.HandlerFunc {
 				GlobalScrapeInterval: promConfig.GlobalScrapeInterval,
 				StorageTsdbRetention: promConfig.StorageTsdbRetention,
 			},
+			RunMode: conf.RunMode,
 		}
 
 		// The following code fetches the cluster info. Cluster info is not critical.

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -1470,7 +1470,7 @@ func istiodTestServer(t *testing.T) *httptest.Server {
 			return
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
-			t.Fatalf("Unexpected request path: %s", r.URL.Path)
+			t.Logf("Unexpected request path: %s", r.URL.Path)
 			return
 		}
 		if _, err := w.Write(kubernetes.ReadFile(t, file)); err != nil {

--- a/istio/version.go
+++ b/istio/version.go
@@ -144,7 +144,8 @@ func GetVersion(ctx context.Context, conf *config.Config, client kubernetes.Clie
 	// If kiali is running on the same cluster as the istio control plane, use the URL instead
 	// of port forwarding. For remote clusters we need to port forward to get the version since the
 	// http monitoring port (15014) is not exposed publicly.
-	if client.ClusterInfo().Name == conf.KubernetesConfig.ClusterName {
+	// TODO: Better check for this?
+	if conf.Deployment.RemoteSecretPath == "" && client.ClusterInfo().Name == conf.KubernetesConfig.ClusterName {
 		url := ""
 		// If the config has a URL for the service version, use that until the config option is removed.
 		if istioConfig.UrlServiceVersion != "" {

--- a/kiali.go
+++ b/kiali.go
@@ -29,29 +29,27 @@ package main
 
 import (
 	"context"
+	"embed"
 	"flag"
+	"io/fs"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"syscall"
 
 	_ "go.uber.org/automaxprocs"
 
-	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/cmd/local"
+	"github.com/kiali/kiali/cmd/server"
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/controller"
-	"github.com/kiali/kiali/grafana"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/models"
-	"github.com/kiali/kiali/prometheus"
-	"github.com/kiali/kiali/prometheus/internalmetrics"
-	"github.com/kiali/kiali/server"
-	"github.com/kiali/kiali/tracing"
 	"github.com/kiali/kiali/util"
 )
+
+//go:embed frontend/build/*
+var folder embed.FS
 
 // Identifies the build. These are set via ldflags during the build (see Makefile).
 var (
@@ -62,10 +60,40 @@ var (
 
 // Command line arguments
 var (
-	argConfigFile = flag.String("config", "", "Path to the YAML configuration file. If not specified, environment variables will be used for configuration.")
+	argConfigFile         string
+	homeClusterContext    string
+	kubeConfig            string
+	remoteClusterContexts []string
+	openBrowser           bool
 )
 
+func kubeConfigDir() string {
+	if kubeEnv, ok := os.LookupEnv("KUBECONFIG"); ok {
+		return kubeEnv
+	}
+	if homedir, err := os.UserHomeDir(); err == nil {
+		return path.Join(homedir, ".kube/config")
+	}
+	return ""
+}
+
 func init() {
+	// Registering these flags here is only necessary because controller-runtime already registers the "kubeconfig" flag
+	// and double registering causes a panic. Creating a new default FlagSet here drops the controller-runtime flag.
+	// See this bug: https://github.com/kubernetes-sigs/controller-runtime/issues/878.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	flag.StringVar(&argConfigFile, "config", "", "Path to the YAML configuration file. If not specified, environment variables will be used for configuration.")
+	flag.StringVar(&homeClusterContext, "home-cluster-context", "", "Sets Kiali's home cluster context in local mode.")
+	flag.StringVar(&kubeConfig, "kubeconfig", kubeConfigDir(), "Path to the kubeconfig file for Kiali to use.")
+	flag.Func("remote-cluster-contexts", "Comma separated list of remote cluster contexts.", func(flagValue string) error {
+		// Need to check for empty string because strings.Split on "" returns [""]
+		if flagValue != "" {
+			remoteClusterContexts = strings.Split(flagValue, ",")
+		}
+		return nil
+	})
+	flag.BoolVar(&openBrowser, "open-browser", true, "If true, will open the default browser after startup.")
+
 	// log everything to stderr so that it can be easily gathered by logs, separate log files are problematic with containers
 	_ = flag.Set("logtostderr", "true")
 }
@@ -74,17 +102,15 @@ func main() {
 	log.InitializeLogger()
 	util.Clock = util.RealClock{}
 
-	// process command line
 	flag.Parse()
 	validateFlags()
 
 	// log startup information
 	log.Infof("Kiali: Version: %v, Commit: %v, Go: %v", version, commitHash, goVersion)
-	log.Debugf("Kiali: Command line: [%v]", strings.Join(os.Args, " "))
 
 	// load config file if specified, otherwise, rely on environment variables to configure us
-	if *argConfigFile != "" {
-		c, err := config.LoadFromFile(*argConfigFile)
+	if argConfigFile != "" {
+		c, err := config.LoadFromFile(argConfigFile)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -94,107 +120,48 @@ func main() {
 		config.Set(config.NewConfig())
 	}
 
-	updateConfigWithIstioInfo()
-
-	conf := config.Get()
-	log.Tracef("Kiali Configuration:\n%s", conf)
-
-	if err := config.Validate(*conf); err != nil {
-		log.Fatal(err)
-	}
-
-	// prepare our internal metrics so Prometheus can scrape them
-	internalmetrics.RegisterInternalMetrics()
-
-	// Create the business package dependencies.
-	clientFactory, err := kubernetes.GetClientFactory()
+	f, err := fs.Sub(folder, "frontend/build")
 	if err != nil {
-		log.Fatalf("Failed to create client factory. Err: %s", err)
+		log.Fatalf("Error getting subfolder: %v", err)
 	}
 
-	log.Info("Initializing Kiali Cache")
-	cache, err := cache.NewKialiCache(clientFactory.GetSAClients(), *conf)
-	if err != nil {
-		log.Fatalf("Error initializing Kiali Cache. Details: %s", err)
-	}
-	defer cache.Stop()
-
-	cache.SetBuildInfo(models.BuildInfo{
-		CommitHash:       commitHash,
-		ContainerVersion: determineContainerVersion(version),
-		GoVersion:        goVersion,
-		Version:          version,
-	})
-
-	discovery := istio.NewDiscovery(clientFactory.GetSAClients(), cache, conf)
-	cpm := business.NewControlPlaneMonitor(cache, clientFactory, conf, discovery)
-
-	// This context is used for polling and for creating some high level clients like tracing.
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	conf := config.Get()
 
-	if conf.ExternalServices.Istio.IstioAPIEnabled {
-		cpm.PollIstiodForProxyStatus(ctx)
+	var serverStopped <-chan struct{}
+
+	switch flag.CommandLine.Arg(0) {
+	case "open":
+		// Override some settings in local mode.
+		conf.RunMode = config.RunModeLocal
+		conf.Auth.Strategy = config.AuthStrategyAnonymous
+		conf.Deployment.RemoteSecretPath = kubeConfig
+		config.Set(conf)
+		if err := config.Validate(*conf); err != nil {
+			log.Fatal(err)
+		}
+		serverStopped, err = local.Run(ctx, conf, version, commitHash, goVersion, f, homeClusterContext, remoteClusterContexts, openBrowser)
+		if err != nil {
+			log.Fatalf("Unable to run kiali locally: %s", err)
+		}
+	default:
+		if err := config.Validate(*conf); err != nil {
+			log.Fatal(err)
+		}
+		log.Tracef("Kiali Configuration:\n%s", conf)
+		clientFactory, err := kubernetes.GetClientFactory()
+		if err != nil {
+			log.Fatalf("Failed to create client factory. Err: %s", err)
+		}
+
+		serverStopped = server.Run(ctx, conf, version, commitHash, goVersion, f, clientFactory)
 	}
-
-	// Create shared prometheus client shared by all prometheus requests in the business layer.
-	prom, err := prometheus.NewClient()
-	if err != nil {
-		log.Fatalf("Error creating Prometheus client: %s", err)
-	}
-
-	// Create shared tracing client shared by all tracing requests in the business layer.
-	// Because tracing is not an essential component, we don't want to block startup
-	// of the server if the tracing client fails to initialize. tracing.NewClient will
-	// continue to retry until the client is initialized or the context is cancelled.
-	// Passing in a loader function allows the tracing client to be used once it is
-	// finally initialized.
-	var tracingClient tracing.ClientInterface
-	tracingLoader := func() tracing.ClientInterface {
-		return tracingClient
-	}
-	if conf.ExternalServices.Tracing.Enabled {
-		go func() {
-			client, err := tracing.NewClient(ctx, conf, clientFactory.GetSAHomeClusterClient().GetToken())
-			if err != nil {
-				log.Fatalf("Error creating tracing client: %s", err)
-				return
-			}
-			tracingClient = client
-		}()
-	} else {
-		log.Debug("Tracing is disabled")
-	}
-
-	grafana := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
-
-	// Start listening to requests
-	server, err := server.NewServer(cpm, clientFactory, cache, conf, prom, tracingLoader, discovery)
-	if err != nil {
-		log.Fatal(err)
-	}
-	server.Start()
-
-	// Needs to be started after the server so that the cache is started because the controllers use the cache.
-	// Passing nil here because the tracing client is not used for validations and that is all this layer is used for.
-	// Passing the `tracingClient` above would be a race condition since it gets set in a goroutine.
-	layer, err := business.NewLayerWithSAClients(conf, cache, prom, nil, cpm, grafana, discovery, clientFactory.GetSAClients())
-	if err != nil {
-		log.Fatalf("Error creating business layer: %s", err)
-	}
-	if err := controller.Start(ctx, conf, clientFactory, cache, &layer.Validations); err != nil {
-		log.Fatalf("Error creating validations controller: %s", err)
-	}
-
-	// wait forever, or at least until we are told to exit
-	waitForTermination()
-
-	// Shutdown internal components
-	log.Info("Shutting down internal components")
-	server.Stop()
+	waitForTermination(cancel)
+	// This ensures that the Run process has fully cleaned itself up.
+	<-serverStopped
 }
 
-func waitForTermination() {
+func waitForTermination(cancel context.CancelFunc) {
 	// Channel that is notified when we are done and should exit
 	// TODO: may want to make this a package variable - other things might want to tell us to exit
 	doneChan := make(chan bool)
@@ -204,6 +171,7 @@ func waitForTermination() {
 	go func() {
 		for range signalChan {
 			log.Info("Termination Signal Received")
+			cancel()
 			doneChan <- true
 		}
 	}()
@@ -212,69 +180,11 @@ func waitForTermination() {
 }
 
 func validateFlags() {
-	if *argConfigFile != "" {
-		if _, err := os.Stat(*argConfigFile); err != nil {
+	if argConfigFile != "" {
+		if _, err := os.Stat(argConfigFile); err != nil {
 			if os.IsNotExist(err) {
-				log.Debugf("Configuration file [%v] does not exist.", *argConfigFile)
+				log.Debugf("Configuration file [%v] does not exist.", argConfigFile)
 			}
 		}
 	}
-}
-
-// determineContainerVersion will return the version of the image container.
-// It does this by looking at an ENV defined in the Dockerfile when the image is built.
-// If the ENV is not defined, the version is assumed the same as the given default value.
-func determineContainerVersion(defaultVersion string) string {
-	v := os.Getenv("KIALI_CONTAINER_VERSION")
-	if v == "" {
-		return defaultVersion
-	}
-	return v
-}
-
-// This is used to update the config with information about istio that
-// comes from the environment such as the cluster name.
-func updateConfigWithIstioInfo() {
-	conf := *config.Get()
-
-	homeCluster := conf.KubernetesConfig.ClusterName
-	if homeCluster != "" {
-		// If the cluster name is already set, we don't need to do anything
-		return
-	}
-
-	err := func() error {
-		log.Debug("Cluster name is not set. Attempting to auto-detect the cluster name from the home cluster environment.")
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// Need to create a temporary client factory here so that we can create a client
-		// to auto-detect the istio cluster name from the environment. There's a bit of a
-		// chicken and egg problem with the client factory because the client factory
-		// uses the cluster id to keep track of all the clients. But in order to create
-		// a client to get the cluster id from the environment, you need to create a client factory.
-		// To get around that we create a temporary client factory here and then set the kiali
-		// config cluster name. We then create the global client factory later in the business
-		// package and that global client factory has the cluster id set properly.
-		cf, err := kubernetes.NewClientFactory(ctx, conf)
-		if err != nil {
-			return err
-		}
-
-		// Try to auto-detect the cluster name
-		homeCluster, err = kubernetes.ClusterNameFromIstiod(conf, cf.GetSAHomeClusterClient())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}()
-	if err != nil {
-		log.Warningf("Cannot resolve local cluster name. Err: %s. Falling back to [%s]", err, config.DefaultClusterID)
-		homeCluster = config.DefaultClusterID
-	}
-
-	log.Debugf("Auto-detected the istio cluster name to be [%s]. Updating the kiali config", homeCluster)
-	conf.KubernetesConfig.ClusterName = homeCluster
-	config.Set(&conf)
 }

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -198,7 +198,7 @@ func NewKialiCache(kialiSAClients map[string]kubernetes.ClientInterface, conf co
 	// TODO: Treat all clusters the same way.
 	// Ensure home client got set.
 	if _, found := kialiCacheImpl.kubeCache[conf.KubernetesConfig.ClusterName]; !found {
-		return nil, fmt.Errorf("home cluster not configured in kiali cache")
+		return nil, fmt.Errorf("[Kiali Cache] home cluster: '%s' not configured in kiali cache", conf.KubernetesConfig.ClusterName)
 	}
 
 	return &kialiCacheImpl, nil

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	osappsclient "github.com/openshift/client-go/apps/clientset/versioned"
@@ -15,6 +16,7 @@ import (
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	kialiconfig "github.com/kiali/kiali/config"
@@ -119,9 +121,35 @@ func NewClientWithRemoteClusterInfo(config *rest.Config, remoteClusterInfo *Remo
 			return nil, err
 		}
 
+		// TODO: This ain't right.
+		// TODO: We need to be able to read multiple clusters/contexts from the kubeconfig file.
 		clusterName := getClusterName(&cfg)
 		client.clusterInfo = ClusterInfo{
 			Name:       clusterName,
+			SecretName: remoteClusterInfo.SecretName,
+		}
+	} else {
+		client.clusterInfo = ClusterInfo{
+			Name: kialiconfig.Get().KubernetesConfig.ClusterName,
+		}
+	}
+	// Copy config
+	clientConfig := *config
+	client.clusterInfo.ClientConfig = &clientConfig
+
+	return client, nil
+}
+
+// TODO: Combine this with newClientWithRemoteClusterInfo
+func NewClientWithRemoteClusterInfoWithClusterName(config *rest.Config, remoteClusterInfo *RemoteClusterInfo) (*K8SClient, error) {
+	client, err := newClientFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if remoteClusterInfo != nil {
+		client.clusterInfo = ClusterInfo{
+			Name:       remoteClusterInfo.ClusterName,
 			SecretName: remoteClusterInfo.SecretName,
 		}
 	} else {
@@ -140,8 +168,8 @@ func NewClientWithRemoteClusterInfo(config *rest.Config, remoteClusterInfo *Remo
 // Returns configuration if Kiali is in Cluster when InCluster is true
 // Returns configuration if Kiali is not in Cluster when InCluster is false
 // It returns an error on any problem
-func getConfigForLocalCluster() (*rest.Config, error) {
-	remoteSecretPath := kialiconfig.Get().Deployment.RemoteSecretPath
+func getConfigForLocalCluster(conf *kialiconfig.Config) (*rest.Config, error) {
+	remoteSecretPath := conf.Deployment.RemoteSecretPath
 	if remoteSecret, readErr := GetRemoteSecret(remoteSecretPath); readErr == nil {
 		log.Debugf("Using remote secret for local cluster config found at: [%s]. Kiali must be running outside the kube cluster.", remoteSecretPath)
 		return clientcmd.NewDefaultClientConfig(*remoteSecret, nil).ClientConfig()
@@ -237,4 +265,44 @@ func NewClient(
 		userClient:     userClient,
 		oAuthClient:    oAuthClient,
 	}
+}
+
+func NewClientsFromRemotePath(ctx context.Context, conf kialiconfig.Config) (map[string]ClientInterface, error) {
+	kubeConfig, err := clientcmd.LoadFromFile(conf.Deployment.RemoteSecretPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read kubeconfig from file: %s", conf.Deployment.RemoteSecretPath)
+	}
+
+	// TODO: Just current context for now but expand this out with args from cmdline.
+	currentContext := kubeConfig.Contexts[kubeConfig.CurrentContext]
+	if currentContext == nil {
+		return nil, fmt.Errorf("current context not set in kubeconfig file: %s", conf.Deployment.RemoteSecretPath)
+	}
+
+	// TODO: Figure out best place to put this.
+	// Current context is home cluster. This is a hack.
+	conf.KubernetesConfig.ClusterName = currentContext.Cluster
+	kialiconfig.Set(&conf)
+
+	contexts := map[string]*api.Context{kubeConfig.CurrentContext: currentContext}
+	clients := map[string]ClientInterface{}
+	for context, clusterInfo := range contexts {
+		remoteClusterInfo := &RemoteClusterInfo{
+			ClusterName: clusterInfo.Cluster,
+			Config:      clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{CurrentContext: context}),
+		}
+		clientConfig, err := remoteClusterInfo.Config.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get client config for remote cluster [%s]. Err: %s", context, err)
+		}
+
+		client, err := NewClientWithRemoteClusterInfoWithClusterName(clientConfig, remoteClusterInfo)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create remote Kiali Service Account client. Err: %s", err)
+		}
+
+		clients[clusterInfo.Cluster] = client
+	}
+
+	return clients, nil
 }

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	kialiConfig "github.com/kiali/kiali/config"
+	conf "github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
@@ -41,6 +42,8 @@ type clientFactory struct {
 	// Not all of the data in this base config is used - some will be overridden per client like token and host info.
 	baseRestConfig *rest.Config
 
+	conf *conf.Config
+
 	// clientEntries contain user clients that are used to authenticate as logged in users.
 	// Keyed by hash code generated from auth data.
 	clientEntries map[string]map[string]ClientInterface // By token by cluster
@@ -48,8 +51,6 @@ type clientFactory struct {
 	// Name of the home cluster. This is the cluster where Kiali is deployed which is usually the
 	// "in cluster" config. This name comes from the istio cluster id.
 	homeCluster string
-
-	kialiConfig *kialiConfig.Config
 
 	// mutex for when accessing the stored clients
 	mutex sync.RWMutex
@@ -66,6 +67,7 @@ type clientFactory struct {
 }
 
 // GetClientFactory returns the client factory. Creates a new one if necessary
+// TODO: Remove?
 func GetClientFactory() (ClientFactory, error) {
 	var err error
 	once.Do(func() {
@@ -73,15 +75,15 @@ func GetClientFactory() (ClientFactory, error) {
 			return
 		}
 
-		factory, err = getClientFactory(*kialiConfig.Get())
+		factory, err = getClientFactory(*conf.Get())
 	})
 	return factory, err
 }
 
-func getClientFactory(conf kialiConfig.Config) (*clientFactory, error) {
+func getClientFactory(conf conf.Config) (*clientFactory, error) {
 	// Get the normal configuration
 	var config *rest.Config
-	config, err := getConfigForLocalCluster()
+	config, err := getConfigForLocalCluster(&conf)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +104,7 @@ func getClientFactory(conf kialiConfig.Config) (*clientFactory, error) {
 // Does not set the global ClientFactory. You should probably use
 // GetClientFactory instead of this method unless you temporaily need
 // to create a client like when Kiali sets the cluster id.
-func NewClientFactory(ctx context.Context, conf kialiConfig.Config) (ClientFactory, error) {
+func NewClientFactory(ctx context.Context, conf conf.Config) (ClientFactory, error) {
 	cf, err := getClientFactory(conf)
 	if err != nil {
 		return nil, err
@@ -118,16 +120,99 @@ func NewClientFactory(ctx context.Context, conf kialiConfig.Config) (ClientFacto
 	return cf, nil
 }
 
-// newClientFactory allows for specifying the config and expiry duration
-// Mock friendly for testing purposes
-func newClientFactory(conf *kialiConfig.Config, restConfig *rest.Config) (*clientFactory, error) {
+func NewClientFactoryWithSAClients(ctx context.Context, conf conf.Config, saClients map[string]ClientInterface) (ClientFactory, error) {
 	f := &clientFactory{
-		kialiConfig:     conf,
-		baseRestConfig:  restConfig,
+		// Create a new config based on what was gathered above but don't specify the bearer token to use
+		baseRestConfig:  &rest.Config{},
+		conf:            &conf,
+		clientEntries:   make(map[string]map[string]ClientInterface),
+		recycleChan:     make(chan string),
+		saClientEntries: saClients,
+		homeCluster:     conf.KubernetesConfig.ClusterName,
+	}
+
+	// after creating a client factory
+	// background goroutines will be watching the clients` expiration
+	// if a client is expired, it will be removed from clientEntries
+	go f.watchClients()
+
+	// Need to cleanup the recycle chan since this client factory could be transitory.
+	go func() {
+		<-ctx.Done()
+		log.Debug("Stopping client factory recycle chan")
+		close(f.recycleChan)
+	}()
+
+	return f, nil
+}
+
+// NewClientFactory creates a new client factory that can be transitory.
+// Callers should close the ctx when done with the client factory.
+// Does not set the global ClientFactory. You should probably use
+// GetClientFactory instead of this method unless you temporaily need
+// to create a client like when Kiali sets the cluster id.
+func NewClientFactoryFromKubeConfig(ctx context.Context, conf conf.Config) (ClientFactory, error) {
+	f := &clientFactory{
+		// Create a new config based on what was gathered above but don't specify the bearer token to use
+		baseRestConfig:  &rest.Config{},
+		conf:            &conf,
 		clientEntries:   make(map[string]map[string]ClientInterface),
 		recycleChan:     make(chan string),
 		saClientEntries: make(map[string]ClientInterface),
-		homeCluster:     kialiConfig.Get().KubernetesConfig.ClusterName,
+		homeCluster:     conf.KubernetesConfig.ClusterName,
+	}
+
+	kubeConfig, err := clientcmd.LoadFromFile(conf.Deployment.RemoteSecretPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read kubeconfig from file: %s", conf.Deployment.RemoteSecretPath)
+	}
+
+	// TODO: Just current context for now but expand this out with args from cmdline.
+	currentContext := kubeConfig.Contexts[kubeConfig.CurrentContext]
+	if currentContext == nil {
+		return nil, fmt.Errorf("current context not set in kubeconfig file: %s", conf.Deployment.RemoteSecretPath)
+	}
+
+	// after creating a client factory
+	// background goroutines will be watching the clients` expiration
+	// if a client is expired, it will be removed from clientEntries
+	go f.watchClients()
+
+	contexts := map[string]*api.Context{kubeConfig.CurrentContext: currentContext}
+	for context, clusterInfo := range contexts {
+		remoteClusterInfo := &RemoteClusterInfo{Config: clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{CurrentContext: context})}
+		clientConfig, err := remoteClusterInfo.Config.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get client config for remote cluster [%s]. Err: %s", context, err)
+		}
+
+		client, err := NewClientWithRemoteClusterInfo(clientConfig, remoteClusterInfo)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create remote Kiali Service Account client. Err: %s", err)
+		}
+
+		f.saClientEntries[clusterInfo.Cluster] = client
+	}
+	// Need to cleanup the recycle chan since this client factory could be transitory.
+	go func() {
+		<-ctx.Done()
+		log.Debug("Stopping client factory recycle chan")
+		close(f.recycleChan)
+	}()
+
+	return f, nil
+}
+
+// newClientFactory allows for specifying the config and expiry duration
+// Mock friendly for testing purposes
+func newClientFactory(conf *conf.Config, restConfig *rest.Config) (*clientFactory, error) {
+	f := &clientFactory{
+		baseRestConfig:  restConfig,
+		conf:            conf,
+		clientEntries:   make(map[string]map[string]ClientInterface),
+		recycleChan:     make(chan string),
+		saClientEntries: make(map[string]ClientInterface),
+		homeCluster:     conf.KubernetesConfig.ClusterName,
 	}
 	// after creating a client factory
 	// background goroutines will be watching the clients` expiration
@@ -182,9 +267,9 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 	// So, if OpenID strategy is active, check if a proxy is configured.
 	// If there is, use it UNLESS the token is the one of the Kiali SA. If
 	// the token is the one of the Kiali SA, the proxy can be bypassed.
-	if cf.kialiConfig.Auth.Strategy == kialiConfig.AuthStrategyOpenId && cf.kialiConfig.Auth.OpenId.ApiProxy != "" && cf.kialiConfig.Auth.OpenId.ApiProxyCAData != "" {
+	if cf.conf.Auth.Strategy == conf.AuthStrategyOpenId && cf.conf.Auth.OpenId.ApiProxy != "" && cf.conf.Auth.OpenId.ApiProxyCAData != "" {
 		// Override the CA data on the client with the proxy CA from the Kiali config.
-		caData := cf.kialiConfig.Auth.OpenId.ApiProxyCAData
+		caData := cf.conf.Auth.OpenId.ApiProxyCAData
 		rootCaDecoded, err := base64.StdEncoding.DecodeString(caData)
 		if err != nil {
 			return nil, err
@@ -193,11 +278,11 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 		config.TLSClientConfig = rest.TLSClientConfig{
 			CAData: []byte(rootCaDecoded),
 		}
-		config.Host = cf.kialiConfig.Auth.OpenId.ApiProxy
+		config.Host = cf.conf.Auth.OpenId.ApiProxy
 	}
 
 	// Impersonation is valid only for header authentication strategy
-	if cf.kialiConfig.Auth.Strategy == kialiConfig.AuthStrategyHeader && authInfo.Impersonate != "" {
+	if cf.conf.Auth.Strategy == conf.AuthStrategyHeader && authInfo.Impersonate != "" {
 		config.Impersonate.UserName = authInfo.Impersonate
 		config.Impersonate.Groups = authInfo.ImpersonateGroups
 		config.Impersonate.Extra = authInfo.ImpersonateUserExtra
@@ -276,7 +361,7 @@ func (cf *clientFactory) GetSAClients() map[string]ClientInterface {
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClient(authInfo *api.AuthInfo, cluster string) (ClientInterface, error) {
-	if cf.kialiConfig.IsRBACDisabled() {
+	if cf.conf.IsRBACDisabled() {
 		return cf.GetSAClient(cluster), nil
 	}
 
@@ -285,7 +370,7 @@ func (cf *clientFactory) GetClient(authInfo *api.AuthInfo, cluster string) (Clie
 
 // getClient returns a client for the specified token. Creating one if necessary.
 func (cf *clientFactory) GetClients(authInfos map[string]*api.AuthInfo) (map[string]ClientInterface, error) {
-	if cf.kialiConfig.IsRBACDisabled() {
+	if cf.conf.IsRBACDisabled() {
 		return cf.GetSAClients(), nil
 	}
 
@@ -417,7 +502,6 @@ func (cf *clientFactory) GetSAHomeClusterClient() ClientInterface {
 }
 
 func (cf *clientFactory) getConfig(clusterInfo *RemoteClusterInfo) (*rest.Config, error) {
-	kialiConfig := kialiConfig.Get()
 	clientConfig := *cf.baseRestConfig
 
 	// Remote Cluster
@@ -432,7 +516,7 @@ func (cf *clientFactory) getConfig(clusterInfo *RemoteClusterInfo) (*rest.Config
 	} else {
 		// Just read the token and then use the base config.
 		// We're an in cluster client. Read the kiali service account token.
-		kialiToken, kialiTokenFile, err := GetKialiTokenForHomeCluster()
+		kialiToken, kialiTokenFile, err := GetKialiTokenForHomeCluster(cf.conf)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get Kiali service account token: %s", err)
 		}
@@ -442,13 +526,13 @@ func (cf *clientFactory) getConfig(clusterInfo *RemoteClusterInfo) (*rest.Config
 		clientConfig.BearerTokenFile = kialiTokenFile
 	}
 
-	if !kialiConfig.KialiFeatureFlags.Clustering.EnableExecProvider {
+	if !cf.conf.KialiFeatureFlags.Clustering.EnableExecProvider {
 		clientConfig.ExecProvider = nil
 	}
 
 	// Override some settings with what's in kiali config
-	clientConfig.QPS = kialiConfig.KubernetesConfig.QPS
-	clientConfig.Burst = kialiConfig.KubernetesConfig.Burst
+	clientConfig.QPS = cf.conf.KubernetesConfig.QPS
+	clientConfig.Burst = cf.conf.KubernetesConfig.Burst
 
 	return &clientConfig, nil
 }

--- a/kubernetes/cluster_secret.go
+++ b/kubernetes/cluster_secret.go
@@ -14,6 +14,8 @@ import (
 // RemoteClusterInfo is data that identifies a cluster particpating in the mesh. Multi-cluster meshes have multiple RemoteClusterInfos.
 // Information obtained for a RemoteClusterInfo comes from remote cluster secrets.
 type RemoteClusterInfo struct {
+	// TODO: Right place for this?
+	ClusterName string
 	// Config contains information necessary to connect to the remote cluster
 	Config clientcmd.ClientConfig
 	// SecretFile is the absolute file location of the secret as found on the file system

--- a/kubernetes/token.go
+++ b/kubernetes/token.go
@@ -20,10 +20,10 @@ var (
 )
 
 // GetKialiTokenForHomeCluster returns the Kiali SA token to be used to communicate with the local data plane k8s api endpoint and the token file.
-func GetKialiTokenForHomeCluster() (string, string, error) {
+func GetKialiTokenForHomeCluster(conf *config.Config) (string, string, error) {
 	// TODO: refresh the token when it changes rather than after it expires
 	if KialiTokenForHomeCluster == "" || shouldRefreshToken() {
-		if remoteSecret, err := GetRemoteSecret(config.Get().Deployment.RemoteSecretPath); err == nil { // for experimental feature - for when data plane is in a remote cluster
+		if remoteSecret, err := GetRemoteSecret(conf.Deployment.RemoteSecretPath); err == nil { // for experimental feature - for when data plane is in a remote cluster
 			currentContextAuthInfo := remoteSecret.Contexts[remoteSecret.CurrentContext].AuthInfo
 			if authInfo, ok := remoteSecret.AuthInfos[currentContextAuthInfo]; ok {
 				KialiTokenForHomeCluster = authInfo.Token

--- a/kubernetes/token_test.go
+++ b/kubernetes/token_test.go
@@ -22,12 +22,11 @@ func TestIsTokenExpired(t *testing.T) {
 	assert := assert.New(t)
 	config := config.NewConfig()
 	config.Deployment.RemoteSecretPath = t.TempDir()
-	SetConfig(t, *config)
 
 	DefaultServiceAccountPath = tmpFileTokenExpired
 
 	setupFile(t, "thisisarandomtoken", tmpFileTokenExpired)
-	token, _, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster(config)
 	require.NoError(err)
 
 	assert.True(token != "")
@@ -40,14 +39,13 @@ func TestGetKialiToken(t *testing.T) {
 	assert := assert.New(t)
 	config := config.NewConfig()
 	config.Deployment.RemoteSecretPath = t.TempDir()
-	SetConfig(t, *config)
 
 	DefaultServiceAccountPath = tmpFileGetToken
 	data := "thisisarandomtoken"
 
 	setupFile(t, data, tmpFileGetToken)
 
-	token, _, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster(config)
 	require.NoError(err)
 
 	assert.Equal(data, token)
@@ -58,10 +56,9 @@ func TestGetKialiTokenRemoteCluster(t *testing.T) {
 
 	config := config.NewConfig()
 	config.Deployment.RemoteSecretPath = "testdata/remote-cluster-multiple-users.yaml"
-	SetConfig(t, *config)
 	tokenRead = time.Time{}
 
-	token, _, err := GetKialiTokenForHomeCluster()
+	token, _, err := GetKialiTokenForHomeCluster(config)
 	require.NoError(err)
 
 	require.Equal("token2", token)

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -145,6 +145,7 @@
             "CacheEnabled": true,
             "CacheExpiration": 300,
             "CustomHeaders": {},
+            "Enabled": true,
             "HealthCheckUrl": "",
             "IsCore": false,
             "QueryScope": {},

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -83,7 +83,7 @@ func NewClientForConfig(cfg config.PrometheusConfig) (*Client, error) {
 		// Note: if we are using the 'bearer' authentication method then we want to use the Kiali
 		// service account token and not the user's token. This is because Kiali does filtering based
 		// on the user's token and prevents people who shouldn't have access to particular metrics.
-		token, _, err := kubernetes.GetKialiTokenForHomeCluster()
+		token, _, err := kubernetes.GetKialiTokenForHomeCluster(config.Get())
 		if err != nil {
 			log.Errorf("Could not read the Kiali Service Account token: %v", err)
 			return nil, err

--- a/routing/router.go
+++ b/routing/router.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	hpprof "net/http/pprof"
 	"os"
@@ -37,14 +38,22 @@ func NewRouter(
 	cpm business.ControlPlaneMonitor,
 	grafana *grafana.Service,
 	discovery *istio.Discovery,
+	staticAssetFS fs.FS,
 ) (*mux.Router, error) {
 	webRoot := conf.Server.WebRoot
 	webRootWithSlash := webRoot + "/"
 
 	rootRouter := mux.NewRouter().StrictSlash(false)
 	appRouter := rootRouter
-
-	staticFileServer := http.FileServer(http.Dir(conf.Server.StaticContentRootDirectory))
+	var staticFileServer http.Handler
+	if conf.RunMode == config.RunModeLocal {
+		log.Info("Serving from embedded assets content root dir")
+		staticFileServer = http.FileServerFS(staticAssetFS)
+	} else {
+		log.Info("Serving from static content root dir")
+		staticFileServer = http.FileServer(http.Dir(conf.Server.StaticContentRootDirectory))
+	}
+	log.Infof("Webroot: %s", webRootWithSlash)
 
 	if webRoot != "/" {
 		// help the user out - if a request comes in for "/", redirect to our true webroot
@@ -76,9 +85,9 @@ func NewRouter(
 		}
 
 		if urlPath == webRootWithSlash || urlPath == webRoot || urlPath == webRootWithSlash+"index.html" {
-			serveIndexFile(w)
+			serveIndexFile(conf, w, staticAssetFS)
 		} else if urlPath == webRootWithSlash+"env.js" {
-			serveEnvJsFile(w)
+			serveEnvJsFile(conf, w)
 		} else {
 			staticFileServer.ServeHTTP(w, r)
 		}
@@ -238,11 +247,15 @@ func NewRouter(
 		}
 	}
 
-	// All client-side routes are prefixed with /console.
-	// They are forwarded to index.html and will be handled by react-router.
-	appRouter.PathPrefix("/console").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		serveIndexFile(w)
-	})
+	if conf.RunMode == config.RunModeLocal {
+		appRouter.PathPrefix("/console").Handler(staticFileServer)
+	} else {
+		// All client-side routes are prefixed with /console.
+		// They are forwarded to index.html and will be handled by react-router.
+		appRouter.PathPrefix("/console").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serveIndexFile(conf, w, staticAssetFS)
+		})
+	}
 
 	if authController != nil {
 		if ac, ok := authController.(*authentication.OpenIdAuthController); ok {
@@ -293,8 +306,7 @@ func metricHandler(next http.Handler, route Route) http.Handler {
 
 // serveEnvJsFile generates the env.js file needed by the UI from Kiali configs. The
 // generated file is sent to the HTTP response.
-func serveEnvJsFile(w http.ResponseWriter) {
-	conf := config.Get()
+func serveEnvJsFile(conf *config.Config, w http.ResponseWriter) {
 	var body string
 	if len(conf.Server.WebHistoryMode) > 0 {
 		body += fmt.Sprintf("window.HISTORY_MODE='%s';", conf.Server.WebHistoryMode)
@@ -311,19 +323,32 @@ func serveEnvJsFile(w http.ResponseWriter) {
 
 // serveIndexFile takes UI's index.html as a template to generate a modified index file that takes
 // into account the web_root path configured in the Kiali CR. The result is sent to the HTTP response.
-func serveIndexFile(w http.ResponseWriter) {
-	webRootPath := config.Get().Server.WebRoot
+func serveIndexFile(conf *config.Config, w http.ResponseWriter, staticAssetFS fs.FS) {
+	webRootPath := conf.Server.WebRoot
 	webRootPath = strings.TrimSuffix(webRootPath, "/")
 
-	path, _ := filepath.Abs("./console/index.html")
-	b, err := os.ReadFile(path)
-	if err != nil {
-		log.Errorf("File I/O error [%v]", err.Error())
-		handlers.RespondWithDetailedError(w, http.StatusInternalServerError, "Unable to read index.html template file", err.Error())
-		return
+	var (
+		contents []byte
+		err      error
+	)
+	if conf.RunMode == config.RunModeLocal {
+		contents, err = fs.ReadFile(staticAssetFS, "index.html")
+		if err != nil {
+			log.Errorf("File I/O error: %s", err)
+			handlers.RespondWithDetailedError(w, http.StatusInternalServerError, "Unable to read index.html template file", err.Error())
+			return
+		}
+	} else {
+		path, _ := filepath.Abs("./console/index.html")
+		contents, err = os.ReadFile(path)
+		if err != nil {
+			log.Errorf("File I/O error [%v]", err.Error())
+			handlers.RespondWithDetailedError(w, http.StatusInternalServerError, "Unable to read index.html template file", err.Error())
+			return
+		}
 	}
 
-	html := string(b)
+	html := string(contents)
 	newHTML := html
 
 	if len(webRootPath) != 0 {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -20,7 +20,7 @@ import (
 func TestDrawPathProperly(t *testing.T) {
 	conf := new(config.Config)
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	testRoute(router, "Root", "GET", t)
 }
 
@@ -46,7 +46,7 @@ func TestWebRootRedirect(t *testing.T) {
 	conf.Server.WebRoot = "/test"
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -69,7 +69,7 @@ func TestSimpleRoute(t *testing.T) {
 	conf := new(config.Config)
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -88,7 +88,7 @@ func TestProfilerRoute(t *testing.T) {
 	conf.Server.Profiler.Enabled = true
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -120,7 +120,7 @@ func TestDisabledProfilerRoute(t *testing.T) {
 	conf.Server.Profiler.Enabled = false
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -157,7 +157,7 @@ func TestRedirectWithSetWebRootKeepsParams(t *testing.T) {
 	conf.Server.WebRoot = "/test"
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(kubetest.NewFakeK8sClient())
-	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil)
+	router, _ := NewRouter(conf, nil, mockClientFactory, nil, nil, nil, nil, nil, nil)
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/tls"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"time"
 
@@ -47,10 +48,21 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 	prom prometheus.ClientInterface,
 	traceClientLoader func() tracing.ClientInterface,
 	discovery *istio.Discovery,
+	staticAssetFS fs.FS,
 ) (*Server, error) {
 	grafana := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
 	// create a router that will route all incoming API server requests to different handlers
-	router, err := routing.NewRouter(conf, cache, clientFactory, prom, traceClientLoader, controlPlaneMonitor, grafana, discovery)
+	router, err := routing.NewRouter(
+		conf,
+		cache,
+		clientFactory,
+		prom,
+		traceClientLoader,
+		controlPlaneMonitor,
+		grafana,
+		discovery,
+		staticAssetFS,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,7 +68,7 @@ func TestRootContextPath(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil)
+	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -132,7 +132,7 @@ func TestAnonymousMode(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil)
+	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -224,7 +224,7 @@ func TestSecureComm(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil)
+	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -338,7 +338,7 @@ func TestTracingConfigured(t *testing.T) {
 
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil)
+	server, _ := NewServer(cpm, cf, cache, conf, nil, nil, nil, nil)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {

--- a/util/httputil/port_forwarder.go
+++ b/util/httputil/port_forwarder.go
@@ -30,6 +30,8 @@ func (f forwarder) Start() error {
 	// It starts the port-forward
 	errCh := make(chan error, 1)
 	go func() {
+		// TODO: Need a mechanism to catch errors and retry pod forwarding
+		// with a different pod if the connection to the current pod gets closed.
 		errCh <- f.forwarder.ForwardPorts()
 	}()
 


### PR DESCRIPTION
### Describe the change

Adds the ability to run Kiali locally.

### Steps to test the PR

1. Checkout PR
2. `make build-ui`. At least in this POC, you need to build the ui first before running.
3. `hack/run-integration-tests.sh --test-suite backend --setup-only true`. Only using this to setup the environment. You can delete the Kiali in the cluster after the script finishes to prove a point.
4. `go run kiali.go open`

`go run kiali.go --help open` to see options. You can provide a Kiali kubeconfig file to set any options.

Also works with multi-cluster. Sometimes the `CLUSTER_ID` in istio does not match the name in your kubeconfig. For these cases you can provide aliases in the Kiali config file.

```yaml
# kiali-config.yaml
deployment:
  cluster_name_overrides:
    kind-east: east
    kind-west: west
```

1. `hack/run-integration-tests.sh --test-suite frontend-multi-primary --setup-only true`. Again you can delete the Kiali.
2. `go run kiali.go -remote-cluster-contexts kind-west -config kiali-config.yaml open`

### Automation testing

N/A - POC

### Issue reference

POC for https://github.com/kiali/kiali/issues/8263