### PR TITLE
[v1.73]backport: test container takes go version from makefile (#7372)

### DIFF
--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -38,10 +38,10 @@ endif
 container-build-int-tests:
 ifeq ($(DORP),docker)
 	@echo Building container image for Kiali integration tests using docker
-	docker build --pull -t ${INT_TESTS_QUAY_TAG} -f tests/integration/Dockerfile .
+	docker build --pull -t ${INT_TESTS_QUAY_TAG} --build-arg="GO_VERSION=${GO_VERSION_KIALI}" -f tests/integration/Dockerfile .
 else
 	@echo Building container image for Kiali integration tests using podman
-	podman build --pull -t ${INT_TESTS_QUAY_TAG} -f tests/integration/Dockerfile .
+	podman build --pull -t ${INT_TESTS_QUAY_TAG} --build-arg="GO_VERSION=${GO_VERSION_KIALI}" -f tests/integration/Dockerfile .
 endif
 
 ## container-build-cypress-tests: Build Kiali cypress tests container image

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG GO_VERSION
 ENV GOPATH=/go
@@ -8,15 +8,15 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make which gettext git \
+RUN microdnf install -y --nodocs tar gzip make which gettext git \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \
     && curl -Lo ./golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
     && tar -xf golang.tar.gz -C /usr/local \
     && rm -f golang.tar.gz \
-    && microdnf update \
-    && microdnf clean all \
+    && microdnf update -y \
+    && microdnf clean all -y \
     && mkdir -p "$GOPATH/src/kiali" "$GOPATH/bin"
 
 COPY . $GOPATH/src/kiali

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+ARG GO_VERSION
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
 # we need to set HOME when running on OCP with random UID, otherwise the home is set to / and any writing there will fail with permission denied
@@ -11,7 +12,7 @@ RUN microdnf install --nodocs tar gzip make which gettext git \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \
-    && curl -Lo ./golang.tar.gz https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && curl -Lo ./golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
     && tar -xf golang.tar.gz -C /usr/local \
     && rm -f golang.tar.gz \
     && microdnf update \


### PR DESCRIPTION
### Describe the change

Backport of https://github.com/kiali/kiali/pull/7372 + update kiali int test container to rhel9

Resolving: https://github.com/kiali/kiali/issues/8376 to be able to rebuild v1.73 kiali integration test image
(the new image is needed to use LPINTEROP env for kiali integration tests https://github.com/kiali/kiali/pull/8375 in LPINTEROP pipelines)

===

Verified manually in my fork (https://github.com/mkralik3/kiali/actions/runs/14705552918 (https://quay.io/repository/mkralik3/kiali-int-tests?tab=tags))
(the PR gating jobs are not working due to https://github.com/kiali/kiali/pull/8366 )
