### PR TITLE
Move graph types out of Graph.ts file

### DIFF
--- a/frontend/src/actions/GraphActions.ts
+++ b/frontend/src/actions/GraphActions.ts
@@ -1,8 +1,7 @@
 import { ActionType, createAction, createStandardAction } from 'typesafe-actions';
-import { GraphEvent, EdgeMode, GraphDefinition, NodeParamsType, RankResult } from '../types/Graph';
+import { GraphEvent, EdgeMode, GraphDefinition, NodeParamsType, RankResult, GraphLayout } from '../types/Graph';
 import { ActionKeys } from './ActionKeys';
 import { TimeInMilliseconds } from 'types/Common';
-import { GraphLayout } from 'pages/Graph/Graph';
 
 export const GraphActions = {
   onNamespaceChange: createAction(ActionKeys.GRAPH_ON_NAMESPACE_CHANGE),

--- a/frontend/src/components/Nav/NavUtils.tsx
+++ b/frontend/src/components/Nav/NavUtils.tsx
@@ -1,10 +1,17 @@
-import { EdgeLabelMode, NodeType, NodeParamsType, GraphType, TrafficRate, EdgeMode } from '../../types/Graph';
+import {
+  EdgeLabelMode,
+  NodeType,
+  NodeParamsType,
+  GraphType,
+  TrafficRate,
+  EdgeMode,
+  GraphLayout
+} from '../../types/Graph';
 import { DurationInSeconds, IntervalInMilliseconds } from '../../types/Common';
 import { Namespace } from '../../types/Namespace';
 import { URLParam } from '../../app/History';
 import { getKioskMode, isKioskMode } from '../../utils/SearchParamUtils';
 import { isMultiCluster } from 'config';
-import { GraphLayout } from 'pages/Graph/Graph';
 
 export type GraphUrlParams = {
   activeNamespaces: Namespace[];

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -32,7 +32,10 @@ import {
   BoxByType,
   EdgeLabelMode,
   EdgeMode,
+  FocusNode,
   GraphEvent,
+  GraphLayout,
+  LayoutType,
   NodeAttr,
   NodeType,
   RankMode,
@@ -74,38 +77,10 @@ import { GraphHighlighter } from './GraphHighlighter';
 const DEFAULT_NODE_SIZE = 40;
 const ZOOM_IN = 4 / 3;
 const ZOOM_OUT = 3 / 4;
-
-export const FIT_PADDING = 90;
-
-export enum LayoutType {
-  Layout = 'layout',
-  LayoutNoFit = 'layoutNoFit',
-  Resize = 'resize'
-}
+const FIT_PADDING = 90;
 
 let initialLayout = false;
 let layoutInProgress: LayoutType | undefined;
-
-// the layouts offered by the traffic graph page
-export enum GraphLayout {
-  BreadthFirst = 'breadthfirst',
-  Concentric = 'concentric',
-  Dagre = 'dagre',
-  Grid = 'grid'
-}
-
-export function getValidGraphLayout(layout: string): GraphLayout {
-  switch (layout) {
-    case GraphLayout.BreadthFirst:
-      return GraphLayout.BreadthFirst;
-    case GraphLayout.Concentric:
-      return GraphLayout.Concentric;
-    case GraphLayout.Grid:
-      return GraphLayout.Grid;
-    default:
-      return GraphLayout.Dagre;
-  }
-}
 
 export function graphLayout(controller: Controller, layoutType: LayoutType, reset = true): void {
   if (!controller?.hasGraph()) {
@@ -126,11 +101,6 @@ export function graphLayout(controller: Controller, layoutType: LayoutType, rese
     controller.getGraph().reset();
   }
   controller.getGraph().layout();
-}
-
-export interface FocusNode {
-  id: string;
-  isSelected?: boolean;
 }
 
 // The is the main graph rendering component

--- a/frontend/src/pages/Graph/GraphElems.tsx
+++ b/frontend/src/pages/Graph/GraphElems.tsx
@@ -20,6 +20,7 @@ import {
   DecoratedGraphEdgeWrapper,
   DecoratedGraphNodeData,
   EdgeLabelMode,
+  GraphLayout,
   GraphType,
   NodeType,
   numLabels,
@@ -35,7 +36,6 @@ import { getEdgeHealth } from 'types/ErrorRate/GraphEdgeStatus';
 import { Span } from 'types/TracingInfo';
 import { IconType } from 'config/Icons';
 import { NodeDecorator } from './NodeDecorator';
-import { GraphLayout } from './Graph';
 import { supportsGroups } from 'utils/GraphUtils';
 import { kialiStyle } from 'styles/StyleUtils';
 import { TrafficPointGenerator } from '../Graph/TrafficAnimation/TrafficRenderer';

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -18,7 +18,9 @@ import {
   TrafficRate,
   RankMode,
   RankResult,
-  EdgeMode
+  EdgeMode,
+  GraphLayout,
+  FocusNode
 } from '../../types/Graph';
 import { computePrometheusRateParams } from '../../services/Prometheus';
 import * as AlertUtils from '../../utils/AlertUtils';
@@ -67,11 +69,12 @@ import { deleteServiceTrafficRouting } from 'services/Api';
 import { canCreate, canUpdate } from '../../types/Permissions';
 import { connectRefresh } from '../../components/Refresh/connectRefresh';
 import { triggerRefresh } from '../../hooks/refresh';
-import { Graph, FocusNode, getValidGraphLayout, GraphLayout } from './Graph';
+import { Graph } from './Graph';
 import { Controller } from '@patternfly/react-topology';
 import { GraphLegend } from './GraphLegend';
 import { HistoryManager, URLParam } from 'app/History';
 import { elementsChanged } from 'helpers/GraphHelpers';
+import { getValidGraphLayout } from 'utils/GraphUtils';
 
 // GraphURLPathProps holds path variable values.  Currently all path variables are relevant only to a node graph
 export type GraphURLPathProps = {

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -19,7 +19,7 @@ import { KialiAppState } from '../../../store/Store';
 import { findValueSelector, hideValueSelector, edgeLabelsSelector, edgeModeSelector } from '../../../store/Selectors';
 import { GraphToolbarActions } from '../../../actions/GraphToolbarActions';
 import { GraphHelpFind } from '../../../pages/Graph/GraphHelpFind';
-import { EdgeLabelMode, NodeType, EdgeMode, NodeAttr, EdgeAttr } from '../../../types/Graph';
+import { EdgeLabelMode, NodeType, EdgeMode, NodeAttr, EdgeAttr, LayoutType } from '../../../types/Graph';
 import * as AlertUtils from '../../../utils/AlertUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -35,7 +35,7 @@ import { EdgeData, NodeData } from 'pages/Graph/GraphElems';
 import { elems, SelectAnd, SelectExp, selectOr, SelectOr, setObserved, toSafeFieldName } from 'helpers/GraphHelpers';
 import { descendents } from 'helpers/GraphHelpers';
 import { isArray } from 'lodash';
-import { graphLayout, LayoutType } from 'pages/Graph/Graph';
+import { graphLayout } from 'pages/Graph/Graph';
 import { infoStyle } from 'styles/IconStyle';
 
 type ReduxStateProps = {

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -15,13 +15,13 @@ import {
 import { Edge, EdgeModel, Node, NodeModel } from '@patternfly/react-topology';
 import { URLParam, location, router } from '../../app/History';
 import { GraphDataSource } from '../../services/GraphDataSource';
-import { DecoratedGraphElements, EdgeMode, GraphEvent, GraphType, NodeType } from '../../types/Graph';
+import { DecoratedGraphElements, EdgeMode, GraphEvent, GraphLayout, GraphType, NodeType } from '../../types/Graph';
 import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
 import { store } from 'store/ConfigStore';
 import { TimeInMilliseconds } from '../../types/Common';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
 import { KialiAppState } from '../../store/Store';
-import { GraphLayout, Graph } from './Graph';
+import { Graph } from './Graph';
 import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
 import { isKiosk, isParentKiosk, kioskContextMenuAction } from 'components/Kiosk/KioskActions';
 import { ServiceWizardActionsDropdownGroup } from 'components/IstioWizards/ServiceWizardActionsDropdownGroup';

--- a/frontend/src/pages/Graph/layouts/layoutFactory.ts
+++ b/frontend/src/pages/Graph/layouts/layoutFactory.ts
@@ -6,8 +6,8 @@ import {
   LayoutFactory,
   BreadthFirstLayout
 } from '@patternfly/react-topology';
-import { GraphLayout } from '../Graph';
 import { ExtendedDagreLayout } from './ExtendedDagreLayout';
+import { GraphLayout } from 'types/Graph';
 
 /*
 This is just for reference, a copy of PFT defaults, so we can compare any tweaks we've made below...

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -56,13 +56,12 @@ const DEFAULT_NODE_SIZE = 100;
 const NAMESPACE_NODE_SIZE = 70;
 const ZOOM_IN = 4 / 3;
 const ZOOM_OUT = 3 / 4;
-
-export const FIT_PADDING = 90;
+const FIT_PADDING = 90;
 
 let initialLayout = false;
 let layoutInProgress: MeshLayoutType | undefined;
 
-export function layoutMesh(controller: Controller, layoutType: MeshLayoutType, reset: boolean = true): void {
+export function layoutMesh(controller: Controller, layoutType: MeshLayoutType, reset = true): void {
   if (!controller?.hasGraph()) {
     console.debug('Skip meshLayout, no graph');
     return;

--- a/frontend/src/reducers/GraphDataState.ts
+++ b/frontend/src/reducers/GraphDataState.ts
@@ -2,10 +2,9 @@ import { getType } from 'typesafe-actions';
 import { GraphActions } from '../actions/GraphActions';
 import { KialiAppAction } from '../actions/KialiAppAction';
 import { GraphState } from '../store/Store';
-import { EdgeMode, GraphType, TrafficRate } from '../types/Graph';
+import { EdgeMode, GraphLayout, GraphType, TrafficRate } from '../types/Graph';
 import { GraphToolbarActions } from '../actions/GraphToolbarActions';
 import { updateState } from '../utils/Reducer';
-import { GraphLayout } from 'pages/Graph/Graph';
 
 export const INITIAL_GRAPH_STATE: GraphState = {
   edgeMode: EdgeMode.ALL,

--- a/frontend/src/reducers/__tests__/GraphDataState.test.ts
+++ b/frontend/src/reducers/__tests__/GraphDataState.test.ts
@@ -1,10 +1,9 @@
 import { GraphDataStateReducer } from '../GraphDataState';
 import { GraphActions } from '../../actions/GraphActions';
 import { GlobalActions } from '../../actions/GlobalActions';
-import { DefaultTrafficRates, EdgeMode, GraphType } from '../../types/Graph';
+import { DefaultTrafficRates, EdgeMode, GraphLayout, GraphType } from '../../types/Graph';
 import { GraphState } from 'store/Store';
 import { GraphElement } from '@patternfly/react-topology';
-import { GraphLayout } from 'pages/Graph/Graph';
 
 describe('GraphDataState', () => {
   it('should return the initial state', () => {

--- a/frontend/src/store/Store.ts
+++ b/frontend/src/store/Store.ts
@@ -12,6 +12,7 @@ import {
   EdgeLabelMode,
   EdgeMode,
   GraphDefinition,
+  GraphLayout,
   GraphType,
   NodeParamsType,
   RankMode,
@@ -27,7 +28,6 @@ import { TracingState } from 'reducers/TracingState';
 import { MetricsStatsState } from 'reducers/MetricsStatsState';
 import { CertsInfo } from 'types/CertsInfo';
 import { MeshCluster, MeshDefinition, MeshTarget } from '../types/Mesh';
-import { GraphLayout } from 'pages/Graph/Graph';
 import { MeshLayout } from 'pages/Mesh/layouts/layoutFactory';
 
 // Store is the Redux Data store

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -196,6 +196,20 @@ export const toTcpRate = (rate: string): TrafficRate | undefined => {
   }
 };
 
+export enum LayoutType {
+  Layout = 'layout',
+  LayoutNoFit = 'layoutNoFit',
+  Resize = 'resize'
+}
+
+// the layouts offered by the traffic graph page
+export enum GraphLayout {
+  BreadthFirst = 'breadthfirst',
+  Concentric = 'concentric',
+  Dagre = 'dagre',
+  Grid = 'grid'
+}
+
 export enum GraphType {
   APP = 'app',
   SERVICE = 'service',
@@ -232,6 +246,11 @@ export interface NodeParamsType {
   service: string;
   version?: string;
   workload: string;
+}
+
+export interface FocusNode {
+  id: string;
+  isSelected?: boolean;
 }
 
 export interface GraphEvent {

--- a/frontend/src/utils/GraphUtils.ts
+++ b/frontend/src/utils/GraphUtils.ts
@@ -1,6 +1,19 @@
-import { GraphLayout } from 'pages/Graph/Graph';
+import { GraphLayout } from 'types/Graph';
 
 // check if the graph layout supports grouping
 export const supportsGroups = (layoutName: GraphLayout): boolean => {
   return layoutName === GraphLayout.Dagre;
 };
+
+export function getValidGraphLayout(layout: string): GraphLayout {
+  switch (layout) {
+    case GraphLayout.BreadthFirst:
+      return GraphLayout.BreadthFirst;
+    case GraphLayout.Concentric:
+      return GraphLayout.Concentric;
+    case GraphLayout.Grid:
+      return GraphLayout.Grid;
+    default:
+      return GraphLayout.Dagre;
+  }
+}


### PR DESCRIPTION
### Describe the change

There is a circular import issue involving GraphPage and Graph that prevents the graph state from loading correctly. GraphPage depends on State, but State depends on Graph, and Graph depends on GraphPage. This is resolved by moving the types defined in Graph to a separate file (`types/Graph.ts`), eliminating the dependency of State on Graph.

### Steps to test the PR

This fix only affects OSSMC. You can execute the command `./hack/copy-frontend-src-to-ossmc -pr` in OSSMC to load this PR code.

### Automation testing

N/A

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/432
