### PR TITLE
Added cypress test for Mesh page unavailable component

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -250,3 +250,13 @@ Then('user sees tracing node side panel', () => {
       cy.contains(new RegExp('jaeger|Jaeger|tempo|Tempo', 'g'));
     });
 });
+
+Then('user sees {string} icon side panel', (iconType: string) => {
+  cy.waitForReact();
+  cy.get('#target-panel-node').get(`[data-test="icon-${iconType}-validation"]`).should('be.visible');
+});
+
+Then('user does not see {string} icon side panel', (iconType: string) => {
+  cy.waitForReact();
+  cy.get('#target-panel-node').get(`[data-test="icon-${iconType}-validation"]`).should('not.exist');
+});

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -97,3 +97,19 @@ Feature: Kiali Mesh page
     And user sees 1 "dataplane" nodes on the "west" cluster
     And user sees 1 "istiod" nodes on the "east" cluster
     And user sees 1 "istiod" nodes on the "west" cluster
+
+  @component-health-upscale
+  Scenario: Grafana Infra unreachable
+    When user scales to "0" the "grafana" in namespace "istio-system"
+    Then the user refreshes the page
+    When user selects mesh node with label "Grafana"
+    Then user sees "Grafana" node side panel
+    Then user sees "Version: unknown" node side panel
+    Then user sees "error" icon side panel
+    When user scales to "1" the "grafana" in namespace "istio-system"
+    Then the user refreshes the page
+    When user selects mesh node with label "Grafana"
+    Then user sees "Grafana" node side panel
+    Then user sees "correct" icon side panel
+    Then user does not see "error" icon side panel
+    Then user does not see "warning" icon side panel


### PR DESCRIPTION
Added cypress test for downscaled to 0 Grafana component status in Mesh page sidepanel.

### Issue reference
https://github.com/kiali/kiali/issues/8308
