### PR TITLE
[v1.73] Skip integration tests in lpinterop pipelines regarding tracing

### DIFF
--- a/tests/integration/tests/kiali_urls_test.go
+++ b/tests/integration/tests/kiali_urls_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,9 @@ func TestIstioPermissions(t *testing.T) {
 }
 
 func TestJaeger(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	response, statusCode, err := kiali.Jaeger()
 

--- a/tests/integration/tests/traces_spans_test.go
+++ b/tests/integration/tests/traces_spans_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,9 @@ import (
 )
 
 func TestServiceTraces(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details"
 	traces, statusCode, err := kiali.Traces("services", name, kiali.BOOKINFO)
@@ -18,6 +22,9 @@ func TestServiceTraces(t *testing.T) {
 }
 
 func TestWorkloadTraces(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details-v1"
 	traces, statusCode, err := kiali.Traces("workloads", name, kiali.BOOKINFO)
@@ -25,6 +32,9 @@ func TestWorkloadTraces(t *testing.T) {
 }
 
 func TestAppTraces(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details"
 	traces, statusCode, err := kiali.Traces("apps", name, kiali.BOOKINFO)
@@ -49,6 +59,9 @@ func TestWrongNamespaceTraces(t *testing.T) {
 }
 
 func TestServiceSpans(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details"
 	spans, statusCode, err := kiali.Spans("services", name, kiali.BOOKINFO)
@@ -56,6 +69,9 @@ func TestServiceSpans(t *testing.T) {
 }
 
 func TestAppSpans(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details"
 	spans, statusCode, err := kiali.Spans("apps", name, kiali.BOOKINFO)
@@ -63,6 +79,9 @@ func TestAppSpans(t *testing.T) {
 }
 
 func TestWorkloadSpans(t *testing.T) {
+	if os.Getenv("LPINTEROP") == "true" {
+		t.Skip("This test is not supported in LPINTEROP, skipping test...")
+	}
 	require := require.New(t)
 	name := "details-v1"
 	spans, statusCode, err := kiali.Spans("workloads", name, kiali.BOOKINFO)


### PR DESCRIPTION
### Describe the change

Jaeger is not available in OCP 4.19+ . Due to that, skip integration tests regarding tracing ( that tests will still be running as part of our downstream pipelines with Tempo )

Ticket: https://issues.redhat.com/browse/OSSM-9386 

Verified manually ([jenkins job](https://jenkins-csb-servicemesh-master.dno.corp.redhat.com/job/kiali/job/test-jobs/job/kiali-integration-tests/3539/)) against cluster without jaeger. (the PR gating job is not working due to https://github.com/kiali/kiali/pull/8366 ) 

