### PR TITLE
Added default cluster name in addon status

### DIFF
--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -153,7 +153,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 			cluster, namespace, isExternal := discoverInfraService(es.Prometheus.URL, ctx, gi)
 			var node *mesh.Node
 			name := "Prometheus"
-			node, _, err = addInfra(meshMap, mesh.InfraTypeMetricStore, cluster, namespace, name, es.Prometheus, esVersions[name], isExternal, healthData["prometheus"])
+			node, _, err = addInfra(meshMap, mesh.InfraTypeMetricStore, cluster, namespace, name, es.Prometheus, esVersions[name], isExternal, healthData[fmt.Sprintf("%s%s", "prometheus", gi.Conf.KubernetesConfig.ClusterName)])
 			mesh.CheckError(err)
 
 			kiali.AddEdge(node)
@@ -162,7 +162,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 			if conf.ExternalServices.Tracing.Enabled {
 				cluster, namespace, isExternal = discoverInfraService(es.Tracing.InternalURL, ctx, gi)
 				name = string(es.Tracing.Provider)
-				node, _, err = addInfra(meshMap, mesh.InfraTypeTraceStore, cluster, namespace, name, es.Tracing, esVersions[name], isExternal, healthData["tracing"])
+				node, _, err = addInfra(meshMap, mesh.InfraTypeTraceStore, cluster, namespace, name, es.Tracing, esVersions[name], isExternal, healthData[fmt.Sprintf("%s%s", "tracing", gi.Conf.KubernetesConfig.ClusterName)])
 				mesh.CheckError(err)
 
 				kiali.AddEdge(node)
@@ -172,7 +172,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 			if conf.ExternalServices.Grafana.Enabled {
 				cluster, namespace, isExternal = discoverInfraService(es.Grafana.InternalURL, ctx, gi)
 				name = "Grafana"
-				node, _, err = addInfra(meshMap, mesh.InfraTypeGrafana, cluster, namespace, name, es.Grafana, esVersions[name], isExternal, healthData["grafana"])
+				node, _, err = addInfra(meshMap, mesh.InfraTypeGrafana, cluster, namespace, name, es.Grafana, esVersions[name], isExternal, healthData[fmt.Sprintf("%s%s", "grafana", gi.Conf.KubernetesConfig.ClusterName)])
 				mesh.CheckError(err)
 
 				kiali.AddEdge(node)


### PR DESCRIPTION
### Describe the change

There was missing cluster name in getting addons component status for Mesh page.
Causing wrong status in Mesh page for Obsevability components.
![428040308-9145461c-3bba-4e90-8043-bd4a414e83e1](https://github.com/user-attachments/assets/86fd99d4-a1dc-4b22-9203-9ec339591e65)

### Steps to test the PR

Set 0 replicas on adsons Grafana and Jaeger.
The Warning should be in masthead.
Those 2 Observability components should be displayed Unreachable.
![Screenshot from 2025-04-04 14-03-51](https://github.com/user-attachments/assets/e83b486e-079e-4a34-b5d4-40e17af84bd1)


### Automation testing
n/a

### Issue reference
https://github.com/kiali/kiali/issues/8279
