### PR TITLE
Add logic to show GW icon

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -390,6 +390,7 @@ type IstioLabels struct {
 	AppLabelName                string `yaml:"app_label_name,omitempty" json:"appLabelName"`
 	InjectionLabelName          string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev           string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
+	ServiceCanonicalName        string `yaml:"service_canonical_name,omitempty" json:"serviceCanonicalName"`
 	VersionLabelName            string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
@@ -836,6 +837,7 @@ func NewConfig() (c *Config) {
 			AppLabelName:                "",
 			InjectionLabelName:          "istio-injection",
 			InjectionLabelRev:           IstioRevisionLabel,
+			ServiceCanonicalName:        "service.istio.io/canonical-name",
 			VersionLabelName:            "",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
@@ -1059,7 +1061,7 @@ func Set(conf *Config) {
 			appLabelNames = []string{conf.IstioLabels.AppLabelName}
 			versionLabelNames = []string{conf.IstioLabels.VersionLabelName}
 		} else {
-			appLabelNames = []string{"service.istio.io/canonical-name", "app.kubernetes.io/name", "app"}
+			appLabelNames = []string{conf.IstioLabels.ServiceCanonicalName, "app.kubernetes.io/name", "app"}
 			versionLabelNames = []string{"service.istio.io/canonical-revision", "app.kubernetes.io/version", "version"}
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -391,6 +391,7 @@ type IstioLabels struct {
 	InjectionLabelName          string `yaml:"injection_label_name,omitempty" json:"injectionLabelName"`
 	InjectionLabelRev           string `yaml:"injection_label_rev,omitempty" json:"injectionLabelRev"`
 	ServiceCanonicalName        string `yaml:"service_canonical_name,omitempty" json:"serviceCanonicalName"`
+	ServiceCanonicalRevision    string `yaml:"service_canonical_revision,omitempty" json:"serviceCanonicalRevision"`
 	VersionLabelName            string `yaml:"version_label_name,omitempty" json:"versionLabelName"`
 }
 
@@ -838,6 +839,7 @@ func NewConfig() (c *Config) {
 			InjectionLabelName:          "istio-injection",
 			InjectionLabelRev:           IstioRevisionLabel,
 			ServiceCanonicalName:        "service.istio.io/canonical-name",
+			ServiceCanonicalRevision:    "service.istio.io/canonical-revision",
 			VersionLabelName:            "",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
@@ -1062,7 +1064,7 @@ func Set(conf *Config) {
 			versionLabelNames = []string{conf.IstioLabels.VersionLabelName}
 		} else {
 			appLabelNames = []string{conf.IstioLabels.ServiceCanonicalName, "app.kubernetes.io/name", "app"}
-			versionLabelNames = []string{"service.istio.io/canonical-revision", "app.kubernetes.io/version", "version"}
+			versionLabelNames = []string{conf.IstioLabels.ServiceCanonicalRevision, "app.kubernetes.io/version", "version"}
 		}
 	}
 }

--- a/frontend/src/pages/Graph/GraphElems.tsx
+++ b/frontend/src/pages/Graph/GraphElems.tsx
@@ -273,7 +273,10 @@ export const setNodeLabel = (
       data.labelIcon = <span className={`${badgeMap.get('RO')?.className} ${rootIconStyle}`}></span>;
     }
   } else {
-    if (data.isGateway?.egressInfo?.hostnames?.length !== undefined) {
+    if (
+      data.isGateway?.egressInfo?.hostnames?.length !== undefined ||
+      data.isGateway?.gatewayAPIInfo?.hostnames?.length !== undefined
+    ) {
       data.labelIcon = <span className={`${badgeMap.get('GW')?.className} ${gatewayIconStyle}`}></span>;
     }
     // A Waypoint should be mutually exclusive with being a traffic source

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -267,8 +267,7 @@ func decorateMatchingAPIGateways(cluster string, gwCrd *k8s_networking_v1.Gatewa
 		if gw.Cluster != cluster {
 			continue
 		}
-
-		if gwSelector.Matches(labels.Set(gw.Labels)) {
+		if (!gwSelector.Empty() && gwSelector.Matches(labels.Set(gw.Labels))) || (gwSelector.Empty() && gwCrd.Name == gw.Labels[config.GatewayLabel]) {
 			// If we are here, the GatewayCrd selects the GatewayAPI workload.
 			// So, all node graphs associated with the GW API workload should be listening
 			// requests for the hostnames listed in the GatewayAPI CRD.
@@ -283,7 +282,9 @@ func decorateMatchingAPIGateways(cluster string, gwCrd *k8s_networking_v1.Gatewa
 						hostnames = append(hostnames, string(*gwListener.Hostname))
 					}
 				}
-
+				if len(hostnames) == 0 {
+					hostnames = append(hostnames, "*")
+				}
 				// Metadata format: { gatewayName => array of hostnames }
 				node.Metadata[nodeMetadataKey].(graph.GatewaysMetadata)[gwCrd.Name] = hostnames
 			}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -294,7 +294,7 @@ func decorateMatchingAPIGateways(cluster string, gwCrd *k8s_networking_v1.Gatewa
 
 func resolveGatewayNodeMapping(gatewayWorkloads map[string][]models.WorkloadListItem, nodeMetadataKey graph.MetadataKey, trafficMap graph.TrafficMap, gi *graph.GlobalInfo) map[*models.WorkloadListItem][]*graph.Node {
 	gatewayNodeMapping := make(map[*models.WorkloadListItem][]*graph.Node)
-	conf := config.Get()
+	conf := gi.Conf
 	for key, gwWorkloadsList := range gatewayWorkloads {
 		split := strings.Split(key, ":")
 		gwCluster := split[0]

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -296,7 +296,6 @@ func decorateMatchingAPIGateways(cluster string, gwCrd *k8s_networking_v1.Gatewa
 
 func resolveGatewayNodeMapping(gatewayWorkloads map[string][]models.WorkloadListItem, nodeMetadataKey graph.MetadataKey, trafficMap graph.TrafficMap, gi *graph.GlobalInfo) map[*models.WorkloadListItem][]*graph.Node {
 	gatewayNodeMapping := make(map[*models.WorkloadListItem][]*graph.Node)
-	conf := gi.Conf
 	for key, gwWorkloadsList := range gatewayWorkloads {
 		split := strings.Split(key, ":")
 		gwCluster := split[0]
@@ -305,9 +304,7 @@ func resolveGatewayNodeMapping(gatewayWorkloads map[string][]models.WorkloadList
 			for _, node := range trafficMap {
 				if _, ok := node.Metadata[nodeMetadataKey]; !ok {
 					appLabelName, _ := gi.Conf.GetAppLabelName(gw.Labels)
-					// gw app label is not required? In that case use the service canonical name
-					svcLabelName := conf.IstioLabels.ServiceCanonicalName
-					if (node.NodeType == graph.NodeTypeApp || node.NodeType == graph.NodeTypeWorkload) && (node.App != "" && (node.App == gw.Labels[appLabelName] || node.App == gw.Labels[svcLabelName])) && node.Cluster == gwCluster && node.Namespace == gwNs {
+					if (node.NodeType == graph.NodeTypeApp || node.NodeType == graph.NodeTypeWorkload) && node.App != "" && node.App == gw.Labels[appLabelName] && node.Cluster == gwCluster && node.Namespace == gwNs {
 						node.Metadata[nodeMetadataKey] = graph.GatewaysMetadata{}
 						gatewayNodeMapping[&gw] = append(gatewayNodeMapping[&gw], node)
 					}


### PR DESCRIPTION
### Describe the change

Explanation of what this PR does

### Steps to test the PR

- Install any K8s GW and see if it has the GW icon in the graph. 
- An example with Istio Ambient: 

`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

![image](https://github.com/user-attachments/assets/1b3b7298-07ab-4f9f-b470-58f2370259d1)

Already supported: 
![image](https://github.com/user-attachments/assets/cb51e4d3-31c0-48e7-b6c3-2232950f475e)


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #8442 
