### PR TITLE
Replaced workloadGVK param with gvk

### DIFF
--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -90,7 +90,7 @@ Given('a workload without a sidecar', function () {
   // Make sure that the workload does not have override configuration
   cy.request({
     request: 'PATCH',
-    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?gvk="apps/v1, Kind=Deployment"`,
     body: {
       spec: {
         template: {
@@ -142,7 +142,7 @@ Given('a workload with a sidecar', function () {
   // present here for istio.
   cy.request({
     method: 'PATCH',
-    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?gvk="apps/v1, Kind=Deployment"`,
     body: {
       spec: {
         template: {
@@ -206,7 +206,7 @@ Given('the workload does not have override configuration for automatic sidecar i
 
     cy.request({
       method: 'PATCH',
-      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?gvk="apps/v1, Kind=Deployment"`,
       body: {
         spec: {
           template: {
@@ -235,7 +235,7 @@ Given('the workload has override configuration for automatic sidecar injection',
 
     cy.request({
       method: 'PATCH',
-      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+      url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?gvk="apps/v1, Kind=Deployment"`,
       body: {
         spec: {
           template: {
@@ -262,7 +262,7 @@ Given('a workload with override configuration for automatic sidecar injection', 
   // the override annotation on it.
   cy.request({
     method: 'PATCH',
-    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?type=Deployment`,
+    url: `/api/namespaces/${this.targetNamespace}/workloads/${this.targetWorkload}?gvk="apps/v1, Kind=Deployment"`,
     body: {
       spec: {
         template: {

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -110,7 +110,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
             hasSidecar: details.data.workloads.some(w => w.istioSidecar),
             hasAmbient: details.data.workloads.some(w => w.isAmbient)
           }),
-          isSupported: details.data.workloads.some(w => isGVKSupported(w.workloadGVK))
+          isSupported: details.data.workloads.some(w => isGVKSupported(w.gvk))
         });
       })
       .catch(error => {

--- a/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -75,7 +75,7 @@ export const ServiceDescription: React.FC<ServiceInfoDescriptionProps> = (props:
           workloads.push({
             namespace: wk.namespace,
             workloadName: wk.name,
-            workloadGVK: getIstioObjectGVK(wk.resourceVersion, wk.type),
+            gvk: getIstioObjectGVK(wk.resourceVersion, wk.type),
             istioSidecar: wk.istioSidecar,
             isAmbient: wk.isAmbient,
             isGateway: wk.isGateway,

--- a/frontend/src/types/App.ts
+++ b/frontend/src/types/App.ts
@@ -11,6 +11,7 @@ export type AppId = {
 };
 
 export interface AppWorkload {
+  gvk: GroupVersionKind;
   isAmbient: boolean;
   isGateway: boolean;
   isWaypoint: boolean;
@@ -20,7 +21,6 @@ export interface AppWorkload {
   namespace: string;
   serviceAccountNames: string[];
   waypointWorkloads?: WaypointInfo[];
-  workloadGVK: GroupVersionKind;
   workloadName: string;
 }
 

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -38,7 +38,7 @@ type workloadParams struct {
 	Namespace    string `json:"namespace"`
 	WorkloadName string `json:"workload"`
 	// in: query
-	WorkloadGVK schema.GroupVersionKind `json:"workloadGVK"`
+	WorkloadGVK schema.GroupVersionKind `json:"gvk"`
 	// Optional
 	ClusterName           string `json:"clusterName,omitempty"`
 	IncludeHealth         bool   `json:"health"`
@@ -63,7 +63,7 @@ func (p *workloadParams) extract(r *http.Request) error {
 		p.IncludeIstioResources = true
 	}
 
-	p.WorkloadGVK, err = util.StringToGVK(query.Get("workloadGVK"))
+	p.WorkloadGVK, err = util.StringToGVK(query.Get("gvk"))
 	if err != nil {
 		return err
 	}

--- a/models/app.go
+++ b/models/app.go
@@ -76,7 +76,7 @@ type WorkloadItem struct {
 	// Group Version Kind of the workload
 	// required: true
 	// example: 'apps/v1, Kind=Deployment'
-	WorkloadGVK schema.GroupVersionKind `json:"workloadGVK"`
+	WorkloadGVK schema.GroupVersionKind `json:"gvk"`
 
 	// Define if all Pods related to the Workload has an IstioSidecar deployed
 	// required: true


### PR DESCRIPTION
Replaced 'workloadGVK' param in json and requests by a 'gvk'
Fixed sending 'gvk' to server instead of old 'type' param.

Regression testing in Workload/App lists and details pages required.