### PR TITLE
[hack] do not change committed files when running hack scripts

### DIFF
--- a/hack/istio/multicluster/env.sh
+++ b/hack/istio/multicluster/env.sh
@@ -442,7 +442,7 @@ Valid command line arguments:
                               (Default: true)
   -kni|--kind-node-image: Image of the kind cluster. Defaults to latest kind image if not specified.
   -kshc|--kiali-server-helm-charts <path>: If specified, must be the path to a Kiali server helm charts tarball. If not
-                                           specified, the latest published helm charts is used. (Default: kiali-server)
+                                           specified, the latest published helm charts is used.
   -kudi|--kiali-use-dev-image: If "true" the local dev image of Kiali will be pushed and used in the Kiali deployment.
                                The local dev image must be tagged as "quay.io/kiali/kiali:dev" prior to running this script;
                                that will be the image pushed to the clusters. You can "make container-build-kiali" to build it.
@@ -605,6 +605,10 @@ if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
     # The user should set this to a tarball if a different helm chart should be used.
     # e.g. /source/helm-charts/_output/charts/kiali-server-1.64.0-SNAPSHOT.tgz
     KIALI_SERVER_HELM_CHARTS="${KIALI_SERVER_HELM_CHARTS:-kiali-server}"
+  fi
+else
+  if [ -z "${KIALI_SERVER_HELM_CHARTS:-}" ]; then
+    KIALI_SERVER_HELM_CHARTS="kiali/kiali-server"
   fi
 fi
 

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -249,9 +249,12 @@ printf "%s" "${REMOTE_SECRET}" | ${CLIENT_EXE} apply -f -
 ${CLIENT_EXE} patch svc prometheus -n ${ISTIO_NAMESPACE} --context ${CLUSTER2_CONTEXT} -p "{\"spec\": {\"type\": \"LoadBalancer\"}}"
 
 WEST_PROMETHEUS_ADDRESS=$(${CLIENT_EXE} --context=${CLUSTER2_CONTEXT} -n ${ISTIO_NAMESPACE} get svc prometheus -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-sed -i "s/WEST_PROMETHEUS_ADDRESS/$WEST_PROMETHEUS_ADDRESS/g" ${SCRIPT_DIR}/prometheus.yaml
-${CLIENT_EXE} apply -f ${SCRIPT_DIR}/prometheus.yaml -n ${ISTIO_NAMESPACE} --context ${CLUSTER1_CONTEXT} 
-sed -i "s/$WEST_PROMETHEUS_ADDRESS/WEST_PROMETHEUS_ADDRESS/g" ${SCRIPT_DIR}/prometheus.yaml
+if [ -z "${WEST_PROMETHEUS_ADDRESS}" ]; then
+  echo "WARNING! Prometheus not updated - cannot determine the west prometheus load balancer ingress IP"
+else
+  ## TODO: prometheus.yaml has CLUSTER_NAME in it that should also be searched-replaced, but that is not done here
+  cat ${SCRIPT_DIR}/prometheus.yaml | sed -e "s/WEST_PROMETHEUS_ADDRESS/$WEST_PROMETHEUS_ADDRESS/g" | ${CLIENT_EXE} apply -n ${ISTIO_NAMESPACE} --context ${CLUSTER1_CONTEXT} -f -
+fi
 
 # Configure Tracing "federation"
 source ${SCRIPT_DIR}/setup-tracing.sh


### PR DESCRIPTION
fixes: #8512

You only see the bug if prometheus is installed in a cluster that doesn't have a loadbalancer IP (I see this when installing in a cluster of OpenShifts). Now this just spits out a warning rather than erroneously making a change to the hack file prometheus.yaml

NOTE: this also fixes a minor bug regarding the name of the helm chart to be used by default