### PR TITLE
Fix molecule testing to catch errors in the molecule tests

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -103,14 +103,10 @@ jobs:
         echo "Testing with Istio version [${ISTIO_VERSION}] using helm install"
         echo "================================================================"
         echo
-        if ! ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer helm --olm-enabled false; then
-          exit $?
-        fi
+        ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster true -ci true --operator-installer helm --olm-enabled false
         echo
         echo "================================================================"
         echo "Testing with Istio version [${ISTIO_VERSION}] using OLM install"
         echo "================================================================"
         echo
-        if ! ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster false -ci true --operator-installer skip --olm-enabled true --olm-version "${{ inputs.olm_version }}"; then
-          exit $?
-        fi
+        ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster false -ci true --operator-installer skip --olm-enabled true --olm-version "${{ inputs.olm_version }}"


### PR DESCRIPTION
GH actions wan't honoring the exit value of the script ci-kind-molecule-tests.sh, so I simplified the script and now it's working:

Example with no failure:

https://github.com/leandroberetta/kiali/actions/runs/14405688709 (run from my master branch)

Example with failure:

https://github.com/leandroberetta/kiali/actions/runs/14405487031 (run from my molecule-failure branch where I mock the error)

