### PR TITLE
Update tracing query for errors

### DIFF
--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -264,7 +264,12 @@ func (oc *OtelHTTPClient) prepareTraceQL(u *url.URL, tracingServiceName string, 
 
 	if len(query.Tags) > 0 {
 		for k, v := range query.Tags {
-			tag := TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
+			var tag TraceQL
+			if k == "error" {
+				tag = TraceQL{operator1: ".http.status_code", operand: NOTEQUAL, operator2: "200"}
+			} else {
+				tag = TraceQL{operator1: "." + k, operand: EQUAL, operator2: v}
+			}
 			queryPart = TraceQL{operator1: queryPart, operand: AND, operator2: tag}
 		}
 	}


### PR DESCRIPTION
### Describe the change

Update tracing query for errors, error tag doesn't exist, so the query uses http.status_code != 200

### Steps to test the PR

In minikube

- Install Kiali and Tempo (hack/istio/tempo/install-tempo-env.sh -c kubectl)
- Install bookinfo and create an Error rates traffic policy
- Go to a service with errors and select the "Show only traces with errors option"

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #8406 
