### PR TITLE
Removed unused Prometheus client's GetFlags function

### DIFF
--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -34,7 +34,6 @@ type ClientInterface interface {
 	GetAppRequestRates(namespace, cluster, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error)
 	GetConfiguration() (prom_v1.ConfigResult, error)
 	GetExistingMetricNames(metricNames []string) ([]string, error)
-	GetFlags() (prom_v1.FlagsResult, error)
 	GetMetricsForLabels(metricNames []string, labels string) ([]string, error)
 	GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error)
 	GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error)

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -319,11 +319,6 @@ func (o *PromClientMock) GetExistingMetricNames(metricNames []string) ([]string,
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (o *PromClientMock) GetFlags() (prom_v1.FlagsResult, error) {
-	args := o.Called()
-	return args.Get(0).(prom_v1.FlagsResult), args.Error(1)
-}
-
 func (o *PromClientMock) GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	args := o.Called(namespace, cluster, ratesInterval, queryTime)
 	return args.Get(0).(model.Vector), args.Error(1)


### PR DESCRIPTION
### Describe the change

There was unused GetFlags() method in Prometheus client, removed it.

### Steps to test the PR

Regression testing.

### Automation testing

n/a

### Issue reference
https://github.com/kiali/kiali/issues/8405
