### PR TITLE
Make appenders run in parallel

### DIFF
--- a/graph/telemetry/istio/istio.go
+++ b/graph/telemetry/istio/istio.go
@@ -124,7 +124,7 @@ func BuildNamespacesTrafficMap(ctx context.Context, o graph.TelemetryOptions, gl
 // buildAppenderTrafficMap is called per namespace and calls buildNamespaceTrafficMap per appender
 func buildAppenderTrafficMap(ctx context.Context, namespaceInfo graph.NamespaceInfo, o graph.TelemetryOptions, globalInfo *graph.GlobalInfo, a graph.Appender) graph.TrafficMap {
 	zl := log.FromContext(ctx)
-	zl.Trace().Msgf("Build traffic map for namespace [%v] using %s", namespaceInfo, a.Name())
+	zl.Trace().Msgf("Build traffic map for namespace [%s] using appender [%s]", namespaceInfo.Name, a.Name())
 
 	namespaceTrafficMap := buildNamespaceTrafficMap(ctx, namespaceInfo, o, globalInfo)
 


### PR DESCRIPTION
### Describe the change
Make Graph Appenders be run in parallel.
Appenders such us "ThroughputAppender", "SecurityPolicyAppender" and "ResponseTimeAppender" can be run after the rest of appenders and be in parallel.
Make appenders loop over the namespaces loop.
Parallelism is per appender per namespace.

### Steps to test the PR

Regression testing of a Graph with all appenders.
Perf measurements before and after.

### Automation testing

TODO Perf tests modify to include all appenders.

### Issue reference
https://github.com/kiali/kiali/issues/8418
