### PR TITLE
Build our own base image which is essentially ubi-micro + openssl/certs

### DIFF
--- a/deploy/docker/Dockerfile-distroless
+++ b/deploy/docker/Dockerfile-distroless
@@ -1,5 +1,18 @@
-# ubi9/openssl is essentially ubi9-micro with openssl
-FROM registry.access.redhat.com/ubi9/openssl
+# We are building what was the old (now deprecated) ubi9/openssl, which is essentially ubi-micro image with openssl/root certs
+ARG UBI_MAJOR_VERSION="9"
+FROM registry.access.redhat.com/ubi${UBI_MAJOR_VERSION}/ubi AS ubi-build
+ARG UBI_MAJOR_VERSION
+RUN mkdir -p /mnt/rootfs/keys
+RUN chmod 0777 /mnt/rootfs/keys
+RUN yum install --installroot /mnt/rootfs --releasever ${UBI_MAJOR_VERSION} --setopt install_weak_deps=false --nodocs -y bash coreutils-single glibc-minimal-langpack openssl && \
+    yum --installroot /mnt/rootfs clean all
+RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
+
+FROM scratch
+COPY --from=ubi-build /mnt/rootfs/ /
+VOLUME  /keys
+
+# Start Kiali specific build
 
 LABEL maintainer="kiali-dev@googlegroups.com"
 

--- a/deploy/docker/Dockerfile-multi-arch-distroless
+++ b/deploy/docker/Dockerfile-multi-arch-distroless
@@ -1,10 +1,18 @@
-# ubi9/openssl is essentially ubi9-micro with openssl
-FROM registry.access.redhat.com/ubi9/openssl AS base-amd64
-FROM registry.access.redhat.com/ubi9/openssl AS base-arm64
-FROM registry.access.redhat.com/ubi9/openssl AS base-s390x
-FROM registry.access.redhat.com/ubi9/openssl AS base-ppc64le
+# We are building what was the old (now deprecated) ubi9/openssl, which is essentially ubi-micro image with openssl/root certs
+ARG UBI_MAJOR_VERSION="9"
+FROM registry.access.redhat.com/ubi${UBI_MAJOR_VERSION}/ubi AS ubi-build
+ARG UBI_MAJOR_VERSION
+RUN mkdir -p /mnt/rootfs/keys
+RUN chmod 0777 /mnt/rootfs/keys
+RUN yum install --installroot /mnt/rootfs --releasever ${UBI_MAJOR_VERSION} --setopt install_weak_deps=false --nodocs -y bash coreutils-single glibc-minimal-langpack openssl && \
+    yum --installroot /mnt/rootfs clean all
+RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
-FROM base-${TARGETARCH}
+FROM scratch
+COPY --from=ubi-build /mnt/rootfs/ /
+VOLUME  /keys
+
+# Start Kiali specific build
 
 LABEL maintainer="kiali-dev@googlegroups.com"
 


### PR DESCRIPTION
The ubi9/openssl base image is deprecated. We no longer want to use it. Let's create our own base image that is the same thing - this will ensure we get the latest updates for each of our build releases.

This code was taken from the now-deprecated ubi9/openssl Dockerfile: 
* https://catalog.redhat.com/software/containers/ubi9/openssl/6195a359ce09ff98ccc36340?container-tabs=dockerfile

The distro release is still produced for those that want to use it (usually this is just for debugging purposes). The distroless release is the new one. It looks good, I tested in my own fork to see if this works, which it does. The release that I built in my fork was 2.9.1 (`quay.io/jmazzitelli/kiali:v2.9`)

```
$ podman run -it --rm --entrypoint '' quay.io/jmazzitelli/kiali:v2.9 openssl version
OpenSSL 3.2.2 4 Jun 2024 (Library: OpenSSL 3.2.2 4 Jun 2024)

$ podman run -it --rm --entrypoint '' quay.io/jmazzitelli/kiali:v2.9 openssl version -d
OPENSSLDIR: "/etc/pki/tls"

$ podman run -it --rm --entrypoint '' quay.io/jmazzitelli/kiali:v2.9 ls -l /etc/pki/tls
total 28
lrwxrwxrwx. 1 root root    49 Aug 19  2024 cert.pem -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
drwxr-xr-x. 1 root root    64 Apr 21 19:36 certs
-rw-r--r--. 1 root root   412 Jan 29 12:56 ct_log_list.cnf
lrwxrwxrwx. 1 root root    50 Jan 29 13:00 fips_local.cnf -> /etc/crypto-policies/back-ends/openssl_fips.config
drwxr-xr-x. 1 root root     0 Jan 29 13:00 misc
-rw-r--r--. 1 root root 12433 Jan 29 12:56 openssl.cnf
drwxr-xr-x. 1 root root     0 Jan 29 13:00 openssl.d
drwxr-xr-x. 1 root root     0 Jan 29 12:59 private

$ podman run -it --rm --entrypoint '' quay.io/jmazzitelli/kiali:v2.9 ls -l /etc/pki/tls/certs
total 8
lrwxrwxrwx. 1 root root 49 Aug 19  2024 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx. 1 root root 55 Aug 19  2024 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt

$ podman run -it --rm quay.io/jmazzitelli/kiali:v2.9  | head -n 2
2025/04/21 19:49:45 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
2025-04-21T19:49:45Z INF Kiali: Version: v2.9.1, Commit: 05826777b58e2765cc672d3b0e071c9b661589be, Go: 1.23.6
```

I also deployed it in istio-system and it worked:

```
$ kubectl get pods -n istio-system -l app=kiali -ojsonpath='{..spec.containers..image}'
quay.io/jmazzitelli/kiali:v2.9

$ kubectl get pods -n istio-system -l app=kiali 
NAME                     READY   STATUS    RESTARTS   AGE
kiali-76dc9b4459-wqbpj   1/1     Running   0          2m32s

$ kubectl logs -n istio-system -l app=kiali --tail=-1
2025/04/21 19:54:57 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined
2025-04-21T19:54:57Z INF Kiali: Version: v2.9.1, Commit: 05826777b58e2765cc672d3b0e071c9b661589be, Go: 1.23.6
2025-04-21T19:54:57Z DBG Kiali: Command line: [/opt/kiali/kiali -config /kiali-configuration/config.yaml]
2025-04-21T19:54:57Z DBG Reading YAML config from [/kiali-configuration/config.yaml]
2025-04-21T19:54:57Z DBG Custom dashboards [count=21, enabled=true]: envoy,go,istiod,kiali,micrometer-1.0.6-jvm,micrometer-1.0.6-jvm-pool,micrometer-1.1-jvm,microprofile-1.1,microprofile-x.y,nodejs,quarkus,springboot-jvm,springboot-jvm-pool,springboot-tomcat,thorntail,tomcat,vertx-client,vertx-eventbus,vertx-jvm,vertx-pool,vertx-server
2025-04-21T19:54:57Z DBG Credentials loaded from secret file [/kiali-override-secrets/login-token-signing-key/value.txt]
2025-04-21T19:54:57Z DBG Cluster name is not set. Attempting to auto-detect the cluster name from the home cluster environment.
2025-04-21T19:54:57Z DBG Unable to read remote secret. It may or may not exist. Error: open /kiali-remote-secret/kiali: no such file or directory. Falling back to in cluster config
2025-04-21T19:54:57Z DBG Creating new Kiali Service Account client
2025-04-21T19:54:57Z DBG Rest perf config QPS: 175.000000 Burst: 200
2025-04-21T19:54:57Z DBG Auto-detected the istio cluster name to be [Kubernetes]. Updating the kiali config
2025-04-21T19:54:57Z INF Using authentication strategy [anonymous]
2025-04-21T19:54:57Z WRN Kiali auth strategy is configured for anonymous access - users will not be authenticated.
2025-04-21T19:54:57Z INF Some validation errors will be ignored [KIA1301]. If these errors do occur, they will still be logged. If you think the validation errors you see are incorrect, please report them to the Kiali team if you have not done so already and provide the details of your scenario. This will keep Kiali validations strong for the whole community.
2025-04-21T19:54:57Z DBG Unable to read remote secret. It may or may not exist. Error: open /kiali-remote-secret/kiali: no such file or directory. Falling back to in cluster config
2025-04-21T19:54:57Z DBG Creating new Kiali Service Account client
2025-04-21T19:54:57Z DBG Rest perf config QPS: 175.000000 Burst: 200
2025-04-21T19:54:57Z INF Initializing Kiali Cache
2025-04-21T19:54:57Z DBG [Kiali Cache] Using 'cluster' scoped Kiali Cache
2025-04-21T19:54:57Z DBG Stopping client factory recycle chan
2025-04-21T19:54:57Z DBG recycleChan closed when watching clients
2025-04-21T19:54:57Z DBG K8s Gateway API CRDs are not installed. Required K8s Gateway API version: gateway.networking.k8s.io/v1. Gateway API will not be used.
2025-04-21T19:54:57Z DBG [Kiali Cache] Starting cluster-scoped informers
2025-04-21T19:54:57Z INF [Kiali Cache] Waiting for cluster-scoped cache to sync
2025-04-21T19:54:57Z INF [Kiali Cache] Started
2025-04-21T19:54:57Z INF [Kiali Cache] Kube cache is active for cluster: [Kubernetes]
2025-04-21T19:54:57Z DBG Starting polling istiod(s) every 20 seconds for proxy status
2025-04-21T19:54:57Z DBG Scraping istiod for debug info
2025-04-21T19:54:57Z DBG Found controlplane [istiod/istio-system] on cluster [Kubernetes].
2025-04-21T19:54:57Z DBG No ztunnel daemonsets found in Kiali accessible namespaces in cluster 'Kubernetes'
2025-04-21T19:54:57Z DBG Detected Istio version [1.25.1-be4b14ad8be844c5f876a41ad4437217a2e03cf8-Clean]
2025-04-21T19:54:57Z DBG Found webhook [/istio-revision-tag-default] on cluster: [Kubernetes].
2025-04-21T19:54:57Z INF [Prom Cache] Enabled
2025-04-21T19:54:57Z DBG Tracing is disabled
2025-04-21T19:54:57Z DBG [GRAFANA] URL discovery for service 'grafana', namespace 'istio-system'...
2025-04-21T19:54:57Z DBG [GRAFANA] Client is not Openshift, discovery url is only supported in Openshift
2025-04-21T19:54:57Z DBG [GRAFANA] URL discovery for service 'grafana', namespace 'istio-system'...
2025-04-21T19:54:57Z DBG [GRAFANA] Client is not Openshift, discovery url is only supported in Openshift
2025-04-21T19:54:57Z INF Profiler is enabled
2025-04-21T19:54:57Z INF Server endpoint will start at [:20001/kiali]
2025-04-21T19:54:57Z INF Server endpoint will serve static content from [/opt/kiali/console]
2025-04-21T19:54:57Z INF Starting Metrics Server on [:9090]
2025-04-21T19:54:57Z DBG Setting up Validations Contoller
2025-04-21T19:54:57Z INF Kiali will validate Istio configuration every: 1m0s
{"level":"info","ts":"2025-04-21T19:54:57Z","msg":"Starting EventSource","controller":"validations-controller","source":"channel source: 0xc00096bb20"}
{"level":"info","ts":"2025-04-21T19:54:57Z","msg":"Starting Controller","controller":"validations-controller"}
{"level":"info","ts":"2025-04-21T19:54:57Z","msg":"Starting workers","controller":"validations-controller","worker count":1}
2025-04-21T19:54:57Z DBG [ValidationsReconciler] Started reconciling 
2025-04-21T19:54:57Z DBG [ValidationsReconciler] Finished reconciling in 0.00s
2025-04-21T19:55:17Z DBG Scraping istiod for debug info
2025-04-21T19:55:37Z DBG Scraping istiod for debug info
2025-04-21T19:55:37Z DBG Found controlplane [istiod/istio-system] on cluster [Kubernetes].
2025-04-21T19:55:37Z DBG Detected Istio version [1.25.1-be4b14ad8be844c5f876a41ad4437217a2e03cf8-Clean]
2025-04-21T19:55:37Z DBG Found webhook [/istio-revision-tag-default] on cluster: [Kubernetes].
2025-04-21T19:55:57Z DBG [ValidationsReconciler] Started reconciling 
2025-04-21T19:55:57Z DBG [ValidationsReconciler] Finished reconciling in 0.00s
2025-04-21T19:55:57Z DBG Scraping istiod for debug info
2025-04-21T19:56:17Z DBG Scraping istiod for debug info
2025-04-21T19:56:17Z DBG Found controlplane [istiod/istio-system] on cluster [Kubernetes].
2025-04-21T19:56:17Z DBG Detected Istio version [1.25.1-be4b14ad8be844c5f876a41ad4437217a2e03cf8-Clean]
2025-04-21T19:56:17Z DBG Found webhook [/istio-revision-tag-default] on cluster: [Kubernetes].
2025-04-21T19:56:37Z DBG Scraping istiod for debug info
2025-04-21T19:56:57Z DBG [ValidationsReconciler] Started reconciling 
2025-04-21T19:56:57Z DBG Found controlplane [istiod/istio-system] on cluster [Kubernetes].
2025-04-21T19:56:57Z DBG Detected Istio version [1.25.1-be4b14ad8be844c5f876a41ad4437217a2e03cf8-Clean]
2025-04-21T19:56:57Z DBG Found webhook [/istio-revision-tag-default] on cluster: [Kubernetes].
2025-04-21T19:56:57Z DBG [ValidationsReconciler] Finished reconciling in 0.04s
2025-04-21T19:56:57Z DBG Scraping istiod for debug info
2025-04-21T19:57:17Z DBG Scraping istiod for debug info
2025-04-21T19:57:37Z DBG Scraping istiod for debug info
2025-04-21T19:57:37Z DBG Found controlplane [istiod/istio-system] on cluster [Kubernetes].
2025-04-21T19:57:37Z DBG Detected Istio version [1.25.1-be4b14ad8be844c5f876a41ad4437217a2e03cf8-Clean]
2025-04-21T19:57:37Z DBG Found webhook [/istio-revision-tag-default] on cluster: [Kubernetes].

```