### PR TITLE
Fixed the gvk param name in workload update request

### DIFF
--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -247,7 +247,7 @@ func WorkloadUpdate(
 
 		namespace := params["namespace"]
 		workload := params["workload"]
-		workloadGVK, errGVK := util.StringToGVK(query.Get("workloadGVK"))
+		workloadGVK, errGVK := util.StringToGVK(query.Get("gvk"))
 		if errGVK != nil {
 			RespondWithError(w, http.StatusBadRequest, "Update request with bad workloadGVK param: "+errGVK.Error())
 		}


### PR DESCRIPTION
### Describe the change

The 'gvk' param name was wrong in UpdateWorkload, causing conflict in backend.

### Steps to test the PR
Edit Workload Details in Actions, change Annotations or Injection.
It should not fail.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8478
