### PR TITLE
Skip validations if  reconcile interval is 0s

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -918,8 +918,7 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 	in.waitForCacheUpdate(ctx, cluster, istioConfigDetail.Object)
 
 	// Re-run validations for that object to refresh the validation cache.
-	c := config.Get()
-	if c.IsValidationsEnabled() {
+	if in.conf.IsValidationsEnabled() {
 		if _, _, err := in.businessLayer.Validations.ValidateIstioObject(ctx, cluster, namespace, resourceType, name); err != nil {
 			// Logging the error and swallowing it since the object was updated successfully.
 			log.Errorf("Error while validating Istio object: %s", err)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -918,9 +918,12 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 	in.waitForCacheUpdate(ctx, cluster, istioConfigDetail.Object)
 
 	// Re-run validations for that object to refresh the validation cache.
-	if _, _, err := in.businessLayer.Validations.ValidateIstioObject(ctx, cluster, namespace, resourceType, name); err != nil {
-		// Logging the error and swallowing it since the object was updated successfully.
-		log.Errorf("Error while validating Istio object: %s", err)
+	c := config.Get()
+	if c.IsValidationsEnabled() {
+		if _, _, err := in.businessLayer.Validations.ValidateIstioObject(ctx, cluster, namespace, resourceType, name); err != nil {
+			// Logging the error and swallowing it since the object was updated successfully.
+			log.Errorf("Error while validating Istio object: %s", err)
+		}
 	}
 
 	return istioConfigDetail, nil

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -917,7 +917,7 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 
 	in.waitForCacheUpdate(ctx, cluster, istioConfigDetail.Object)
 
-	// Re-run validations for that object to refresh the validation cache.
+	// Re-run validations (if enabled) for that object to refresh the validation cache.
 	if in.conf.IsValidationsEnabled() {
 		if _, _, err := in.businessLayer.Validations.ValidateIstioObject(ctx, cluster, namespace, resourceType, name); err != nil {
 			// Logging the error and swallowing it since the object was updated successfully.

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -715,7 +715,7 @@ func TestUpdateIstioObjectWithoutValidations(t *testing.T) {
 	)
 
 	// Disabling validations
-	duration, err := time.ParseDuration("1s")
+	duration, err := time.ParseDuration("0s")
 	if err != nil {
 		println("Error parsing duration:", err.Error())
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -327,7 +327,7 @@ type IstioConfig struct {
 	UrlServiceVersion                string          `yaml:"url_service_version"`
 	ValidationChangeDetectionEnabled bool            `yaml:"validation_change_detection_enabled,omitempty"`
 	// ValidationReconcileInterval sets how often Kiali will validate Istio configuration.
-	// Validations cannot be disabled at the moment but you can set this to a long period of time.
+	// Validations can be disabled setting the interval to 0
 	ValidationReconcileInterval *time.Duration `yaml:"validation_reconcile_interval,omitempty"`
 }
 
@@ -1373,6 +1373,15 @@ func GetSafeClusterName(cluster string) string {
 		return Get().KubernetesConfig.ClusterName
 	}
 	return cluster
+}
+
+// IsValidationsEnabled checks the value of ValidationReconcileInternal
+// Validations are enabled for values higher than 0, otherwise validations will be disabled
+func (conf Config) IsValidationsEnabled() bool {
+	if conf.ExternalServices.Istio.ValidationReconcileInterval != nil && *conf.ExternalServices.Istio.ValidationReconcileInterval > 0 {
+		return true
+	}
+	return false
 }
 
 // Validate will ensure the config is valid. This should be called after the config

--- a/config/config.go
+++ b/config/config.go
@@ -1378,10 +1378,7 @@ func GetSafeClusterName(cluster string) string {
 // IsValidationsEnabled checks the value of ValidationReconcileInternal
 // Validations are enabled for values higher than 0, otherwise validations will be disabled
 func (conf Config) IsValidationsEnabled() bool {
-	if conf.ExternalServices.Istio.ValidationReconcileInterval != nil && *conf.ExternalServices.Istio.ValidationReconcileInterval > 0 {
-		return true
-	}
-	return false
+	return conf.ExternalServices.Istio.ValidationReconcileInterval != nil && *conf.ExternalServices.Istio.ValidationReconcileInterval > 0
 }
 
 // Validate will ensure the config is valid. This should be called after the config

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -32,6 +32,12 @@ func NewValidationsController(
 	mgr ctrl.Manager,
 ) error {
 	reconcileInterval := conf.ExternalServices.Istio.ValidationReconcileInterval
+
+	if reconcileInterval == nil || *reconcileInterval <= 0 {
+		log.Warning("Validation reconcile interval is 0 or less; skipping periodic validations.")
+		return nil
+	}
+
 	log.Infof("Kiali will validate Istio configuration every: %s", *reconcileInterval)
 	reconciler := NewValidationsReconciler(clusters, conf, kialiCache, validationsService, *reconcileInterval)
 

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -32,12 +32,6 @@ func NewValidationsController(
 	mgr ctrl.Manager,
 ) error {
 	reconcileInterval := conf.ExternalServices.Istio.ValidationReconcileInterval
-
-	if reconcileInterval == nil || *reconcileInterval <= 0 {
-		log.Info("Validation reconcile interval is 0 or less; skipping periodic validations.")
-		return nil
-	}
-
 	log.Infof("Kiali will validate Istio configuration every: %s", *reconcileInterval)
 	reconciler := NewValidationsReconciler(clusters, conf, kialiCache, validationsService, *reconcileInterval)
 

--- a/controller/validations.go
+++ b/controller/validations.go
@@ -34,7 +34,7 @@ func NewValidationsController(
 	reconcileInterval := conf.ExternalServices.Istio.ValidationReconcileInterval
 
 	if reconcileInterval == nil || *reconcileInterval <= 0 {
-		log.Warning("Validation reconcile interval is 0 or less; skipping periodic validations.")
+		log.Info("Validation reconcile interval is 0 or less; skipping periodic validations.")
 		return nil
 	}
 

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -61,7 +61,7 @@ func IstioConfigList(
 		}
 
 		cluster := clusterNameFromQuery(conf, query)
-		if !conf.ExternalServices.Istio.IstioAPIEnabled {
+		if !conf.ExternalServices.Istio.IstioAPIEnabled || !conf.IsValidationsEnabled() {
 			includeValidations = false
 		}
 
@@ -135,7 +135,7 @@ func IstioConfigDetails(
 		}
 
 		cluster := clusterNameFromQuery(conf, query)
-		if !conf.ExternalServices.Istio.IstioAPIEnabled {
+		if !conf.ExternalServices.Istio.IstioAPIEnabled || !conf.IsValidationsEnabled() {
 			includeValidations = false
 		}
 

--- a/kiali.go
+++ b/kiali.go
@@ -201,8 +201,12 @@ func main() {
 		log.Fatalf("Error creating business layer: %s", err)
 	}
 
-	if err := controller.NewValidationsController(ctx, slices.Collect(maps.Keys(kubeCaches)), conf, cache, &layer.Validations, mgr); err != nil {
-		log.Fatal(err)
+	if conf.IsValidationsEnabled() {
+		if err := controller.NewValidationsController(ctx, slices.Collect(maps.Keys(kubeCaches)), conf, cache, &layer.Validations, mgr); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		log.Info("Validation reconcile interval is 0 or less; skipping periodic validations.")
 	}
 
 	go func() {


### PR DESCRIPTION
Resolves https://github.com/kiali/kiali/issues/8317

If *validation_reconcile_interval* is 0 (0s), then Kiali won't create the periodic validations controller.

I believed that there is no need for a change in the operator.

```yaml
spec:
  external_services:
    istio:
      validation_reconcile_interval: "0s"
```