### PR TITLE
[v2.4] Bump to RHEL9 in kiali integration tests container (#8379)

### DIFF
--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG GO_VERSION
 ENV GOPATH=/go
@@ -8,15 +8,15 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install --nodocs tar gzip make which \
+RUN microdnf install -y --nodocs tar gzip make which gettext git \
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \
     && curl -Lo ./golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
     && tar -xf golang.tar.gz -C /usr/local \
     && rm -f golang.tar.gz \
-    && microdnf update \
-    && microdnf clean all \
+    && microdnf update -y \
+    && microdnf clean all -y \
     && mkdir -p "$GOPATH/src/kiali" "$GOPATH/bin"
 
 COPY . $GOPATH/src/kiali


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/8379 