### PR TITLE
Update cypress tests after sidecar was removed from traffic generator

### DIFF
--- a/frontend/cypress/integration/common/traffic_policies_multicluster.ts
+++ b/frontend/cypress/integration/common/traffic_policies_multicluster.ts
@@ -11,7 +11,6 @@ const authorizationPolicies: string[] = [
   'reviews-v3'
 ];
 const sidecars: string[] = [
-  'kiali-traffic-generator',
   'details-v1',
   'productpage-v1',
   'ratings-v1',

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -44,12 +44,11 @@ Feature: Kiali Apps List page
     And user sees "details"
     And user sees "reviews"
     And user sees "ratings"
-    And user sees "kiali-traffic-generator"
 
   @bookinfo-app
   Scenario: Filter workloads table by Istio Sidecar not being present
     When the user filters by "Istio Sidecar" for "Not Present"
-    Then user may only see "kiali-traffic-generator"
+    Then user sees "kiali-traffic-generator"
 
   @bookinfo-app
   Scenario: Filter Apps by Istio Config Type

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -65,7 +65,7 @@ Feature: Kiali Waypoint related features
     Then user "opens" traffic menu
     And user "enables" "ambientZtunnel" traffic option
     And user "closes" traffic menu
-    Then 7 edges appear in the graph
+    Then 5 edges appear in the graph
 
   Scenario: [Traffic Graph] User sees no Ambient traffic
     Given user is at the "graph" page
@@ -84,7 +84,7 @@ Feature: Kiali Waypoint related features
     And user "enables" "ambientTotal" traffic option
     And user "enables" "ambient" traffic option
     And user "closes" traffic menu
-    Then 16 edges appear in the graph
+    Then 14 edges appear in the graph
 
   Scenario: [Traffic Graph] User doesn't see waypoint proxy
     And the "waypoint" node "doesn't" exists


### PR DESCRIPTION
### Describe the change

Sidecar was removed from traffic generator by https://github.com/kiali/kiali-test-mesh/pull/80 . 
Adapted cypress tests