### PR TITLE
Use gcr otel collector image

### DIFF
--- a/hack/istio/multicluster/setup-tracing.sh
+++ b/hack/istio/multicluster/setup-tracing.sh
@@ -85,12 +85,12 @@ ISTIO_INGRESS_IP=$(${CLIENT_EXE} --context "${CLUSTER1_CONTEXT}" get service -n 
 
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 # Disable everything except zipkin. We can't rename the service so disable that too and create one ourselves.
-helm --kube-context "${CLUSTER2_CONTEXT}" upgrade --install --namespace istio-system my-opentelemetry-collector open-telemetry/opentelemetry-collector -f - <<EOF
+helm --kube-context "${CLUSTER2_CONTEXT}" upgrade --wait --install --namespace istio-system my-opentelemetry-collector open-telemetry/opentelemetry-collector -f - <<EOF
 mode: deployment
 service:
   enabled: false
 image:
-  repository: "otel/opentelemetry-collector-contrib"
+  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
 config:
   exporters:
     debug: {}
@@ -116,8 +116,6 @@ config:
           - zipkin
       metrics: null
       logs: null
-image:
-  repository: "otel/opentelemetry-collector-contrib"
 ports:
   jaeger-compact:
     enabled: false

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -200,7 +200,7 @@ ensureKialiServerReady() {
 ensureKialiTracesReady() {
   infomsg "Waiting for Kiali to have traces"
   local start_time=$(date +%s)
-  local end_time=$((start_time + 60))
+  local end_time=$((start_time + 120))
   local multicluster=$1
 
   # Get traces from the last 5m
@@ -220,8 +220,9 @@ ensureKialiTracesReady() {
     if [ "$result" == "[]" ]; then
       local now=$(date +%s)
       if [ "${now}" -gt "${end_time}" ]; then
-        echo "Timed out waiting for Kiali to get any trace"
-        break
+        echo "Timed out waiting for Kiali to get any trace. Examine open telemetry collector logs below:"
+        kubectl logs -l app.kubernetes.io/name=opentelemetry-collector --tail=-1 --context kind-west -n istio-system
+        exit 1
       fi
       sleep 10
     else
@@ -230,13 +231,6 @@ ensureKialiTracesReady() {
     fi
 
   done
-
-  # When there are no traces from the remote cluster, check collector pod logs
-  # Uncomment for debugging purposes
-  #POD_NAME=$(kubectl --context kind-west get pods -l app.kubernetes.io/name=opentelemetry-collector -n istio-system -o custom-columns=":metadata.name" | head -n 2)
-  #echo $POD_NAME
-  #kubectl logs $POD_NAME --context kind-west -n istio-system
-
 }
 
 ensureBookinfoGraphReady() {


### PR DESCRIPTION
### Describe the change

Moves off the docker hub image and onto the gcr otel collector image. My guess is that CI was being rate limited which is why the tracing wasn't being exported. Also we weren't waiting for the helm installation of the otel collector to succeed which is probably the source of a number of other flakes. We also weren't failing the tests when the trace check failed.

### Steps to test the PR

CI passes.

### Automation testing

Covered.

### Issue reference

N/A
