### PR TITLE
[hack] build-ui must now be done first before build

### DIFF
--- a/hack/ci-kind-molecule-tests.sh
+++ b/hack/ci-kind-molecule-tests.sh
@@ -392,7 +392,7 @@ if [ "${USE_DEV_IMAGES}" == "true" ]; then
   infomsg "Dev images are to be tested. Will prepare them now."
 
   infomsg "Building dev image (backend and frontend)..."
-  make -e CLIENT_EXE="${CLIENT_EXE}" -e DORP="${DORP}" clean build test build-ui
+  make -e CLIENT_EXE="${CLIENT_EXE}" -e DORP="${DORP}" clean build-ui build test
 
   infomsg "Pushing the images into the cluster..."
   make -e CLIENT_EXE="${CLIENT_EXE}" -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND="${KIND_EXE}" -e KIND_NAME="${KIND_NAME}" cluster-push

--- a/hack/ci-openshift-molecule-tests.sh
+++ b/hack/ci-openshift-molecule-tests.sh
@@ -380,7 +380,7 @@ if [ "${USE_DEV_IMAGES}" == "true" ]; then
   infomsg "Dev images are to be tested. Will prepare them now using GOPATH=${GOPATH}"
 
   infomsg "Building backend server and frontend UI..."
-  make -e OC="${OC}" -e DORP="${DORP}" -e GOPATH="${GOPATH}" clean build test build-ui
+  make -e OC="${OC}" -e DORP="${DORP}" -e GOPATH="${GOPATH}" clean build-ui build test
 
   infomsg "Logging into the image registry..."
   eval $(make -e OC="${OC}" -e DORP="${DORP}" cluster-status | grep "Image Registry login:" | sed 's/Image Registry login: \(.*\)$/\1/')

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -87,7 +87,7 @@ deploy_kiali() {
   if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
     if [ "${KIALI_BUILD_DEV_IMAGE}" == "true" ]; then
       echo "Building the dev image..."
-      make -e -C "${KIALI_REPO_ROOT}" build build-ui
+      make -e -C "${KIALI_REPO_ROOT}" build-ui build
     fi
 
     if [ "${MANAGE_KIND}" == "true" ]; then

--- a/hack/istio/skupper/install-skupper-demo.sh
+++ b/hack/istio/skupper/install-skupper-demo.sh
@@ -251,7 +251,7 @@ minikube_install_basic_demo() {
   if [ "${KIALI_VERSION}" == "dev" ]; then
     infomsg "Installing Kiali ..."
     if [ "${KIALI_DEV_BUILD}" == "true" ]; then
-      local make_build_targets="build build-ui"
+      local make_build_targets="build-ui build"
     fi
     make --directory "${ROOT_DIR}" -e OC="$(which ${CLIENT_EXE})" CLUSTER_TYPE=minikube MINIKUBE_PROFILE=${CLUSTER1_ISTIO} SERVICE_TYPE=LoadBalancer ${make_build_targets:-} cluster-push operator-create kiali-create
     ${CLIENT_EXE} patch kiali kiali -n kiali-operator --type merge -p '{"spec":{"extensions":[{"enabled":true,"name":"skupper"}]}}'
@@ -370,7 +370,7 @@ openshift_install_basic_demo() {
   if [ "${KIALI_VERSION}" == "dev" ]; then
     infomsg "Installing Kiali ..."
     if [ "${KIALI_DEV_BUILD}" == "true" ]; then
-      local make_build_targets="build build-ui"
+      local make_build_targets="build-ui build"
     fi
     make --directory "${ROOT_DIR}" -e OC="$(which ${CLIENT_EXE})" CLUSTER_TYPE=openshift ${make_build_targets:-} cluster-push operator-create kiali-create
     ${CLIENT_EXE} patch kiali kiali -n kiali-operator --type merge -p '{"spec":{"extensions":[{"enabled":true,"name":"skupper"}]}}'

--- a/hack/perf-ibmcloud-openshift.sh
+++ b/hack/perf-ibmcloud-openshift.sh
@@ -245,7 +245,7 @@ install_kiali() {
     local kiali_dir=""
     kiali_dir="${SCRIPT_DIR}/.."
     make -C "${kiali_dir}" -e HELM_CHARTS_REPO="${HELM_CHARTS_REPO}" .ensure-operator-helm-chart-exists
-    make -C "${kiali_dir}" -e DORP=podman build build-ui cluster-push
+    make -C "${kiali_dir}" -e DORP=podman build-ui build cluster-push
     # Dev images need to be built and pushed to the registry.
     additional_set='--set allowAdHocKialiNamespace=true --set allowAdHocKialiImage=true --set image.pullSecrets={kiali-pull-creds}'
     # Need to provide a image pull secret for the kiali and operator pods.

--- a/hack/test-pull-request.sh
+++ b/hack/test-pull-request.sh
@@ -230,7 +230,7 @@ cd kiali
 # Build and push the images to the cluster
 
 echo "Building backend server and frontend UI using GOPATH=${GOPATH}..."
-make clean build test build-ui
+make clean build-ui build test
 
 if [ "${IS_OPENSHIFT}" == "true" ]; then
   echo "Logging into the image registry..."


### PR DESCRIPTION
Now that the frontend UI code is embedded in the container, we have to run build-ui target first, and then build. I found this change (swapping the order of the make targets) was not done in some hack scripts. This PR fixes that.