### PR TITLE
Merge shared config map

### DIFF
--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -144,7 +144,7 @@ func (in *Discovery) setControlPlaneConfig(kubeCache ctrlclient.Reader, controlP
 	}
 
 	// When using the SHARED_MESH_CONFIG env var, istio merges the ProxyConfig unlike the other settings that are overridden
-	if controlPlaneConf.SharedConfig != nil {
+	if controlPlaneConf.SharedConfig != nil && controlPlane.SharedMeshConfig != "" {
 		if err := fusionMeshConfigs(controlPlaneConf.SharedConfig.ConfigMap.Mesh, controlPlaneConf.EffectiveConfig.ConfigMap.Mesh); err != nil {
 			return err
 		}
@@ -213,7 +213,9 @@ func deepMerge(dst, src map[string]interface{}) {
 				continue
 			}
 		}
-		dst[k] = v
+		if dst[k] == nil {
+			dst[k] = v
+		}
 	}
 }
 


### PR DESCRIPTION
### Describe the change

Merge shared config map 

### Steps to test the PR

- Install Istio with: 
```
   "--set values.pilot.env.SHARED_MESH_CONFIG=istio-cn" \
   "--set values.meshConfig.defaultConfig.proxyMetadata.group1=group" \
```
Create a configmap: 

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: istio-cn
  namespace: istio-system
data:
  mesh: |-
    defaultConfig:
      proxyMetadata:
        group2: group
```

Apply it, and verify proxyMetadata is using both values, for example: 
![image](https://github.com/user-attachments/assets/1ad1b1e6-7cec-474c-98ea-c89d8e2d8ad0)

Verify the Istio config map in Kiali has merged values as well: 
![image](https://github.com/user-attachments/assets/9c2926fe-aac5-4812-bd42-463c6a7809ae)


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
