### PR TITLE
Refactor istio config handlers and update clusterName func

### DIFF
--- a/business/layer.go
+++ b/business/layer.go
@@ -141,7 +141,7 @@ func NewLayer(
 	traceClient tracing.ClientInterface,
 	cpm ControlPlaneMonitor,
 	grafana *grafana.Service,
-	discovery *istio.Discovery,
+	discovery istio.MeshDiscovery,
 	authInfos map[string]*api.AuthInfo,
 ) (*Layer, error) {
 	userClients, err := cf.GetClients(authInfos)

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -40,7 +40,7 @@ func (p *appParams) extract(r *http.Request) {
 	query := r.URL.Query()
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
-	p.ClusterName = clusterNameFromQuery(query)
+	p.ClusterName = clusterNameFromQuery(config.Get(), query)
 	p.AppName = vars["app"]
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -20,7 +20,7 @@ func CustomDashboard(conf *config.Config, grafana *grafana.Service) http.Handler
 	return func(w http.ResponseWriter, r *http.Request) {
 		queryParams := r.URL.Query()
 		pathParams := mux.Vars(r)
-		cluster := clusterNameFromQuery(queryParams)
+		cluster := clusterNameFromQuery(conf, queryParams)
 		namespace := pathParams["namespace"]
 		dashboardName := pathParams["dashboard"]
 
@@ -117,7 +117,7 @@ func AppDashboard(conf *config.Config, grafana *grafana.Service) http.HandlerFun
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 		app := vars["app"]
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(conf, r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, DefaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 		if metricsService == nil {
@@ -150,7 +150,7 @@ func ServiceDashboard(conf *config.Config, grafana *grafana.Service) http.Handle
 		service := vars["service"]
 
 		queryParams := r.URL.Query()
-		cluster := clusterNameFromQuery(queryParams)
+		cluster := clusterNameFromQuery(conf, queryParams)
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, DefaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 		if metricsService == nil {
@@ -200,7 +200,7 @@ func WorkloadDashboard(conf *config.Config, grafana *grafana.Service) http.Handl
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 		workload := vars["workload"]
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(conf, r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespace(w, r, DefaultPromClientSupplier, models.Namespace{Name: namespace, Cluster: cluster})
 		if metricsService == nil {
@@ -231,7 +231,7 @@ func ZtunnelDashboard(promSupplier promClientSupplier, conf *config.Config, graf
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(conf, r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 		if metricsService == nil {

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util"
@@ -25,7 +26,7 @@ func ClustersHealth(w http.ResponseWriter, r *http.Request) {
 	if len(namespaces) > 0 {
 		nss = strings.Split(namespaces, ",")
 	}
-	cluster := clusterNameFromQuery(params)
+	cluster := clusterNameFromQuery(config.Get(), params)
 
 	businessLayer, err := getBusiness(r)
 	if err != nil {
@@ -111,7 +112,7 @@ func (p *baseHealthParams) baseExtract(r *http.Request, vars map[string]string) 
 	if rateInterval := queryParams.Get("rateInterval"); rateInterval != "" {
 		p.RateInterval = rateInterval
 	}
-	p.ClusterName = clusterNameFromQuery(queryParams)
+	p.ClusterName = clusterNameFromQuery(config.Get(), queryParams)
 	if queryTime := queryParams.Get("queryTime"); queryTime != "" {
 		unix, err := strconv.ParseInt(queryTime, 10, 64)
 		if err == nil {
@@ -149,7 +150,6 @@ func (p *namespaceHealthParams) extract(r *http.Request, namespace string) (bool
 }
 
 func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time, cluster string) (string, error) {
-
 	namespaceInfo, err := business.Namespace.GetClusterNamespace(ctx, namespace, cluster)
 	if err != nil {
 		return "", err

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -7,317 +7,372 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 	"github.com/kiali/kiali/util/sliceutil"
 )
 
-func IstioConfigList(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	namespace := params["namespace"]
-	query := r.URL.Query()
-	objects := ""
-	parsedTypes := make([]string, 0)
-	if _, ok := query["objects"]; ok {
-		objects = query.Get("objects")
-		if len(objects) > 0 {
-			parsedTypes = strings.Split(objects, ";")
+func IstioConfigList(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		namespace := params["namespace"]
+		query := r.URL.Query()
+		objects := ""
+		parsedTypes := make([]string, 0)
+		if _, ok := query["objects"]; ok {
+			objects = query.Get("objects")
+			if len(objects) > 0 {
+				parsedTypes = strings.Split(objects, ";")
+			}
 		}
-	}
 
-	includeValidations := false
-	if _, found := query["validate"]; found {
-		includeValidations = true
-	}
-
-	labelSelector := ""
-	if _, found := query["labelSelector"]; found {
-		labelSelector = query.Get("labelSelector")
-	}
-
-	workloadSelector := ""
-	if _, found := query["workloadSelector"]; found {
-		workloadSelector = query.Get("workloadSelector")
-	}
-
-	cluster := clusterNameFromQuery(query)
-	if !config.Get().ExternalServices.Istio.IstioAPIEnabled {
-		includeValidations = false
-	}
-
-	criteria := business.ParseIstioConfigCriteria(objects, labelSelector, workloadSelector)
-
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	var istioConfig *models.IstioConfigList
-	if namespace != "" {
-		istioConfig, err = business.IstioConfig.GetIstioConfigListForNamespace(r.Context(), cluster, namespace, criteria)
-		if err != nil {
-			handleErrorResponse(w, err)
-			return
+		includeValidations := false
+		if _, found := query["validate"]; found {
+			includeValidations = true
 		}
-	} else {
-		istioConfig, err = business.IstioConfig.GetIstioConfigList(r.Context(), cluster, criteria)
-		if err != nil {
-			handleErrorResponse(w, err)
-			return
-		}
-	}
 
-	if includeValidations {
-		istioConfig.IstioValidations, err = business.Validations.GetValidations(r.Context(), cluster)
+		labelSelector := ""
+		if _, found := query["labelSelector"]; found {
+			labelSelector = query.Get("labelSelector")
+		}
+
+		workloadSelector := ""
+		if _, found := query["workloadSelector"]; found {
+			workloadSelector = query.Get("workloadSelector")
+		}
+
+		cluster := clusterNameFromQuery(conf, query)
+		if !conf.ExternalServices.Istio.IstioAPIEnabled {
+			includeValidations = false
+		}
+
+		criteria := business.ParseIstioConfigCriteria(objects, labelSelector, workloadSelector)
+
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
-			RespondWithError(w, http.StatusInternalServerError, "Error while getting validations: "+err.Error())
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
 			return
 		}
 
-		// We don't filter by objects when calling validations, because certain validations require fetching all types to get the correct errors
-		if len(parsedTypes) > 0 {
-			istioConfig.IstioValidations = istioConfig.IstioValidations.FilterByTypes(parsedTypes)
+		var istioConfig *models.IstioConfigList
+		if namespace != "" {
+			istioConfig, err = business.IstioConfig.GetIstioConfigListForNamespace(r.Context(), cluster, namespace, criteria)
+			if err != nil {
+				handleErrorResponse(w, err)
+				return
+			}
+		} else {
+			istioConfig, err = business.IstioConfig.GetIstioConfigList(r.Context(), cluster, criteria)
+			if err != nil {
+				handleErrorResponse(w, err)
+				return
+			}
 		}
-	}
 
-	RespondWithAPIResponse(w, http.StatusOK, istioConfig)
+		if includeValidations {
+			istioConfig.IstioValidations, err = business.Validations.GetValidations(r.Context(), cluster)
+			if err != nil {
+				RespondWithError(w, http.StatusInternalServerError, "Error while getting validations: "+err.Error())
+				return
+			}
+
+			// We don't filter by objects when calling validations, because certain validations require fetching all types to get the correct errors
+			if len(parsedTypes) > 0 {
+				istioConfig.IstioValidations = istioConfig.IstioValidations.FilterByTypes(parsedTypes)
+			}
+		}
+
+		RespondWithAPIResponse(w, http.StatusOK, istioConfig)
+	}
 }
 
-func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	namespace := params["namespace"]
-	objectGroup := params["group"]
-	objectVersion := params["version"]
-	objectKind := params["kind"]
-	object := params["object"]
+func IstioConfigDetails(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		namespace := params["namespace"]
+		objectGroup := params["group"]
+		objectVersion := params["version"]
+		objectKind := params["kind"]
+		object := params["object"]
 
-	includeValidations := false
-	query := r.URL.Query()
-	if _, found := query["validate"]; found {
-		includeValidations = true
-	}
+		includeValidations := false
+		query := r.URL.Query()
+		if _, found := query["validate"]; found {
+			includeValidations = true
+		}
 
-	includeHelp := false
-	if _, found := query["help"]; found {
-		includeHelp = true
-	}
+		includeHelp := false
+		if _, found := query["help"]; found {
+			includeHelp = true
+		}
 
-	cluster := clusterNameFromQuery(query)
-	if !config.Get().ExternalServices.Istio.IstioAPIEnabled {
-		includeValidations = false
-	}
+		cluster := clusterNameFromQuery(conf, query)
+		if !conf.ExternalServices.Istio.IstioAPIEnabled {
+			includeValidations = false
+		}
 
-	gvk := schema.GroupVersionKind{
-		Group:   objectGroup,
-		Version: objectVersion,
-		Kind:    objectKind,
-	}
+		gvk := schema.GroupVersionKind{
+			Group:   objectGroup,
+			Version: objectVersion,
+			Kind:    objectKind,
+		}
 
-	if !checkObjectType(gvk) {
-		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
-		return
-	}
+		if !checkObjectType(gvk) {
+			RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
+			return
+		}
 
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
 
-	istioConfigDetails, err := business.IstioConfig.GetIstioConfigDetails(context.TODO(), cluster, namespace, gvk, object)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
+		istioConfigDetails, err := business.IstioConfig.GetIstioConfigDetails(context.TODO(), cluster, namespace, gvk, object)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
 
-	exportTo := istioConfigDetails.GetExportTo()
-	istioConfigValidations := models.IstioValidations{}
-	istioConfigReferences := models.IstioReferencesMap{}
+		exportTo := istioConfigDetails.GetExportTo()
+		istioConfigValidations := models.IstioValidations{}
+		istioConfigReferences := models.IstioReferencesMap{}
 
-	validationsResult := make(chan error)
-	if includeValidations {
-		go func(istioConfigValidations *models.IstioValidations, istioConfigReferences *models.IstioReferencesMap) {
-			defer func() {
-				close(validationsResult)
-			}()
-			if len(exportTo) != 0 {
-				// validations should be done per exported namespaces to apply exportTo configs
-				loadedNamespaces, _ := business.Namespace.GetClusterNamespaces(r.Context(), cluster)
-				for _, ns := range loadedNamespaces {
-					if sliceutil.SomeString(exportTo, ns.Name) && ns.Name != namespace {
-						istioConfigValidationResults, istioConfigReferencesResults, err := business.Validations.ValidateIstioObject(r.Context(), cluster, ns.Name, gvk, object)
-						if err != nil {
-							validationsResult <- err
+		validationsResult := make(chan error)
+		if includeValidations {
+			go func(istioConfigValidations *models.IstioValidations, istioConfigReferences *models.IstioReferencesMap) {
+				defer func() {
+					close(validationsResult)
+				}()
+				if len(exportTo) != 0 {
+					// validations should be done per exported namespaces to apply exportTo configs
+					loadedNamespaces, _ := business.Namespace.GetClusterNamespaces(r.Context(), cluster)
+					for _, ns := range loadedNamespaces {
+						if sliceutil.SomeString(exportTo, ns.Name) && ns.Name != namespace {
+							istioConfigValidationResults, istioConfigReferencesResults, err := business.Validations.ValidateIstioObject(r.Context(), cluster, ns.Name, gvk, object)
+							if err != nil {
+								validationsResult <- err
+							}
+							*istioConfigValidations = istioConfigValidations.MergeValidations(istioConfigValidationResults)
+							*istioConfigReferences = istioConfigReferences.MergeReferencesMap(istioConfigReferencesResults)
 						}
-						*istioConfigValidations = istioConfigValidations.MergeValidations(istioConfigValidationResults)
-						*istioConfigReferences = istioConfigReferences.MergeReferencesMap(istioConfigReferencesResults)
 					}
 				}
-			}
-			// also validate own namespace
-			istioConfigValidationResults, istioConfigReferencesResults, err := business.Validations.ValidateIstioObject(r.Context(), cluster, namespace, gvk, object)
+				// also validate own namespace
+				istioConfigValidationResults, istioConfigReferencesResults, err := business.Validations.ValidateIstioObject(r.Context(), cluster, namespace, gvk, object)
+				if err != nil {
+					validationsResult <- err
+				}
+				*istioConfigValidations = istioConfigValidations.MergeValidations(istioConfigValidationResults)
+				*istioConfigReferences = istioConfigReferences.MergeReferencesMap(istioConfigReferencesResults)
+			}(&istioConfigValidations, &istioConfigReferences)
+		}
+
+		if includeHelp {
+			istioConfigDetails.IstioConfigHelpFields = models.IstioConfigHelpMessages[gvk.String()]
+		}
+
+		if includeValidations {
+			err := <-validationsResult
 			if err != nil {
-				validationsResult <- err
+				handleErrorResponse(w, err)
+				return
 			}
-			*istioConfigValidations = istioConfigValidations.MergeValidations(istioConfigValidationResults)
-			*istioConfigReferences = istioConfigReferences.MergeReferencesMap(istioConfigReferencesResults)
-		}(&istioConfigValidations, &istioConfigReferences)
-	}
 
-	if includeHelp {
-		istioConfigDetails.IstioConfigHelpFields = models.IstioConfigHelpMessages[gvk.String()]
-	}
+			if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectGVK: gvk, Namespace: namespace, Name: object, Cluster: cluster}]; found {
+				istioConfigDetails.IstioValidation = validation
+			}
+			if references, found := istioConfigReferences[models.IstioReferenceKey{ObjectGVK: gvk, Namespace: namespace, Name: object}]; found {
+				istioConfigDetails.IstioReferences = references
+			}
+		}
 
-	if includeValidations {
-		err := <-validationsResult
+		RespondWithJSON(w, http.StatusOK, istioConfigDetails)
+	}
+}
+
+func IstioConfigDelete(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		namespace := params["namespace"]
+		objectGroup := params["group"]
+		objectVersion := params["version"]
+		objectKind := params["kind"]
+		object := params["object"]
+
+		query := r.URL.Query()
+		cluster := clusterNameFromQuery(conf, query)
+
+		gvk := schema.GroupVersionKind{
+			Group:   objectGroup,
+			Version: objectVersion,
+			Kind:    objectKind,
+		}
+
+		if !business.GetIstioAPI(gvk) {
+			RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
+			return
+		}
+
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
+		err = business.IstioConfig.DeleteIstioConfigDetail(r.Context(), cluster, namespace, gvk, object)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		} else {
+			audit(r, "DELETE on Namespace: "+namespace+" Type: "+gvk.String()+" Name: "+object)
+			RespondWithCode(w, http.StatusOK)
+		}
+	}
+}
+
+func IstioConfigUpdate(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		namespace := params["namespace"]
+		objectGroup := params["group"]
+		objectVersion := params["version"]
+		objectKind := params["kind"]
+		object := params["object"]
+
+		query := r.URL.Query()
+		cluster := clusterNameFromQuery(conf, query)
+
+		gvk := schema.GroupVersionKind{
+			Group:   objectGroup,
+			Version: objectVersion,
+			Kind:    objectKind,
+		}
+
+		if !business.GetIstioAPI(gvk) {
+			RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
+			return
+		}
+
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			RespondWithError(w, http.StatusBadRequest, "Update request with bad update patch: "+err.Error())
+		}
+		jsonPatch := string(body)
+		updatedConfigDetails, err := business.IstioConfig.UpdateIstioConfigDetail(r.Context(), cluster, namespace, gvk, object, jsonPatch)
 		if err != nil {
 			handleErrorResponse(w, err)
 			return
 		}
 
-		if validation, found := istioConfigValidations[models.IstioValidationKey{ObjectGVK: gvk, Namespace: namespace, Name: object, Cluster: cluster}]; found {
-			istioConfigDetails.IstioValidation = validation
+		audit(r, "UPDATE on Namespace: "+namespace+" Type: "+gvk.String()+" Name: "+object+" Patch: "+jsonPatch)
+		RespondWithJSON(w, http.StatusOK, updatedConfigDetails)
+	}
+}
+
+func IstioConfigCreate(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Feels kinda replicated for multiple functions..
+		params := mux.Vars(r)
+		namespace := params["namespace"]
+		objectGroup := params["group"]
+		objectVersion := params["version"]
+		objectKind := params["kind"]
+
+		query := r.URL.Query()
+		cluster := clusterNameFromQuery(conf, query)
+
+		gvk := schema.GroupVersionKind{
+			Group:   objectGroup,
+			Version: objectVersion,
+			Kind:    objectKind,
 		}
-		if references, found := istioConfigReferences[models.IstioReferenceKey{ObjectGVK: gvk, Namespace: namespace, Name: object}]; found {
-			istioConfigDetails.IstioReferences = references
+
+		if !business.GetIstioAPI(gvk) {
+			RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
+			return
 		}
+
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			RespondWithError(w, http.StatusBadRequest, "Create request could not be read: "+err.Error())
+		}
+
+		createdConfigDetails, err := business.IstioConfig.CreateIstioConfigDetail(r.Context(), cluster, namespace, gvk, body)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
+
+		audit(r, "CREATE on Namespace: "+namespace+" Type: "+gvk.String()+" Object: "+string(body))
+		RespondWithJSON(w, http.StatusOK, createdConfigDetails)
 	}
-
-	RespondWithJSON(w, http.StatusOK, istioConfigDetails)
-}
-
-func IstioConfigDelete(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	namespace := params["namespace"]
-	objectGroup := params["group"]
-	objectVersion := params["version"]
-	objectKind := params["kind"]
-	object := params["object"]
-
-	query := r.URL.Query()
-	cluster := clusterNameFromQuery(query)
-
-	gvk := schema.GroupVersionKind{
-		Group:   objectGroup,
-		Version: objectVersion,
-		Kind:    objectKind,
-	}
-
-	if !business.GetIstioAPI(gvk) {
-		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
-		return
-	}
-
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-	err = business.IstioConfig.DeleteIstioConfigDetail(r.Context(), cluster, namespace, gvk, object)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	} else {
-		audit(r, "DELETE on Namespace: "+namespace+" Type: "+gvk.String()+" Name: "+object)
-		RespondWithCode(w, http.StatusOK)
-	}
-}
-
-func IstioConfigUpdate(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	namespace := params["namespace"]
-	objectGroup := params["group"]
-	objectVersion := params["version"]
-	objectKind := params["kind"]
-	object := params["object"]
-
-	query := r.URL.Query()
-	cluster := clusterNameFromQuery(query)
-
-	gvk := schema.GroupVersionKind{
-		Group:   objectGroup,
-		Version: objectVersion,
-		Kind:    objectKind,
-	}
-
-	if !business.GetIstioAPI(gvk) {
-		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
-		return
-	}
-
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		RespondWithError(w, http.StatusBadRequest, "Update request with bad update patch: "+err.Error())
-	}
-	jsonPatch := string(body)
-	updatedConfigDetails, err := business.IstioConfig.UpdateIstioConfigDetail(r.Context(), cluster, namespace, gvk, object, jsonPatch)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
-
-	audit(r, "UPDATE on Namespace: "+namespace+" Type: "+gvk.String()+" Name: "+object+" Patch: "+jsonPatch)
-	RespondWithJSON(w, http.StatusOK, updatedConfigDetails)
-}
-
-func IstioConfigCreate(w http.ResponseWriter, r *http.Request) {
-	// Feels kinda replicated for multiple functions..
-	params := mux.Vars(r)
-	namespace := params["namespace"]
-	objectGroup := params["group"]
-	objectVersion := params["version"]
-	objectKind := params["kind"]
-
-	query := r.URL.Query()
-	cluster := clusterNameFromQuery(query)
-
-	gvk := schema.GroupVersionKind{
-		Group:   objectGroup,
-		Version: objectVersion,
-		Kind:    objectKind,
-	}
-
-	if !business.GetIstioAPI(gvk) {
-		RespondWithError(w, http.StatusBadRequest, "Object type not managed: "+gvk.String())
-		return
-	}
-
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		RespondWithError(w, http.StatusBadRequest, "Create request could not be read: "+err.Error())
-	}
-
-	createdConfigDetails, err := business.IstioConfig.CreateIstioConfigDetail(r.Context(), cluster, namespace, gvk, body)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
-
-	audit(r, "CREATE on Namespace: "+namespace+" Type: "+gvk.String()+" Object: "+string(body))
-	RespondWithJSON(w, http.StatusOK, createdConfigDetails)
 }
 
 func checkObjectType(gvk schema.GroupVersionKind) bool {
@@ -331,27 +386,38 @@ func audit(r *http.Request, message string) {
 	}
 }
 
-func IstioConfigPermissions(w http.ResponseWriter, r *http.Request) {
-	// query params
-	params := r.URL.Query()
-	namespaces := params.Get("namespaces") // csl of namespaces
-	cluster := clusterNameFromQuery(params)
+func IstioConfigPermissions(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// query params
+		params := r.URL.Query()
+		namespaces := params.Get("namespaces") // csl of namespaces
+		cluster := clusterNameFromQuery(conf, params)
 
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
 
-	if !business.Mesh.IsValidCluster(cluster) {
-		RespondWithError(w, http.StatusBadRequest, "Cluster %s does not exist "+cluster)
-		return
-	}
+		if !business.Mesh.IsValidCluster(cluster) {
+			RespondWithError(w, http.StatusBadRequest, "Cluster %s does not exist "+cluster)
+			return
+		}
 
-	istioConfigPermissions := models.IstioConfigPermissions{}
-	if len(namespaces) > 0 {
-		ns := strings.Split(namespaces, ",")
-		istioConfigPermissions = business.IstioConfig.GetIstioConfigPermissions(r.Context(), ns, cluster)
+		istioConfigPermissions := models.IstioConfigPermissions{}
+		if len(namespaces) > 0 {
+			ns := strings.Split(namespaces, ",")
+			istioConfigPermissions = business.IstioConfig.GetIstioConfigPermissions(r.Context(), ns, cluster)
+		}
+		RespondWithJSON(w, http.StatusOK, istioConfigPermissions)
 	}
-	RespondWithJSON(w, http.StatusOK, istioConfigPermissions)
 }

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -31,7 +31,7 @@ func getAppMetrics(w http.ResponseWriter, r *http.Request, promSupplier promClie
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	app := vars["app"]
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
@@ -65,7 +65,7 @@ func getWorkloadMetrics(w http.ResponseWriter, r *http.Request, promSupplier pro
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	workload := vars["workload"]
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil || namespaceInfo == nil {
@@ -99,7 +99,7 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promSupplier prom
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
 	service := vars["service"]
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 	metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 	if metricsService == nil {
@@ -177,7 +177,7 @@ func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 		controlPlane := vars["controlplane"]
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 		if metricsService == nil {
@@ -231,11 +231,10 @@ func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 // ResourceUsageMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
 func ResourceUsageMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 		app := vars["app"]
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 		if metricsService == nil {
@@ -285,7 +284,7 @@ func NamespaceMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
-		cluster := clusterNameFromQuery(r.URL.Query())
+		cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 
 		metricsService, namespaceInfo := createMetricsServiceForNamespaceMC(w, r, promSupplier, namespace)
 		if metricsService == nil {
@@ -322,7 +321,7 @@ func ClustersMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 		if len(namespaces) > 0 {
 			nss = strings.Split(namespaces, ",")
 		}
-		cluster := clusterNameFromQuery(query)
+		cluster := clusterNameFromQuery(config.Get(), query)
 
 		business, err := getBusiness(r)
 		if err != nil {

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
@@ -34,7 +35,7 @@ func NamespaceInfo(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
-	cluster := clusterNameFromQuery(query)
+	cluster := clusterNameFromQuery(config.Get(), query)
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -61,7 +62,7 @@ func NamespaceValidationSummary(discovery *istio.Discovery) http.HandlerFunc {
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 
-		cluster := clusterNameFromQuery(query)
+		cluster := clusterNameFromQuery(config.Get(), query)
 
 		business, err := getBusiness(r)
 		if err != nil {
@@ -108,7 +109,7 @@ func ConfigValidationSummary(w http.ResponseWriter, r *http.Request) {
 	if len(namespaces) > 0 {
 		nss = strings.Split(namespaces, ",")
 	}
-	cluster := clusterNameFromQuery(params)
+	cluster := clusterNameFromQuery(config.Get(), params)
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -154,7 +155,7 @@ func NamespaceUpdate(w http.ResponseWriter, r *http.Request) {
 	jsonPatch := string(body)
 
 	query := r.URL.Query()
-	cluster := clusterNameFromQuery(query)
+	cluster := clusterNameFromQuery(config.Get(), query)
 
 	ns, err := business.Namespace.UpdateNamespace(r.Context(), namespace, jsonPatch, cluster)
 	if err != nil {

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -40,7 +40,7 @@ func LoggingUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster := clusterNameFromQuery(query)
+	cluster := clusterNameFromQuery(config.Get(), query)
 
 	if err := businessLayer.ProxyLogging.SetLogLevel(cluster, namespace, pod, level); err != nil {
 		handleErrorResponse(w, err)

--- a/handlers/proxy_status.go
+++ b/handlers/proxy_status.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
+	"github.com/kiali/kiali/config"
 )
 
 func ConfigDump(w http.ResponseWriter, r *http.Request) {
@@ -15,7 +17,7 @@ func ConfigDump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	namespace := params["namespace"]
 	pod := params["pod"]
 
@@ -37,7 +39,7 @@ func ConfigDumpResourceEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	namespace := params["namespace"]
 	pod := params["pod"]
 	resource := params["resource"]

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util"
 )
@@ -140,7 +141,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := mux.Vars(r)
-	cluster := clusterNameFromQuery(queryParams)
+	cluster := clusterNameFromQuery(config.Get(), queryParams)
 
 	namespace := params["namespace"]
 	service := params["service"]
@@ -203,7 +204,7 @@ func ServiceUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := mux.Vars(r)
-	cluster := clusterNameFromQuery(queryParams)
+	cluster := clusterNameFromQuery(config.Get(), queryParams)
 
 	namespace := params["namespace"]
 	service := params["service"]

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/sliceutil"
@@ -24,7 +25,7 @@ func NamespaceTls(w http.ResponseWriter, r *http.Request) {
 
 	namespace := params["namespace"]
 
-	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, clusterNameFromQuery(r.URL.Query()))
+	status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, clusterNameFromQuery(config.Get(), r.URL.Query()))
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -44,7 +45,7 @@ func ClustersTls(w http.ResponseWriter, r *http.Request) {
 			namespaceNamesFromQuery[name] = struct{}{}
 		}
 	}
-	cluster := clusterNameFromQuery(params)
+	cluster := clusterNameFromQuery(config.Get(), params)
 
 	business, err := getBusiness(r)
 	if err != nil {
@@ -87,7 +88,7 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	revision := r.URL.Query().Get("revision")
 	if revision == "" {
 		revision = "default"

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -56,7 +56,7 @@ func AppTraces(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	tracingName := business.App.GetAppTracingName(r.Context(), cluster, namespace, app)
 	traces, err := business.Tracing.GetAppTraces(namespace, tracingName.Lookup, app, q)
 	if err != nil {
@@ -172,7 +172,7 @@ func AppSpans(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	spans, err := business.Tracing.GetAppSpans(r.Context(), cluster, namespace, app, q)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
@@ -239,7 +239,7 @@ func readQuery(values url.Values) (models.TracingQuery, error) {
 		End:     time.Now(),
 		Limit:   100,
 		Tags:    make(map[string]string),
-		Cluster: clusterNameFromQuery(values),
+		Cluster: clusterNameFromQuery(config.Get(), values),
 	}
 
 	if v := values.Get("startMicros"); v != "" {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -184,10 +184,10 @@ func getBusiness(r *http.Request) (*business.Layer, error) {
 
 // clusterNameFromQuery extracts the cluster name from the query parameters
 // and provides a default value if it's not present.
-func clusterNameFromQuery(queryParams url.Values) string {
+func clusterNameFromQuery(conf *config.Config, queryParams url.Values) string {
 	cluster := queryParams.Get("clusterName")
 	if cluster == "" {
-		cluster = config.Get().KubernetesConfig.ClusterName
+		cluster = conf.KubernetesConfig.ClusterName
 	}
 	return cluster
 }
@@ -201,7 +201,7 @@ func getLayer(
 	prom prometheus.ClientInterface,
 	traceClientLoader func() tracing.ClientInterface,
 	grafana *grafana.Service,
-	discovery *istio.Discovery,
+	discovery istio.MeshDiscovery,
 ) (*business.Layer, error) {
 	authInfo, err := getAuthInfo(r)
 	if err != nil {

--- a/handlers/utils_test.go
+++ b/handlers/utils_test.go
@@ -119,14 +119,14 @@ func TestCreateMetricsServiceForSeveralNamespaces(t *testing.T) {
 
 func TestClusterNameFromQuery(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.Get()
+	conf := config.NewConfig()
 
 	query := url.Values{"clusterName": []string{"east"}}
-	assert.Equal("east", clusterNameFromQuery(query))
+	assert.Equal("east", clusterNameFromQuery(conf, query))
 
 	query = url.Values{}
-	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(query))
+	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(conf, query))
 
 	query = url.Values{"notcluster": []string{"east"}}
-	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(query))
+	assert.Equal(conf.KubernetesConfig.ClusterName, clusterNameFromQuery(conf, query))
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -44,7 +44,7 @@ func (p *workloadParams) extract(r *http.Request) error {
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
-	p.ClusterName = clusterNameFromQuery(query)
+	p.ClusterName = clusterNameFromQuery(config.Get(), query)
 
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -216,7 +216,7 @@ func WorkloadUpdate(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, "Update request with bad workloadGVK param: "+errGVK.Error())
 	}
 
-	cluster := clusterNameFromQuery(query)
+	cluster := clusterNameFromQuery(config.Get(), query)
 	log.Debugf("Cluster: %s", cluster)
 
 	includeValidations := false
@@ -268,7 +268,7 @@ func PodDetails(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Pods initialization error: "+err.Error())
 		return
 	}
-	cluster := clusterNameFromQuery(query)
+	cluster := clusterNameFromQuery(config.Get(), query)
 	namespace := vars["namespace"]
 	pod := vars["pod"]
 
@@ -297,7 +297,7 @@ func PodLogs(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, "Pod Logs initialization error: "+err.Error())
 		return
 	}
-	cluster := clusterNameFromQuery(queryParams)
+	cluster := clusterNameFromQuery(config.Get(), queryParams)
 	namespace := vars["namespace"]
 	pod := vars["pod"]
 
@@ -330,7 +330,7 @@ func ConfigDumpZtunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster := clusterNameFromQuery(r.URL.Query())
+	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
 	namespace := params["namespace"]
 	pod := params["pod"]
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -235,7 +235,7 @@ func NewRoutes(
 			"IstioConfigPermissions",
 			"GET",
 			"/api/istio/permissions",
-			handlers.IstioConfigPermissions,
+			handlers.IstioConfigPermissions(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/istio config istioConfigList
@@ -255,7 +255,7 @@ func NewRoutes(
 			"IstioConfigList",
 			"GET",
 			"/api/namespaces/{namespace}/istio",
-			handlers.IstioConfigList,
+			handlers.IstioConfigList(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route GET /istio config istioConfigListAll
@@ -275,7 +275,7 @@ func NewRoutes(
 			"IstioConfigListAll",
 			"GET",
 			"/api/istio/config",
-			handlers.IstioConfigList,
+			handlers.IstioConfigList(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/istio/{group}/{version}/{kind}/{object} config istioConfigDetails
@@ -297,7 +297,7 @@ func NewRoutes(
 			"IstioConfigDetails",
 			"GET",
 			"/api/namespaces/{namespace}/istio/{group}/{version}/{kind}/{object}",
-			handlers.IstioConfigDetails,
+			handlers.IstioConfigDetails(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route DELETE /namespaces/{namespace}/istio/{group}/{version}/{kind}/{object} config istioConfigDelete
@@ -318,7 +318,7 @@ func NewRoutes(
 			"IstioConfigDelete",
 			"DELETE",
 			"/api/namespaces/{namespace}/istio/{group}/{version}/{kind}/{object}",
-			handlers.IstioConfigDelete,
+			handlers.IstioConfigDelete(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route PATCH /namespaces/{namespace}/istio/{group}/{version}/{kind}/{object} config istioConfigUpdate
@@ -343,7 +343,7 @@ func NewRoutes(
 			"IstioConfigUpdate",
 			"PATCH",
 			"/api/namespaces/{namespace}/istio/{group}/{version}/{kind}/{object}",
-			handlers.IstioConfigUpdate,
+			handlers.IstioConfigUpdate(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route POST /namespaces/{namespace}/istio/{group}/{version}/{kind} config istioConfigCreate
@@ -366,7 +366,7 @@ func NewRoutes(
 			"IstioConfigCreate",
 			"POST",
 			"/api/namespaces/{namespace}/istio/{group}/{version}/{kind}",
-			handlers.IstioConfigCreate,
+			handlers.IstioConfigCreate(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route GET /clusters/services services serviceList


### PR DESCRIPTION
### Describe the change

Refactors the istio config handlers and passing config into `clusterNameFromQuery` func. Where `config.Get()` is used now, it will be updated to pass conf once the signature of the remaining handlers are updated.

### Steps to test the PR

N/A

### Automation testing

Covered by existing tests.

### Issue reference

https://github.com/kiali/kiali/issues/6923
