### PR TITLE
Prevent returning the istiod status if no access to ztunnel config dump

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -412,11 +412,12 @@ type KubernetesConfig struct {
 
 // CacheExpirationConfig sets expiration time for various cache stores
 type CacheExpirationConfig struct {
-	AmbientCheck time.Duration `yaml:"ambient_check,omitempty"`
-	IstioStatus  time.Duration `yaml:"istio_status,omitempty"`
-	Gateway      time.Duration `yaml:"gateway,omitempty"`
-	Mesh         time.Duration `yaml:"mesh,omitempty"`
-	Waypoint     time.Duration `yaml:"waypoint,omitempty"`
+	AmbientCheck  time.Duration `yaml:"ambient_check,omitempty"`
+	IstioStatus   time.Duration `yaml:"istio_status,omitempty"`
+	Gateway       time.Duration `yaml:"gateway,omitempty"`
+	Mesh          time.Duration `yaml:"mesh,omitempty"`
+	Waypoint      time.Duration `yaml:"waypoint,omitempty"`
+	ZtunnelConfig time.Duration `yaml:"ztunnel_config,omitempty"`
 }
 
 // KialiInternalConfig holds configuration that is not typically touched by users, but could be in the event of
@@ -911,11 +912,12 @@ func NewConfig() (c *Config) {
 		},
 		KialiInternal: KialiInternalConfig{
 			CacheExpiration: CacheExpirationConfig{
-				AmbientCheck: 10 * time.Minute,
-				Gateway:      4 * time.Minute,
-				IstioStatus:  30 * time.Second, // Set to 0 to disable
-				Mesh:         20 * time.Second,
-				Waypoint:     4 * time.Minute,
+				AmbientCheck:  10 * time.Minute,
+				Gateway:       4 * time.Minute,
+				IstioStatus:   30 * time.Second, // Set to 0 to disable
+				Mesh:          20 * time.Second,
+				Waypoint:      4 * time.Minute,
+				ZtunnelConfig: 2 * time.Minute,
 			},
 		},
 		KubernetesConfig: KubernetesConfig{

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -103,33 +103,6 @@ func (in *Discovery) getControlPlaneConfiguration(kubeCache cache.KubeCache, con
 		istioConfigMapInfo.Certificates = append(istioConfigMapInfo.Certificates, cert)
 	}
 
-	// Check ztunnel pods to get the config dump
-	if in.kialiCache.IsAmbientEnabled(controlPlane.Cluster.Name) {
-		ztunnelPods := in.kialiCache.GetZtunnelPods(controlPlane.Cluster.Name)
-		if len(ztunnelPods) > 0 {
-			client := in.kialiSAClients[controlPlane.Cluster.Name]
-			zTunnel := make(map[string]*kubernetes.ZtunnelConfigDump)
-
-			for _, zPod := range ztunnelPods {
-				resp, err := client.ForwardGetRequest(zPod.Namespace, zPod.Name, 15000, "/config_dump")
-				if err != nil {
-					log.Errorf("[getZtunnelConfigDump] Error forwarding the /config_dump request: %v", err)
-					continue
-				}
-
-				configDump := &kubernetes.ZtunnelConfigDump{}
-				err = json.Unmarshal(resp, configDump)
-				if err != nil {
-					log.Errorf("[getZtunnelConfigDump] Error Unmarshalling the config_dump: %v", err)
-				} else {
-					key := fmt.Sprintf("%s%s%s", client.ClusterInfo().Name, zPod.Namespace, zPod.Name)
-					zTunnel[key] = configDump
-				}
-			}
-			in.kialiCache.SetZtunnelDump(zTunnel)
-		}
-	}
-
 	return &models.ControlPlaneConfiguration{
 		IstioMeshConfig: *istioConfigMapInfo,
 		Network:         in.resolveNetwork(kubeCache, controlPlane),

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -114,7 +114,7 @@ func (in *Discovery) getControlPlaneConfiguration(kubeCache cache.KubeCache, con
 				resp, err := client.ForwardGetRequest(zPod.Namespace, zPod.Name, 15000, "/config_dump")
 				if err != nil {
 					log.Errorf("[getZtunnelConfigDump] Error forwarding the /config_dump request: %v", err)
-					return nil, err
+					continue
 				}
 
 				configDump := &kubernetes.ZtunnelConfigDump{}

--- a/kubernetes/cache/cache.go
+++ b/kubernetes/cache/cache.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -352,21 +351,9 @@ func (in *kialiCacheImpl) GetZtunnelPods(cluster string) []v1.Pod {
 		return ztunnelPods
 	}
 
-	dsPods, err := kubeCache.GetPods(daemonsets[0].Namespace, "")
+	ztunnelPods, err = kubeCache.GetPods(daemonsets[0].Namespace, fmt.Sprintf("app=%s", config.Ztunnel))
 	if err != nil {
 		log.Errorf("Unable to get ztunnel pods: %s", err)
-		return ztunnelPods
-
-	}
-
-	for _, pod := range dsPods {
-		podName := pod.Name
-		if len(pod.OwnerReferences) > 0 {
-			podName = pod.OwnerReferences[0].Name
-		}
-		if strings.Contains(podName, config.Ztunnel) {
-			ztunnelPods = append(ztunnelPods, pod)
-		}
 	}
 
 	return ztunnelPods

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -82,16 +82,19 @@ func ztunnelDaemonSet() *apps_v1.DaemonSet {
 func k8sClientWithControlPlanePods(includeZtunnel bool) *kubetest.FakeK8sClient {
 	istioNamespace := "istio-system"
 	objs := []runtime.Object{}
+	// ztunnel pod with no label: Should not be selected
+	pod := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel-khq59-123", Namespace: istioNamespace}}
 	pod1 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istiod-864675749b-lpq8c", Namespace: istioNamespace}}
 	pod2 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-cni-node-vd5sh", Namespace: istioNamespace}}
 	pod3 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-65db697fd-bfq5v", Namespace: istioNamespace}}
 	pod4 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-egressgateway-7bcb795b58-6jj6w", Namespace: istioNamespace}}
 	pod5 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-ingressgateway-7d97cd5c49-qhpcp", Namespace: istioNamespace}}
-	objs = append(objs, kubetest.FakeNamespace("istio-system"), ztunnelDaemonSet(), pod1, pod2, pod3, pod4, pod5)
+	objs = append(objs, kubetest.FakeNamespace("istio-system"), ztunnelDaemonSet(), pod, pod1, pod2, pod3, pod4, pod5)
 
 	if includeZtunnel {
 		pod6 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel-khq59", Namespace: istioNamespace, Labels: map[string]string{"app": "ztunnel"}}}
-		objs = append(objs, pod6)
+		pod7 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "i-khq59", Namespace: istioNamespace, Labels: map[string]string{"app": "ztunnel"}}}
+		objs = append(objs, pod6, pod7)
 	}
 	return kubetest.NewFakeK8sClient(objs...)
 }
@@ -323,6 +326,7 @@ func TestGetNoZtunnelPods(t *testing.T) {
 	require.Equal(0, len(ztunnelPods))
 }
 
+// TestGetZtunnelPods: Just pods that are part of the
 func TestGetZtunnelPods(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
@@ -330,5 +334,5 @@ func TestGetZtunnelPods(t *testing.T) {
 	cache := cache.NewTestingCache(t, client, *conf)
 
 	ztunnelPods := cache.GetZtunnelPods(client.ClusterInfo().Name)
-	require.Equal(1, len(ztunnelPods))
+	require.Equal(2, len(ztunnelPods))
 }

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -2,15 +2,15 @@ package cache_test
 
 import (
 	"encoding/json"
-	core_v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"

--- a/kubernetes/cache/cache_test.go
+++ b/kubernetes/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache_test
 
 import (
 	"encoding/json"
+	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"sync"
 	"testing"
@@ -75,6 +77,23 @@ func ztunnelDaemonSet() *apps_v1.DaemonSet {
 			},
 		},
 	}
+}
+
+func k8sClientWithControlPlanePods(includeZtunnel bool) *kubetest.FakeK8sClient {
+	istioNamespace := "istio-system"
+	objs := []runtime.Object{}
+	pod1 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istiod-864675749b-lpq8c", Namespace: istioNamespace}}
+	pod2 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-cni-node-vd5sh", Namespace: istioNamespace}}
+	pod3 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-65db697fd-bfq5v", Namespace: istioNamespace}}
+	pod4 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-egressgateway-7bcb795b58-6jj6w", Namespace: istioNamespace}}
+	pod5 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "istio-ingressgateway-7d97cd5c49-qhpcp", Namespace: istioNamespace}}
+	objs = append(objs, kubetest.FakeNamespace("istio-system"), ztunnelDaemonSet(), pod1, pod2, pod3, pod4, pod5)
+
+	if includeZtunnel {
+		pod6 := &core_v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ztunnel-khq59", Namespace: istioNamespace, Labels: map[string]string{"app": "ztunnel"}}}
+		objs = append(objs, pod6)
+	}
+	return kubetest.NewFakeK8sClient(objs...)
 }
 
 func TestIsAmbientEnabled(t *testing.T) {
@@ -292,4 +311,24 @@ func TestZtunnelDump(t *testing.T) {
 	require.Equal(cacheData.Services[36].Hostname, "waypoint.bookinfo.svc.cluster.local")
 	require.Equal(cacheData.Services[36].Name, "waypoint")
 	require.Equal(cacheData.Services[36].Namespace, "bookinfo")
+}
+
+func TestGetNoZtunnelPods(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	client := k8sClientWithControlPlanePods(false)
+	cache := cache.NewTestingCache(t, client, *conf)
+
+	ztunnelPods := cache.GetZtunnelPods(client.ClusterInfo().Name)
+	require.Equal(0, len(ztunnelPods))
+}
+
+func TestGetZtunnelPods(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	client := k8sClientWithControlPlanePods(true)
+	cache := cache.NewTestingCache(t, client, *conf)
+
+	ztunnelPods := cache.GetZtunnelPods(client.ClusterInfo().Name)
+	require.Equal(1, len(ztunnelPods))
 }

--- a/kubernetes/cache/ztunnel_dump.go
+++ b/kubernetes/cache/ztunnel_dump.go
@@ -1,7 +1,11 @@
 package cache
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 )
 
 func ztunnelDumpKey(cluster, namespace, pod string) string {
@@ -21,7 +25,36 @@ func (c *kialiCacheImpl) GetZtunnelDump(cluster, namespace, pod string) *kuberne
 	key := ztunnelDumpKey(cluster, namespace, pod)
 	config, found := c.ztunnelConfigStore.Get(key)
 	if !found {
-		return nil
+		if c.IsAmbientEnabled(cluster) {
+
+			ztunnelPods := c.GetZtunnelPods(cluster)
+			if len(ztunnelPods) > 0 {
+				client, err := c.GetKubeCache(cluster)
+				if err != nil {
+					log.Errorf("[GetZtunnelDump] Error getting kubecache for cluster %s: %v", cluster, err)
+				} else {
+					zTunnel := make(map[string]*kubernetes.ZtunnelConfigDump)
+
+					for _, zPod := range ztunnelPods {
+						resp, err := client.Client().ForwardGetRequest(zPod.Namespace, zPod.Name, 15000, "/config_dump")
+						if err != nil {
+							log.Errorf("[GetZtunnelDump] Error forwarding the /config_dump request: %v", err)
+							continue
+						}
+						configDump := &kubernetes.ZtunnelConfigDump{}
+						err = json.Unmarshal(resp, configDump)
+						if err != nil {
+							log.Errorf("[GetZtunnelDump] Error Unmarshalling the config_dump: %v", err)
+						} else {
+							key := fmt.Sprintf("%s%s%s", client.Client().ClusterInfo().Name, zPod.Namespace, zPod.Name)
+							zTunnel[key] = configDump
+						}
+					}
+					c.SetZtunnelDump(zTunnel)
+					return zTunnel[cluster]
+				}
+			}
+		}
 	}
 	return config
 }

--- a/kubernetes/cache/ztunnel_dump.go
+++ b/kubernetes/cache/ztunnel_dump.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -80,7 +80,6 @@ type IstioClientInterface interface {
 	GatewayAPI() gatewayapiclient.Interface
 
 	GetConfigDump(namespace, podName string) (*ConfigDump, error)
-	GetZtunnelConfigDump(namespace, podName string) (*ZtunnelConfigDump, error)
 }
 
 type IstioUserClientInterface interface {
@@ -112,25 +111,6 @@ func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, erro
 	err = json.Unmarshal(resp, cd)
 	if err != nil {
 		log.Errorf("Error Unmarshalling the config_dump: %v", err)
-	}
-
-	return cd, err
-}
-
-func (in *K8SClient) GetZtunnelConfigDump(namespace, podName string) (*ZtunnelConfigDump, error) {
-	// Fetching the Config Dump from the pod's ztunnel.
-	// The port 15000 is open on each ztunnel pod (managed by Istio)
-	// And returns different data than the Envoy Proxy
-	resp, err := in.ForwardGetRequest(namespace, podName, 15000, "/config_dump")
-	if err != nil {
-		log.Errorf("Error forwarding the /config_dump request: %s", err.Error())
-		return nil, err
-	}
-
-	cd := &ZtunnelConfigDump{}
-	err = json.Unmarshal(resp, cd)
-	if err != nil {
-		log.Errorf("Error Unmarshalling the ztunnel config_dump: %s", err.Error())
 	}
 
 	return cd, err


### PR DESCRIPTION
### Describe the change

Prevent returning the istiod status if there are no access to ztunnel config dump, making the code more robust. 

### Steps to test the PR

I was not able to reproduce the scenario where the ztunnel pod is not correct, but if this situation happens, returning the istiod status might prevent some errors:

![image](https://github.com/user-attachments/assets/f1bb1808-b0bb-4885-84ff-d38f60513812)

I've emulated the situation changing here: https://github.com/kiali/kiali/blob/master/kubernetes/cache/cache.go#L363 `config.ztunnel` for "cni" (Or whatever string that matches).

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

https://github.com/kiali/kiali/discussions/8364
