### PR TITLE
Add XARGS to kiali-int-tests image

### DIFF
--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME=$GOPATH/src/kiali
 
 # install required packages and prepare go dirs
 WORKDIR /bin
-RUN microdnf install -y --nodocs tar gzip make which gettext git \
+RUN microdnf install -y --nodocs tar gzip make which gettext git findutils\
     && curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
     && tar -xf oc.tar.gz \
     && rm -f oc.tar.gz \


### PR DESCRIPTION
### Describe the change

xargs is required since it is used in `hack/use-openshift-prometheus.sh` script.
