### PR TITLE
Use -latest as patch version

### DIFF
--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -74,8 +74,9 @@ jobs:
               }
             }
             END {
-              for (m in minor_ga) { print minor_ga[m] }
-              for (m in minor_rc) { print minor_rc[m] }
+              # The latest patch version is not always available in Sail. Use -latest as patch version
+              for (m in minor_ga) { split(minor_ga[m], version_parts, "."); minor_ga[m] = version_parts[1] "." version_parts[2] "-latest"; print minor_ga[m] }
+              for (m in minor_rc) { split(minor_rc[m], version_parts, "."); minor_rc[m] = version_parts[1] "." version_parts[2] "-latest"; print minor_rc[m] }
             }' | sort -Vr | grep -v '^$' | head -n $((OFFSET + 1)))"
           ISTIO_VERSION=$(echo "${LATEST_ISTIO_VERSIONS}" | tail -n 1)
           echo "The latest Istio versions are:"

--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -114,6 +114,7 @@ if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
     fi
     echo "Will use Istio ${LATEST}"
     VERSION_WE_WANT=${LATEST}
+    ISTIO_VERSION=${LATEST}
   fi
   if [ -z "${DEV_ISTIO_VERSION}" ]; then
     export ISTIO_VERSION

--- a/hack/istio/download-istio.sh
+++ b/hack/istio/download-istio.sh
@@ -98,6 +98,7 @@ if [ ! -d "./istio-${VERSION_WE_WANT}" ]; then
     OLD_IFS=$IFS
     IFS='.' read -r major minor_patch <<< "$VERSION_WE_WANT"
     IFS='-' read -r minor patch <<< "$minor_patch"
+    IFS=$OLD_IFS
     if [[ "${patch}" != *latest* ]]; then
       echo "Latest just supported as the patch version"
        exit 1


### PR DESCRIPTION
### Describe the change

Test Istio Version GH run is failing because the latest minor Istio version is not available in Sail (ex. https://github.com/kiali/kiali/actions/runs/14688366334/job/41220128371). Use as patch version -latest, supported in Sail

### Steps to test the PR

I wasn't sure how to test this in the GH actions, so I run the run: command isolated on a sh script. 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
