### PR TITLE
Minor perf enhancement to improve key generation

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -254,7 +254,7 @@ func (in *validationInfo) changeDetectionEnabled() bool {
 }
 
 func (in *validationInfo) update(kind, cluster, namespace, name, value string) bool {
-	key := fmt.Sprintf("%s:%s:%s:%s", kind, cluster, namespace, name)
+	key := strings.Join([]string{kind, cluster, namespace, name}, ":")
 	return in.changeMap.update(key, value, in.reportChange)
 }
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1454,7 +1454,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 
 			// Add some precalculated fields useful for validation
-			w.ValidationKey = fmt.Sprintf("%s:%s:%s", w.Cluster, w.Namespace, w.Name)
+			w.ValidationKey = strings.Join([]string{w.Cluster, w.Namespace, w.Name}, ":")
 
 			w.ServiceAccountNames = w.Pods.ServiceAccounts()
 			slices.Sort(w.ServiceAccountNames)

--- a/graph/options.go
+++ b/graph/options.go
@@ -100,7 +100,7 @@ type ClusterSensitiveKey = string
 
 // GetClusterSensitiveKey returns a valid key for maps using a ClusterSensitiveKey
 func GetClusterSensitiveKey(cluster, name string) ClusterSensitiveKey {
-	return fmt.Sprintf("%s:%s", cluster, name)
+	return cluster + ":" + name
 }
 
 type AccessibleNamespace struct {

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
@@ -341,7 +342,7 @@ func getServiceDefinition(cluster, namespace, serviceName string, gi *graph.Glob
 // getServiceEntryHosts returns ServiceEntryHost information cached for a specific cluster and namespace. If not
 // previously cached a new, empty cache entry is created and returned.
 func getServiceEntryHosts(cluster, namespace string, gi *graph.GlobalInfo) (serviceEntryHosts, bool) {
-	key := fmt.Sprintf("%s:%s:%s", serviceEntryHostsKey, cluster, namespace)
+	key := strings.Join([]string{serviceEntryHostsKey, cluster, namespace}, ":")
 	if seHosts, ok := gi.Vendor[key]; ok {
 		return seHosts.(serviceEntryHosts), true
 	}

--- a/graph/telemetry/istio/appender/extensions.go
+++ b/graph/telemetry/istio/appender/extensions.go
@@ -241,7 +241,7 @@ func (a ExtensionsAppender) addTraffic(ext config.ExtensionConfig, trafficMap gr
 	// processing the same information twice we keep track of the time series applied to a particular edge. The
 	// edgeTSHash incorporates information about the time series' source, destination and metric information,
 	// and uses that unique TS has to protect against applying the same information twice.
-	edgeTSHash := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s", metric, source.Metadata[tsHash], dest.Metadata[tsHash], code, flags, destName))))
+	edgeTSHash := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{metric, source.Metadata[tsHash].(string), dest.Metadata[tsHash].(string), code, flags, destName}, ":"))))
 
 	a.addEdgeTraffic(val, protocol, code, flags, secure, destName, source, dest, edgeTSHash)
 }
@@ -355,5 +355,5 @@ func (a ExtensionsAppender) addEdgeTraffic(val float64, protocol, code, flags, s
 }
 
 func timeSeriesHash(cluster, serviceNs, service, workloadNs, workload, app, version string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", cluster, serviceNs, service, workloadNs, workload, app, version))))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{cluster, serviceNs, service, workloadNs, workload, app, version}, ":"))))
 }

--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -463,7 +463,7 @@ func addTraffic(trafficMap graph.TrafficMap, metric string, inject bool, val flo
 	// processing the same information twice we keep track of the time series applied to a particular edge. The
 	// edgeTSHash incorporates information about the time series' source, destination and metric information,
 	// and uses that unique TS has to protect against applying the same intomation twice.
-	edgeTSHash := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s", metric, source.Metadata[tsHash], dest.Metadata[tsHash], code, flags, host))))
+	edgeTSHash := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{metric, source.Metadata[tsHash].(string), dest.Metadata[tsHash].(string), code, flags, host}, ":"))))
 
 	if inject {
 		injectedService, _, err := addNode(trafficMap, destCluster, destSvcNs, destSvcName, "", "", "", "", o)
@@ -543,7 +543,7 @@ func addNode(trafficMap graph.TrafficMap, cluster, serviceNs, service, workloadN
 }
 
 func timeSeriesHash(cluster, serviceNs, service, workloadNs, workload, app, version string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", cluster, serviceNs, service, workloadNs, workload, app, version))))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{cluster, serviceNs, service, workloadNs, workload, app, version}, ":"))))
 }
 
 // BuildNodeTrafficMap is required by the graph/TelemtryVendor interface

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -436,5 +436,5 @@ func discoverInfraService(url string, ctx context.Context, gi *mesh.GlobalInfo) 
 }
 
 func timeSeriesHash(cluster, namespace, name string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s", cluster, namespace, name))))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{cluster, namespace, name}, ":"))))
 }

--- a/mesh/options.go
+++ b/mesh/options.go
@@ -52,7 +52,7 @@ type ClusterSensitiveKey = string
 
 // GetClusterSensitiveKey returns a valid key for maps using a ClusterSensitiveKey
 func GetClusterSensitiveKey(cluster, name string) ClusterSensitiveKey {
-	return fmt.Sprintf("%s:%s", cluster, name)
+	return cluster + ":" + name
 }
 
 type AccessibleNamespace struct {

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	pmod "github.com/prometheus/common/model"
@@ -108,11 +109,11 @@ func (q *MetricsStatsQuery) GenKey() string {
 	if q.PeerTarget != nil {
 		peer = q.PeerTarget.GenKey()
 	}
-	return fmt.Sprintf("%s:%s:%s:%s", q.Target.GenKey(), peer, q.Direction, q.RawInterval)
+	return strings.Join([]string{q.Target.GenKey(), peer, q.Direction, q.RawInterval}, ":")
 }
 
 func (t *Target) GenKey() string {
-	return fmt.Sprintf("%s:%s:%s", t.Namespace, t.Kind, t.Name)
+	return strings.Join([]string{t.Namespace, t.Kind, t.Name}, ":")
 }
 
 // ControlPlaneMetricsQuery holds query parameters for a control plane metrics query

--- a/tracing/client.go
+++ b/tracing/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -133,7 +134,7 @@ func newClient(ctx context.Context, conf *config.Config, token string) (*Client,
 		log.Errorf("Error while building GRPC dial options: %v", err)
 		return nil, err
 	}
-	address := fmt.Sprintf("%s:%s", u.Hostname(), port)
+	address := u.Hostname() + ":" + port
 	log.Tracef("%s GRPC client info: address=%s, auth.type=%s", cfgTracing.Provider, address, auth.Type)
 
 	if len(cfgTracing.CustomHeaders) > 0 {
@@ -193,7 +194,7 @@ func newClient(ctx context.Context, conf *config.Config, token string) (*Client,
 				if cfgTracing.Auth.Type == "basic" {
 					dialOps = append(dialOps, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 					dialOps = append(dialOps, grpc.WithPerRPCCredentials(&basicAuth{
-						Header: fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", cfgTracing.Auth.Username, cfgTracing.Auth.Password)))),
+						Header: fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(strings.Join([]string{cfgTracing.Auth.Username, cfgTracing.Auth.Password}, ":")))),
 					}))
 				} else {
 					dialOps = append(dialOps, grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
Minor perf enhancement to generate keys by concatenating string.Join or +, as opposed to fmt.Sprintf. These alternatives are faster and use less memory.

This is related to, and will close #8007 subtask, `pre-compute validation keys for istio config objects`. The pre-compute wasn't really viable, it was doable but not worth the complexity, as we would need to create type wrappers to hold the pre-compute value, for likely nominal gain.

There isn't much testing here, probably a visual sanity check and green CI.