### PR TITLE
get mesh graph generation metrics

### DIFF
--- a/mesh/api/api.go
+++ b/mesh/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kiali/kiali/mesh/config/common"
 	"github.com/kiali/kiali/mesh/generator"
 	"github.com/kiali/kiali/observability"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
 // GraphMesh generates a mesh graph using the provided options
@@ -37,9 +38,6 @@ func GraphMesh(
 		observability.Attribute("package", "api"),
 	)
 	defer end()
-	// time how long it takes to generate this graph
-	// promtimer := internalmetrics.GetMeshGraphGenerationTimePrometheusTimer()
-	// defer promtimer.ObserveDuration()
 
 	// Create a 'global' object to store the business. Global only to the request.
 	globalInfo := mesh.NewGlobalInfo()
@@ -50,6 +48,9 @@ func GraphMesh(
 	globalInfo.Grafana = grafana
 	globalInfo.KialiCache = kialiCache
 	globalInfo.IstioStatusGetter = &business.IstioStatus
+
+	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer("mesh", "mesh", false)
+	promtimer.ObserveDuration()
 
 	code, config = graphMesh(ctx, globalInfo, o)
 
@@ -73,8 +74,8 @@ func graphMesh(ctx context.Context, globalInfo *mesh.GlobalInfo, o mesh.Options)
 func generateGraph(meshMap mesh.MeshMap, o mesh.Options) (int, interface{}) {
 	log.Tracef("Generating config for [%s] graph...", o.ConfigVendor)
 
-	//	promtimer := internalmetrics.GetMeshGraphMarshalTimePrometheusTimer()
-	//	defer promtimer.ObserveDuration()
+	promtimer := internalmetrics.GetGraphMarshalTimePrometheusTimer("mesh", "mesh", false)
+	defer promtimer.ObserveDuration()
 
 	var vendorConfig interface{}
 	switch o.ConfigVendor {

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -35,9 +35,6 @@ type MetricsType struct {
 	GraphMarshalTime               *prometheus.HistogramVec
 	GraphNodes                     *prometheus.GaugeVec
 	KubernetesClients              *prometheus.GaugeVec
-	MeshGraphAppenderTime          *prometheus.HistogramVec
-	MeshGraphGenerationTime        *prometheus.HistogramVec
-	MeshGraphMarshalTime           *prometheus.HistogramVec
 	PrometheusProcessingTime       *prometheus.HistogramVec
 	SingleValidationProcessingTime *prometheus.HistogramVec
 	CacheTotalRequests             *prometheus.CounterVec
@@ -271,34 +268,6 @@ func GetGraphMarshalTimePrometheusTimer(graphKind string, graphType string, with
 		labelGraphKind:        graphKind,
 		labelGraphType:        graphType,
 		labelWithServiceNodes: strconv.FormatBool(withServiceNodes),
-	}))
-	return timer
-}
-
-// GetMeshGraphGenerationTimePrometheusTimer returns a timer that can be used to store
-// a value for the mesh graph generation time metric. The timer is ticking immediately
-// when this function returns.
-// Typical usage is as follows:
-//
-//	promtimer := GetMeshGraphGenerationTimePrometheusTimer(...)
-//	defer promtimer.ObserveDuration()
-func GetMeshGraphGenerationTimePrometheusTimer() *prometheus.Timer {
-	timer := prometheus.NewTimer(Metrics.MeshGraphGenerationTime.With(prometheus.Labels{
-		labelGraphKind: "mesh",
-	}))
-	return timer
-}
-
-// GetMeshGraphMarshalTimePrometheusTimer returns a timer that can be used to store
-// a value for the graph marshal time metric. The timer is ticking immediately
-// when this function returns.
-// Typical usage is as follows:
-//
-//	promtimer := GetGraphMarshalTimePrometheusTimer(...)
-//	defer promtimer.ObserveDuration()
-func GetMeshGraphMarshalTimePrometheusTimer() *prometheus.Timer {
-	timer := prometheus.NewTimer(Metrics.MeshGraphMarshalTime.With(prometheus.Labels{
-		labelGraphKind: "mesh",
 	}))
 	return timer
 }


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/8429

This code will need to be updated to use the new common observe-and-log function once [this](https://github.com/kiali/kiali/pull/8427) is merged, but we can do that as part of that PR, if we can merge this one first.

@jshaughn I just need confirmation - there are NO appenders that are invoked when generating a mesh graph, correct?