### PR TITLE
[2.4] Update cypress tests after sidecar was removed from traffic generator

### DIFF
--- a/frontend/cypress/integration/common/traffic_policies_multicluster.ts
+++ b/frontend/cypress/integration/common/traffic_policies_multicluster.ts
@@ -10,15 +10,7 @@ const authorizationPolicies: string[] = [
   'reviews-v2',
   'reviews-v3'
 ];
-const sidecars: string[] = [
-  'kiali-traffic-generator',
-  'details-v1',
-  'productpage-v1',
-  'ratings-v1',
-  'reviews-v1',
-  'reviews-v2',
-  'reviews-v3'
-];
+const sidecars: string[] = ['details-v1', 'productpage-v1', 'ratings-v1', 'reviews-v1', 'reviews-v2', 'reviews-v3'];
 
 When('user deletes a Traffic Policy and the resource is no longer available in any cluster', () => {
   authorizationPolicies.forEach(policy => {

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -44,12 +44,11 @@ Feature: Kiali Apps List page
     And user sees "details"
     And user sees "reviews"
     And user sees "ratings"
-    And user sees "kiali-traffic-generator"
 
   @bookinfo-app
   Scenario: Filter workloads table by Istio Sidecar not being present
     When the user filters by "Istio Sidecar" for "Not Present"
-    Then user may only see "kiali-traffic-generator"
+    Then user sees "kiali-traffic-generator"
 
   @bookinfo-app
   Scenario: Filter Apps by Istio Config Type

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -63,7 +63,7 @@ Feature: Kiali Waypoint related features
     Then user sees the "bookinfo" namespace
     Then user opens traffic menu
     And user "enables" "ambientZtunnel" traffic option
-    Then 7 edges appear in the graph
+    Then 5 edges appear in the graph
 
   @waypoint
   Scenario: [Traffic Graph] User sees no Ambient traffic
@@ -82,7 +82,7 @@ Feature: Kiali Waypoint related features
     Then user opens traffic menu
     And user "enables" "ambientTotal" traffic option
     And user "enables" "ambient" traffic option
-    Then 16 edges appear in the graph
+    Then 14 edges appear in the graph
 
   @waypoint
   Scenario: [Traffic Graph] User doesn't see waypoint proxy


### PR DESCRIPTION
### Describe the change

Backport of https://github.com/kiali/kiali/pull/8488
