### PR TITLE
Skip KIA0301 when both hosts are wildcard but not equal

### DIFF
--- a/business/checkers/gateways/multi_match_checker.go
+++ b/business/checkers/gateways/multi_match_checker.go
@@ -177,6 +177,14 @@ func (m MultiMatchChecker) findMatch(host Host, otherHosts []Host) (bool, []Host
 			continue
 		}
 
+		isHostWildcard := strings.HasPrefix(hostName, "*.")
+		isOtherWildcard := strings.HasPrefix(otherName, "*.")
+
+		// skip comparing wildcard to wildcard, for instance "*.host.com" does not match "*.subdomain.host.com"
+		if isHostWildcard && isOtherWildcard {
+			continue
+		}
+
 		// lazily compile hostname Regex
 		hostRegexp, ok := m.regexpMap[hostName]
 		if !ok {


### PR DESCRIPTION
### Describe the change

In Gateway config validation there is a Warning "KIA0301 More than one Gateway for the same host port combination".
Skip this warning when two hosts have wildcards in their FQDN, like "*.host.com" and "*.subdomain.host.com"

### Steps to test the PR

Create a Gateway with hosts:
"*.host.com" and "*.subdomain.host.com"
Make sure that the validation warning is not shown for them:
![Screenshot from 2025-04-09 19-54-30](https://github.com/user-attachments/assets/04f4e403-6c90-4a25-84e1-7675d47f7330)
Modify the hosts **both** to be:
"*.host.com"
Verify that the validation KIA0301 is shown:
![Screenshot from 2025-04-09 19-54-17](https://github.com/user-attachments/assets/b49b0a24-89a5-47a9-a070-db4b88ddd798)


### Automation testing

Added more automations.

### Issue reference

https://github.com/kiali/kiali/issues/8174
