### PR TITLE
Fix failures for Test Istio Version jobs

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -415,7 +415,7 @@ setup_kind_multicluster() {
       --certs-dir "${certs_dir}" \
       -dorp docker \
       --istio-dir "${istio_dir}" \
-      ${kind_node_image:-}
+      ${kind_node_image:-} \
       ${hub_arg:-} \
       ${istio_version_arg}
 

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -89,6 +89,13 @@ test-integration: test-integration-setup
 test-integration-controller: .ensure-envtest-bin-dir-exists .ensure-yq-exists
 	$(eval ISTIO_VERSION ?= $(shell helm show chart --repo https://istio-release.storage.googleapis.com/charts base | yq '.version'))
 	$(eval ISTIO_MINOR_VERSION := $(shell cut -d "." -f 1-2 <<< ${ISTIO_VERSION}))
+	@if [[ "$(ISTIO_MINOR_VERSION)" == *latest ]]; then \
+		$(eval latest := $(shell echo "$(ISTIO_MINOR_VERSION)" | sed 's/-latest$$//')) \
+		if [ -z "$$latest" ]; then \
+			$(eval ISTIO_MINOR_VERSION := $(shell echo ${latest})) \
+			echo "Istio minor with latest: ${latest}"; \
+		fi \
+	fi
 	$(eval CRD_FILE := tests/integration/controller/testdata/istio-crds/${ISTIO_MINOR_VERSION}.yaml)
 	@if [ ! -f "${CRD_FILE}" ]; then \
 		echo "the CRD yamls for Istio version '${ISTIO_MINOR_VERSION}' are missing at '${CRD_FILE}' - run 'make download-istio-crds' to download them and then check them into git" && exit 1; \

--- a/tests/integration/controller/suite_test.go
+++ b/tests/integration/controller/suite_test.go
@@ -81,9 +81,10 @@ var _ = BeforeSuite(func() {
 		if len(parts) < 2 {
 			Fail(fmt.Sprintf("Invalid ISTIO_VERSION env var. Expected version of the form '1.23.0'. Got: %s", istioVersion))
 		}
+		parts2 := strings.Split(parts[1], "-") // For the 1.23-latest format
 
 		// Put it back together with just the major/minor
-		istioVersion = parts[0] + "." + parts[1]
+		istioVersion = parts[0] + "." + parts2[0]
 	} else {
 		// Find the latest version
 		crdFiles, err := istioCRDDir.ReadDir("testdata/istio-crds")

--- a/tests/integration/controller/suite_test.go
+++ b/tests/integration/controller/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 		// Take version of the form 1.23.0 and convert it to it's minor form: 1.23
 		parts := strings.Split(istioVersion, ".")
 		if len(parts) < 2 {
-			Fail(fmt.Sprintf("Invalid ISTIO_VERSION env var. Expected version of the form '1.23.0' of '1.23-latest'. Got: %s", istioVersion))
+			Fail(fmt.Sprintf("Invalid ISTIO_VERSION env var. Expected version of the form '1.23.0' or '1.23-latest'. Got: %s", istioVersion))
 		}
 		parts2 := strings.Split(parts[1], "-") // For the 1.23-latest format
 

--- a/tests/integration/controller/suite_test.go
+++ b/tests/integration/controller/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 		// Take version of the form 1.23.0 and convert it to it's minor form: 1.23
 		parts := strings.Split(istioVersion, ".")
 		if len(parts) < 2 {
-			Fail(fmt.Sprintf("Invalid ISTIO_VERSION env var. Expected version of the form '1.23.0'. Got: %s", istioVersion))
+			Fail(fmt.Sprintf("Invalid ISTIO_VERSION env var. Expected version of the form '1.23.0' of '1.23-latest'. Got: %s", istioVersion))
 		}
 		parts2 := strings.Split(parts[1], "-") // For the 1.23-latest format
 


### PR DESCRIPTION
### Describe the change

Follow up of: https://github.com/kiali/kiali/pull/8378
Some tests are still failing: https://github.com/kiali/kiali/actions/runs/14746679127/job/41395384846 

### Steps to test the PR

- `make $(if [ -n "1.24-latest" ]; then echo "ISTIO_VERSION=1.24-latest"; fi) test-integration-controller`
- `hack/run-integration-tests.sh --test-suite frontend-multi-primary $(if [ -n "1.24-latest" ]; then echo "--istio-version 1.24-latest"; fi)`

### Automation testing

Test Istio Version pipeline

### Issue reference

Ref. https://github.com/kiali/kiali/pull/8378
