### PR TITLE
[hack-scripts] Support for auto-injection-label in all install scripts

### DIFF
--- a/hack/istio/install-electronic-shop-demo.sh
+++ b/hack/istio/install-electronic-shop-demo.sh
@@ -8,6 +8,8 @@
 # Works on both openshift and non-openshift environments.
 ##############################################################################
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 : ${ESHOP:=electronic-shop}
@@ -54,7 +56,9 @@ install_eshop_app() {
     $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${APP}
   fi
 
-  ${CLIENT_EXE} label namespace ${APP} istio-injection=enabled --overwrite=true
+  if [ "${AUTO_INJECTION}" == "true" ]; then
+    ${CLIENT_EXE} label namespace ${APP} ${AUTO_INJECTION_LABEL} --overwrite=true
+  fi
 
   ${CLIENT_EXE} apply -n ${APP} -f <(curl -L ${BASE_URL}/${APP}/${APP}.yaml)
 }
@@ -62,6 +66,14 @@ install_eshop_app() {
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -73,6 +85,8 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed.
   -h|--help: this text

--- a/hack/istio/install-fraud-detection-demo.sh
+++ b/hack/istio/install-fraud-detection-demo.sh
@@ -5,9 +5,10 @@
 HACK_SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source ${HACK_SCRIPT_DIR}/functions.sh
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMO:=false}
-: ${ENABLE_INJECTION:=true}
 : ${ISTIO_NAMESPACE:=istio-system}
 : ${NAMESPACE:=fraud-detection}
 : ${SOURCE:="https://raw.githubusercontent.com/kiali/demos/master"}
@@ -15,16 +16,20 @@ source ${HACK_SCRIPT_DIR}/functions.sh
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
       ;;
     -d|--delete)
       DELETE_DEMO="$2"
-      shift;shift
-      ;;
-    -ei|--enable-injection)
-      ENABLE_INJECTION="$2"
       shift;shift
       ;;
     -in|--istio-namespace)
@@ -34,9 +39,10 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: either 'true' or 'false'. If 'true' the fraud detection demo will be deleted, not installed.
-  -ei|--enable-injection: either 'true' or 'false' (default is true). If 'true' auto-inject proxies for the workloads.
   -in|--istio-namespace <name>: Where the Istio control plane is installed (default: istio-system).
   -h|--help: this text
   -s|--source: demo file source. For example: file:///home/me/demos Default: https://raw.githubusercontent.com/kiali/demos/master
@@ -57,7 +63,8 @@ done
 echo Will deploy Error Rates Demo using these settings:
 echo CLIENT_EXE=${CLIENT_EXE}
 echo DELETE_DEMO=${DELETE_DEMO}
-echo ENABLE_INJECTION=${ENABLE_INJECTION}
+echo AUTO_INJECTION=${AUTO_INJECTION}
+echo AUTO_INJECTION_LABEL=${AUTO_INJECTION_LABEL}
 echo ISTIO_NAMESPACE=${ISTIO_NAMESPACE}
 echo NAMESPACE=${NAMESPACE}
 echo SOURCE=${SOURCE}
@@ -112,8 +119,8 @@ SCC
 fi
    
 
-if [ "${ENABLE_INJECTION}" == "true" ]; then
-  ${CLIENT_EXE} label namespace ${NAMESPACE} istio-injection=enabled
+if [ "${AUTO_INJECTION}" == "true" ]; then
+  ${CLIENT_EXE} label namespace ${NAMESPACE} ${AUTO_INJECTION_LABEL}
 fi
 
 # Deploy the demo

--- a/hack/istio/install-music-store-demo.sh
+++ b/hack/istio/install-music-store-demo.sh
@@ -8,6 +8,8 @@
 # Works on both openshift and non-openshift environments.
 ##############################################################################
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 : ${MSTORE:=music-store}
@@ -54,7 +56,9 @@ install_mstore_app() {
     $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${MSTORE}
   fi
 
-  ${CLIENT_EXE} label namespace ${MSTORE} istio-injection=enabled --overwrite=true
+  if [ "${AUTO_INJECTION}" != "" ]; then
+    ${CLIENT_EXE} label namespace ${MSTORE} ${AUTO_INJECTION_LABEL} --overwrite=true
+  fi
   ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/ui.yaml -n ${MSTORE}
   ${CLIENT_EXE} apply -f https://raw.githubusercontent.com/leandroberetta/demos/master/music-store/backend.yaml -n ${MSTORE}
 
@@ -129,6 +133,14 @@ EOF
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -144,6 +156,8 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -mp|--minikube-profile <name>: If using minikube, this is the minikube profile name (default: minikube)

--- a/hack/istio/install-scale-mesh-demo.sh
+++ b/hack/istio/install-scale-mesh-demo.sh
@@ -8,6 +8,8 @@
 # Works on both openshift and non-openshift environments.
 ##############################################################################
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 : ${SMESH:=scale-mesh}
@@ -52,7 +54,9 @@ install_scale_mesh_demo() {
     else
       ${CLIENT_EXE} create ns depth-${x}
     fi
-    ${CLIENT_EXE} label namespace  depth-${x} istio-injection=enabled --overwrite=true
+    if [ "${AUTO_INJECTION}" != "" ]; then
+      ${CLIENT_EXE} label namespace  depth-${x} ${AUTO_INJECTION_LABEL} --overwrite=true
+    fi
     x=$(( $x + 1 ))
   done
 
@@ -62,6 +66,14 @@ install_scale_mesh_demo() {
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -81,6 +93,8 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -n|--namespaces: Number of namespaces. Default: 1
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed

--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -8,6 +8,8 @@
 # Works on both openshift and non-openshift environments.
 ##############################################################################
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 : ${SSPAWNER:=service-spawner}
@@ -50,7 +52,9 @@ install_service_spawner_demo() {
     ${CLIENT_EXE} create ns ${SSPAWNER}
   fi
 
-  ${CLIENT_EXE} label namespace ${SSPAWNER} istio-injection=enabled --overwrite=true
+  if [ "${AUTO_INJECTION}" != "" ]; then
+    ${CLIENT_EXE} label namespace ${SSPAWNER} ${AUTO_INJECTION_LABEL} --overwrite=true
+  fi
 
   for (( c=0; c<$NUM_SPAWNS; c++ ))
   do
@@ -77,6 +81,14 @@ install_service_spawner_demo() {
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -92,6 +104,8 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -n|--spawns: Number of spawns. Default: 10
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed

--- a/hack/istio/install-topology-generator-demo.sh
+++ b/hack/istio/install-topology-generator-demo.sh
@@ -8,6 +8,8 @@
 # Works on both openshift and non-openshift environments.
 ##############################################################################
 
+: ${AUTO_INJECTION:=true}
+: ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
 : ${DELETE_CONFIG:=false}
@@ -55,7 +57,9 @@ install_topology_generator_demo() {
     $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${TOPO}
   fi
 
-  ${CLIENT_EXE} label namespace  ${TOPO} istio-injection=enabled --overwrite=true
+  if [ "${AUTO_INJECTION}" != "" ]; then
+    ${CLIENT_EXE} label namespace  ${TOPO} ${AUTO_INJECTION_LABEL} --overwrite=true
+  fi
   ${CLIENT_EXE} apply -n ${TOPO}  -f ${BASE_URL}/topology-generator/deploy/generator.yaml
 }
 
@@ -71,6 +75,14 @@ generate_config() {
 while [ $# -gt 0 ]; do
   key="$1"
   case $key in
+    -ai|--auto-injection)
+      AUTO_INJECTION="$2"
+      shift;shift
+      ;;
+    -ail|--auto-injection-label)
+      AUTO_INJECTION_LABEL="$2"
+      shift;shift
+      ;;
     -c|--client)
       CLIENT_EXE="$2"
       shift;shift
@@ -90,6 +102,8 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
   -c|--client: either 'oc' or 'kubectl'
   -n|--namespaces: number of namespaces to be created in the generator to apply the network policies
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed


### PR DESCRIPTION
### Describe the change

All hack scripts got params
-ai|--auto-injection <true|false>, default: true
-ail|--auto-injection-label <name=value>, default: istio-injection=enabled

https://github.com/kiali/kiali/issues/7952