### PR TITLE
Use Sail in external controlplane pipeline

### DIFF
--- a/hack/istio/multicluster/setup-external-controlplane.sh
+++ b/hack/istio/multicluster/setup-external-controlplane.sh
@@ -18,6 +18,8 @@ else
   exit 1
 fi
 
+ISTIO_INSTALL_SCRIPT="${SCRIPT_DIR}/../install-istio-via-sail.sh"
+
 install_bookinfo() {
   local profile="${1}"
   local traffic_gen_enabled="${2}"
@@ -47,68 +49,62 @@ if ! kind get clusters -q | grep -q "${REMOTE_CLUSTER_NAME}" ; then
     ./hack/start-kind.sh --load-balancer-range 255.85-255.98 -n "${REMOTE_CLUSTER_NAME}" -eir false --image "${KIND_NODE_IMAGE}"
 fi
 
-# Following: https://istio.io/latest/docs/setup/install/external-controlplane/
+# Following: https://github.com/istio-ecosystem/sail-operator/tree/main/docs#external-control-plane
 # Create the Istio install configuration for the ingress gateway that will expose the external control plane ports to other clusters:
 
-MANIFEST_DIR=$(mktemp -d)
-
-"${ISTIOCTL}" install -f - -y --context="${CTX_EXTERNAL_CLUSTER}" <<EOF
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-metadata:
-  namespace: istio-system
+EXTERNAL_ISTIO_YAML=$(mktemp)
+cat <<EOF > "$EXTERNAL_ISTIO_YAML"
 spec:
-  components:
-    ingressGateways:
-      - name: istio-ingressgateway
-        enabled: true
-        k8s:
-          service:
-            ports:
-              - port: 15021
-                targetPort: 15021
-                name: status-port
-              - port: 15012
-                targetPort: 15012
-                name: tls-xds
-              - port: 15017
-                targetPort: 15017
-                name: tls-webhook
+  values:
+    global:
+      network: network1
+      multiCluster:
+        clusterName: Kubernetes
+EOF
+
+switch_cluster "${CTX_EXTERNAL_CLUSTER}"
+${ISTIO_INSTALL_SCRIPT} --patch-file "${EXTERNAL_ISTIO_YAML}" -a "prometheus"
+kubectl wait --context "${CTX_EXTERNAL_CLUSTER}" --for=condition=Ready istios/default --timeout=3m
+
+helm upgrade --install --kube-context "${CTX_EXTERNAL_CLUSTER}" --wait -n istio-system istio-ingressgateway gateway --repo https://istio-release.storage.googleapis.com/charts -f - <<EOF
+service:
+  ports:
+    - port: 15021
+      targetPort: 15021
+      name: status-port
+    - port: 15012
+      targetPort: 15012
+      name: tls-xds
+    - port: 15017
+      targetPort: 15017
+      name: tls-webhook
 EOF
 
 kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' -n istio-system service/istio-ingressgateway --context="${CTX_EXTERNAL_CLUSTER}"
 
 export EXTERNAL_ISTIOD_ADDR=$(kubectl -n istio-system --context="${CTX_EXTERNAL_CLUSTER}" get svc istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-export SSL_SECRET_NAME=NONE
 
-cat <<EOF > ${MANIFEST_DIR}/remote-config-cluster.yaml
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
+REMOTE_ISTIO_YAML=$(mktemp)
+cat <<EOF > "$REMOTE_ISTIO_YAML"
 metadata:
-  namespace: external-istiod
+  name: external-istiod
 spec:
+  namespace: external-istiod
   profile: remote
   values:
+    defaultRevision: external-istiod
     global:
       istioNamespace: external-istiod
+      remotePilotAddress: ${EXTERNAL_ISTIOD_ADDR}
       configCluster: true
     pilot:
       configMap: true
     istiodRemote:
-      injectionURL: https://${EXTERNAL_ISTIOD_ADDR}:15017/inject/cluster/${REMOTE_CLUSTER_NAME}/net/network1
-    base:
-      validationURL: https://${EXTERNAL_ISTIOD_ADDR}:15017/validate
+      injectionPath: /inject/cluster/${REMOTE_CLUSTER_NAME}/net/network1
 EOF
 
-sed  -i'.bk' \
-  -e "s|injectionURL: https://${EXTERNAL_ISTIOD_ADDR}:15017|injectionPath: |" \
-  -e "/istioNamespace:/a\\
-      remotePilotAddress: ${EXTERNAL_ISTIOD_ADDR}" \
-  -e '/base:/,+1d' \
-  ${MANIFEST_DIR}/remote-config-cluster.yaml; rm ${MANIFEST_DIR}/remote-config-cluster.yaml.bk
-
-kubectl get ns external-istiod --context="${CTX_REMOTE_CLUSTER}" || kubectl create namespace external-istiod --context="${CTX_REMOTE_CLUSTER}"
-"${ISTIOCTL}" manifest generate -f ${MANIFEST_DIR}/remote-config-cluster.yaml --set values.defaultRevision=default | kubectl apply --context="${CTX_REMOTE_CLUSTER}" -f -
+switch_cluster "${CTX_REMOTE_CLUSTER}"
+${ISTIO_INSTALL_SCRIPT} --patch-file "${REMOTE_ISTIO_YAML}" -a "prometheus" --wait false
 
 # Set up the control plane in the external cluster: https://istio.io/latest/docs/setup/install/external-controlplane/#set-up-the-control-plane-in-the-external-cluster
 
@@ -116,70 +112,50 @@ kubectl get ns external-istiod --context="${CTX_EXTERNAL_CLUSTER}" || kubectl cr
 
 KIND_IP=$(docker inspect ${REMOTE_CLUSTER_NAME}-control-plane --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
 REMOTE_KUBE_API_SERVER_URL="https://${KIND_IP}:6443"
-kubectl get sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}" || kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
+[ "$(kubectl get istios external-istiod -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ] || kubectl --context="${CTX_REMOTE_CLUSTER}" wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}="readiness probe on remote istiod failed"' istios/external-istiod --timeout=1m
 "${ISTIOCTL}" create-remote-secret \
   --context="${CTX_REMOTE_CLUSTER}" \
   --type=config \
   --namespace=external-istiod \
-  --service-account=istiod \
+  --service-account=istiod-external-istiod \
   --server="${REMOTE_KUBE_API_SERVER_URL}" \
   --create-service-account=false | \
   kubectl apply -f - --context="${CTX_EXTERNAL_CLUSTER}"
 
-cat <<EOF > ${MANIFEST_DIR}/external-istiod.yaml
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
+kubectl apply --context "${CTX_EXTERNAL_CLUSTER}" -f - <<EOF
+apiVersion: sailoperator.io/v1
+kind: Istio
 metadata:
-  namespace: external-istiod
+  name: external-istiod
 spec:
+  namespace: external-istiod
   profile: empty
-  meshConfig:
-    rootNamespace: external-istiod
-    defaultConfig:
-      discoveryAddress: $EXTERNAL_ISTIOD_ADDR:15012
-      proxyMetadata:
-        XDS_ROOT_CA: /etc/ssl/certs/ca-certificates.crt
-        CA_ROOT_CA: /etc/ssl/certs/ca-certificates.crt
-  components:
+  values:
+    meshConfig:
+      rootNamespace: external-istiod
+      defaultConfig:
+        discoveryAddress: $EXTERNAL_ISTIOD_ADDR:15012
     pilot:
       enabled: true
-      k8s:
-        overlays:
-        - kind: Deployment
-          name: istiod
-          patches:
-          - path: spec.template.spec.volumes[100]
-            value: |-
-              name: config-volume
-              configMap:
-                name: istio
-          - path: spec.template.spec.volumes[100]
-            value: |-
-              name: inject-volume
-              configMap:
-                name: istio-sidecar-injector
-          - path: spec.template.spec.containers[0].volumeMounts[100]
-            value: |-
-              name: config-volume
-              mountPath: /etc/istio/config
-          - path: spec.template.spec.containers[0].volumeMounts[100]
-            value: |-
-              name: inject-volume
-              mountPath: /var/lib/istio/inject
-        env:
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: ""
-        - name: VALIDATION_WEBHOOK_CONFIG_NAME
-          value: ""
-        - name: EXTERNAL_ISTIOD
-          value: "true"
-        - name: LOCAL_CLUSTER_SECRET_WATCHER
-          value: "true"
-        - name: CLUSTER_ID
-          value: ${REMOTE_CLUSTER_NAME}
-        - name: SHARED_MESH_CONFIG
-          value: istio
-  values:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: istio-external-istiod
+        - name: inject-volume
+          configMap:
+            name: istio-sidecar-injector-external-istiod
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/istio/config
+        - name: inject-volume
+          mountPath: /var/lib/istio/inject
+      env:
+        INJECTION_WEBHOOK_CONFIG_NAME: "istio-sidecar-injector-external-istiod-external-istiod"
+        VALIDATION_WEBHOOK_CONFIG_NAME: "istio-validator-external-istiod-external-istiod"
+        EXTERNAL_ISTIOD: "true"
+        LOCAL_CLUSTER_SECRET_WATCHER: "true"
+        CLUSTER_ID: ${REMOTE_CLUSTER_NAME}
+        SHARED_MESH_CONFIG: istio
     global:
       caAddress: $EXTERNAL_ISTIOD_ADDR:15012
       istioNamespace: external-istiod
@@ -191,17 +167,7 @@ spec:
       network: network1
 EOF
 
-sed  -i'.bk' \
-  -e '/proxyMetadata:/,+2d' \
-  -e '/INJECTION_WEBHOOK_CONFIG_NAME/{n;s/value: ""/value: istio-sidecar-injector-external-istiod/;}' \
-  -e '/VALIDATION_WEBHOOK_CONFIG_NAME/{n;s/value: ""/value: istio-validator-external-istiod/;}' \
-  ${MANIFEST_DIR}/external-istiod.yaml ; rm ${MANIFEST_DIR}/external-istiod.yaml.bk
-
-"${ISTIOCTL}" install -y -f ${MANIFEST_DIR}/external-istiod.yaml --context="${CTX_EXTERNAL_CLUSTER}"
-
-INGRESS_IP=$(kubectl get service istio-ingressgateway --context="${CTX_EXTERNAL_CLUSTER}" -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-cat <<EOF > ${MANIFEST_DIR}/external-istiod-gw.yaml
+kubectl apply --context "${CTX_EXTERNAL_CLUSTER}" -f - <<EOF
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
@@ -213,84 +179,53 @@ spec:
   servers:
     - port:
         number: 15012
-        protocol: https
-        name: https-XDS
+        protocol: tls
+        name: tls-XDS
       tls:
-        mode: SIMPLE
-        credentialName: $SSL_SECRET_NAME
+        mode: PASSTHROUGH
       hosts:
-      - $EXTERNAL_ISTIOD_ADDR
+      - "*"
     - port:
         number: 15017
-        protocol: https
-        name: https-WEBHOOK
+        protocol: tls
+        name: tls-WEBHOOK
       tls:
-        mode: SIMPLE
-        credentialName: $SSL_SECRET_NAME
+        mode: PASSTHROUGH
       hosts:
-      - $EXTERNAL_ISTIOD_ADDR
+      - "*"
 ---
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
-   name: external-istiod-vs
-   namespace: external-istiod
+  name: external-istiod-vs
+  namespace: external-istiod
 spec:
     hosts:
-    - $EXTERNAL_ISTIOD_ADDR
+    - "*"
     gateways:
     - external-istiod-gw
-    http:
+    tls:
     - match:
       - port: 15012
+        sniHosts:
+        - "*"
       route:
       - destination:
-          host: istiod.external-istiod.svc.cluster.local
+          host: istiod-external-istiod.external-istiod.svc.cluster.local
           port:
             number: 15012
     - match:
       - port: 15017
+        sniHosts:
+        - "*"
       route:
       - destination:
-          host: istiod.external-istiod.svc.cluster.local
+          host: istiod-external-istiod.external-istiod.svc.cluster.local
           port:
             number: 443
----
-apiVersion: networking.istio.io/v1
-kind: DestinationRule
-metadata:
-  name: external-istiod-dr
-  namespace: external-istiod
-spec:
-  host: istiod.external-istiod.svc.cluster.local
-  trafficPolicy:
-    portLevelSettings:
-    - port:
-        number: 15012
-      tls:
-        mode: SIMPLE
-      connectionPool:
-        http:
-          h2UpgradePolicy: UPGRADE
-    - port:
-        number: 443
-      tls:
-        mode: SIMPLE
 EOF
 
-sed  -i'.bk' \
-  -e '55,$d' \
-  -e 's/mode: SIMPLE/mode: PASSTHROUGH/' -e '/credentialName:/d' -e "s/${EXTERNAL_ISTIOD_ADDR}/\"*\"/" \
-  -e 's/http:/tls:/' -e 's/https/tls/' -e '/route:/i\
-        sniHosts:\
-        - "*"' \
-  ${MANIFEST_DIR}/external-istiod-gw.yaml; rm ${MANIFEST_DIR}/external-istiod-gw.yaml.bk
-
-kubectl apply -f ${MANIFEST_DIR}/external-istiod-gw.yaml --context="${CTX_EXTERNAL_CLUSTER}"
-
-# Install prometheus on both clusters.
-cat ${ISTIO_DIR}/samples/addons/prometheus.yaml | ${CLIENT_EXE} apply --context "${CTX_EXTERNAL_CLUSTER}" -n "istio-system" -f -
-cat ${ISTIO_DIR}/samples/addons/prometheus.yaml | sed "s/istio-system/external-istiod/g" | ${CLIENT_EXE} apply --context "${CTX_REMOTE_CLUSTER}" -n external-istiod -f -
+kubectl wait --context="${CTX_REMOTE_CLUSTER}" --for=condition=Ready istios/external-istiod --timeout=3m
 
 # There's no istio on the remote cluster so install gateway CRDs. 
 kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" &> /dev/null || \

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -330,7 +330,7 @@ elif [ "${TEST_SUITE}" == "${BACKEND_EXTERNAL_CONTROLPLANE}" ]; then
     # Switch to the dataplane cluster before installing the demo apps because
     # that's where all the workloads should be in the external controlplane deployment.
     kubectl config use-context "${CLUSTER2_CONTEXT}"
-    "${SCRIPT_DIR}/istio/install-bookinfo-demo.sh" -c kubectl -tg -in istio-system -g "${ISTIO_DIR}/samples/bookinfo/gateway-api/bookinfo-gateway.yaml"
+    "${SCRIPT_DIR}/istio/install-bookinfo-demo.sh" -c kubectl -tg -in istio-system --auto-injection-label istio.io/rev=external-istiod
 
     # Switch back to controlplane since that is where kiali is installed.
     kubectl config use-context "${CLUSTER1_CONTEXT}"


### PR DESCRIPTION
### Describe the change

Use Sail Operator to install Istio in external controlplane pipeline.

### Steps to test the PR

`hack/run-integration-tests.sh --test-suite backend-external-controlplane`

### Automation testing

Included

### Issue reference

Fixes #8098 
