### PR TITLE
Refactor istio status and workload handlers

### DIFF
--- a/handlers/istio_status.go
+++ b/handlers/istio_status.go
@@ -2,22 +2,41 @@ package handlers
 
 import (
 	"net/http"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 )
 
 // IstioStatus returns a list of istio components and its status
-func IstioStatus(w http.ResponseWriter, r *http.Request) {
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
-	}
+func IstioStatus(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	discovery istio.MeshDiscovery,
+	cpm business.ControlPlaneMonitor,
+	grafana *grafana.Service,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
+			return
+		}
 
-	istioStatus, err := business.IstioStatus.GetStatus(r.Context())
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
+		istioStatus, err := business.IstioStatus.GetStatus(r.Context())
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
 
-	RespondWithJSON(w, http.StatusOK, istioStatus)
+		RespondWithJSON(w, http.StatusOK, istioStatus)
+	}
 }

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -474,3 +474,258 @@ func TestValidateBadRequest(t *testing.T) {
 	assert.Contains(errs.Error(), "bad request")
 	assert.Len(errs.Strings(), 2)
 }
+
+func TestWorkloadMetricsDefault(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	url := ts.URL + "/api/namespaces/ns/workloads/my_workload/metrics"
+	now := time.Now()
+	delta := 15 * time.Second
+	var gaugeSentinel uint32
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		query := args[1].(string)
+		assert.IsType(t, prom_v1.Range{}, args[2])
+		r := args[2].(prom_v1.Range)
+		assert.Contains(t, query, "_workload=\"my_workload\"")
+		assert.Contains(t, query, "_namespace=\"ns\"")
+		assert.Contains(t, query, "[1m]")
+		assert.NotContains(t, query, "histogram_quantile")
+		atomic.AddUint32(&gaugeSentinel, 1)
+		assert.Equal(t, 15*time.Second, r.Step)
+		assert.WithinDuration(t, now, r.End, delta)
+		assert.WithinDuration(t, now.Add(-30*time.Minute), r.Start, delta)
+	})
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	// Assert branch coverage
+	assert.NotZero(t, gaugeSentinel)
+}
+
+func TestWorkloadMetricsWithParams(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("rateFunc", "rate")
+	q.Add("step", "2")
+	q.Add("queryTime", "1523364075")
+	q.Add("duration", "1000")
+	q.Add("byLabels[]", "response_code")
+	q.Add("quantiles[]", "0.5")
+	q.Add("quantiles[]", "0.95")
+	q.Add("filters[]", "request_count")
+	q.Add("filters[]", "request_size")
+	req.URL.RawQuery = q.Encode()
+
+	queryTime := time.Unix(1523364075, 0)
+	delta := 2 * time.Second
+	var histogramSentinel, gaugeSentinel uint32
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		query := args[1].(string)
+		assert.IsType(t, prom_v1.Range{}, args[2])
+		r := args[2].(prom_v1.Range)
+		assert.Contains(t, query, "rate(")
+		assert.Contains(t, query, "[5h]")
+		if strings.Contains(query, "histogram_quantile") {
+			// Histogram specific queries
+			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, "istio_request_bytes")
+			atomic.AddUint32(&histogramSentinel, 1)
+		} else {
+			assert.Contains(t, query, " by (response_code)")
+			atomic.AddUint32(&gaugeSentinel, 1)
+		}
+		assert.Equal(t, 2*time.Second, r.Step)
+		assert.WithinDuration(t, queryTime, r.End, delta)
+		assert.WithinDuration(t, queryTime.Add(-1000*time.Second), r.Start, delta)
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	// Assert branch coverage
+	assert.NotZero(t, histogramSentinel)
+	assert.NotZero(t, gaugeSentinel)
+}
+
+func TestWorkloadMetricsBadQueryTime(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "99")
+	q.Add("queryTime", "abc")
+	q.Add("duration", "1000")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "cannot parse query parameter 'queryTime'")
+}
+
+func TestWorkloadMetricsBadDuration(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "99")
+	q.Add("duration", "abc")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "cannot parse query parameter 'duration'")
+}
+
+func TestWorkloadMetricsBadStep(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "abc")
+	q.Add("duration", "1000")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "cannot parse query parameter 'step'")
+}
+
+func TestWorkloadMetricsBadRateFunc(t *testing.T) {
+	ts, api := setupWorkloadMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("rateFunc", "invalid rate func")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "query parameter 'rateFunc' must be either 'rate' or 'irate'")
+}
+
+func TestWorkloadMetricsInaccessibleNamespace(t *testing.T) {
+	ts, _ := setupWorkloadMetricsEndpoint(t)
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("ns"),
+		kubetest.FakeNamespace("my_namespace"))
+	business.SetupBusinessLayer(t, &nsForbidden{k8s, "my_namespace"}, *config.Get())
+
+	url := ts.URL + "/api/namespaces/my_namespace/workloads/my_workload/metrics"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func setupWorkloadMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+	xapi := new(prometheustest.PromAPIMock)
+	prom, err := prometheus.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prom.Inject(xapi)
+
+	mr := mux.NewRouter()
+	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
+	mr.HandleFunc("/api/namespaces/{namespace}/workloads/{workload}/metrics", http.HandlerFunc(
+		WithAuthInfo(authInfo, func(w http.ResponseWriter, r *http.Request) {
+			getWorkloadMetrics(w, r, func() (*prometheus.Client, error) {
+				return prom, nil
+			})
+		})),
+	)
+
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("ns"))
+
+	business.SetupBusinessLayer(t, k8s, *conf)
+
+	return ts, xapi
+}

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -15,8 +15,14 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 	"github.com/kiali/kiali/util"
 )
 
@@ -44,7 +50,6 @@ func (p *workloadParams) extract(r *http.Request) error {
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
-	p.ClusterName = clusterNameFromQuery(config.Get(), query)
 
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
@@ -63,278 +68,340 @@ func (p *workloadParams) extract(r *http.Request) error {
 	return nil
 }
 
-// ClustersWorkloads is the API handler to fetch all the workloads to be displayed, related to a single namespace
-func ClustersWorkloads(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-	namespacesQueryParam := query.Get("namespaces") // csl of namespaces
-	p := workloadParams{}
-	errParse := p.extract(r)
-	if errParse != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
-		return
-	}
+// ClusterWorkloads is the API handler to fetch all the workloads to be displayed, related to a single namespace
+func ClusterWorkloads(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		namespacesQueryParam := query.Get("namespaces") // csl of namespaces
+		p := workloadParams{}
+		errParse := p.extract(r)
+		if errParse != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
+			return
+		}
 
-	// Get business layer
-	businessLayer, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Workloads initialization error: "+err.Error())
-		return
-	}
+		businessLayer, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
 
-	nss := []string{}
-	namespacesFromQueryParams := strings.Split(namespacesQueryParam, ",")
-	loadedNamespaces, _ := businessLayer.Namespace.GetClusterNamespaces(r.Context(), p.ClusterName)
-	for _, ns := range loadedNamespaces {
-		// If namespaces have been provided in the query, further filter the results to only include those namespaces.
-		if len(namespacesQueryParam) > 0 {
-			if slices.Contains(namespacesFromQueryParams, ns.Name) {
+		nss := []string{}
+		namespacesFromQueryParams := strings.Split(namespacesQueryParam, ",")
+		loadedNamespaces, _ := businessLayer.Namespace.GetClusterNamespaces(r.Context(), p.ClusterName)
+		for _, ns := range loadedNamespaces {
+			// If namespaces have been provided in the query, further filter the results to only include those namespaces.
+			if len(namespacesQueryParam) > 0 {
+				if slices.Contains(namespacesFromQueryParams, ns.Name) {
+					nss = append(nss, ns.Name)
+				}
+			} else {
+				// Otherwise no namespaces have been provided in the query params, so include all namespaces the user has access to.
 				nss = append(nss, ns.Name)
 			}
-		} else {
-			// Otherwise no namespaces have been provided in the query params, so include all namespaces the user has access to.
-			nss = append(nss, ns.Name)
-		}
-	}
-
-	clusterWorkloadsList := &models.ClusterWorkloads{
-		Cluster:     p.ClusterName,
-		Workloads:   []models.WorkloadListItem{},
-		Validations: models.IstioValidations{},
-	}
-
-	for _, ns := range nss {
-		criteria := business.WorkloadCriteria{
-			Cluster: p.ClusterName, Namespace: ns, IncludeHealth: p.IncludeHealth,
-			IncludeIstioResources: p.IncludeIstioResources, RateInterval: p.RateInterval, QueryTime: p.QueryTime,
 		}
 
-		if p.IncludeHealth {
-			rateInterval, err := adjustRateInterval(r.Context(), businessLayer, ns, p.RateInterval, p.QueryTime, p.ClusterName)
+		clusterWorkloadsList := &models.ClusterWorkloads{
+			Cluster:     p.ClusterName,
+			Workloads:   []models.WorkloadListItem{},
+			Validations: models.IstioValidations{},
+		}
+
+		for _, ns := range nss {
+			criteria := business.WorkloadCriteria{
+				Cluster: p.ClusterName, Namespace: ns, IncludeHealth: p.IncludeHealth,
+				IncludeIstioResources: p.IncludeIstioResources, RateInterval: p.RateInterval, QueryTime: p.QueryTime,
+			}
+
+			if p.IncludeHealth {
+				rateInterval, err := adjustRateInterval(r.Context(), businessLayer, ns, p.RateInterval, p.QueryTime, p.ClusterName)
+				if err != nil {
+					handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
+					return
+				}
+				criteria.RateInterval = rateInterval
+			}
+
+			// Fetch and build workloads
+			workloadList, err := businessLayer.Workload.GetWorkloadList(r.Context(), criteria)
 			if err != nil {
-				handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
+				handleErrorResponse(w, err)
 				return
 			}
-			criteria.RateInterval = rateInterval
+			clusterWorkloadsList.Workloads = append(clusterWorkloadsList.Workloads, workloadList.Workloads...)
+			clusterWorkloadsList.Validations = clusterWorkloadsList.Validations.MergeValidations(workloadList.Validations)
 		}
 
-		// Fetch and build workloads
-		workloadList, err := businessLayer.Workload.GetWorkloadList(r.Context(), criteria)
+		RespondWithJSON(w, http.StatusOK, clusterWorkloadsList)
+	}
+}
+
+// WorkloadDetails is the API handler to fetch all details to be displayed, related to a single workload
+func WorkloadDetails(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := workloadParams{}
+		errParse := p.extract(r)
+		if errParse != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
+			return
+		}
+
+		criteria := business.WorkloadCriteria{
+			Namespace: p.Namespace, WorkloadName: p.WorkloadName,
+			WorkloadGVK: p.WorkloadGVK, IncludeIstioResources: true, IncludeServices: true, IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval,
+			QueryTime: p.QueryTime, Cluster: p.ClusterName,
+		}
+
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
+
+		includeValidations := false
+		if p.IncludeIstioResources {
+			includeValidations = true
+		}
+
+		istioConfigValidations := models.IstioValidations{}
+		var errValidations error
+
+		wg := sync.WaitGroup{}
+		if includeValidations {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				istioConfigValidations, errValidations = business.Validations.GetValidationsForWorkload(r.Context(), criteria.Cluster, criteria.Namespace, criteria.WorkloadName)
+			}()
+		}
+
+		// Fetch and build workload
+		workloadDetails, err := business.Workload.GetWorkload(r.Context(), criteria)
+		if includeValidations && err == nil {
+			wg.Wait()
+			workloadDetails.Validations = istioConfigValidations
+			err = errValidations
+		}
+
+		if criteria.IncludeHealth && err == nil {
+			workloadDetails.Health, err = business.Health.GetWorkloadHealth(r.Context(), criteria.Namespace, criteria.Cluster, criteria.WorkloadName, criteria.RateInterval, criteria.QueryTime, workloadDetails)
+			if err != nil {
+				handleErrorResponse(w, err)
+			}
+		}
+
 		if err != nil {
 			handleErrorResponse(w, err)
 			return
 		}
-		clusterWorkloadsList.Workloads = append(clusterWorkloadsList.Workloads, workloadList.Workloads...)
-		clusterWorkloadsList.Validations = clusterWorkloadsList.Validations.MergeValidations(workloadList.Validations)
+
+		RespondWithJSON(w, http.StatusOK, workloadDetails)
 	}
-
-	RespondWithJSON(w, http.StatusOK, clusterWorkloadsList)
-}
-
-// WorkloadDetails is the API handler to fetch all details to be displayed, related to a single workload
-func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
-	p := workloadParams{}
-	errParse := p.extract(r)
-	if errParse != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
-		return
-	}
-
-	criteria := business.WorkloadCriteria{
-		Namespace: p.Namespace, WorkloadName: p.WorkloadName,
-		WorkloadGVK: p.WorkloadGVK, IncludeIstioResources: true, IncludeServices: true, IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval,
-		QueryTime: p.QueryTime, Cluster: p.ClusterName,
-	}
-
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Workloads initialization error: "+err.Error())
-		return
-	}
-
-	includeValidations := false
-	if p.IncludeIstioResources {
-		includeValidations = true
-	}
-
-	istioConfigValidations := models.IstioValidations{}
-	var errValidations error
-
-	wg := sync.WaitGroup{}
-	if includeValidations {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			istioConfigValidations, errValidations = business.Validations.GetValidationsForWorkload(r.Context(), criteria.Cluster, criteria.Namespace, criteria.WorkloadName)
-		}()
-	}
-
-	// Fetch and build workload
-	workloadDetails, err := business.Workload.GetWorkload(r.Context(), criteria)
-	if includeValidations && err == nil {
-		wg.Wait()
-		workloadDetails.Validations = istioConfigValidations
-		err = errValidations
-	}
-
-	if criteria.IncludeHealth && err == nil {
-		workloadDetails.Health, err = business.Health.GetWorkloadHealth(r.Context(), criteria.Namespace, criteria.Cluster, criteria.WorkloadName, criteria.RateInterval, criteria.QueryTime, workloadDetails)
-		if err != nil {
-			handleErrorResponse(w, err)
-		}
-	}
-
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
-
-	RespondWithJSON(w, http.StatusOK, workloadDetails)
 }
 
 // WorkloadUpdate is the API to perform a patch on a Workload configuration
-func WorkloadUpdate(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	query := r.URL.Query()
+func WorkloadUpdate(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		query := r.URL.Query()
 
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Workloads initialization error: "+err.Error())
-		return
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
+
+		patchType := query.Get("patchType")
+		if patchType == "" {
+			patchType = defaultPatchType
+		}
+
+		namespace := params["namespace"]
+		workload := params["workload"]
+		workloadGVK, errGVK := util.StringToGVK(query.Get("workloadGVK"))
+		if errGVK != nil {
+			RespondWithError(w, http.StatusBadRequest, "Update request with bad workloadGVK param: "+errGVK.Error())
+		}
+
+		cluster := clusterNameFromQuery(conf, query)
+		log.Debugf("Cluster: %s", cluster)
+
+		includeValidations := false
+		if _, found := query["validate"]; found {
+			includeValidations = true
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			RespondWithError(w, http.StatusBadRequest, "Update request with bad update patch: "+err.Error())
+		}
+		jsonPatch := string(body)
+
+		istioConfigValidations := models.IstioValidations{}
+		var errValidations error
+
+		wg := sync.WaitGroup{}
+		if includeValidations {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				istioConfigValidations, errValidations = business.Validations.GetValidationsForWorkload(r.Context(), cluster, namespace, workload)
+			}()
+		}
+
+		workloadDetails, err := business.Workload.UpdateWorkload(r.Context(), cluster, namespace, workload, workloadGVK, true, jsonPatch, patchType)
+		if includeValidations && err == nil {
+			wg.Wait()
+			workloadDetails.Validations = istioConfigValidations
+			err = errValidations
+		}
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
+		auditMsg := fmt.Sprintf("UPDATE on Cluster: [%s] Namespace: [%s] Workload name: [%s] Type: [%s] Patch: [%s]", cluster, namespace, workload, workloadGVK, jsonPatch)
+		audit(r, auditMsg)
+		RespondWithJSON(w, http.StatusOK, workloadDetails)
 	}
-
-	patchType := query.Get("patchType")
-	if patchType == "" {
-		patchType = defaultPatchType
-	}
-
-	namespace := params["namespace"]
-	workload := params["workload"]
-	workloadGVK, errGVK := util.StringToGVK(query.Get("workloadGVK"))
-	if errGVK != nil {
-		RespondWithError(w, http.StatusBadRequest, "Update request with bad workloadGVK param: "+errGVK.Error())
-	}
-
-	cluster := clusterNameFromQuery(config.Get(), query)
-	log.Debugf("Cluster: %s", cluster)
-
-	includeValidations := false
-	if _, found := query["validate"]; found {
-		includeValidations = true
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		RespondWithError(w, http.StatusBadRequest, "Update request with bad update patch: "+err.Error())
-	}
-	jsonPatch := string(body)
-
-	istioConfigValidations := models.IstioValidations{}
-	var errValidations error
-
-	wg := sync.WaitGroup{}
-	if includeValidations {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			istioConfigValidations, errValidations = business.Validations.GetValidationsForWorkload(r.Context(), cluster, namespace, workload)
-		}()
-	}
-
-	workloadDetails, err := business.Workload.UpdateWorkload(r.Context(), cluster, namespace, workload, workloadGVK, true, jsonPatch, patchType)
-	if includeValidations && err == nil {
-		wg.Wait()
-		workloadDetails.Validations = istioConfigValidations
-		err = errValidations
-	}
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
-	auditMsg := fmt.Sprintf("UPDATE on Cluster: [%s] Namespace: [%s] Workload name: [%s] Type: [%s] Patch: [%s]", cluster, namespace, workload, workloadGVK, jsonPatch)
-	audit(r, auditMsg)
-	RespondWithJSON(w, http.StatusOK, workloadDetails)
 }
 
 // PodDetails is the API handler to fetch all details to be displayed, related to a single pod
-func PodDetails(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	query := r.URL.Query()
+func PodDetails(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		query := r.URL.Query()
 
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Pods initialization error: "+err.Error())
-		return
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
+
+		cluster := clusterNameFromQuery(conf, query)
+		namespace := vars["namespace"]
+		pod := vars["pod"]
+
+		// Fetch and build pod
+		podDetails, err := business.Workload.GetPod(cluster, namespace, pod)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
+
+		RespondWithJSON(w, http.StatusOK, podDetails)
 	}
-	cluster := clusterNameFromQuery(config.Get(), query)
-	namespace := vars["namespace"]
-	pod := vars["pod"]
-
-	// Fetch and build pod
-	podDetails, err := business.Workload.GetPod(cluster, namespace, pod)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
-
-	RespondWithJSON(w, http.StatusOK, podDetails)
 }
 
 // PodLogs is the API handler to fetch logs for a single pod container
-func PodLogs(w http.ResponseWriter, r *http.Request) {
-	if config.IsFeatureDisabled(config.FeatureLogView) {
-		RespondWithError(w, http.StatusForbidden, "Pod Logs access is disabled")
-		return
-	}
-	vars := mux.Vars(r)
-	queryParams := r.URL.Query()
+func PodLogs(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if config.IsFeatureDisabled(config.FeatureLogView) {
+			RespondWithError(w, http.StatusForbidden, "Pod Logs access is disabled")
+			return
+		}
+		vars := mux.Vars(r)
+		queryParams := r.URL.Query()
 
-	// Get business layer
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Pod Logs initialization error: "+err.Error())
-		return
-	}
-	cluster := clusterNameFromQuery(config.Get(), queryParams)
-	namespace := vars["namespace"]
-	pod := vars["pod"]
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
 
-	// Get log options
-	opts, err := business.Workload.BuildLogOptionsCriteria(
-		queryParams.Get("container"),
-		queryParams.Get("duration"),
-		models.LogType(queryParams.Get("logType")),
-		queryParams.Get("sinceTime"),
-		queryParams.Get("maxLines"))
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
-	}
+		cluster := clusterNameFromQuery(conf, queryParams)
+		namespace := vars["namespace"]
+		pod := vars["pod"]
 
-	// Fetch pod logs
-	err = business.Workload.StreamPodLogs(r.Context(), cluster, namespace, queryParams.Get("workload"), queryParams.Get("service"), pod, opts, w)
-	if err != nil {
-		handleErrorResponse(w, err)
-		return
+		// Get log options
+		opts, err := business.Workload.BuildLogOptionsCriteria(
+			queryParams.Get("container"),
+			queryParams.Get("duration"),
+			models.LogType(queryParams.Get("logType")),
+			queryParams.Get("sinceTime"),
+			queryParams.Get("maxLines"))
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
+
+		// Fetch pod logs
+		err = business.Workload.StreamPodLogs(r.Context(), cluster, namespace, queryParams.Get("workload"), queryParams.Get("service"), pod, opts, w)
+		if err != nil {
+			handleErrorResponse(w, err)
+			return
+		}
 	}
 }
 
-func ConfigDumpZtunnel(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
+func ConfigDumpZtunnel(
+	conf *config.Config,
+	kialiCache cache.KialiCache,
+	clientFactory kubernetes.ClientFactory,
+	cpm business.ControlPlaneMonitor,
+	prom prometheus.ClientInterface,
+	traceClientLoader func() tracing.ClientInterface,
+	grafana *grafana.Service,
+	discovery istio.MeshDiscovery,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
 
-	business, err := getBusiness(r)
-	if err != nil {
-		RespondWithError(w, http.StatusInternalServerError, "Services initialization error: "+err.Error())
-		return
+		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
+			return
+		}
+
+		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		namespace := params["namespace"]
+		pod := params["pod"]
+
+		dump := business.Workload.GetZtunnelConfig(cluster, namespace, pod)
+		RespondWithJSON(w, http.StatusOK, dump)
 	}
-
-	cluster := clusterNameFromQuery(config.Get(), r.URL.Query())
-	namespace := params["namespace"]
-	pod := params["pod"]
-
-	dump := business.Workload.GetZtunnelConfig(cluster, namespace, pod)
-
-	RespondWithJSON(w, http.StatusOK, dump)
 }

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -30,6 +30,8 @@ import (
 //
 // swagger:parameters workloadParams
 type workloadParams struct {
+	// TODO: No need to override Namespace and ClusterName here.
+	// Combine with baseHealthParams.
 	baseHealthParams
 	// The target workload
 	//
@@ -50,6 +52,7 @@ func (p *workloadParams) extract(r *http.Request) error {
 	p.baseExtract(r, vars)
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
+	p.ClusterName = clusterNameFromQuery(config.Get(), query)
 
 	var err error
 	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -4,38 +4,34 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
-	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
-	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
+	"github.com/kiali/kiali/tracing"
 )
 
-func setupWorkloadList(t *testing.T, k8s *kubetest.FakeK8sClient) (*httptest.Server, *prometheustest.PromClientMock) {
+func setupWorkloadList(t *testing.T, k8s *kubetest.FakeK8sClient, conf *config.Config) (*httptest.Server, *prometheustest.PromClientMock) {
 	prom := new(prometheustest.PromClientMock)
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := istio.NewDiscovery(cf.Clients, cache, conf)
+	cpm := &business.FakeControlPlaneMonitor{}
+	traceLoader := func() tracing.ClientInterface { return nil }
+	grafana := grafana.NewService(conf, cf.GetSAHomeClusterClient())
 
-	business.SetupBusinessLayer(t, k8s, *config.Get())
-
+	handler := WithFakeAuthInfo(conf, ClusterWorkloads(conf, cache, cf, cpm, prom, traceLoader, grafana, discovery))
 	mr := mux.NewRouter()
-
-	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
-	mr.HandleFunc("/api/clusters/workloads", http.HandlerFunc(
-		WithAuthInfo(authInfo, func(w http.ResponseWriter, r *http.Request) {
-			ClustersWorkloads(w, r)
-		})),
-	)
+	mr.HandleFunc("/api/clusters/workloads", handler)
 
 	ts := httptest.NewServer(mr)
 	t.Cleanup(ts.Close)
@@ -43,27 +39,25 @@ func setupWorkloadList(t *testing.T, k8s *kubetest.FakeK8sClient) (*httptest.Ser
 }
 
 func TestWorkloadsEndpoint(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.ExternalServices.Istio.IstioAPIEnabled = false
-	config.Set(cfg)
+	conf := config.NewConfig()
 
 	mockClock()
 
 	kubeObjects := []runtime.Object{kubetest.FakeNamespace("ns")}
-	for _, obj := range business.FakeDepSyncedWithRS(cfg) {
+	for _, obj := range business.FakeDepSyncedWithRS(conf) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
-	for _, obj := range business.FakeRSSyncedWithPods(cfg) {
+	for _, obj := range business.FakeRSSyncedWithPods(conf) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
-	for _, obj := range business.FakePodsSyncedWithDeployments(cfg) {
+	for _, obj := range business.FakePodsSyncedWithDeployments(conf) {
 		o := obj
 		kubeObjects = append(kubeObjects, &o)
 	}
 	k8s := kubetest.NewFakeK8sClient(kubeObjects...)
-	ts, _ := setupWorkloadList(t, k8s)
+	ts, _ := setupWorkloadList(t, k8s, conf)
 
 	url := ts.URL + "/api/clusters/workloads?namespaces=ns"
 
@@ -75,259 +69,4 @@ func TestWorkloadsEndpoint(t *testing.T) {
 
 	assert.NotEmpty(t, actual)
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
-}
-
-func TestWorkloadMetricsDefault(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	url := ts.URL + "/api/namespaces/ns/workloads/my_workload/metrics"
-	now := time.Now()
-	delta := 15 * time.Second
-	var gaugeSentinel uint32
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		query := args[1].(string)
-		assert.IsType(t, prom_v1.Range{}, args[2])
-		r := args[2].(prom_v1.Range)
-		assert.Contains(t, query, "_workload=\"my_workload\"")
-		assert.Contains(t, query, "_namespace=\"ns\"")
-		assert.Contains(t, query, "[1m]")
-		assert.NotContains(t, query, "histogram_quantile")
-		atomic.AddUint32(&gaugeSentinel, 1)
-		assert.Equal(t, 15*time.Second, r.Step)
-		assert.WithinDuration(t, now, r.End, delta)
-		assert.WithinDuration(t, now.Add(-30*time.Minute), r.Start, delta)
-	})
-
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.NotEmpty(t, actual)
-	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	// Assert branch coverage
-	assert.NotZero(t, gaugeSentinel)
-}
-
-func TestWorkloadMetricsWithParams(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("rateFunc", "rate")
-	q.Add("step", "2")
-	q.Add("queryTime", "1523364075")
-	q.Add("duration", "1000")
-	q.Add("byLabels[]", "response_code")
-	q.Add("quantiles[]", "0.5")
-	q.Add("quantiles[]", "0.95")
-	q.Add("filters[]", "request_count")
-	q.Add("filters[]", "request_size")
-	req.URL.RawQuery = q.Encode()
-
-	queryTime := time.Unix(1523364075, 0)
-	delta := 2 * time.Second
-	var histogramSentinel, gaugeSentinel uint32
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		query := args[1].(string)
-		assert.IsType(t, prom_v1.Range{}, args[2])
-		r := args[2].(prom_v1.Range)
-		assert.Contains(t, query, "rate(")
-		assert.Contains(t, query, "[5h]")
-		if strings.Contains(query, "histogram_quantile") {
-			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
-			assert.Contains(t, query, "istio_request_bytes")
-			atomic.AddUint32(&histogramSentinel, 1)
-		} else {
-			assert.Contains(t, query, " by (response_code)")
-			atomic.AddUint32(&gaugeSentinel, 1)
-		}
-		assert.Equal(t, 2*time.Second, r.Step)
-		assert.WithinDuration(t, queryTime, r.End, delta)
-		assert.WithinDuration(t, queryTime.Add(-1000*time.Second), r.Start, delta)
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.NotEmpty(t, actual)
-	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	// Assert branch coverage
-	assert.NotZero(t, histogramSentinel)
-	assert.NotZero(t, gaugeSentinel)
-}
-
-func TestWorkloadMetricsBadQueryTime(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("step", "99")
-	q.Add("queryTime", "abc")
-	q.Add("duration", "1000")
-	req.URL.RawQuery = q.Encode()
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		// Make sure there's no client call and we fail fast
-		t.Error("Unexpected call to client while having bad request")
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, string(actual), "cannot parse query parameter 'queryTime'")
-}
-
-func TestWorkloadMetricsBadDuration(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("step", "99")
-	q.Add("duration", "abc")
-	req.URL.RawQuery = q.Encode()
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		// Make sure there's no client call and we fail fast
-		t.Error("Unexpected call to client while having bad request")
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, string(actual), "cannot parse query parameter 'duration'")
-}
-
-func TestWorkloadMetricsBadStep(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("step", "abc")
-	q.Add("duration", "1000")
-	req.URL.RawQuery = q.Encode()
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		// Make sure there's no client call and we fail fast
-		t.Error("Unexpected call to client while having bad request")
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, string(actual), "cannot parse query parameter 'step'")
-}
-
-func TestWorkloadMetricsBadRateFunc(t *testing.T) {
-	ts, api := setupWorkloadMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/workloads/my-workload/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("rateFunc", "invalid rate func")
-	req.URL.RawQuery = q.Encode()
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		// Make sure there's no client call and we fail fast
-		t.Error("Unexpected call to client while having bad request")
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, string(actual), "query parameter 'rateFunc' must be either 'rate' or 'irate'")
-}
-
-func TestWorkloadMetricsInaccessibleNamespace(t *testing.T) {
-	ts, _ := setupWorkloadMetricsEndpoint(t)
-	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("ns"),
-		kubetest.FakeNamespace("my_namespace"))
-	business.SetupBusinessLayer(t, &nsForbidden{k8s, "my_namespace"}, *config.Get())
-
-	url := ts.URL + "/api/namespaces/my_namespace/workloads/my_workload/metrics"
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
-}
-
-func setupWorkloadMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
-	conf := config.NewConfig()
-	conf.ExternalServices.Istio.IstioAPIEnabled = false
-	config.Set(conf)
-	xapi := new(prometheustest.PromAPIMock)
-	prom, err := prometheus.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	prom.Inject(xapi)
-
-	mr := mux.NewRouter()
-	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
-	mr.HandleFunc("/api/namespaces/{namespace}/workloads/{workload}/metrics", http.HandlerFunc(
-		WithAuthInfo(authInfo, func(w http.ResponseWriter, r *http.Request) {
-			getWorkloadMetrics(w, r, func() (*prometheus.Client, error) {
-				return prom, nil
-			})
-		})),
-	)
-
-	ts := httptest.NewServer(mr)
-	t.Cleanup(ts.Close)
-
-	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("ns"))
-
-	business.SetupBusinessLayer(t, k8s, *conf)
-
-	return ts, xapi
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -611,10 +611,10 @@ func NewRoutes(
 		//      200: workloadListResponse
 		//
 		{
-			"ClustersWorkloads",
+			"ClusterWorkloads",
 			"GET",
 			"/api/clusters/workloads",
-			handlers.ClustersWorkloads,
+			handlers.ClusterWorkloads(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/workloads/{workload} workloads workloadDetails
@@ -635,7 +635,7 @@ func NewRoutes(
 			"WorkloadDetails",
 			"GET",
 			"/api/namespaces/{namespace}/workloads/{workload}",
-			handlers.WorkloadDetails,
+			handlers.WorkloadDetails(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route PATCH /namespaces/{namespace}/workloads/{workload} workloads workloadUpdate
@@ -660,7 +660,7 @@ func NewRoutes(
 			"WorkloadUpdate",
 			"PATCH",
 			"/api/namespaces/{namespace}/workloads/{workload}",
-			handlers.WorkloadUpdate,
+			handlers.WorkloadUpdate(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /clusters/apps apps appList
@@ -1165,7 +1165,7 @@ func NewRoutes(
 			"IstioStatus",
 			"GET",
 			"/api/istio/status",
-			handlers.IstioStatus,
+			handlers.IstioStatus(conf, kialiCache, clientFactory, prom, traceClientLoader, discovery, cpm, grafana),
 			true,
 		},
 		// swagger:route GET /namespaces/graph graphs graphNamespaces
@@ -1418,7 +1418,7 @@ func NewRoutes(
 			"PodDetails",
 			"GET",
 			"/api/namespaces/{namespace}/pods/{pod}",
-			handlers.PodDetails,
+			handlers.PodDetails(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/pods/{pod}/logs pods podLogs
@@ -1439,7 +1439,7 @@ func NewRoutes(
 			"PodLogs",
 			"GET",
 			"/api/namespaces/{namespace}/pods/{pod}/logs",
-			handlers.PodLogs,
+			handlers.PodLogs(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/pods/{pod}/config_dump pods podProxyDump
@@ -1502,7 +1502,7 @@ func NewRoutes(
 			"ZtunnelConfigDump",
 			"GET",
 			"/api/namespaces/{namespace}/pods/{pod}/config_dump_ztunnel",
-			handlers.ConfigDumpZtunnel,
+			handlers.ConfigDumpZtunnel(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route POST /namespaces/{namespace}/pods/{pod}/logging pods podProxyLogging


### PR DESCRIPTION
### Describe the change

Refactors istio status and workload handlers to use closures instead of global vars. Moves workload metrics tests into the `metrics_test.go` file since that's where the handler is.

### Steps to test the PR

N/A

### Automation testing

Existing tests pass.

### Issue reference

https://github.com/kiali/kiali/issues/6923
