### PR TITLE
Bump to RHEL9 in kiali integration tests container

### DIFF
--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -11,7 +11,7 @@ ENV HOME=/tmp/kiali
 # install required packages and oc bin
 WORKDIR /usr/bin
 RUN apt -y update && \
-    apt install -y tar gzip bash gettext curl git && \
+    apt install -y tar gzip bash gettext curl && \
     apt-get clean && \
     curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz && \
     tar -xf oc.tar.gz && \

--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -11,7 +11,7 @@ ENV HOME=/tmp/kiali
 # install required packages and oc bin
 WORKDIR /usr/bin
 RUN apt -y update && \
-    apt install -y tar gzip bash gettext curl && \
+    apt install -y tar gzip bash gettext curl git && \
     apt-get clean && \
     curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz && \
     tar -xf oc.tar.gz && \

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make which \
+RUN microdnf install --nodocs tar gzip make which gettext git \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG GO_VERSION
 ENV GOPATH=/go
@@ -8,15 +8,15 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make which gettext git \
+RUN microdnf install -y --nodocs tar gzip make which gettext git \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \
     && curl -Lo ./golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
     && tar -xf golang.tar.gz -C /usr/local \
     && rm -f golang.tar.gz \
-    && microdnf update \
-    && microdnf clean all \
+    && microdnf update -y \
+    && microdnf clean all -y \
     && mkdir -p "$GOPATH/src/kiali" "$GOPATH/bin"
 
 COPY . $GOPATH/src/kiali


### PR DESCRIPTION
### Describe the change

Backport https://github.com/kiali/kiali/pull/7236 (which is only in v1.73 branch)
Fix for [runtime error](https://github.com/kiali/kiali/issues/8376) in the current kiali integration test container
```
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```
