### PR TITLE
Refactor proxy_logging and namespace handlers

### DIFF
--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -729,3 +729,158 @@ func setupWorkloadMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheuste
 
 	return ts, xapi
 }
+
+// TestNamespaceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)
+func TestNamespaceMetricsDefault(t *testing.T) {
+	ts, api := setupNamespaceMetricsEndpoint(t)
+
+	url := ts.URL + "/api/namespaces/ns/metrics"
+	now := time.Now()
+	delta := 15 * time.Second
+	var gaugeSentinel uint32
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		query := args[1].(string)
+		assert.IsType(t, prom_v1.Range{}, args[2])
+		r := args[2].(prom_v1.Range)
+		assert.Contains(t, query, "_namespace=\"ns\"")
+		assert.Contains(t, query, "[1m]")
+		assert.NotContains(t, query, "histogram_quantile")
+		atomic.AddUint32(&gaugeSentinel, 1)
+		assert.Equal(t, 15*time.Second, r.Step)
+		assert.WithinDuration(t, now, r.End, delta)
+		assert.WithinDuration(t, now.Add(-30*time.Minute), r.Start, delta)
+	})
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	// Assert branch coverage
+	assert.NotZero(t, gaugeSentinel)
+}
+
+func TestNamespaceMetricsWithParams(t *testing.T) {
+	ts, api := setupNamespaceMetricsEndpoint(t)
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("rateFunc", "rate")
+	q.Add("step", "2")
+	q.Add("queryTime", "1523364075")
+	q.Add("duration", "1000")
+	q.Add("byLabels[]", "response_code")
+	q.Add("quantiles[]", "0.5")
+	q.Add("quantiles[]", "0.95")
+	q.Add("filters[]", "request_count")
+	q.Add("filters[]", "request_size")
+	req.URL.RawQuery = q.Encode()
+
+	queryTime := time.Unix(1523364075, 0)
+	delta := 2 * time.Second
+	var histogramSentinel, gaugeSentinel uint32
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		query := args[1].(string)
+		assert.IsType(t, prom_v1.Range{}, args[2])
+		r := args[2].(prom_v1.Range)
+		assert.Contains(t, query, "rate(")
+		assert.Contains(t, query, "[5h]")
+		if strings.Contains(query, "histogram_quantile") {
+			// Histogram specific queries
+			assert.Contains(t, query, " by (le,response_code)")
+			assert.Contains(t, query, "istio_request_bytes")
+			atomic.AddUint32(&histogramSentinel, 1)
+		} else {
+			assert.Contains(t, query, " by (response_code)")
+			atomic.AddUint32(&gaugeSentinel, 1)
+		}
+		assert.Equal(t, 2*time.Second, r.Step)
+		assert.WithinDuration(t, queryTime, r.End, delta)
+		assert.WithinDuration(t, queryTime.Add(-1000*time.Second), r.Start, delta)
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := io.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	// Assert branch coverage
+	assert.NotZero(t, histogramSentinel)
+	assert.NotZero(t, gaugeSentinel)
+}
+
+func TestNamespaceMetricsInaccessibleNamespace(t *testing.T) {
+	ts, _ := setupNamespaceMetricsEndpoint(t)
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("my_namespace"))
+	business.SetupBusinessLayer(t, &noPrivClient{k8s}, *config.NewConfig())
+
+	url := ts.URL + "/api/namespaces/my_namespace/metrics"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func setupNamespaceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
+	client, xapi := setupMocked(t)
+
+	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/metrics", http.HandlerFunc(
+		WithAuthInfo(
+			authInfo,
+			NamespaceMetrics(func() (*prometheus.Client, error) { return client, nil }),
+		),
+	))
+
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+	return ts, xapi
+}
+
+// Setup mock
+
+func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock) {
+	t.Helper()
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("tutorial"),
+		kubetest.FakeNamespace("ns"),
+		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "bookinfo"}},
+		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "tutorial"}},
+		&osproject_v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	k.OpenShift = true
+
+	api := new(prometheustest.PromAPIMock)
+	client, err := prometheus.NewClient()
+	if err != nil {
+		t.Fatal(err)
+		return nil, nil
+	}
+	client.Inject(api)
+
+	business.SetupBusinessLayer(t, k, *conf)
+
+	return client, api
+}

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -1,142 +1,37 @@
-package handlers
+package handlers_test
 
 import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	osproject_v1 "github.com/openshift/api/project/v1"
-	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes/cache"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 )
 
-// TestNamespaceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)
-func TestNamespaceMetricsDefault(t *testing.T) {
-	ts, api := setupNamespaceMetricsEndpoint(t)
-
-	url := ts.URL + "/api/namespaces/ns/metrics"
-	now := time.Now()
-	delta := 15 * time.Second
-	var gaugeSentinel uint32
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		query := args[1].(string)
-		assert.IsType(t, prom_v1.Range{}, args[2])
-		r := args[2].(prom_v1.Range)
-		assert.Contains(t, query, "_namespace=\"ns\"")
-		assert.Contains(t, query, "[1m]")
-		assert.NotContains(t, query, "histogram_quantile")
-		atomic.AddUint32(&gaugeSentinel, 1)
-		assert.Equal(t, 15*time.Second, r.Step)
-		assert.WithinDuration(t, now, r.End, delta)
-		assert.WithinDuration(t, now.Add(-30*time.Minute), r.Start, delta)
-	})
-
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.NotEmpty(t, actual)
-	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	// Assert branch coverage
-	assert.NotZero(t, gaugeSentinel)
-}
-
-func TestNamespaceMetricsWithParams(t *testing.T) {
-	ts, api := setupNamespaceMetricsEndpoint(t)
-
-	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/metrics", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	q := req.URL.Query()
-	q.Add("rateInterval", "5h")
-	q.Add("rateFunc", "rate")
-	q.Add("step", "2")
-	q.Add("queryTime", "1523364075")
-	q.Add("duration", "1000")
-	q.Add("byLabels[]", "response_code")
-	q.Add("quantiles[]", "0.5")
-	q.Add("quantiles[]", "0.95")
-	q.Add("filters[]", "request_count")
-	q.Add("filters[]", "request_size")
-	req.URL.RawQuery = q.Encode()
-
-	queryTime := time.Unix(1523364075, 0)
-	delta := 2 * time.Second
-	var histogramSentinel, gaugeSentinel uint32
-
-	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
-		query := args[1].(string)
-		assert.IsType(t, prom_v1.Range{}, args[2])
-		r := args[2].(prom_v1.Range)
-		assert.Contains(t, query, "rate(")
-		assert.Contains(t, query, "[5h]")
-		if strings.Contains(query, "histogram_quantile") {
-			// Histogram specific queries
-			assert.Contains(t, query, " by (le,response_code)")
-			assert.Contains(t, query, "istio_request_bytes")
-			atomic.AddUint32(&histogramSentinel, 1)
-		} else {
-			assert.Contains(t, query, " by (response_code)")
-			atomic.AddUint32(&gaugeSentinel, 1)
-		}
-		assert.Equal(t, 2*time.Second, r.Step)
-		assert.WithinDuration(t, queryTime, r.End, delta)
-		assert.WithinDuration(t, queryTime.Add(-1000*time.Second), r.Start, delta)
-	})
-
-	httpclient := &http.Client{}
-	resp, err := httpclient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := io.ReadAll(resp.Body)
-
-	assert.NotEmpty(t, actual)
-	assert.Equal(t, 200, resp.StatusCode, string(actual))
-	// Assert branch coverage
-	assert.NotZero(t, histogramSentinel)
-	assert.NotZero(t, gaugeSentinel)
-}
-
-func TestNamespaceMetricsInaccessibleNamespace(t *testing.T) {
-	ts, _ := setupNamespaceMetricsEndpoint(t)
-	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("my_namespace"))
-	business.SetupBusinessLayer(t, &noPrivClient{k8s}, *config.NewConfig())
-
-	url := ts.URL + "/api/namespaces/my_namespace/metrics"
-
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
-}
-
 func TestNamespaceInfo(t *testing.T) {
-	setupMocked(t)
+	conf := config.NewConfig()
+	_, _, k8s := setupMocked(t)
 
-	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := istio.NewDiscovery(cf.Clients, cache, conf)
+
+	handler := handlers.WithFakeAuthInfo(conf, handlers.NamespaceInfo(conf, cache, cf, discovery))
+
 	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/info", WithAuthInfo(authInfo, NamespaceInfo))
+	mr.HandleFunc("/api/namespaces/{namespace}/info", handler)
 
 	ts := httptest.NewServer(mr)
 	t.Cleanup(ts.Close)
@@ -157,30 +52,8 @@ func TestNamespaceInfo(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode, string(actual))
 }
 
-func setupNamespaceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
-	client, xapi := setupMocked(t)
-
-	authInfo := map[string]*api.AuthInfo{config.Get().KubernetesConfig.ClusterName: {Token: "test"}}
-	mr := mux.NewRouter()
-	mr.HandleFunc("/api/namespaces/{namespace}/metrics", http.HandlerFunc(
-		WithAuthInfo(
-			authInfo,
-			NamespaceMetrics(func() (*prometheus.Client, error) { return client, nil }),
-		),
-	))
-
-	ts := httptest.NewServer(mr)
-	t.Cleanup(ts.Close)
-	return ts, xapi
-}
-
-// Setup mock
-
-func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock) {
+func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock, *kubetest.FakeK8sClient) {
 	t.Helper()
-
-	conf := config.NewConfig()
-	config.Set(conf)
 
 	k := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("bookinfo"),
@@ -196,11 +69,9 @@ func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock)
 	client, err := prometheus.NewClient()
 	if err != nil {
 		t.Fatal(err)
-		return nil, nil
+		return nil, nil, nil
 	}
 	client.Inject(api)
 
-	business.SetupBusinessLayer(t, k, *conf)
-
-	return client, api
+	return client, api, k
 }

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -167,5 +167,8 @@ func (c *FakeK8sClient) IsGatewayAPI() bool                 { return c.GatewayAP
 func (c *FakeK8sClient) IsIstioAPI() bool                   { return c.IstioAPIEnabled }
 func (c *FakeK8sClient) GetToken() string                   { return c.Token }
 func (c *FakeK8sClient) ClusterInfo() kialikube.ClusterInfo { return c.KubeClusterInfo }
+func (c *FakeK8sClient) SetProxyLogLevel(namespace string, podName string, level string) error {
+	return nil
+}
 
 var _ kialikube.ClientInterface = &FakeK8sClient{}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -721,7 +721,7 @@ func NewRoutes(
 			"NamespaceList",
 			"GET",
 			"/api/namespaces",
-			handlers.NamespaceList,
+			handlers.NamespaceList(conf, kialiCache, clientFactory, discovery),
 			true,
 		},
 		// swagger:route PATCH /namespaces/{namespace} namespaces namespaceUpdate
@@ -746,7 +746,7 @@ func NewRoutes(
 			"NamespaceUpdate",
 			"PATCH",
 			"/api/namespaces/{namespace}",
-			handlers.NamespaceUpdate,
+			handlers.NamespaceUpdate(conf, kialiCache, clientFactory, discovery),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/info namespaces namespaceInfo
@@ -766,7 +766,7 @@ func NewRoutes(
 			"NamespaceInfo",
 			"GET",
 			"/api/namespaces/{namespace}/info",
-			handlers.NamespaceInfo,
+			handlers.NamespaceInfo(conf, kialiCache, clientFactory, discovery),
 			true,
 		},
 		// swagger:route GET /namespaces/{namespace}/services/{service}/metrics services serviceMetrics
@@ -1060,7 +1060,7 @@ func NewRoutes(
 			"NamespaceValidationSummary",
 			"GET",
 			"/api/namespaces/{namespace}/validations",
-			handlers.NamespaceValidationSummary(discovery),
+			handlers.NamespaceValidationSummary(conf, kialiCache, clientFactory, prom, cpm, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /istio/validations namespaces namespacesValidations
@@ -1081,7 +1081,7 @@ func NewRoutes(
 			"ConfigValidationSummary",
 			"GET",
 			"/api/istio/validations",
-			handlers.ConfigValidationSummary,
+			handlers.IstioConfigValidationSummary(conf, kialiCache, clientFactory, prom, cpm, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /mesh/tls tls meshTls
@@ -1524,7 +1524,7 @@ func NewRoutes(
 			"PodProxyLogging",
 			"POST",
 			"/api/namespaces/{namespace}/pods/{pod}/logging",
-			handlers.LoggingUpdate,
+			handlers.LoggingUpdate(conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery),
 			true,
 		},
 		// swagger:route GET /clusters/metrics clusterName namespaces clustersMetrics


### PR DESCRIPTION
### Describe the change

Refactors proxy logging and namespace handlers. Moves some namespace metrics tests into `metrics_test.go` and moves an istio config handler into `istio_config.go`.

### Steps to test the PR

N/A

### Automation testing

Covered by existing tests.

### Issue reference

https://github.com/kiali/kiali/issues/6923