### PR TITLE
Gateway API Classes auto-discovery

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1122,10 +1122,6 @@ func (in *IstioConfigService) CreateIstioConfigDetail(ctx context.Context, clust
 	return istioConfigDetail, nil
 }
 
-func (in *IstioConfigService) GatewayAPIClasses(cluster string) []config.GatewayAPIClass {
-	return kubernetes.GatewayAPIClasses(in.kialiCache.IsAmbientEnabled(cluster), in.conf)
-}
-
 func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, namespaces []string, cluster string) models.IstioConfigPermissions {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetIstioConfigPermissions",

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -468,7 +468,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) [
 		checkers.AuthorizationPolicyChecker{Conf: conf, AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: nsNames, ServiceEntries: istioConfigList.ServiceEntries, WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: *mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices, PolicyAllowAny: in.isPolicyAllowAny(vInfo.mesh), Cluster: cluster, ServiceAccounts: vInfo.saMap},
 		checkers.DestinationRulesChecker{Conf: conf, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: *mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries, Cluster: cluster},
 		checkers.GatewayChecker{Conf: conf, Gateways: istioConfigList.Gateways, WorkloadsPerNamespace: workloadsPerNamespace, IsGatewayToNamespace: in.isGatewayToNamespace(vInfo.mesh), Cluster: cluster},
-		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.istioConfig.GatewayAPIClasses(cluster)},
+		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.kialiCache.GatewayAPIClasses(cluster)},
 		checkers.K8sGRPCRouteChecker{Conf: conf, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
 		checkers.K8sHTTPRouteChecker{Conf: conf, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
 		checkers.K8sReferenceGrantChecker{K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Cluster: cluster},
@@ -634,7 +634,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 	case kubernetes.K8sGateways:
 		// Validations on K8sGateways
 		objectCheckers = []checkers.ObjectChecker{
-			checkers.K8sGatewayChecker{Cluster: cluster, K8sGateways: istioConfigList.K8sGateways, GatewayClasses: in.istioConfig.GatewayAPIClasses(cluster)},
+			checkers.K8sGatewayChecker{Cluster: cluster, K8sGateways: istioConfigList.K8sGateways, GatewayClasses: in.kialiCache.GatewayAPIClasses(cluster)},
 		}
 		referenceChecker = references.K8sGatewayReferences{Conf: conf, K8sGateways: istioConfigList.K8sGateways, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.K8sGRPCRoutes:

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -408,8 +408,8 @@ func (c *kialiCacheImpl) GatewayAPIClasses(cluster string) []config.GatewayAPICl
 		}
 
 		for _, class := range classList.Items {
-			// Filter out classes that don't use Istio as a controller
-			if strings.HasPrefix(string(class.Spec.ControllerName), "istio.io") {
+			// Filter out classes that don't use Istio as a controller when the label filter is set
+			if strings.HasPrefix(string(class.Spec.ControllerName), "istio.io") || len(labelSelector) > 0 {
 				result = append(result, config.GatewayAPIClass{Name: class.Name, ClassName: class.Name})
 			}
 		}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -402,7 +402,7 @@ func (c *kialiCacheImpl) GatewayAPIClasses(cluster string) []config.GatewayAPICl
 		}
 	}
 
-	if len(result) == 0 {
+	if len(result) == 0 && k8sCache.Client().IsGatewayAPI() {
 		klog.Errorf("No GatewayAPIClasses configured or found in cluster '%s' by label selector '%s'", cluster, labelSelector)
 	}
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 

--- a/config/config.go
+++ b/config/config.go
@@ -312,6 +312,7 @@ type IstioConfig struct {
 	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
 	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
+	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty"`
 	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
 	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
 	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`

--- a/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
@@ -58,7 +58,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
       newGateway: props.k8sGateways.length === 0,
       selectedGateway:
         props.k8sGateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.k8sGateways[0]) : '',
-      gatewayClass: serverConfig?.gatewayAPIClasses[0]?.className,
+      gatewayClass: serverConfig?.gatewayAPIClasses?.length > 0 ? serverConfig.gatewayAPIClasses[0].className : '',
       addMesh: false,
       port: 80,
       isOpen: false

--- a/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/K8sGatewayForm.tsx
@@ -23,7 +23,7 @@ export type K8sGatewayState = {
 
 export const initK8sGateway = (): K8sGatewayState => ({
   addresses: [],
-  gatewayClass: serverConfig.gatewayAPIClasses[0].className,
+  gatewayClass: serverConfig.gatewayAPIClasses.length > 0 ? serverConfig.gatewayAPIClasses[0].className : '',
   listeners: [],
   listenersForm: [],
   validHosts: false

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -113,7 +113,7 @@ func Config(conf *config.Config, cache cache.KialiCache, discovery istio.MeshDis
 			publicConfig.GatewayAPIEnabled = client.IsGatewayAPI()
 		}
 		publicConfig.AmbientEnabled = cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName)
-		publicConfig.GatewayAPIClasses = kubernetes.GatewayAPIClasses(publicConfig.AmbientEnabled, conf)
+		publicConfig.GatewayAPIClasses = cache.GatewayAPIClasses(conf.KubernetesConfig.ClusterName)
 
 		// Fetch the list of all clusters in the mesh
 		// One usage of this data is to cross-link Kiali instances, when possible.

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -363,20 +363,3 @@ func ClusterNameFromIstiod(conf config.Config, k8s ClientInterface) (string, err
 
 	return clusterName, nil
 }
-
-func GatewayAPIClasses(ambientEnabled bool, conf *config.Config) []config.GatewayAPIClass {
-	result := []config.GatewayAPIClass{}
-	for _, gwClass := range conf.ExternalServices.Istio.GatewayAPIClasses {
-		if gwClass.ClassName != "" && gwClass.Name != "" {
-			result = append(result, gwClass)
-		}
-	}
-	if len(result) == 0 {
-		result = append(result, config.GatewayAPIClass{Name: "Istio", ClassName: "istio"})
-		if ambientEnabled {
-			result = append(result, config.GatewayAPIClass{Name: "Waypoint", ClassName: "istio-waypoint"})
-		}
-	}
-
-	return result
-}

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -308,6 +308,7 @@
             "ConfigMapName": "",
             "EnvoyAdminLocalPort": 15000,
             "GatewayAPIClasses": [],
+            "GatewayAPIClassesLabelSelector": "",
             "IstioAPIEnabled": true,
             "IstioIdentityDomain": "svc.cluster.local",
             "IstioInjectionAnnotation": "sidecar.istio.io/inject",


### PR DESCRIPTION
### Describe the change

When `gateway_api_classes:` is not set in Kiali CR, when Gateway API Classes are auto-discovered.
The auto discovery can use `gateway_api_classes_label_selector:` config for filtering those objects, which by default is empty.

### Steps to test the PR

a. Regression testing then K8s Gateway API CRDs are not installed. No error in Kiali logs.
b. Install CRDs, leave  `gateway_api_classes:` empty. Go to Isto configs page's Actions wizard, create a new K8sGateway. Verify that the system installed Gateway API Classes are shown in dropdown.
Verify that in created K8sGateway, the `gatewayClassName` is set, and when has a wrong value, the validation error is shown.
b1. Similar to previous one, but add a value for `gateway_api_classes_label_selector: "key=value"`. Verify that the filtered list is shown.
b2. `gateway_api_classes_label_selector: wrong`, verify that Kiali logs Error message that no Classes found.
c. Regression testing when `gateway_api_classes:` is set. And the wizards and validations are using Classes from those configs.

### Automation testing

existing ones should pass

### Issue reference

Original community issue https://github.com/kiali/kiali/issues/8220
Initial PR by a community https://github.com/kiali/kiali/pull/8226

