### PR TITLE
[hack] bump to CRC 2.49 / OS 4.18 and fix status command

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -243,9 +243,9 @@ print_all_service_endpoints() {
 
 exec_ssh() {
   local sshcmd=${1}
-  # when network-mode is "user", the port is 2222.
+  # when network-mode is explicitly set to "user" or it is the default, the port is 2222.
   local port=22
-  if ${CRC_COMMAND} config get network-mode | grep -q ' user$'; then
+  if ${CRC_COMMAND} config get network-mode | grep -Eq " user$|'user'"; then
     port=2222
   fi
   ssh -y -p ${port} -i ${CRC_ROOT_DIR}/machines/crc/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@$(${CRC_COMMAND} ip) ${sshcmd}
@@ -509,10 +509,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="2.45.0"
+DEFAULT_CRC_DOWNLOAD_VERSION="2.49.0"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
-DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.17.7"
+DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.18.2"
 
 # The default virtual CPUs assigned to the CRC VM
 DEFAULT_CRC_CPUS="6"


### PR DESCRIPTION
The network-mode is now "user" by default, check for that and use ssh port 2222 if so

### To Test

1. Clean up your old CRC install: `hack/crc-openshift.sh cleanup`
2. Move your old crc binary to make room for the new one: `mv "$(which crc)" "$(dirname "$(which crc)")/crc.old"`
3. Run the new CRC hack script, making sure to pass in your pull secret file: `hack/crc-openshift.sh start -p <your pull secret file> start`

It should install file, you should now be running OpenShift 4.18, and the status output should be complete. Run `hack/crc-openshift.sh status` again to see that you do not get any prompts - you should see all the status information for your cluster.