### PR TITLE
Get Service Endpoint IP Addresses from Pods.

### DIFF
--- a/cache/transform.go
+++ b/cache/transform.go
@@ -28,11 +28,12 @@ func TransformPod(pod any) (any, error) {
 			Hostname:           obj.Spec.Hostname,
 		},
 		Status: corev1.PodStatus{
-			Phase:                 obj.Status.Phase,
-			Message:               obj.Status.Message,
-			Reason:                obj.Status.Reason,
-			InitContainerStatuses: obj.Status.InitContainerStatuses,
 			ContainerStatuses:     obj.Status.ContainerStatuses,
+			InitContainerStatuses: obj.Status.InitContainerStatuses,
+			Message:               obj.Status.Message,
+			Phase:                 obj.Status.Phase,
+			PodIP:                 obj.Status.PodIP,
+			Reason:                obj.Status.Reason,
 		},
 	}
 

--- a/kiali.go
+++ b/kiali.go
@@ -379,7 +379,6 @@ func newManager(ctx context.Context, conf *config.Config, logger *zerolog.Logger
 						&batchv1.CronJob{},
 						&batchv1.Job{},
 						&appsv1.Deployment{},
-						&corev1.Endpoints{},
 						&appsv1.ReplicaSet{},
 						&networkingv1.Gateway{},
 						&networkingv1.DestinationRule{},

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -269,30 +269,6 @@ func FilterPeerAuthenticationsBySelector(workloadSelector string, peerauthentica
 	return filtered
 }
 
-// FilterPodsByEndpoints performs a second pass was selector may return too many data
-// This case happens when a "nil" selector (such as one of default/kubernetes service) is used
-func FilterPodsByEndpoints(endpoints *core_v1.Endpoints, unfiltered []core_v1.Pod) []core_v1.Pod {
-	var pods []core_v1.Pod
-	if endpoints == nil {
-		return pods
-	}
-	endpointPods := make(map[string]bool)
-	for _, subset := range endpoints.Subsets {
-		for _, address := range subset.Addresses {
-			if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
-				endpointPods[address.TargetRef.Name] = true
-			}
-		}
-	}
-
-	for _, pod := range unfiltered {
-		if _, ok := endpointPods[pod.Name]; ok {
-			pods = append(pods, pod)
-		}
-	}
-	return pods
-}
-
 func FilterPodsBySelector(selector labels.Selector, allPods []core_v1.Pod) []core_v1.Pod {
 	var pods []core_v1.Pod
 	for _, pod := range allPods {

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -19,62 +19,6 @@ import (
 	"github.com/kiali/kiali/config"
 )
 
-func TestFilterPodsForEndpoints(t *testing.T) {
-	assert := assert.New(t)
-
-	endpoints := core_v1.Endpoints{
-		Subsets: []core_v1.EndpointSubset{
-			{
-				Addresses: []core_v1.EndpointAddress{
-					{
-						TargetRef: &core_v1.ObjectReference{
-							Name: "pod-1",
-							Kind: "Pod",
-						},
-					},
-					{
-						TargetRef: &core_v1.ObjectReference{
-							Name: "pod-2",
-							Kind: "Pod",
-						},
-					},
-					{
-						TargetRef: &core_v1.ObjectReference{
-							Name: "other",
-							Kind: "Other",
-						},
-					},
-					{},
-				},
-			},
-			{
-				Addresses: []core_v1.EndpointAddress{
-					{
-						TargetRef: &core_v1.ObjectReference{
-							Name: "pod-3",
-							Kind: "Pod",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	pods := []core_v1.Pod{
-		{ObjectMeta: meta_v1.ObjectMeta{Name: "pod-1"}},
-		{ObjectMeta: meta_v1.ObjectMeta{Name: "pod-2"}},
-		{ObjectMeta: meta_v1.ObjectMeta{Name: "pod-3"}},
-		{ObjectMeta: meta_v1.ObjectMeta{Name: "pod-999"}},
-		{ObjectMeta: meta_v1.ObjectMeta{Name: "other"}},
-	}
-
-	filtered := FilterPodsByEndpoints(&endpoints, pods)
-	assert.Len(filtered, 3)
-	assert.Equal("pod-1", filtered[0].Name)
-	assert.Equal("pod-2", filtered[1].Name)
-	assert.Equal("pod-3", filtered[2].Name)
-}
-
 func TestFilterGateways(t *testing.T) {
 	assert := assert.New(t)
 

--- a/kubernetes/kubetest/mock_kubernetes.go
+++ b/kubernetes/kubetest/mock_kubernetes.go
@@ -57,11 +57,6 @@ func (o *K8SClientMock) GetDeploymentsByLabel(namespace string, labelSelector st
 	return args.Get(0).([]apps_v1.Deployment), args.Error(1)
 }
 
-func (o *K8SClientMock) GetEndpoints(namespace string, name string) (*core_v1.Endpoints, error) {
-	args := o.Called(namespace, name)
-	return args.Get(0).(*core_v1.Endpoints), args.Error(1)
-}
-
 func (o *K8SClientMock) GetJobs(namespace string) ([]batch_v1.Job, error) {
 	args := o.Called(namespace)
 	return args.Get(0).([]batch_v1.Job), args.Error(1)

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -44,7 +44,6 @@ const (
 	DaemonSetType             = "DaemonSet"
 	DeploymentType            = "Deployment"
 	DeploymentConfigType      = "DeploymentConfig"
-	EndpointsType             = "Endpoints"
 	JobType                   = "Job"
 	PodType                   = "Pod"
 	ReplicationControllerType = "ReplicationController"
@@ -90,7 +89,6 @@ var (
 	DaemonSets             = AppsGroupVersionV1.WithKind(DaemonSetType)
 	Deployments            = AppsGroupVersionV1.WithKind(DeploymentType)
 	DeploymentConfigs      = AppsOpenShiftGroupVersionV1.WithKind(DeploymentConfigType)
-	Endpoints              = CoreGroupVersionV1.WithKind(EndpointsType)
 	Jobs                   = BatchGroupVersionV1.WithKind(JobType)
 	Pods                   = CoreGroupVersionV1.WithKind(PodType)
 	ReplicationControllers = CoreGroupVersionV1.WithKind(ReplicationControllerType)

--- a/models/address.go
+++ b/models/address.go
@@ -1,28 +1,8 @@
 package models
 
-import core_v1 "k8s.io/api/core/v1"
-
 type Addresses []Address
 type Address struct {
 	Kind string `json:"kind"`
 	Name string `json:"name"`
 	IP   string `json:"ip"`
-	Port uint32 `json:"port"`
-}
-
-func (addresses *Addresses) Parse(as []core_v1.EndpointAddress) {
-	for _, address := range as {
-		castedAddress := Address{}
-		castedAddress.Parse(address)
-		*addresses = append(*addresses, castedAddress)
-	}
-}
-
-func (address *Address) Parse(a core_v1.EndpointAddress) {
-	address.IP = a.IP
-
-	if a.TargetRef != nil {
-		address.Kind = a.TargetRef.Kind
-		address.Name = a.TargetRef.Name
-	}
 }

--- a/models/endpoint.go
+++ b/models/endpoint.go
@@ -12,18 +12,18 @@ type Endpoint struct {
 func GetEndpointsFromPods(pods []core_v1.Pod) *Endpoints {
 	endpointPodAddresses := Endpoints{}
 	for _, pod := range pods {
-		ep := Endpoint{
-			Addresses: make(Addresses, 0),
-			Ports:     make(Ports, 0),
-		}
 		if pod.Status.PodIP != "" { // make sure Pod's IP address is not empty
+			ep := Endpoint{
+				Addresses: make(Addresses, 0),
+				Ports:     make(Ports, 0),
+			}
 			ep.Addresses = append(ep.Addresses, Address{
 				Kind: pod.Kind,
 				Name: pod.Name,
 				IP:   pod.Status.PodIP,
 			})
+			endpointPodAddresses = append(endpointPodAddresses, ep)
 		}
-		endpointPodAddresses = append(endpointPodAddresses, ep)
 	}
 
 	return &endpointPodAddresses

--- a/models/endpoint.go
+++ b/models/endpoint.go
@@ -1,8 +1,6 @@
 package models
 
-import (
-	core_v1 "k8s.io/api/core/v1"
-)
+import core_v1 "k8s.io/api/core/v1"
 
 type Endpoints []Endpoint
 type Endpoint struct {
@@ -10,19 +8,23 @@ type Endpoint struct {
 	Ports     Ports     `json:"ports"`
 }
 
-func (endpoints *Endpoints) Parse(es *core_v1.Endpoints) {
-	if es == nil {
-		return
+// GetEndpointsFromPods gets IP addresses from Pods
+func GetEndpointsFromPods(pods []core_v1.Pod) *Endpoints {
+	endpointPodAddresses := Endpoints{}
+	for _, pod := range pods {
+		ep := Endpoint{
+			Addresses: make(Addresses, 0),
+			Ports:     make(Ports, 0),
+		}
+		if pod.Status.PodIP != "" { // make sure Pod's IP address is not empty
+			ep.Addresses = append(ep.Addresses, Address{
+				Kind: pod.Kind,
+				Name: pod.Name,
+				IP:   pod.Status.PodIP,
+			})
+		}
+		endpointPodAddresses = append(endpointPodAddresses, ep)
 	}
 
-	for _, subset := range es.Subsets {
-		endpoint := Endpoint{}
-		endpoint.Parse(subset)
-		*endpoints = append(*endpoints, endpoint)
-	}
-}
-
-func (endpoint *Endpoint) Parse(s core_v1.EndpointSubset) {
-	(&endpoint.Ports).ParseEndpointPorts(s.Ports)
-	(&endpoint.Addresses).Parse(s.Addresses)
+	return &endpointPodAddresses
 }

--- a/models/endpoints_test.go
+++ b/models/endpoints_test.go
@@ -1,0 +1,105 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEndpointsFromPods(t *testing.T) {
+	cases := []struct {
+		name      string
+		inputPods []core_v1.Pod
+		expected  *Endpoints
+	}{
+		{
+			name:      "Nil input slice",
+			inputPods: nil,
+			expected:  &Endpoints{},
+		},
+		{
+			name:      "Empty input slice",
+			inputPods: []core_v1.Pod{},
+			expected:  &Endpoints{},
+		},
+		{
+			name: "Single pod with IP",
+			inputPods: []core_v1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "",
+					},
+					ObjectMeta: v1.ObjectMeta{Name: "pod1"},
+					Spec:       core_v1.PodSpec{},
+					Status:     core_v1.PodStatus{PodIP: "10.0.0.1"},
+				},
+			},
+			expected: &Endpoints{
+				{
+					Addresses: Addresses{{Kind: "Pod", Name: "pod1", IP: "10.0.0.1"}},
+					Ports:     make(Ports, 0),
+				},
+			},
+		},
+		{
+			name: "Multiple pods, some with IPs, some without",
+			inputPods: []core_v1.Pod{
+				{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "",
+					},
+					ObjectMeta: v1.ObjectMeta{Name: "podA"},
+					Spec:       core_v1.PodSpec{},
+					Status:     core_v1.PodStatus{PodIP: "192.168.1.10"},
+				},
+				{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "",
+					},
+					ObjectMeta: v1.ObjectMeta{Name: "podB"},
+					Spec:       core_v1.PodSpec{},
+					Status:     core_v1.PodStatus{PodIP: ""},
+				},
+				{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "",
+					},
+					ObjectMeta: v1.ObjectMeta{Name: "podC"},
+					Spec:       core_v1.PodSpec{},
+					Status:     core_v1.PodStatus{PodIP: "192.168.1.12"},
+				},
+			},
+			expected: &Endpoints{
+				{
+					Addresses: Addresses{{Kind: "Pod", Name: "podA", IP: "192.168.1.10"}},
+					Ports:     make(Ports, 0),
+				},
+				{
+					Addresses: Addresses{{Kind: "Pod", Name: "podC", IP: "192.168.1.12"}},
+					Ports:     make(Ports, 0),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetEndpointsFromPods(tc.inputPods)
+			require := require.New(t)
+			a, err := json.Marshal(tc.expected)
+			require.NoError(err)
+			b, err := json.Marshal(result)
+			require.NoError(err)
+
+			require.Equal(string(b), string(a))
+		})
+	}
+}

--- a/models/port.go
+++ b/models/port.go
@@ -8,10 +8,9 @@ import (
 
 type Ports []Port
 type Port struct {
-	Name        string  `json:"name"`
-	Protocol    string  `json:"protocol"`
-	AppProtocol *string `json:"appProtocol,omitempty"`
-	Port        int32   `json:"port"`
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
+	Port     int32  `json:"port"`
 }
 
 func (ports *Ports) Parse(ps []core_v1.ServicePort) {
@@ -25,7 +24,6 @@ func (ports *Ports) Parse(ps []core_v1.ServicePort) {
 func (port *Port) Parse(p core_v1.ServicePort) {
 	port.Name = p.Name
 	port.Protocol = string(p.Protocol)
-	port.AppProtocol = p.AppProtocol
 	port.Port = p.Port
 }
 

--- a/models/service.go
+++ b/models/service.go
@@ -212,10 +212,6 @@ func (s *ServiceDetails) SetService(cluster string, svc *core_v1.Service, conf *
 	s.Service.Parse(cluster, svc, conf)
 }
 
-func (s *ServiceDetails) SetEndpoints(eps *core_v1.Endpoints) {
-	(&s.Endpoints).Parse(eps)
-}
-
 func (s *ServiceDetails) SetPods(pods []core_v1.Pod) {
 	mPods := Pods{}
 	mPods.Parse(pods)

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -18,7 +18,6 @@ func TestServiceDetailParsing(t *testing.T) {
 
 	service := ServiceDetails{}
 	service.SetService(config.DefaultClusterID, fakeService(), config.Get())
-	service.SetEndpoints(fakeEndpoints())
 	service.SetPods(fakePods())
 	service.SetIstioSidecar(fakeWorkloads())
 
@@ -36,16 +35,6 @@ func TestServiceDetailParsing(t *testing.T) {
 	assert.Equal(service.Service.Ports, Ports{
 		Port{Name: "http", Protocol: "TCP", Port: 3001},
 		Port{Name: "http", Protocol: "TCP", Port: 3000}})
-	assert.Equal(service.Endpoints, Endpoints{
-		Endpoint{
-			Addresses: Addresses{
-				Address{Kind: "Pod", Name: "recommendation-v1", IP: "172.17.0.9"},
-				Address{Kind: "Pod", Name: "recommendation-v2", IP: "172.17.0.8"},
-			},
-			Ports: Ports{
-				Port{Name: "http", Protocol: "TCP", Port: 3001},
-				Port{Name: "http", Protocol: "TCP", Port: 3000},
-			}}})
 }
 
 func TestServiceParse(t *testing.T) {
@@ -97,28 +86,6 @@ func fakeService() *core_v1.Service {
 					Name:     "http",
 					Protocol: "TCP",
 					Port:     3000}}}}
-}
-
-func fakeEndpoints() *core_v1.Endpoints {
-	return &core_v1.Endpoints{
-		Subsets: []core_v1.EndpointSubset{
-			{
-				Addresses: []core_v1.EndpointAddress{
-					{
-						IP: "172.17.0.9",
-						TargetRef: &core_v1.ObjectReference{
-							Kind: "Pod",
-							Name: "recommendation-v1"}},
-					{
-						IP: "172.17.0.8",
-						TargetRef: &core_v1.ObjectReference{
-							Kind: "Pod",
-							Name: "recommendation-v2"}},
-				},
-				Ports: []core_v1.EndpointPort{
-					{Name: "http", Protocol: "TCP", Port: 3001},
-					{Name: "http", Protocol: "TCP", Port: 3000},
-				}}}}
 }
 
 func fakePods() []core_v1.Pod {


### PR DESCRIPTION
### Describe the change

Removed loading Endpoints from the cache, and instead load the necessary data for Service details from Pods.

### Steps to test the PR

Regression testing that Service detail's Networking Section Endpoints is still showing correct IP addresses and tooltip:
![Screenshot from 2025-05-21 14-49-15](https://github.com/user-attachments/assets/3b703634-7649-4af1-bd76-3240021af53c)


### Automation testing

existing tests should not pass

### Issue reference
https://github.com/kiali/kiali/issues/8396
