### PR TITLE
remove docker.io from as many places in hack scripts as possible

### DIFF
--- a/hack/README.adoc
+++ b/hack/README.adoc
@@ -37,7 +37,7 @@ Runs OpenShift on the local machine using link:https://github.com/code-ready/crc
 
 * `link:docker-io-auth.sh[]`
 
-Creates the necessary resources allowing your cluster to authenticate itself with docker.io when pulling Docker Hub images. This helps avoid the annoying docker.io rate limiting errors.
+Creates the necessary resources allowing your cluster to authenticate itself with Docker Hub when pulling Docker Hub images. This helps avoid the annoying Docker Hub rate limiting errors.
 
 * `link:fix_imports.sh[]`
 

--- a/hack/istio/bookinfo-traffic/bookinfo-service-entry.yaml
+++ b/hack/istio/bookinfo-traffic/bookinfo-service-entry.yaml
@@ -10,7 +10,7 @@
 # To create this simulated external ratings:v1 service, you must run a ratings service
 # by executing this command:
 #
-#   $ docker run -t -i --network=host docker.io/istio/examples-bookinfo-ratings-v1
+#   $ docker run -t -i --network=host quay.io/sail-dev/examples-bookinfo-ratings-v1
 #
 # At this point, you have a ratings service running outside of your local cluster bound
 # to your host's IP on port 9080. To test, make sure you get a response (albeit a 404)

--- a/hack/istio/install-bookinfo-demo.sh
+++ b/hack/istio/install-bookinfo-demo.sh
@@ -315,6 +315,7 @@ if [ "${MONGO_ENABLED}" == "true" ]; then
   MONGO_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-db.yaml"
   MONGO_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml"
 
+  # Leaving these alone since they involve IBM arch testing. This is moving off docker.io anyway (https://github.com/kiali/kiali/issues/8278)
   if [ "${ARCH}" == "ppc64le" ]; then
     sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mongodb:2.0.0-ibm-p;g" ${MONGO_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-db-ppc64le.yaml
     MONGO_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-db-ppc64le.yaml"
@@ -352,6 +353,7 @@ if [ "${MYSQL_ENABLED}" == "true" ]; then
   MYSQL_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql.yaml"
   MYSQL_SERVICE_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml"
 
+  # Leaving these alone since they involve IBM arch testing. This is moving off docker.io anyway (https://github.com/kiali/kiali/issues/8278)
   if [ "${ARCH}" == "ppc64le" ]; then
     sed  "s;docker.io/istio.*;quay.io/maistra/examples-bookinfo-mysqldb:2.0.0-ibm-p;g" ${MYSQL_DB_YAML} > ${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-ppc64le.yaml
     MYSQL_DB_YAML="${ISTIO_DIR}/samples/bookinfo/platform/kube/bookinfo-mysql-ppc64le.yaml"

--- a/hack/istio/install-bookinfo-workload-entry.sh
+++ b/hack/istio/install-bookinfo-workload-entry.sh
@@ -90,7 +90,7 @@ function create_workload_pod {
     inject_sidecar "${POD_NAME}" "${WORKLOAD_NAME}"
     sudo podman run --name ${WORKLOAD_NAME} \
         -d --rm --pod "${POD_NAME}" \
-        docker.io/istio/examples-bookinfo-${WORKLOAD_NAME}:latest
+        quay.io/sail-dev/examples-bookinfo-${WORKLOAD_NAME}:latest
     # Wait for pod to be running to ensure it has been assigned an IP address.
     sudo podman wait "${WORKLOAD_NAME}" --condition "running"
     cat ${TEMPLATE_DIR}/bookinfo-service-entry.yaml | \

--- a/hack/istio/install-istio-via-istioctl.sh
+++ b/hack/istio/install-istio-via-istioctl.sh
@@ -247,7 +247,7 @@ Valid command line arguments:
   -ih|--image-hub <hub id>
        The hub where the Istio images will be pulled from.
        You can set this to "default" in order to use the default hub that the Istio charts use but
-       this may be using docker.io and docker hub rate limiting may cause the installation to fail.
+       this may be using Docker Hub, and Docker Hub rate limiting may cause the installation to fail.
        Default: gcr.io/istio-release
   -it|--image-tag <tag>
        The tag of the Istio images. Leave this as "default" (which means the default images are pulled)

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -210,7 +210,7 @@ deploy_kiali() {
   # If using openid auth strategy, create the keycloak realm and the kiali user.
 
   if [ "${KIALI_AUTH_STRATEGY}" == "openid" ]; then
-    # Get a token from keycloak to use the admin api
+    echo "## Kiali auth strategy is openid; get a token from keycloak at [${KEYCLOAK_ADDRESS}] to use the admin api"
     TOKEN_KEY=$(curl -k -X POST https://"${KEYCLOAK_ADDRESS}"/realms/master/protocol/openid-connect/token \
                 -d grant_type=password \
                 -d client_id=admin-cli \

--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -57,7 +57,7 @@ ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
 # If you want to pull Istio images from a different image repository than what the hack script
 # will tell Istio to pull from, then set that hub name here. If you set this to "default",
 # the images will come from the repo that the Istio distro pulls from.
-# Suffice it to say, this setting is needed to avoid docker.io (and its throttling behavior) for
+# Suffice it to say, this setting is needed to avoid Docker Hub (and its throttling behavior) for
 # Istio production releases but allows you to run with Istio dev builds (set this to "default" for dev builds).
 ISTIO_HUB=""
 

--- a/hack/k8s-minikube.sh
+++ b/hack/k8s-minikube.sh
@@ -168,7 +168,7 @@ EOF
 26c26
 <       - image: dexidp/dex:v2.27.0 #or quay.io/dexidp/dex:v2.26.0
 ---
->       - image: docker.io/dexidp/dex:${DEX_VERSION}
+>       - image: ghcr.io/dexidp/dex:${DEX_VERSION}
 41c41
 <         - name: GITHUB_CLIENT_ID
 ---


### PR DESCRIPTION
rely on other more friendly image repos

Run this to see the hack files that have `docker.io` in them - many of those need to change.
```
grep -Rl 'docker[.]io' --exclude docker-io-auth.sh hack
```

fixes: https://github.com/kiali/kiali/issues/8278
