### PR TITLE
Include filter by name/namespace in ztunnel table

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,5 +1,6 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { openTab } from './transition';
+import { getCellsForCol } from './table';
 
 // waitForWorkloadEnrolled waits until Kiali returns the namespace labels updated
 // Adding the waypoint label into the bookinfo namespace
@@ -154,7 +155,7 @@ Then('validates waypoint Info data for {string}', (type: string) => {
   cy.get('[role="grid"]').should('be.visible').get('[data-label=RDS]').and('contain', 'IGNORED');
 });
 
-When('the user validates the Ztunnel tab', () => {
+When('the user validates the Ztunnel tab for the {string} namespace', (namespace: string) => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
   cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]');
@@ -164,4 +165,13 @@ When('the user validates the Ztunnel tab', () => {
   cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Node]');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  // Validate filters in the Namespace column
+  cy.get('button#filter_select_type-toggle').click();
+  cy.contains('div#filter_select_type button', 'Namespace').click();
+  cy.get('input[placeholder="Filter by Namespace"]').type(`${namespace}{enter}`);
+  cy.get(`li[label="${namespace}"]`).should('be.visible').find('button').click();
+
+  getCellsForCol('Namespace').each($cell => {
+    cy.wrap($cell).contains(namespace);
+  });
 });

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -56,7 +56,7 @@ Feature: Kiali Waypoint related features
     Given user is at the details page for the "workload" "istio-system/ztunnel" located in the "" cluster
     Then the user cannot see the "missing-sidecar" badge for "ztunnel" workload in "istio-system" namespace
     And the proxy status is "healthy"
-    And the user validates the Ztunnel tab
+    And the user validates the Ztunnel tab for the "bookinfo" namespace
 
   Scenario: [Traffic Graph] User sees ztunnel traffic
     Given user is at the "graph" page

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -177,6 +177,7 @@
   "Failure": "Failure",
   "Fault Injection": "Fault Injection",
   "Fault Injection not valid": "Fault Injection not valid",
+  "Filter": "Filter",
   "Filter by Application Health": "Filtrar por la salud de la aplicación",
   "Filter by mTLS": "Filtrar por mTLS",
   "Filter by Namespace": "Filtrar por el espacio de nombres",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -165,6 +165,7 @@
   "Failure": "Failure",
   "Fault Injection": "故障注入",
   "Fault Injection not valid": "故障注入无效",
+  "Filter": "Filter",
   "Filter by Application Health": "Filter by Application Health",
   "Filter by mTLS": "Filter by mTLS",
   "Filter by Namespace": "Filter by Namespace",

--- a/frontend/src/components/Ambient/Filters/Filters.tsx
+++ b/frontend/src/components/Ambient/Filters/Filters.tsx
@@ -1,0 +1,61 @@
+import { FILTER_ACTION_APPEND, AllFilterTypes, FilterValue, RunnableFilter } from 'types/Filters';
+import { ZtunnelConfigDump, ZtunnelItem, ZtunnelService, ZtunnelWorkload } from '../../../types/IstioObjects';
+import { ConfigType } from './ZtunnelLabels';
+
+const byName = (item: FilterValue[], type: ConfigType): RunnableFilter<ZtunnelItem> => {
+  return {
+    category: type,
+    placeholder: `Filter by ${type}`,
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: item,
+    run: (item, filters) => filters.filters.some(f => f.value === item.name)
+  };
+};
+
+const byNamespace = (services: FilterValue[]): RunnableFilter<ZtunnelItem> => {
+  return {
+    category: 'Namespace',
+    placeholder: 'Filter by Namespace',
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: services,
+    run: (services, filters) => filters.filters.some(f => f.value === services.namespace)
+  };
+};
+
+export const servicesFilters = (config: ZtunnelConfigDump): RunnableFilter<ZtunnelService>[] => {
+  const name = new Set<string>();
+  const namespace = new Set<string>();
+
+  config?.services?.forEach(s => {
+    name.add(s.name);
+    namespace.add(s.namespace);
+  });
+
+  return [
+    byName(
+      Array.from(name).map(w => ({ id: w, title: w })),
+      ConfigType.SERVICE
+    ),
+    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
+  ];
+};
+
+export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<ZtunnelWorkload>[] => {
+  const name = new Set<string>();
+  const namespace = new Set<string>();
+
+  config?.workloads?.forEach(s => {
+    name.add(s.name);
+    namespace.add(s.namespace);
+  });
+
+  return [
+    byName(
+      Array.from(name).map(w => ({ id: w, title: w })),
+      ConfigType.WORKLOAD
+    ),
+    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
+  ];
+};

--- a/frontend/src/components/Ambient/Filters/Filters.tsx
+++ b/frontend/src/components/Ambient/Filters/Filters.tsx
@@ -106,7 +106,7 @@ export const servicesFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztunn
 };
 
 const getWorstStatus = (endpoints: Record<string, ZtunnelEndpoint>): string => {
-  const anyUnhealthy = Object.values(endpoints).find(e => e.status.toLowerCase() != 'healthy');
+  const anyUnhealthy = Object.values(endpoints).find(e => e.status.toLowerCase() !== 'healthy');
   return anyUnhealthy ? anyUnhealthy[0].status : 'Healthy';
 };
 

--- a/frontend/src/components/Ambient/Filters/Filters.tsx
+++ b/frontend/src/components/Ambient/Filters/Filters.tsx
@@ -1,11 +1,10 @@
 import { FILTER_ACTION_APPEND, AllFilterTypes, FilterValue, RunnableFilter } from 'types/Filters';
 import { ZtunnelConfigDump, ZtunnelItem, ZtunnelService, ZtunnelWorkload } from '../../../types/IstioObjects';
-import { ConfigType } from './ZtunnelLabels';
 
-const byName = (item: FilterValue[], type: ConfigType): RunnableFilter<ZtunnelItem> => {
+const byName = (item: FilterValue[], name: string): RunnableFilter<ZtunnelItem> => {
   return {
-    category: type,
-    placeholder: `Filter by ${type}`,
+    category: name,
+    placeholder: `Filter by ${name}`,
     filterType: AllFilterTypes.typeAhead,
     action: FILTER_ACTION_APPEND,
     filterValues: item,
@@ -36,7 +35,7 @@ export const servicesFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztunn
   return [
     byName(
       Array.from(name).map(w => ({ id: w, title: w })),
-      ConfigType.SERVICE
+      'Service'
     ),
     byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
   ];
@@ -54,7 +53,7 @@ export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztun
   return [
     byName(
       Array.from(name).map(w => ({ id: w, title: w })),
-      ConfigType.WORKLOAD
+      'Pod Name'
     ),
     byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
   ];

--- a/frontend/src/components/Ambient/Filters/Filters.tsx
+++ b/frontend/src/components/Ambient/Filters/Filters.tsx
@@ -1,5 +1,11 @@
 import { FILTER_ACTION_APPEND, AllFilterTypes, FilterValue, RunnableFilter } from 'types/Filters';
-import { ZtunnelConfigDump, ZtunnelItem, ZtunnelService, ZtunnelWorkload } from '../../../types/IstioObjects';
+import {
+  ZtunnelConfigDump,
+  ZtunnelEndpoint,
+  ZtunnelItem,
+  ZtunnelService,
+  ZtunnelWorkload
+} from '../../../types/IstioObjects';
 
 const byName = (item: FilterValue[], name: string): RunnableFilter<ZtunnelItem> => {
   return {
@@ -23,13 +29,69 @@ const byNamespace = (services: FilterValue[]): RunnableFilter<ZtunnelItem> => {
   };
 };
 
+const byWaypointService = (services: FilterValue[]): RunnableFilter<ZtunnelService> => {
+  return {
+    category: 'Waypoint',
+    placeholder: 'Filter by Waypoint',
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: services,
+    run: (services, filters) =>
+      filters.filters.some(f => {
+        return f.value === 'None' ? services.waypoint.destination === '' : f.value === services.waypoint.destination;
+      })
+  };
+};
+
+const byUnhealthy = (services: FilterValue[]): RunnableFilter<ZtunnelService> => {
+  return {
+    category: 'Endpoints Health',
+    placeholder: 'Filter by Endpoints',
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: services,
+    run: (services, filters) =>
+      filters.filters.some(f => {
+        return Object.values(services.endpoints).some(e => {
+          return e.status.toLowerCase() === f.value.toLowerCase();
+        });
+      })
+  };
+};
+
+const byNode = (workloads: FilterValue[]): RunnableFilter<ZtunnelWorkload> => {
+  return {
+    category: 'Node',
+    placeholder: 'Filter by Node',
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: workloads,
+    run: (workloads, filters) => filters.filters.some(f => f.value === workloads.node)
+  };
+};
+
+const byProtocol = (workloads: FilterValue[]): RunnableFilter<ZtunnelWorkload> => {
+  return {
+    category: 'Protocol',
+    placeholder: 'Filter by Protocol',
+    filterType: AllFilterTypes.typeAhead,
+    action: FILTER_ACTION_APPEND,
+    filterValues: workloads,
+    run: (workloads, filters) => filters.filters.some(f => f.value === workloads.protocol)
+  };
+};
+
 export const servicesFilters = (config: ZtunnelConfigDump): RunnableFilter<ZtunnelService>[] => {
   const name = new Set<string>();
   const namespace = new Set<string>();
+  const waypoint = new Set<string>();
+  const unhealthy = new Set<string>();
 
   config?.services?.forEach(s => {
     name.add(s.name);
     namespace.add(s.namespace);
+    waypoint.add(s.waypoint.destination);
+    unhealthy.add(getWorstStatus(s.endpoints));
   });
 
   return [
@@ -37,17 +99,28 @@ export const servicesFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztunn
       Array.from(name).map(w => ({ id: w, title: w })),
       'Service'
     ),
-    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
+    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w }))),
+    byWaypointService(Array.from(waypoint).map(w => ({ id: w, title: w !== '' ? w : 'None' }))),
+    byUnhealthy(Array.from(unhealthy).map(w => ({ id: w.toString(), title: w.toString() })))
   ];
+};
+
+const getWorstStatus = (endpoints: Record<string, ZtunnelEndpoint>): string => {
+  const anyUnhealthy = Object.values(endpoints).find(e => e.status.toLowerCase() != 'healthy');
+  return anyUnhealthy ? anyUnhealthy[0].status : 'Healthy';
 };
 
 export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<ZtunnelWorkload>[] => {
   const name = new Set<string>();
   const namespace = new Set<string>();
+  const node = new Set<string>();
+  const protocol = new Set<string>();
 
   config?.workloads?.forEach(s => {
     name.add(s.name);
     namespace.add(s.namespace);
+    node.add(s.node);
+    protocol.add(s.protocol);
   });
 
   return [
@@ -55,6 +128,8 @@ export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztun
       Array.from(name).map(w => ({ id: w, title: w })),
       'Pod Name'
     ),
-    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w })))
+    byNamespace(Array.from(namespace).map(w => ({ id: w, title: w }))),
+    byNode(Array.from(node).map(w => ({ id: w, title: w }))),
+    byProtocol(Array.from(protocol).map(w => ({ id: w, title: w })))
   ];
 };

--- a/frontend/src/components/Ambient/Filters/ZtunnelFilters.tsx
+++ b/frontend/src/components/Ambient/Filters/ZtunnelFilters.tsx
@@ -66,7 +66,10 @@ const byNode = (workloads: FilterValue[]): RunnableFilter<ZtunnelWorkload> => {
     filterType: AllFilterTypes.typeAhead,
     action: FILTER_ACTION_APPEND,
     filterValues: workloads,
-    run: (workloads, filters) => filters.filters.some(f => f.value === workloads.node)
+    run: (workloads, filters) =>
+      filters.filters.some(f => {
+        return f.value === 'N/A' ? workloads.node === '' : f.value === workloads.node;
+      })
   };
 };
 
@@ -129,7 +132,7 @@ export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztun
       'Pod Name'
     ),
     byNamespace(Array.from(namespace).map(w => ({ id: w, title: w }))),
-    byNode(Array.from(node).map(w => ({ id: w, title: w }))),
+    byNode(Array.from(node).map(w => ({ id: w, title: w == '' ? 'N/A' : w }))),
     byProtocol(Array.from(protocol).map(w => ({ id: w, title: w })))
   ];
 };

--- a/frontend/src/components/Ambient/Filters/ZtunnelFilters.tsx
+++ b/frontend/src/components/Ambient/Filters/ZtunnelFilters.tsx
@@ -132,7 +132,7 @@ export const workloadsFilters = (config: ZtunnelConfigDump): RunnableFilter<Ztun
       'Pod Name'
     ),
     byNamespace(Array.from(namespace).map(w => ({ id: w, title: w }))),
-    byNode(Array.from(node).map(w => ({ id: w, title: w == '' ? 'N/A' : w }))),
+    byNode(Array.from(node).map(w => ({ id: w, title: w === '' ? 'N/A' : w }))),
     byProtocol(Array.from(protocol).map(w => ({ id: w, title: w })))
   ];
 };

--- a/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
+++ b/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Label, pluralize } from '@patternfly/react-core';
+
+import { ZtunnelItem } from '../../../types/IstioObjects';
+
+export enum ConfigType {
+  SERVICE = 'service',
+  WORKLOAD = 'workload'
+}
+
+type Props = {
+  filteredConfig?: ZtunnelItem[];
+  type: ConfigType;
+};
+
+export const ZtunnelLabels = (p: Props): React.ReactElement => {
+  return (
+    <>
+      <Label style={{ margin: 10 }} color="blue" key={p.type}>
+        {`${p.filteredConfig && p.filteredConfig.length} / `}
+        {p.filteredConfig && pluralize(p.filteredConfig?.length, p.type)}
+      </Label>
+    </>
+  );
+};

--- a/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
+++ b/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const ZtunnelLabels = (p: Props): React.ReactElement => {
   return (
     <>
-      <Label style={{ margin: 10 }} color="blue" key={p.type}>
+      <Label color="blue" key={p.type}>
         {`${p.filteredConfig && p.filteredConfig.length} / `}
         {p.filteredConfig && pluralize(p.filteredConfig?.length, p.type)}
       </Label>

--- a/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
+++ b/frontend/src/components/Ambient/Filters/ZtunnelLabels.tsx
@@ -10,6 +10,7 @@ export enum ConfigType {
 
 type Props = {
   filteredConfig?: ZtunnelItem[];
+  total: number;
   type: ConfigType;
 };
 
@@ -18,7 +19,7 @@ export const ZtunnelLabels = (p: Props): React.ReactElement => {
     <>
       <Label color="blue" key={p.type}>
         {`${p.filteredConfig && p.filteredConfig.length} / `}
-        {p.filteredConfig && pluralize(p.filteredConfig?.length, p.type)}
+        {p.filteredConfig && pluralize(p.total, p.type)}
       </Label>
     </>
   );

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -188,7 +188,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               <StatefulFilters
                 initialFilters={serviceFilters}
                 onFilterChange={active => setActiveServiceFilters(active)}
-                key="service-filter"
+                cleanState
               >
                 <ZtunnelLabels
                   key="service-labels"
@@ -226,7 +226,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               <StatefulFilters
                 initialFilters={workloadFilters}
                 onFilterChange={active => setActiveWorkloadFilters(active)}
-                key="workload-filters"
+                cleanState
               >
                 <ZtunnelLabels
                   key="workload-labels"
@@ -235,7 +235,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
                 />
               </StatefulFilters>
             </div>
-            <ZtunnelWorkloadsTable config={config?.workloads} />
+            <ZtunnelWorkloadsTable config={filteredWorkloads} />
           </div>
         </CardBody>
       </Card>

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -22,7 +22,7 @@ import { SortableTh } from '../Table/SimpleTable';
 import { ZtunnelMetrics } from './ZtunnelMetrics';
 import { RenderComponentScroll } from 'components/Nav/Page';
 import { FilterSelected, StatefulFilters } from '../Filters/StatefulFilters';
-import { servicesFilters, workloadsFilters } from './Filters/Filters';
+import { servicesFilters, workloadsFilters } from './Filters/ZtunnelFilters';
 import { ActiveFiltersInfo } from '../../types/Filters';
 import { runFilters } from '../FilterList/FilterHelper';
 import { ConfigType, ZtunnelLabels } from './Filters/ZtunnelLabels';

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -198,8 +198,9 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               >
                 <ZtunnelLabels
                   key="service-labels"
-                  type={ConfigType.SERVICE}
                   filteredConfig={activeServiceFilters.filters.length > 0 ? filteredServices : config.services}
+                  total={config?.services?.length ?? filteredServices.length}
+                  type={ConfigType.SERVICE}
                 />
               </StatefulFilters>
             </div>
@@ -237,8 +238,9 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               >
                 <ZtunnelLabels
                   key="workload-labels"
-                  type={ConfigType.WORKLOAD}
                   filteredConfig={activeWorkloadFilters.filters.length > 0 ? filteredWorkloads : config?.workloads}
+                  total={config?.workloads?.length ?? filteredWorkloads.length}
+                  type={ConfigType.WORKLOAD}
                 />
               </StatefulFilters>
             </div>

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -51,6 +51,11 @@ const toolbarStyle = kialiStyle({
   alignItems: 'center'
 });
 
+const toolbarClass = kialiStyle({
+  display: 'flex',
+  paddingTop: '0'
+});
+
 export interface SortableCompareTh<T> extends SortableTh {
   compare?: (a: T, b: T) => number;
 }
@@ -188,6 +193,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               <StatefulFilters
                 initialFilters={serviceFilters}
                 onFilterChange={active => setActiveServiceFilters(active)}
+                toolbarClass={toolbarClass}
                 cleanState
               >
                 <ZtunnelLabels
@@ -226,6 +232,7 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
               <StatefulFilters
                 initialFilters={workloadFilters}
                 onFilterChange={active => setActiveWorkloadFilters(active)}
+                toolbarClass={toolbarClass}
                 cleanState
               >
                 <ZtunnelLabels

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -42,6 +42,7 @@ import { t } from 'utils/I18nUtils';
 import { connect } from 'react-redux';
 import { KialiAppState } from 'store/Store';
 import { languageSelector } from 'store/Selectors';
+import { classes } from 'typestyle';
 
 const toolbarStyle = kialiStyle({
   padding: 0,
@@ -82,6 +83,7 @@ type StatefulFiltersProps = ReduxProps & {
   onFilterChange: (active: ActiveFiltersInfo) => void;
   onToggleChange?: (active: ActiveTogglesInfo) => void;
   ref?: React.RefObject<StatefulFiltersComponent>;
+  toolbarClass?: string;
 };
 
 interface StatefulFiltersState {
@@ -630,7 +632,11 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
 
     return (
       <>
-        <Toolbar id="filter-selection" className={toolbarStyle} clearAllFilters={this.clearFilters}>
+        <Toolbar
+          id="filter-selection"
+          className={this.props.toolbarClass ? classes(toolbarStyle, this.props.toolbarClass) : toolbarStyle}
+          clearAllFilters={this.clearFilters}
+        >
           {this.props.childrenFirst && this.renderChildren()}
           <ToolbarContent>
             <ToolbarGroup variant="filter-group">

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -76,6 +76,7 @@ type ReduxProps = {
 type StatefulFiltersProps = ReduxProps & {
   children?: React.ReactNode;
   childrenFirst?: boolean;
+  cleanState?: boolean; // For shared components, state is not saved in the URL
   initialFilters: FilterType[];
   initialToggles?: ToggleType[];
   onFilterChange: (active: ActiveFiltersInfo) => void;
@@ -186,11 +187,9 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
 
   constructor(props: StatefulFiltersProps) {
     super(props);
-
     this.textInputRef = React.createRef<HTMLInputElement>();
-
     this.state = {
-      activeFilters: FilterSelected.init(this.props.initialFilters),
+      activeFilters: this.props.cleanState ? { filters: [], op: 'or' } : FilterSelected.init(this.props.initialFilters),
       activeToggles: Toggles.init(this.props.initialToggles ?? []),
       currentFilterType: this.props.initialFilters[0],
       filterTypes: this.props.initialFilters,
@@ -265,7 +264,10 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
       });
 
       this.loadDynamicFilters();
-    } else if (!FilterHelper.filtersMatchURL(this.state.filterTypes, this.state.activeFilters)) {
+    } else if (
+      !this.props.cleanState &&
+      !FilterHelper.filtersMatchURL(this.state.filterTypes, this.state.activeFilters)
+    ) {
       FilterHelper.setFiltersToURL(this.state.filterTypes, this.state.activeFilters);
     }
 

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1568,12 +1568,15 @@ export type SocketAddress = {
   SocketAddr: string;
 };
 
-export type ZtunnelService = {
+export interface ZtunnelItem {
+  name: string;
+  namespace: string;
+}
+
+export type ZtunnelService = ZtunnelItem & {
   endpoints: Record<string, ZtunnelEndpoint>;
   hostname: string;
   ipFamilies: string;
-  name: string;
-  namespace: string;
   ports: Record<string, number>;
   subjectAltNames: string[];
   vips: string[];
@@ -1591,12 +1594,10 @@ export type ZtunnelWaypoint = {
   hboneMtlsPort: number;
 };
 
-export type ZtunnelWorkload = {
+export type ZtunnelWorkload = ZtunnelItem & {
   canonicalName: string;
   canonicalRevision: string;
   clusterId: string;
-  name: string;
-  namespace: string;
   networkMode: string;
   node: string;
   protocol: string;


### PR DESCRIPTION
### Describe the change

Include filter by name/namespace in ztunnel table

![image](https://github.com/user-attachments/assets/d0218d6e-cea6-40e5-9754-72529992856e)

### Steps to test the PR

- Install Istio Ambient
- Go to ztunnel workload details
- Go to ztunnel tab
- Use the filters in services/Workloads. Validate it work as expected

### Automation testing

- cy test for filter

### Issue reference

Closes #7996 
