### PR TITLE
Fix timing issue causing OSSMC test fail for manual refresh interval

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -461,6 +461,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
     );
     const isReady = !(isEmpty || this.state.graphData.isError);
     const isReplayReady = this.props.replayActive && !!this.props.replayQueryTime;
+    const refreshInterval = HistoryManager.getRefresh() ?? this.props.refreshInterval;
 
     return (
       <>
@@ -502,7 +503,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
                     isMiniGraph={false}
                     loaded={this.state.graphData.loaded}
                     namespaces={this.props.activeNamespaces}
-                    refreshInterval={this.props.refreshInterval}
+                    refreshInterval={refreshInterval}
                     showIdleNodes={this.props.showIdleNodes}
                     toggleIdleNodes={this.props.toggleIdleNodes}
                   >

--- a/frontend/src/pages/Mesh/MeshPage.tsx
+++ b/frontend/src/pages/Mesh/MeshPage.tsx
@@ -223,6 +223,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
     const conStyle = isKioskMode() ? kioskContainerStyle : containerStyle;
     const isEmpty = !(this.state.meshData.elements.nodes && Object.keys(this.state.meshData.elements.nodes).length > 0);
     const isReady = !(isEmpty || this.state.meshData.isError);
+    const refreshInterval = HistoryManager.getRefresh() ?? this.props.refreshInterval;
 
     return (
       <>
@@ -256,7 +257,7 @@ class MeshPageComponent extends React.Component<MeshPageProps, MeshPageState> {
                   isLoading={this.state.meshData.isLoading}
                   isMiniMesh={false}
                   loaded={this.state.meshData.loaded}
-                  refreshInterval={this.props.refreshInterval}
+                  refreshInterval={refreshInterval}
                 >
                   <Mesh {...this.props} isMiniMesh={false} meshData={this.state.meshData} onReady={this.handleReady} />
                 </EmptyMeshLayout>


### PR DESCRIPTION
Because the redux prop is not set until the toolbar is mounted, ensure the EmptyGraphLayout wrapper uses the refresh URL param, if set. This protects us from possibly using the default refresh interval by mistake.

This is especially important when the URL specifies the "manual" refresh interval.

related to #8344. The timing in OSSMC surfaces this issue.
