### PR TITLE
[v1.73] Skip tracing tests in lpinterop pipelines

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -33,12 +33,16 @@ Feature: Kiali App Details page
   Scenario: See Outbound Metrics
     Then user sees outbound metrics information
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See tracing info after selecting a trace
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See span info after selecting app span
     And user sees trace information

--- a/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/app_details_multicluster.feature
@@ -47,6 +47,8 @@ Feature: Kiali App Details page for multicluster
     When user selects a trace
     Then user sees trace details
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @app-details-page
   Scenario: See span info after selecting app span
     And user is at the details page for the "app" "bookinfo/productpage" located in the "west" cluster

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -10,6 +10,8 @@ Feature: Kiali Service Details page
     Given user is at administrator perspective
     And user is at the details page for the "service" "bookinfo/productpage" located in the "" cluster
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See details for productpage
     Then sd::user sees a list with content "Overview"
@@ -51,12 +53,16 @@ Feature: Kiali Service Details page
   Scenario: See Graph data for productspage service details Inbound Metrics graphs
     Then sd::user does not see No data message in the "Request volume" graph
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See graph traces for productspage service details
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See span info after selecting service span
     And user sees trace information

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -44,6 +44,8 @@ Feature: Workload logs tab
     When I select only the "productpage" container
     Then the log pane should only show logs for the "productpage" container
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: The log pane of the logs tab should show spans
     Given I am on the logs tab of the "productpage-v1" workload detail page of the "bookinfo" namespace

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -31,12 +31,16 @@ Feature: Kiali Workload Details page
   Scenario: See workload Outbound Metrics
     Then user sees workload outbound metrics information
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See workload tracing info after selecting a trace
     And user sees trace information
     When user selects a trace
     Then user sees trace details
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   @bookinfo-app
   Scenario: See workload span info after selecting a span
     And user sees trace information


### PR DESCRIPTION
### Describe the change
The Jaeger operator is no longer available in the OCP 4.19 catalog, so it will be removed from our LPINTEROP jobs. (We have not set Tempo yet; it will be part of OSSM3 lpinterop.)
Due to that, we need to skip tracing tests in lpinterop pipelines (the tests are still running in our downstream pipeline with Tempo integration)
