### PR TITLE
[CI] skip molecule tests with OLM-installed operator in release workflow

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -15,7 +15,7 @@ on:
         default: ""
         type: string
       olm_version:
-        description: "Version of OLM to install or 'latest'. e.g. v0.28.0"
+        description: "Version of OLM to install or 'latest'. e.g. v0.28.0. Can be 'skip' if you want to skip the OLM tests."
         required: false
         default: "latest"
         type: string
@@ -122,6 +122,10 @@ jobs:
     - name: Run molecule tests OLM
       id: run-molecule-tests-olm
       run: |
+        if [ "${{ inputs.olm_version }}" == "skip" ]; then
+          echo "OLM version is [skip] - will skip OLM tests." && exit 0
+        fi
+
         ISTIO_VERSION="${{ env.ISTIO_VERSION }}"
         if [ -z "${ISTIO_VERSION}" ]; then
           echo "Could not determine the Istio version to use." && exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
     needs: [initialize]
     with:
       all_tests: ""
-      olm_version: "latest"
+      olm_version: "skip"
       istio_minor_version_offset: 0
 
   release:


### PR DESCRIPTION
For release workflow, we do not want to run molecule tests with the operator installed via OLM because OperatorHub.io will not have the new operator being released. OperatorHub.io will only have the last release and it might not pass the tests meant for the new version of the operator that is about to be released.