### PR TITLE
Optimize unit tests

### DIFF
--- a/kubernetes/cache/kube_cache_test.go
+++ b/kubernetes/cache/kube_cache_test.go
@@ -25,7 +25,7 @@ const IstioAPIEnabled = true
 func newTestingKubeCache(t *testing.T, cfg *config.Config, objects ...runtime.Object) *kubeCache {
 	t.Helper()
 
-	kubeCache, err := NewKubeCache(kubetest.NewFakeK8sClient(objects...), *cfg, nil)
+	kubeCache, err := NewKubeCache(kubetest.NewFakeK8sClient(objects...), *cfg, nil, ConstantWaitForSync)
 	if err != nil {
 		t.Fatalf("Unable to create kube cache for testing. Err: %s", err)
 	}
@@ -326,7 +326,7 @@ func TestIstioAPIDisabled(t *testing.T) {
 	cfg := config.NewConfig()
 	fakeClient := kubetest.NewFakeK8sClient(ns)
 	fakeClient.IstioAPIEnabled = false
-	kubeCache, err := NewKubeCache(fakeClient, *cfg, nil)
+	kubeCache, err := NewKubeCache(fakeClient, *cfg, nil, ConstantWaitForSync)
 	if err != nil {
 		t.Fatalf("Unable to create kube cache for testing. Err: %s", err)
 	}


### PR DESCRIPTION
### Describe the change

Pass a custom sync func to reduce polling times in unit tests.

Reduces unit tests times on my machine from ~27s --> 18.3s

### Steps to test the PR

Run this before and after to see the time difference:
`go clean -testcache && make test`

### Automation testing

N/A

### Issue reference

N/A

Thanks to @howardjohn blog for pointing this out to me: https://blog.howardjohn.info/posts/kube-client/#better-testing!