### PR TITLE
Add partial selector match for ztunnel

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -1076,7 +1076,7 @@ func FakeZtunnelDaemonSet(conf *config.Config) []apps_v1.DaemonSet {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
-	kubernetesLabel := config.KubernetesIstioLabel
+	kubernetesLabel := config.KubernetesAppLabel
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 	return []apps_v1.DaemonSet{
 		{

--- a/business/test_util.go
+++ b/business/test_util.go
@@ -1076,6 +1076,7 @@ func FakeZtunnelDaemonSet(conf *config.Config) []apps_v1.DaemonSet {
 	conf.KubernetesConfig.ExcludeWorkloads = []string{}
 
 	appLabel := conf.IstioLabels.AppLabelName
+	kubernetesLabel := config.KubernetesIstioLabel
 	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
 	return []apps_v1.DaemonSet{
 		{
@@ -1087,6 +1088,7 @@ func FakeZtunnelDaemonSet(conf *config.Config) []apps_v1.DaemonSet {
 				Name:              "ztunnel",
 				Namespace:         "istio-system",
 				CreationTimestamp: meta_v1.NewTime(t1),
+				Labels:            map[string]string{kubernetesLabel: "ztunnel"},
 			},
 			Spec: apps_v1.DaemonSetSpec{
 				Template: core_v1.PodTemplateSpec{

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2713,8 +2713,10 @@ func (in *WorkloadService) StreamPodLogs(ctx context.Context, cluster, namespace
 		for _, pod := range pods {
 			names = append(names, pod.Name)
 		}
-		// They should be all in the same ns
-		return in.streamParsedLogs(cluster, pods[0].Namespace, names, opts, w)
+		if len(pods) > 0 {
+			// They should be all in the same ns
+			return in.streamParsedLogs(cluster, pods[0].Namespace, names, opts, w)
+		}
 	}
 	if opts.LogType == models.LogTypeWaypoint {
 		wk, err := in.GetWorkload(ctx, WorkloadCriteria{Cluster: cluster, Namespace: namespace, WorkloadName: workload, IncludeServices: false})

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -293,7 +293,7 @@ func (in *kialiCacheImpl) IsAmbientEnabled(cluster string) bool {
 		selector := map[string]string{
 			config.IstioAppLabel: config.Ztunnel,
 		}
-		daemonsets, err := kubernetes.FilterDaemonSetsBySelector(daemonSetList.Items, selector)
+		daemonsets, err := kubernetes.FilterDaemonSetsBySelector(daemonSetList.Items, selector, true)
 		if err != nil {
 			// Don't set the check so we will check again the next time since this error may be transient.
 			in.zl.Debug().Msgf("Error checking for ztunnel in Kiali accessible namespaces in cluster '%s': %s", cluster, err.Error())
@@ -331,7 +331,7 @@ func (in *kialiCacheImpl) GetZtunnelPods(cluster string) []v1.Pod {
 	selector := map[string]string{
 		config.IstioAppLabel: config.Ztunnel,
 	}
-	daemonsets, err := kubernetes.FilterDaemonSetsBySelector(daemonSetList.Items, selector)
+	daemonsets, err := kubernetes.FilterDaemonSetsBySelector(daemonSetList.Items, selector, true)
 	if err != nil {
 		in.zl.Debug().Msgf("Error checking for ztunnel in Kiali accessible namespaces in cluster '%s': %s", cluster, err.Error())
 		return nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -286,7 +286,7 @@ func (in *kialiCacheImpl) IsAmbientEnabled(cluster string) bool {
 
 		daemonSetList := &appsv1.DaemonSetList{}
 		selector := map[string]string{
-			config.KubernetesIstioLabel: config.Ztunnel,
+			config.KubernetesAppLabel: config.Ztunnel,
 		}
 		listOpts := []client.ListOption{client.MatchingLabels(selector)}
 		if err := kubeCache.List(context.TODO(), daemonSetList, listOpts...); err != nil {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -318,7 +318,7 @@ func (in *kialiCacheImpl) GetZtunnelPods(cluster string) []v1.Pod {
 
 	daemonSetList := &appsv1.DaemonSetList{}
 	selector := map[string]string{
-		config.KubernetesIstioLabel: config.Ztunnel,
+		config.KubernetesAppLabel: config.Ztunnel,
 	}
 	listOpts := []client.ListOption{client.MatchingLabels(selector)}
 	if err := kubeCache.List(context.TODO(), daemonSetList, listOpts...); err != nil {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -78,6 +78,7 @@ func ztunnelDaemonSet() *apps_v1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ztunnel",
 			Namespace: "istio-system",
+			Labels:    map[string]string{"app.kubernetes.io/name": "ztunnel"},
 		},
 		Spec: apps_v1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ const (
 	IstioAppLabel             = "app"                                    // we can assume istio components are labeled with "app"
 	IstioRevisionLabel        = "istio.io/rev"                           // the standard label key used to identify the istio revision.
 	IstioVersionLabel         = "version"                                // we can assume istio components are labeled with "version", if versioned
-	KubernetesIstioLabel      = "app.kubernetes.io/name"
+	KubernetesAppLabel      = "app.kubernetes.io/name"
 	Waypoint                  = "waypoint"
 	WaypointFor               = "istio.io/waypoint-for"
 	WaypointForAll            = "all"

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ const (
 	IstioAppLabel             = "app"                                    // we can assume istio components are labeled with "app"
 	IstioRevisionLabel        = "istio.io/rev"                           // the standard label key used to identify the istio revision.
 	IstioVersionLabel         = "version"                                // we can assume istio components are labeled with "version", if versioned
-	KubernetesAppLabel      = "app.kubernetes.io/name"
+	KubernetesAppLabel        = "app.kubernetes.io/name"
 	Waypoint                  = "waypoint"
 	WaypointFor               = "istio.io/waypoint-for"
 	WaypointForAll            = "all"

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ const (
 	IstioAppLabel             = "app"                                    // we can assume istio components are labeled with "app"
 	IstioRevisionLabel        = "istio.io/rev"                           // the standard label key used to identify the istio revision.
 	IstioVersionLabel         = "version"                                // we can assume istio components are labeled with "version", if versioned
+	KubernetesIstioLabel      = "app.kubernetes.io/name"
 	Waypoint                  = "waypoint"
 	WaypointFor               = "istio.io/waypoint-for"
 	WaypointForAll            = "all"

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -746,17 +746,3 @@ func FilterDeploymentsBySelector(deployments []appsv1.Deployment, l map[string]s
 	}
 	return retDep, nil
 }
-
-func selectorIncludes(dsSelector *metav1.LabelSelector, filter labels.Set) bool {
-	dsLabels, err := metav1.LabelSelectorAsMap(dsSelector)
-	if err != nil {
-		return false
-	}
-
-	for key, val := range filter {
-		if dsVal, ok := dsLabels[key]; !ok || dsVal != val {
-			return false
-		}
-	}
-	return true
-}

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -712,33 +712,6 @@ func FilterByNamespace[T runtime.Object](objects []T, namespace string) []T {
 	return filtered
 }
 
-func FilterDaemonSetsBySelector(daemonSets []appsv1.DaemonSet, l map[string]string, partialMatch bool) ([]appsv1.DaemonSet, error) {
-	selector := labels.Set(l)
-	retDS := []appsv1.DaemonSet{}
-	for _, ds := range daemonSets {
-		// TODO: Can we eliminate error?
-		labelMap, err := metav1.LabelSelectorAsMap(ds.Spec.Selector)
-		if err != nil {
-			return nil, err
-		}
-		labelSet := labels.Set(labelMap)
-
-		svcSelector := labelSet.AsSelector()
-		if partialMatch {
-			if selectorIncludes(ds.Spec.Selector, selector) {
-				retDS = append(retDS, ds)
-			}
-		} else {
-			// selector match is done after listing all daemonSets, similar to registry reading
-			if selector.AsSelector().Empty() || (!svcSelector.Empty() && svcSelector.Matches(selector)) {
-				retDS = append(retDS, ds)
-			}
-		}
-
-	}
-	return retDS, nil
-}
-
 func FilterServicesBySelector(services []core_v1.Service, l map[string]string) []core_v1.Service {
 	selector := labels.Set(l)
 	retSvc := []core_v1.Service{}

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -1,616 +1,537 @@
 {
-  "elements": {
-    "nodes": [
-      {
-        "data": {
-          "id": "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
-          "cluster": "_external_",
-          "infraName": "External Deployments",
-          "infraType": "cluster",
-          "namespace": "",
-          "nodeType": "box",
-          "healthData": "Healthy",
-          "isBox": "cluster",
-          "isExternal": true,
-          "isInaccessible": true
-        }
-      },
-      {
-        "data": {
-          "id": "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
-          "cluster": "cluster-primary",
-          "infraName": "cluster-primary",
-          "infraType": "cluster",
-          "namespace": "",
-          "nodeType": "box",
-          "healthData": "Healthy",
-          "infraData": {
-            "apiEndpoint": "http://127.0.0.2:9443",
-            "isKialiHome": true,
-            "kialiInstances": [
-              {
-                "namespace": "istio-system",
-                "operatorResource": "",
-                "serviceName": "kiali",
-                "url": "",
-                "version": ""
-              }
-            ],
-            "name": "cluster-primary",
-            "secretName": "",
-            "accessible": true
+  "elements" : {
+    "nodes" : [ {
+      "data" : {
+        "id" : "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
+        "cluster" : "_external_",
+        "infraName" : "External Deployments",
+        "infraType" : "cluster",
+        "namespace" : "",
+        "nodeType" : "box",
+        "healthData" : "Healthy",
+        "isBox" : "cluster",
+        "isExternal" : true,
+        "isInaccessible" : true
+      }
+    }, {
+      "data" : {
+        "id" : "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
+        "cluster" : "cluster-primary",
+        "infraName" : "cluster-primary",
+        "infraType" : "cluster",
+        "namespace" : "",
+        "nodeType" : "box",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "apiEndpoint" : "http://127.0.0.2:9443",
+          "isKialiHome" : true,
+          "kialiInstances" : [ {
+            "namespace" : "istio-system",
+            "operatorResource" : "",
+            "serviceName" : "kiali",
+            "url" : "",
+            "version" : ""
+          } ],
+          "name" : "cluster-primary",
+          "secretName" : "",
+          "accessible" : true
+        },
+        "isBox" : "cluster",
+        "version" : "Unknown"
+      }
+    }, {
+      "data" : {
+        "id" : "421c6926a61f0f21f1fe0babb48ea9fac6454c1d9a448dea2c559402723ec4da",
+        "cluster" : "cluster-remote",
+        "infraName" : "cluster-remote",
+        "infraType" : "cluster",
+        "namespace" : "",
+        "nodeType" : "box",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "apiEndpoint" : "",
+          "isKialiHome" : false,
+          "kialiInstances" : null,
+          "name" : "cluster-remote",
+          "secretName" : "",
+          "accessible" : true
+        },
+        "isBox" : "cluster"
+      }
+    }, {
+      "data" : {
+        "id" : "5d47c4043773968316f9d71a07212a1c363d76a3d9ffe7c52198f864cde8c5f5",
+        "parent" : "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
+        "cluster" : "cluster-primary",
+        "infraName" : "data-plane-1",
+        "infraType" : "namespace",
+        "namespace" : "data-plane-1",
+        "nodeType" : "box",
+        "healthData" : null,
+        "isBox" : "namespace"
+      }
+    }, {
+      "data" : {
+        "id" : "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
+        "parent" : "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
+        "cluster" : "cluster-primary",
+        "infraName" : "istio-system",
+        "infraType" : "namespace",
+        "namespace" : "istio-system",
+        "nodeType" : "box",
+        "healthData" : null,
+        "isBox" : "namespace"
+      }
+    }, {
+      "data" : {
+        "id" : "33493098cdd63801f773396da680159d0bb57b482ef38a4b208899a2e477e1f0",
+        "parent" : "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
+        "cluster" : "_external_",
+        "infraName" : "Grafana",
+        "infraType" : "grafana",
+        "namespace" : "",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "Auth" : {
+            "CAFile" : "xxx",
+            "InsecureSkipVerify" : false,
+            "Password" : "xxx",
+            "Token" : "xxx",
+            "Type" : "none",
+            "UseKialiToken" : false,
+            "Username" : "xxx"
           },
-          "isBox": "cluster",
-          "version": "Unknown"
-        }
-      },
-      {
-        "data": {
-          "id": "421c6926a61f0f21f1fe0babb48ea9fac6454c1d9a448dea2c559402723ec4da",
-          "cluster": "cluster-remote",
-          "infraName": "cluster-remote",
-          "infraType": "cluster",
-          "namespace": "",
-          "nodeType": "box",
-          "healthData": "Healthy",
-          "infraData": {
-            "apiEndpoint": "",
-            "isKialiHome": false,
-            "kialiInstances": null,
-            "name": "cluster-remote",
-            "secretName": "",
-            "accessible": true
+          "Dashboards" : null,
+          "Enabled" : true,
+          "ExternalURL" : "",
+          "HealthCheckUrl" : "",
+          "InternalURL" : "http://grafana.istio-system:3000",
+          "IsCore" : false
+        },
+        "isExternal" : true,
+        "isInaccessible" : true
+      }
+    }, {
+      "data" : {
+        "id" : "41b50563edf837e2e828b50492b24356bf392be6e0a7a7f21d90eabe551dd686",
+        "parent" : "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
+        "cluster" : "_external_",
+        "infraName" : "Prometheus",
+        "infraType" : "metricStore",
+        "namespace" : "",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "Auth" : {
+            "CAFile" : "xxx",
+            "InsecureSkipVerify" : false,
+            "Password" : "xxx",
+            "Token" : "xxx",
+            "Type" : "none",
+            "UseKialiToken" : false,
+            "Username" : "xxx"
           },
-          "isBox": "cluster"
-        }
-      },
-      {
-        "data": {
-          "id": "5d47c4043773968316f9d71a07212a1c363d76a3d9ffe7c52198f864cde8c5f5",
-          "parent": "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
-          "cluster": "cluster-primary",
-          "infraName": "data-plane-1",
-          "infraType": "namespace",
-          "namespace": "data-plane-1",
-          "nodeType": "box",
-          "healthData": null,
-          "isBox": "namespace"
-        }
-      },
-      {
-        "data": {
-          "id": "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
-          "parent": "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
-          "cluster": "cluster-primary",
-          "infraName": "istio-system",
-          "infraType": "namespace",
-          "namespace": "istio-system",
-          "nodeType": "box",
-          "healthData": null,
-          "isBox": "namespace"
-        }
-      },
-      {
-        "data": {
-          "id": "33493098cdd63801f773396da680159d0bb57b482ef38a4b208899a2e477e1f0",
-          "parent": "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
-          "cluster": "_external_",
-          "infraName": "Grafana",
-          "infraType": "grafana",
-          "namespace": "",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "Auth": {
-              "CAFile": "xxx",
-              "InsecureSkipVerify": false,
-              "Password": "xxx",
-              "Token": "xxx",
-              "Type": "none",
-              "UseKialiToken": false,
-              "Username": "xxx"
-            },
-            "Dashboards": null,
-            "Enabled": true,
-            "ExternalURL": "",
-            "HealthCheckUrl": "",
-            "InternalURL": "http://grafana.istio-system:3000",
-            "IsCore": false
+          "CacheDuration" : 7,
+          "CacheEnabled" : true,
+          "CacheExpiration" : 300,
+          "CustomHeaders" : { },
+          "HealthCheckUrl" : "",
+          "IsCore" : false,
+          "QueryScope" : { },
+          "ThanosProxy" : {
+            "Enabled" : false,
+            "RetentionPeriod" : "7d",
+            "ScrapeInterval" : "30s"
           },
-          "isExternal": true,
-          "isInaccessible": true
-        }
-      },
-      {
-        "data": {
-          "id": "41b50563edf837e2e828b50492b24356bf392be6e0a7a7f21d90eabe551dd686",
-          "parent": "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
-          "cluster": "_external_",
-          "infraName": "Prometheus",
-          "infraType": "metricStore",
-          "namespace": "",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "Auth": {
-              "CAFile": "xxx",
-              "InsecureSkipVerify": false,
-              "Password": "xxx",
-              "Token": "xxx",
-              "Type": "none",
-              "UseKialiToken": false,
-              "Username": "xxx"
-            },
-            "CacheDuration": 7,
-            "CacheEnabled": true,
-            "CacheExpiration": 300,
-            "CustomHeaders": {},
-            "HealthCheckUrl": "",
-            "IsCore": false,
-            "QueryScope": {},
-            "ThanosProxy": {
-              "Enabled": false,
-              "RetentionPeriod": "7d",
-              "ScrapeInterval": "30s"
-            },
-            "URL": "http://prometheus.istio-system:9090"
+          "URL" : "http://prometheus.istio-system:9090"
+        },
+        "isExternal" : true,
+        "isInaccessible" : true
+      }
+    }, {
+      "data" : {
+        "id" : "e0733a58436c292ece7cbcf37db7b77510545c027d03c1798c3d6d8202b93f6f",
+        "parent" : "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
+        "cluster" : "_external_",
+        "infraName" : "jaeger",
+        "infraType" : "traceStore",
+        "namespace" : "",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "Auth" : {
+            "CAFile" : "xxx",
+            "InsecureSkipVerify" : false,
+            "Password" : "xxx",
+            "Token" : "xxx",
+            "Type" : "none",
+            "UseKialiToken" : false,
+            "Username" : "xxx"
           },
-          "isExternal": true,
-          "isInaccessible": true
-        }
-      },
-      {
-        "data": {
-          "id": "e0733a58436c292ece7cbcf37db7b77510545c027d03c1798c3d6d8202b93f6f",
-          "parent": "85774128be9f0db40aeb4c610e9436f63cb0945838e6db0c05ae36b62c6c6c10",
-          "cluster": "_external_",
-          "infraName": "jaeger",
-          "infraType": "traceStore",
-          "namespace": "",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "Auth": {
-              "CAFile": "xxx",
-              "InsecureSkipVerify": false,
-              "Password": "xxx",
-              "Token": "xxx",
-              "Type": "none",
-              "UseKialiToken": false,
-              "Username": "xxx"
-            },
-            "CustomHeaders": {},
-            "DisableVersionCheck": false,
-            "Enabled": true,
-            "ExternalURL": "",
-            "HealthCheckUrl": "",
-            "GrpcPort": 9095,
-            "InternalURL": "http://tracing.istio-system:16685/jaeger",
-            "IsCore": false,
-            "Provider": "jaeger",
-            "TempoConfig": {
-              "cache_capacity": 200,
-              "cache_enabled": true
-            },
-            "NamespaceSelector": true,
-            "QueryScope": {},
-            "QueryTimeout": 5,
-            "UseGRPC": true,
-            "WhiteListIstioSystem": [
-              "jaeger-query",
-              "istio-ingressgateway"
-            ]
+          "CustomHeaders" : { },
+          "DisableVersionCheck" : false,
+          "Enabled" : true,
+          "ExternalURL" : "",
+          "HealthCheckUrl" : "",
+          "GrpcPort" : 9095,
+          "InternalURL" : "http://tracing.istio-system:16685/jaeger",
+          "IsCore" : false,
+          "Provider" : "jaeger",
+          "TempoConfig" : {
+            "cache_capacity" : 200,
+            "cache_enabled" : true
           },
-          "isExternal": true,
-          "isInaccessible": true
-        }
-      },
-      {
-        "data": {
-          "id": "0bb699228f65bc52ec82ed3c72726df27b56e7518b38b7e2021196ea0065233c",
-          "parent": "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
-          "cluster": "cluster-primary",
-          "infraName": "Data Plane",
-          "infraType": "dataplane",
-          "namespace": "",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": [
-            {
-              "name": "data-plane-1",
-              "cluster": "cluster-primary",
-              "isAmbient": false,
-              "labels": {
-                "istio-injection": "enabled",
-                "kubernetes.io/metadata.name": "data-plane-1"
-              },
-              "annotations": null,
-              "revision": "default"
-            },
-            {
-              "name": "data-plane-2",
-              "cluster": "cluster-primary",
-              "isAmbient": false,
-              "labels": {
-                "istio.io/rev": "default",
-                "kubernetes.io/metadata.name": "data-plane-2"
-              },
-              "annotations": null,
-              "revision": "default"
-            }
-          ],
-          "version": "default"
-        }
-      },
-      {
-        "data": {
-          "id": "5d63e313a5acadb4bf9f5bcaa606b69bbaf81a4193a511719a878e9ad8729a5f",
-          "parent": "5d47c4043773968316f9d71a07212a1c363d76a3d9ffe7c52198f864cde8c5f5",
-          "cluster": "cluster-primary",
-          "infraName": "waypoint",
-          "infraType": "waypoint",
-          "namespace": "data-plane-1",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "Annotations": {},
-            "Labels": {
-              "gateway.istio.io/managed": "istio.io-mesh-controller",
-              "gateway.networking.k8s.io/gateway-name": "waypoint"
-            },
-            "TemplateAnnotations": null,
-            "TemplateLabels": {
-              "gateway.istio.io/managed": "istio.io-mesh-controller",
-              "gateway.networking.k8s.io/gateway-name": "waypoint"
-            }
+          "NamespaceSelector" : true,
+          "QueryScope" : { },
+          "QueryTimeout" : 5,
+          "UseGRPC" : true,
+          "WhiteListIstioSystem" : [ "jaeger-query", "istio-ingressgateway" ]
+        },
+        "isExternal" : true,
+        "isInaccessible" : true
+      }
+    }, {
+      "data" : {
+        "id" : "0bb699228f65bc52ec82ed3c72726df27b56e7518b38b7e2021196ea0065233c",
+        "parent" : "52e2139bb2622c3156273a148bb95c794e674e820ffcf433a3e530e31e5fcd36",
+        "cluster" : "cluster-primary",
+        "infraName" : "Data Plane",
+        "infraType" : "dataplane",
+        "namespace" : "",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : [ {
+          "name" : "data-plane-1",
+          "cluster" : "cluster-primary",
+          "isAmbient" : false,
+          "labels" : {
+            "istio-injection" : "enabled",
+            "kubernetes.io/metadata.name" : "data-plane-1"
           },
-          "version": "default"
-        }
-      },
-      {
-        "data": {
-          "id": "1cf59ab6492289f4c7371ad6c0de54505a037f949855c902b5547fa6f15e3674",
-          "parent": "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
-          "cluster": "cluster-primary",
-          "infraName": "ztunnel",
-          "infraType": "ztunnel",
-          "namespace": "istio-system",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "Annotations": null,
-            "Labels": {
-              "app": "ztunnel"
-            },
-            "TemplateAnnotations": null,
-            "TemplateLabels": {
-              "app": "ztunnel"
-            }
+          "annotations" : null,
+          "revision" : "default"
+        }, {
+          "name" : "data-plane-2",
+          "cluster" : "cluster-primary",
+          "isAmbient" : false,
+          "labels" : {
+            "istio.io/rev" : "default",
+            "kubernetes.io/metadata.name" : "data-plane-2"
           },
-          "version": "default"
-        }
-      },
-      {
-        "data": {
-          "id": "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
-          "parent": "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
-          "cluster": "cluster-primary",
-          "infraName": "kiali",
-          "infraType": "kiali",
-          "namespace": "istio-system",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "ComponentStatuses": {
-              "Enabled": true,
-              "Components": []
-            },
-            "ConfigMapName": "",
-            "EnvoyAdminLocalPort": 15000,
-            "GatewayAPIClasses": [],
-            "GatewayAPIClassesLabelSelector": "",
-            "IstioAPIEnabled": true,
-            "IstioIdentityDomain": "svc.cluster.local",
-            "IstioInjectionAnnotation": "sidecar.istio.io/inject",
-            "IstioSidecarInjectorConfigMapName": "",
-            "IstioSidecarAnnotation": "sidecar.istio.io/status",
-            "IstiodDeploymentName": "",
-            "IstiodPodMonitoringPort": 15014,
-            "IstiodPollingIntervalSeconds": 20,
-            "Registry": null,
-            "RootNamespace": "istio-system",
-            "UrlServiceVersion": "",
-            "ValidationChangeDetectionEnabled": true,
-            "ValidationReconcileInterval": 60000000000
+          "annotations" : null,
+          "revision" : "default"
+        } ],
+        "version" : "default"
+      }
+    }, {
+      "data" : {
+        "id" : "5d63e313a5acadb4bf9f5bcaa606b69bbaf81a4193a511719a878e9ad8729a5f",
+        "parent" : "5d47c4043773968316f9d71a07212a1c363d76a3d9ffe7c52198f864cde8c5f5",
+        "cluster" : "cluster-primary",
+        "infraName" : "waypoint",
+        "infraType" : "waypoint",
+        "namespace" : "data-plane-1",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "Annotations" : { },
+          "Labels" : {
+            "gateway.istio.io/managed" : "istio.io-mesh-controller",
+            "gateway.networking.k8s.io/gateway-name" : "waypoint"
+          },
+          "TemplateAnnotations" : null,
+          "TemplateLabels" : {
+            "gateway.istio.io/managed" : "istio.io-mesh-controller",
+            "gateway.networking.k8s.io/gateway-name" : "waypoint"
           }
-        }
-      },
-      {
-        "data": {
-          "id": "4ffd132efe1291fcd70490d6add887f9e160a72c4885a83669432bea09de23f9",
-          "parent": "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
-          "cluster": "cluster-primary",
-          "infraName": "gateway",
-          "infraType": "gateway",
-          "namespace": "istio-system",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "kind": "Gateway",
-            "apiVersion": "networking.istio.io/v1",
-            "metadata": {
-              "name": "gateway",
-              "namespace": "istio-system",
-              "resourceVersion": "999",
-              "creationTimestamp": null
-            },
-            "spec": {
-              "selector": {
-                "istio": "ingressgateway"
-              }
-            },
-            "status": {}
+        },
+        "version" : "default"
+      }
+    }, {
+      "data" : {
+        "id" : "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
+        "parent" : "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
+        "cluster" : "cluster-primary",
+        "infraName" : "kiali",
+        "infraType" : "kiali",
+        "namespace" : "istio-system",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "ComponentStatuses" : {
+            "Enabled" : true,
+            "Components" : [ ]
           },
-          "version": "default"
-        }
-      },
-      {
-        "data": {
-          "id": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "parent": "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
-          "cluster": "cluster-primary",
-          "infraName": "istiod",
-          "infraType": "istiod",
-          "namespace": "istio-system",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": {
-            "cluster": {
-              "apiEndpoint": "http://127.0.0.2:9443",
-              "isKialiHome": true,
-              "kialiInstances": [
-                {
-                  "namespace": "istio-system",
-                  "operatorResource": "",
-                  "serviceName": "kiali",
-                  "url": "",
-                  "version": ""
-                }
-              ],
-              "name": "cluster-primary",
-              "secretName": "",
-              "accessible": true
-            },
-            "config": {
-              "certificates": [
-                {
-                  "dnsNames": null,
-                  "configMapName": "istio-ca-root-cert",
-                  "issuer": "O=cluster.local",
-                  "notBefore": "2021-07-27T14:37:00Z",
-                  "notAfter": "2031-07-25T14:37:00Z",
-                  "error": "",
-                  "accessible": true,
-                  "cluster": ""
-                }
-              ],
-              "effectiveConfig": {
-                "configMap": {
-                  "mesh": {
-                    "accessLogFile": "/dev/stdout",
-                    "enableAutoMtls": true,
-                    "trustDomain": "cluster.local",
-                    "rootNamespace": "istio-system"
-                  }
-                }
-              },
-              "network": "kialiNetwork",
-              "standardConfig": {
-              "cluster": "cluster-primary",
-                "configMap": {
-                  "mesh": {
-                    "accessLogFile": "/dev/stdout",
-                    "enableAutoMtls": true,
-                    "trustDomain": "cluster.local",
-                    "rootNamespace": "istio-system"
-                  }
-                },
-                "name": "istio",
-                "namespace": "istio-system"
-              }
-            },
-            "externalControlPlane": false,
-            "id": "cluster-primary",
-            "istiodName": "istiod",
-            "istiodNamespace": "istio-system",
-            "managedClusters": [
-              {
-                "apiEndpoint": "http://127.0.0.2:9443",
-                "isKialiHome": true,
-                "kialiInstances": [
-                  {
-                    "namespace": "istio-system",
-                    "operatorResource": "",
-                    "serviceName": "kiali",
-                    "url": "",
-                    "version": ""
-                  }
-                ],
-                "name": "cluster-primary",
-                "secretName": "",
-                "accessible": true
-              },
-              {
-                "apiEndpoint": "",
-                "isKialiHome": false,
-                "kialiInstances": null,
-                "name": "cluster-remote",
-                "secretName": "",
-                "accessible": true
-              }
-            ],
-            "managesExternal": true,
-            "managedNamespaces": [
-              {
-                "name": "data-plane-1",
-                "cluster": "cluster-primary",
-                "isAmbient": false,
-                "labels": {
-                  "istio-injection": "enabled",
-                  "kubernetes.io/metadata.name": "data-plane-1"
-                },
-                "annotations": null,
-                "revision": "default"
-              },
-              {
-                "name": "data-plane-2",
-                "cluster": "cluster-primary",
-                "isAmbient": false,
-                "labels": {
-                  "istio.io/rev": "default",
-                  "kubernetes.io/metadata.name": "data-plane-2"
-                },
-                "annotations": null,
-                "revision": "default"
-              },
-              {
-                "name": "data-plane-3",
-                "cluster": "cluster-remote",
-                "isAmbient": false,
-                "labels": {
-                  "istio-injection": "enabled",
-                  "kubernetes.io/metadata.name": "data-plane-3"
-                },
-                "annotations": null,
-                "revision": "default"
-              },
-              {
-                "name": "data-plane-4",
-                "cluster": "cluster-remote",
-                "isAmbient": false,
-                "labels": {
-                  "istio.io/rev": "default",
-                  "kubernetes.io/metadata.name": "data-plane-4"
-                },
-                "annotations": null,
-                "revision": "default"
-              }
-            ],
-            "resources": {},
-            "revision": "default",
-            "status": "",
-            "thresholds": {
-              "memory": 0,
-              "cpu": 0
-            }
-          },
-          "version": "Unknown"
-        }
-      },
-      {
-        "data": {
-          "id": "5ff0f691c850d727e75813fb484e06f5bad835b005b08caf2a62c0cff7cd5405",
-          "parent": "421c6926a61f0f21f1fe0babb48ea9fac6454c1d9a448dea2c559402723ec4da",
-          "cluster": "cluster-remote",
-          "infraName": "Data Plane",
-          "infraType": "dataplane",
-          "namespace": "",
-          "nodeType": "infra",
-          "healthData": "Healthy",
-          "infraData": [
-            {
-              "name": "data-plane-3",
-              "cluster": "cluster-remote",
-              "isAmbient": false,
-              "labels": {
-                "istio-injection": "enabled",
-                "kubernetes.io/metadata.name": "data-plane-3"
-              },
-              "annotations": null,
-              "revision": "default"
-            },
-            {
-              "name": "data-plane-4",
-              "cluster": "cluster-remote",
-              "isAmbient": false,
-              "labels": {
-                "istio.io/rev": "default",
-                "kubernetes.io/metadata.name": "data-plane-4"
-              },
-              "annotations": null,
-              "revision": "default"
-            }
-          ],
-          "version": "default"
+          "ConfigMapName" : "",
+          "EnvoyAdminLocalPort" : 15000,
+          "GatewayAPIClasses" : [ ],
+          "GatewayAPIClassesLabelSelector" : "",
+          "IstioAPIEnabled" : true,
+          "IstioIdentityDomain" : "svc.cluster.local",
+          "IstioInjectionAnnotation" : "sidecar.istio.io/inject",
+          "IstioSidecarInjectorConfigMapName" : "",
+          "IstioSidecarAnnotation" : "sidecar.istio.io/status",
+          "IstiodDeploymentName" : "",
+          "IstiodPodMonitoringPort" : 15014,
+          "IstiodPollingIntervalSeconds" : 20,
+          "Registry" : null,
+          "RootNamespace" : "istio-system",
+          "UrlServiceVersion" : "",
+          "ValidationChangeDetectionEnabled" : true,
+          "ValidationReconcileInterval" : 60000000000
         }
       }
-    ],
-    "edges": [
-      {
-        "data": {
-          "id": "3c1e5459c5b6268c2f2452f3e6b620fd1ae0297b4621175c97e376558bea9d58",
-          "source": "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
-          "target": "33493098cdd63801f773396da680159d0bb57b482ef38a4b208899a2e477e1f0"
-        }
-      },
-      {
-        "data": {
-          "id": "3800bf57dd84bfc7bb159fc26de3fd964dc4faa7274b6250dcde483edeba542d",
-          "source": "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
-          "target": "41b50563edf837e2e828b50492b24356bf392be6e0a7a7f21d90eabe551dd686"
-        }
-      },
-      {
-        "data": {
-          "id": "3444b8aee4ed1e0a9d9388de97152e089e723e1efae8db5658d9558b12346ac4",
-          "source": "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
-          "target": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2"
-        }
-      },
-      {
-        "data": {
-          "id": "6fb152c8305cf91514cbb0d86796cc62eb47e275cf803af3fbb26224c9ddf600",
-          "source": "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
-          "target": "e0733a58436c292ece7cbcf37db7b77510545c027d03c1798c3d6d8202b93f6f"
-        }
-      },
-      {
-        "data": {
-          "id": "8213394da06023363e2d5747d26db6f7e23d0beeacc84fcf97119768822e6dc8",
-          "source": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "target": "0bb699228f65bc52ec82ed3c72726df27b56e7518b38b7e2021196ea0065233c"
-        }
-      },
-      {
-        "data": {
-          "id": "7263daad487f2d7fb6e3b4225f94ccc140429de5456489175644410155bdaead",
-          "source": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "target": "1cf59ab6492289f4c7371ad6c0de54505a037f949855c902b5547fa6f15e3674"
-        }
-      },
-      {
-        "data": {
-          "id": "ea8e134859bb70d340128c62d2468a12174517151b37014f82613d6a0957eb8e",
-          "source": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "target": "4ffd132efe1291fcd70490d6add887f9e160a72c4885a83669432bea09de23f9"
-        }
-      },
-      {
-        "data": {
-          "id": "f25288d2a684e5be99e297439adad0d0f65e5893ba592b397f4841a42e3bab68",
-          "source": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "target": "5d63e313a5acadb4bf9f5bcaa606b69bbaf81a4193a511719a878e9ad8729a5f"
-        }
-      },
-      {
-        "data": {
-          "id": "1622664f016a337006cce1427c522c2e24c1b1b39548109f49ad478594f7d8ca",
-          "source": "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
-          "target": "5ff0f691c850d727e75813fb484e06f5bad835b005b08caf2a62c0cff7cd5405"
-        }
+    }, {
+      "data" : {
+        "id" : "4ffd132efe1291fcd70490d6add887f9e160a72c4885a83669432bea09de23f9",
+        "parent" : "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
+        "cluster" : "cluster-primary",
+        "infraName" : "gateway",
+        "infraType" : "gateway",
+        "namespace" : "istio-system",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "kind" : "Gateway",
+          "apiVersion" : "networking.istio.io/v1",
+          "metadata" : {
+            "name" : "gateway",
+            "namespace" : "istio-system",
+            "resourceVersion" : "999",
+            "creationTimestamp" : null
+          },
+          "spec" : {
+            "selector" : {
+              "istio" : "ingressgateway"
+            }
+          },
+          "status" : { }
+        },
+        "version" : "default"
       }
-    ]
+    }, {
+      "data" : {
+        "id" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
+        "parent" : "d267c54a08bd79c4a07c88b2e0d93b5c93962da0703c7bfd70d1ead571b067f0",
+        "cluster" : "cluster-primary",
+        "infraName" : "istiod",
+        "infraType" : "istiod",
+        "namespace" : "istio-system",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : {
+          "cluster" : {
+            "apiEndpoint" : "http://127.0.0.2:9443",
+            "isKialiHome" : true,
+            "kialiInstances" : [ {
+              "namespace" : "istio-system",
+              "operatorResource" : "",
+              "serviceName" : "kiali",
+              "url" : "",
+              "version" : ""
+            } ],
+            "name" : "cluster-primary",
+            "secretName" : "",
+            "accessible" : true
+          },
+          "config" : {
+            "certificates" : [ {
+              "dnsNames" : null,
+              "configMapName" : "istio-ca-root-cert",
+              "issuer" : "O=cluster.local",
+              "notBefore" : "2021-07-27T14:37:00Z",
+              "notAfter" : "2031-07-25T14:37:00Z",
+              "error" : "",
+              "accessible" : true,
+              "cluster" : ""
+            } ],
+            "effectiveConfig" : {
+              "configMap" : {
+                "mesh" : {
+                  "accessLogFile" : "/dev/stdout",
+                  "enableAutoMtls" : true,
+                  "trustDomain" : "cluster.local",
+                  "rootNamespace" : "istio-system"
+                }
+              }
+            },
+            "network" : "kialiNetwork",
+            "standardConfig" : {
+              "cluster" : "cluster-primary",
+              "configMap" : {
+                "mesh" : {
+                  "accessLogFile" : "/dev/stdout",
+                  "enableAutoMtls" : true,
+                  "trustDomain" : "cluster.local",
+                  "rootNamespace" : "istio-system"
+                }
+              },
+              "name" : "istio",
+              "namespace" : "istio-system"
+            }
+          },
+          "externalControlPlane" : false,
+          "id" : "cluster-primary",
+          "istiodName" : "istiod",
+          "istiodNamespace" : "istio-system",
+          "managedClusters" : [ {
+            "apiEndpoint" : "http://127.0.0.2:9443",
+            "isKialiHome" : true,
+            "kialiInstances" : [ {
+              "namespace" : "istio-system",
+              "operatorResource" : "",
+              "serviceName" : "kiali",
+              "url" : "",
+              "version" : ""
+            } ],
+            "name" : "cluster-primary",
+            "secretName" : "",
+            "accessible" : true
+          }, {
+            "apiEndpoint" : "",
+            "isKialiHome" : false,
+            "kialiInstances" : null,
+            "name" : "cluster-remote",
+            "secretName" : "",
+            "accessible" : true
+          } ],
+          "managesExternal" : true,
+          "managedNamespaces" : [ {
+            "name" : "data-plane-1",
+            "cluster" : "cluster-primary",
+            "isAmbient" : false,
+            "labels" : {
+              "istio-injection" : "enabled",
+              "kubernetes.io/metadata.name" : "data-plane-1"
+            },
+            "annotations" : null,
+            "revision" : "default"
+          }, {
+            "name" : "data-plane-2",
+            "cluster" : "cluster-primary",
+            "isAmbient" : false,
+            "labels" : {
+              "istio.io/rev" : "default",
+              "kubernetes.io/metadata.name" : "data-plane-2"
+            },
+            "annotations" : null,
+            "revision" : "default"
+          }, {
+            "name" : "data-plane-3",
+            "cluster" : "cluster-remote",
+            "isAmbient" : false,
+            "labels" : {
+              "istio-injection" : "enabled",
+              "kubernetes.io/metadata.name" : "data-plane-3"
+            },
+            "annotations" : null,
+            "revision" : "default"
+          }, {
+            "name" : "data-plane-4",
+            "cluster" : "cluster-remote",
+            "isAmbient" : false,
+            "labels" : {
+              "istio.io/rev" : "default",
+              "kubernetes.io/metadata.name" : "data-plane-4"
+            },
+            "annotations" : null,
+            "revision" : "default"
+          } ],
+          "resources" : { },
+          "revision" : "default",
+          "status" : "",
+          "thresholds" : {
+            "memory" : 0,
+            "cpu" : 0
+          }
+        },
+        "version" : "Unknown"
+      }
+    }, {
+      "data" : {
+        "id" : "5ff0f691c850d727e75813fb484e06f5bad835b005b08caf2a62c0cff7cd5405",
+        "parent" : "421c6926a61f0f21f1fe0babb48ea9fac6454c1d9a448dea2c559402723ec4da",
+        "cluster" : "cluster-remote",
+        "infraName" : "Data Plane",
+        "infraType" : "dataplane",
+        "namespace" : "",
+        "nodeType" : "infra",
+        "healthData" : "Healthy",
+        "infraData" : [ {
+          "name" : "data-plane-3",
+          "cluster" : "cluster-remote",
+          "isAmbient" : false,
+          "labels" : {
+            "istio-injection" : "enabled",
+            "kubernetes.io/metadata.name" : "data-plane-3"
+          },
+          "annotations" : null,
+          "revision" : "default"
+        }, {
+          "name" : "data-plane-4",
+          "cluster" : "cluster-remote",
+          "isAmbient" : false,
+          "labels" : {
+            "istio.io/rev" : "default",
+            "kubernetes.io/metadata.name" : "data-plane-4"
+          },
+          "annotations" : null,
+          "revision" : "default"
+        } ],
+        "version" : "default"
+      }
+    } ],
+    "edges" : [ {
+      "data" : {
+        "id" : "3c1e5459c5b6268c2f2452f3e6b620fd1ae0297b4621175c97e376558bea9d58",
+        "source" : "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
+        "target" : "33493098cdd63801f773396da680159d0bb57b482ef38a4b208899a2e477e1f0"
+      }
+    }, {
+      "data" : {
+        "id" : "3800bf57dd84bfc7bb159fc26de3fd964dc4faa7274b6250dcde483edeba542d",
+        "source" : "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
+        "target" : "41b50563edf837e2e828b50492b24356bf392be6e0a7a7f21d90eabe551dd686"
+      }
+    }, {
+      "data" : {
+        "id" : "3444b8aee4ed1e0a9d9388de97152e089e723e1efae8db5658d9558b12346ac4",
+        "source" : "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
+        "target" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2"
+      }
+    }, {
+      "data" : {
+        "id" : "6fb152c8305cf91514cbb0d86796cc62eb47e275cf803af3fbb26224c9ddf600",
+        "source" : "29c05b5dfa30d15d450e54f0651c03c68a25a78ae4dc8f292c6ceb5ce6be7e6d",
+        "target" : "e0733a58436c292ece7cbcf37db7b77510545c027d03c1798c3d6d8202b93f6f"
+      }
+    }, {
+      "data" : {
+        "id" : "8213394da06023363e2d5747d26db6f7e23d0beeacc84fcf97119768822e6dc8",
+        "source" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
+        "target" : "0bb699228f65bc52ec82ed3c72726df27b56e7518b38b7e2021196ea0065233c"
+      }
+    }, {
+      "data" : {
+        "id" : "ea8e134859bb70d340128c62d2468a12174517151b37014f82613d6a0957eb8e",
+        "source" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
+        "target" : "4ffd132efe1291fcd70490d6add887f9e160a72c4885a83669432bea09de23f9"
+      }
+    }, {
+      "data" : {
+        "id" : "f25288d2a684e5be99e297439adad0d0f65e5893ba592b397f4841a42e3bab68",
+        "source" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
+        "target" : "5d63e313a5acadb4bf9f5bcaa606b69bbaf81a4193a511719a878e9ad8729a5f"
+      }
+    }, {
+      "data" : {
+        "id" : "1622664f016a337006cce1427c522c2e24c1b1b39548109f49ad478594f7d8ca",
+        "source" : "9b5c974b8b5c42157a685413c86f2ff15ee4266f307f0c519d9acc50b6c97bc2",
+        "target" : "5ff0f691c850d727e75813fb484e06f5bad835b005b08caf2a62c0cff7cd5405"
+      }
+    } ]
   },
-  "meshName": "",
-  "timestamp": 1523364075
+  "meshName" : "",
+  "timestamp" : 1523364075
 }


### PR DESCRIPTION
### Describe the change

Include a partial match field in FilterDaemonSetsBySelector so the selector can be a superset of the filter.
The motivation is to match ztunnel even if it includes more selectors than just the label app=ztunnel 

### Steps to test the PR

- Verify Istio Ambient is enabled by just installing Istio Ambient
- Verify Istio Ambient is enabled by adding a new selector to ztunnel*
- Verify Istio Ambient is disabled when Istio is installed in the default profile.

*Followed the steps: 
`k get daemonset ztunnel -n istio-system -o yaml > ztunnel.yaml`
edit ztunnel.yaml to add additional selectors
`k delete daemonset ztunnel -n istio-system`
`k apply -f ztunnel.yaml -n istio-system`

### Automation testing

CI should pass

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8464
