### PR TITLE
Reverted workaround changes in PR#5491 for Rollouts support

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -902,7 +902,7 @@ func FakePodsFromCustomController(conf *config.Config) []core_v1.Pod {
 					Controller: &controller,
 					APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
 					Kind:       kubernetes.ReplicaSets.Kind,
-					Name:       "custom-controller-RS-123",
+					Name:       "custom-controller-123",
 				}},
 				Annotations: kubetest.FakeIstioAnnotations(),
 			},
@@ -1119,7 +1119,7 @@ func FakeCustomControllerRSSyncedWithPods(conf *config.Config) []apps_v1.Replica
 				Kind:       kubernetes.ReplicaSets.Kind,
 			},
 			ObjectMeta: meta_v1.ObjectMeta{
-				Name:              "custom-controller-RS-123",
+				Name:              "custom-controller-123",
 				Namespace:         "Namespace",
 				CreationTimestamp: meta_v1.NewTime(t1),
 				OwnerReferences: []meta_v1.OwnerReference{{

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -1922,6 +1922,6 @@ func TestGetWorkloadListWithCustomKindThatMatchesCoreKind(t *testing.T) {
 	assert.Equal("Namespace", workloadList.Namespace)
 
 	require.Equal(1, len(workloads))
-	assert.Equal("custom-controller-RS-123", workloads[0].Name)
+	assert.Equal("custom-controller-123", workloads[0].Name)
 	assert.Equal("DaemonSet", workloads[0].WorkloadGVK.Kind)
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -521,8 +521,8 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	assert.Equal("Namespace", workloadList.Namespace)
 
 	require.Equal(1, len(workloads))
-	assert.Equal("custom-controller-RS-123", workloads[0].Name)
-	assert.Equal("ReplicaSet", workloads[0].WorkloadGVK.Kind)
+	assert.Equal("custom-controller", workloads[0].Name)
+	assert.Equal("CustomController", workloads[0].WorkloadGVK.Kind)
 	assert.Equal(true, workloads[0].AppLabel)
 	assert.Equal(true, workloads[0].VersionLabel)
 }
@@ -693,17 +693,10 @@ func TestGetWorkloadFromPods(t *testing.T) {
 
 	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "custom-controller", WorkloadGVK: schema.GroupVersionKind{}, IncludeServices: false}
 	workload, err := svc.GetWorkload(context.TODO(), criteria)
-	require.Error(err)
-
-	// custom controller is not a workload type, only its replica set(s)
-	assert.Equal((*models.Workload)(nil), workload)
-
-	criteria = WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", WorkloadName: "custom-controller-RS-123", WorkloadGVK: schema.GroupVersionKind{}, IncludeServices: false}
-	workload, err = svc.GetWorkload(context.TODO(), criteria)
 	require.NoError(err)
 
-	assert.Equal("custom-controller-RS-123", workload.Name)
-	assert.Equal("ReplicaSet", workload.WorkloadGVK.Kind)
+	assert.Equal("custom-controller", workload.Name)
+	assert.Equal("CustomController", workload.WorkloadGVK.Kind)
 	assert.Equal(true, workload.AppLabel)
 	assert.Equal(true, workload.VersionLabel)
 	assert.Equal(0, len(workload.Runtimes))
@@ -1297,7 +1290,7 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	workload, _ := svc.GetWorkload(context.TODO(), criteria)
 
 	require.Equal(len(workloads), 1)
-	assert.Nil(workload)
+	assert.NotNil(workload)
 
 	criteria.WorkloadName = workloads[0].Name
 	workload, _ = svc.GetWorkload(context.TODO(), criteria)


### PR DESCRIPTION
### Describe the change

Istio did some changes in support of retrieving Argo Rollouts https://github.com/istio/istio/pull/49256
Thus our changes we did in PR https://github.com/kiali/kiali/pull/5491 is not necessary anymore,
Reverting changes.

### Steps to test the PR

The original issue has well described scenarios how to install the env:
https://github.com/kiali/kiali/issues/8284#issuecomment-2817173896

Before: There was a problem linking to Workload details page, and workload list page was showing odd ReplicaSets with empty names which details page was failing.
Now: Workload lists shown correct info which details page is loaded correctly and is read-only. App details is shown as read-only as well.
![Screenshot from 2025-04-24 10-25-31](https://github.com/user-attachments/assets/282772d7-839c-4c75-a51d-fc15a6092d00)
![Screenshot from 2025-04-24 10-24-51](https://github.com/user-attachments/assets/6c65dcd8-5814-4d00-9434-fab11f065997)
![Screenshot from 2025-04-24 10-24-45](https://github.com/user-attachments/assets/db9e2955-2d73-4067-bb6a-d32cd21caf73)

Only thing is that only one of ReplicaSet's Pods are shown in Workload details.
![Screenshot from 2025-04-24 11-01-15](https://github.com/user-attachments/assets/b202dfd6-1bfc-4ace-bce2-a85b3b0d9b7c)


### Automation testing

n/a

### Issue reference
https://github.com/kiali/kiali/issues/8284
