### PR TITLE
Pass istio version through to all install scripts

### DIFF
--- a/hack/istio/multicluster/setup-external-controlplane.sh
+++ b/hack/istio/multicluster/setup-external-controlplane.sh
@@ -18,8 +18,6 @@ else
   exit 1
 fi
 
-ISTIO_INSTALL_SCRIPT="${SCRIPT_DIR}/../install-istio-via-sail.sh"
-
 install_bookinfo() {
   local profile="${1}"
   local traffic_gen_enabled="${2}"
@@ -63,7 +61,7 @@ spec:
 EOF
 
 switch_cluster "${CTX_EXTERNAL_CLUSTER}"
-${ISTIO_INSTALL_SCRIPT} --patch-file "${EXTERNAL_ISTIO_YAML}" -a "prometheus"
+install_istio --patch-file "${EXTERNAL_ISTIO_YAML}" -a "prometheus"
 kubectl wait --context "${CTX_EXTERNAL_CLUSTER}" --for=condition=Ready istios/default --timeout=3m
 
 helm upgrade --install --kube-context "${CTX_EXTERNAL_CLUSTER}" --wait -n istio-system istio-ingressgateway gateway --repo https://istio-release.storage.googleapis.com/charts -f - <<EOF
@@ -104,7 +102,7 @@ spec:
 EOF
 
 switch_cluster "${CTX_REMOTE_CLUSTER}"
-${ISTIO_INSTALL_SCRIPT} --patch-file "${REMOTE_ISTIO_YAML}" -a "prometheus" --wait false
+install_istio --patch-file "${REMOTE_ISTIO_YAML}" -a "prometheus" --wait false
 
 # Set up the control plane in the external cluster: https://istio.io/latest/docs/setup/install/external-controlplane/#set-up-the-control-plane-in-the-external-cluster
 


### PR DESCRIPTION
### Describe the change

Passes istio version through to various install scripts.

### Steps to test the PR

Run a test suite with `--istio-version` and ensure that the istio version that gets created is the one passed in.

1. `hack/run-integration-tests.sh --test-suite backend-external-controlplane --setup-only true --istio-version 1.24.3`
2. `kubectl get istios`

### Automation testing

Tests passing. Specifically the istio version test.

### Issue reference

Fixes #8289 