### PR TITLE
Mesh Namespace check in ControlPlanes.

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -80,19 +80,3 @@ func (in *MeshService) GetMeshConfig() *models.MeshConfig {
 
 	return &models.MeshConfig{MeshConfig: &istiov1alpha1.MeshConfig{}}
 }
-
-func (in *MeshService) HasControlPlane(ctx context.Context, cluster string, ns string, istiod string) bool {
-	mesh, err := in.discovery.Mesh(ctx)
-	if err != nil {
-		log.Errorf("Error getting mesh config: %s", err)
-		return false
-	}
-
-	for _, controlPlane := range mesh.ControlPlanes {
-		if controlPlane.IstiodNamespace == ns && controlPlane.IstiodName == istiod && controlPlane.Cluster.Name == cluster {
-			return true
-		}
-	}
-
-	return false
-}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -80,3 +80,19 @@ func (in *MeshService) GetMeshConfig() *models.MeshConfig {
 
 	return &models.MeshConfig{MeshConfig: &istiov1alpha1.MeshConfig{}}
 }
+
+func (in *MeshService) HasControlPlane(ctx context.Context, cluster string, ns string, istiod string) bool {
+	mesh, err := in.discovery.Mesh(ctx)
+	if err != nil {
+		log.Errorf("Error getting mesh config: %s", err)
+		return false
+	}
+
+	for _, controlPlane := range mesh.ControlPlanes {
+		if controlPlane.IstiodNamespace == ns && controlPlane.IstiodName == istiod && controlPlane.Cluster.Name == cluster {
+			return true
+		}
+	}
+
+	return false
+}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -220,6 +220,11 @@ func ControlPlaneMetrics(
 			return
 		}
 
+		if !layer.Mesh.HasControlPlane(r.Context(), cluster, namespace, controlPlane) {
+			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
+			return
+		}
+
 		cpWorkload, err := layer.Workload.GetWorkload(r.Context(), business.WorkloadCriteria{
 			Cluster:               cluster,
 			Namespace:             namespace,

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -197,12 +197,13 @@ func ControlPlaneMetrics(
 
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
+
 		controlPlane := vars["controlplane"]
 		conf := config.Get()
 		cluster := clusterNameFromQuery(conf, r.URL.Query())
 
-		if !discovery.IsControlPlane(r.Context(), cluster, namespace) {
-			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
+		if !discovery.HasControlPlane(r.Context(), cluster, namespace, controlPlane) {
+			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("provided namespace [%s] and control plane [%s] are not found in the cluster [%s] ", namespace, controlPlane, cluster))
 			return
 		}
 
@@ -217,11 +218,6 @@ func ControlPlaneMetrics(
 		err = extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 		if err != nil {
 			RespondWithError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		if !layer.Mesh.HasControlPlane(r.Context(), cluster, namespace, controlPlane) {
-			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
 			return
 		}
 

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -296,7 +296,7 @@ func (in *Discovery) IsControlPlane(ctx context.Context, cluster, namespace stri
 	return false
 }
 
-// HasControlPlane returns true if the control plane is in the namespace of provided cluster.
+// HasControlPlane returns true if the control plane is in the namespace of the provided cluster.
 func (in *Discovery) HasControlPlane(ctx context.Context, cluster string, ns string, istiod string) bool {
 	mesh, err := in.Mesh(ctx)
 	if err != nil {

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -296,6 +296,23 @@ func (in *Discovery) IsControlPlane(ctx context.Context, cluster, namespace stri
 	return false
 }
 
+// HasControlPlane returns true if the control plane is in the namespace of provided cluster.
+func (in *Discovery) HasControlPlane(ctx context.Context, cluster string, ns string, istiod string) bool {
+	mesh, err := in.Mesh(ctx)
+	if err != nil {
+		log.Errorf("Error getting mesh config: %s", err)
+		return false
+	}
+
+	for _, controlPlane := range mesh.ControlPlanes {
+		if controlPlane.IstiodNamespace == ns && controlPlane.IstiodName == istiod && controlPlane.Cluster.Name == cluster {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsRemoteCluster determines if the cluster has a controlplane or if it's a remote cluster without one.
 // Clusters that do not exist or are not accessible are considered remote clusters.
 func (in *Discovery) IsRemoteCluster(ctx context.Context, cluster string) bool {


### PR DESCRIPTION
### Describe the change

In Mesh page, when clicking on 'istiod' from another mesh and control-plane, show the into in side panel and do not display error.

![Screenshot from 2025-06-11 09-28-53](https://github.com/user-attachments/assets/ba3d3f10-8d3b-48f8-a048-2ff30db63085)


### Steps to test the PR

Install several versions of Istio on the same cluster, by putting different meshIDs.
`/hack/istio/install-istio-via-istioctl.sh -c oc -iv 1.24.0 -mid istio_24 -n istio-system-24 -ir "default-v1-24-0"`  
`/hack/istio/install-istio-via-istioctl.sh -c oc -iv 1.25.0 -mid istio_25 -n istio-system-25 -ir "default-v1-25-0`
`oc create namespace bookinfo25`
`oc create namespace bookinfo24`
`kubectl label namespace bookinfo25 istio.io/rev=default-v1-25-0`
`kubectl label namespace bookinfo24 istio.io/rev=default-v1-24-0`
or similar.
Go to Mesh page.
Click on all 'istiod's, and you will see the side panel correctly shown with Istio Version and the rest.
![Screenshot from 2025-06-16 18-16-03](https://github.com/user-attachments/assets/13ef6f69-e4df-4074-a9ee-230fd4c84dc1)

And and cluster section:
![Screenshot from 2025-06-16 18-12-57](https://github.com/user-attachments/assets/37c3ccb1-adb0-4e15-8472-3049098cd4e7)


This can be tested on OCP cluster easily, probably hard to test locally because of all 'istiod' versions check is by URL requests.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/8329
