### PR TITLE
[demos] Fix service spawner demo

### DIFF
--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -65,7 +65,7 @@ install_service_spawner_demo() {
     curl -L ${BASE_URL}/service-spawner/deployment-tpl.yaml -o deployment-tpl.yaml
     cat deployment-tpl.yaml \
           | sed -e "s:this-service:service-$c:g" \
-          | sed -e "s:target-service:service-$next\:8080:g" \
+          | sed -e "s:target-service:http\://service-$next:g" \
           | sed -e "s:this-namespace:$SSPAWNER:g" \
           | sed -e "s:quay.io/jotak/nginx-hello:nginxdemos/nginx-hello:g" \
           > tmp-$c.yaml


### PR DESCRIPTION
### Describe the change

Fix regex in service replacement
![image](https://github.com/user-attachments/assets/37f79686-3ced-4720-aa76-8cad2c7fcc67)

### Steps to test the PR

- Run `hack/istio$ ./install-service-spawner-demo.sh -c kubectl`
- Traffic graph should appear in the service-spawner ns

### Automation testing

NA

### Issue reference

Fixes #6357 
