### PR TITLE
[v1.73] Skip flaky cypress tests in lpinterop

### DIFF
--- a/frontend/cypress/integration/featureFiles/kiali_about.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_about.feature
@@ -9,6 +9,8 @@ Feature: Kiali help about verify
     Given user is at administrator perspective
     And user is at the "overview" page
 
+  # Jaeger is not available in OCP 4.19, and we don't have Tempo setup yet in LPINTEROP pipelines (will be for OSSM3+)
+  @skip-lpinterop
   Scenario: Open Kiali about page
 
     And user clicks on Help Button

--- a/frontend/cypress/integration/featureFiles/kiali_alert.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_alert.feature
@@ -9,5 +9,6 @@ Feature: Kiali help about verify
     Given user is at administrator perspective
     And user is at the "overview" page
 
+  @skip-lpinterop
   Scenario: Open Kiali notifications
     Then user should see no Istio Components Status


### PR DESCRIPTION
### Describe the change

Skip one more test after Jaeger removal in lpinterop (note that in our downstream pipeline, the all tests are still running)
