### PR TITLE
Fix primary-remote CI failure

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -68,6 +68,10 @@ func (iss *IstioStatusService) GetStatus(ctx context.Context) (kubernetes.IstioC
 	// for local cluster only get addons
 	result.Merge(iss.getAddonComponentStatus(iss.conf.KubernetesConfig.ClusterName))
 
+	for _, s := range result {
+		log.Infof("**** ISTIO STATUS cluster=[%s] status=[%s]", s.Cluster, s.Status)
+	}
+
 	return result, nil
 }
 

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -56,11 +56,16 @@ func (iss *IstioStatusService) GetStatus(ctx context.Context) (kubernetes.IstioC
 	}
 	result := kubernetes.IstioComponentStatus{}
 
+	log.Infof("**** ISTIO STATUS for [%d] user clients", len(iss.userClients))
 	for cluster := range iss.userClients {
 		ics, err := iss.getIstioComponentStatus(ctx, cluster)
 		if err != nil {
+			log.Infof("**** ISTIO STATUS error for cluster=[%s]: %s", cluster, err)
 			// istiod should be running
 			return nil, err
+		}
+		for _, ic := range ics {
+			log.Infof("**** ISTIO STATUS merge status for cluster=[%s] ics=[%s:%s]", cluster, ic.Cluster, ic.Status)
 		}
 		result.Merge(ics)
 	}

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/util/sliceutil"
 )
 
 func setupWorkloadService(k8s kubernetes.ClientInterface, conf *config.Config) WorkloadService {
@@ -1889,11 +1890,14 @@ func TestGetAllGateways(t *testing.T) {
 	SetupBusinessLayer(t, k8s, *conf)
 	svc := setupWorkloadService(k8s, conf)
 
-	workloads, err := svc.GetAllGateways(context.Background(), conf.KubernetesConfig.ClusterName, "")
+	gateways, err := svc.GetGateways(context.Background())
 	require.NoError(err)
+	gateways = sliceutil.Filter(gateways, func(gw *models.Workload) bool {
+		return gw.Cluster == conf.KubernetesConfig.ClusterName
+	})
 
-	require.Len(workloads, 1)
-	require.True(workloads[0].IsGateway(), "Expected IsGateway to be True but it was false")
+	require.Len(gateways, 1)
+	require.True(gateways[0].IsGateway(), "Expected IsGateway to be True but it was false")
 }
 
 func TestGetWorkloadListWithCustomKindThatMatchesCoreKind(t *testing.T) {


### PR DESCRIPTION
Fix gateway caching. It was caching only gateways of a single cluster.  This was causing a MC test failure because istio status for "west" was coming back as "east", because the gateways were from "east".

Fixes https://github.com/kiali/kiali/issues/8306
