### PR TITLE
Use Sail Operator in primary-remote setup

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -272,8 +272,8 @@ Then(
       cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`5 app`);
       cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else if (ns === 'istio-system') {
-      cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`8 app`);
-      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`3 app`);
+      cy.get(`[data-test="CardItem_${ns}_${cluster1}"]`).find('[data-test="overview-type-app"]').contains(`7 app`);
+      cy.get(`[data-test="CardItem_${ns}_${cluster2}"]`).find('[data-test="overview-type-app"]').contains(`4 app`);
     } else {
       cy.exec(
         `kubectl get pods -n ${ns} -l app --context ${CLUSTER1_CONTEXT} --no-headers | grep Running | wc -l`

--- a/hack/istio/istio-gateway.yaml
+++ b/hack/istio/istio-gateway.yaml
@@ -28,6 +28,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingressgateway
+  labels:
+    app: istio-ingressgateway
 spec:
   selector:
     matchLabels:
@@ -37,6 +39,7 @@ spec:
       annotations:
         inject.istio.io/templates: gateway
       labels:
+        app: istio-ingressgateway
         istio: ingressgateway
         sidecar.istio.io/inject: "true"
     spec:
@@ -49,6 +52,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway
+  labels:
+    app: istio-ingressgateway
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
### Describe the change

Updates the primary-remote pipeline to use sail instead of istioctl.

### Steps to test the PR

`hack/run-integration-tests.sh --test-suite frontend-primary-remote`

### Automation testing

CI should pass.

### Issue reference

Fixes #8097 