### PR TITLE
Change remote cluster secrets dir for tests

### DIFF
--- a/kubernetes/testing.go
+++ b/kubernetes/testing.go
@@ -45,10 +45,13 @@ func NewTestingClientFactory(t *testing.T) *clientFactory {
 	// Reset global vars after test
 	originalToken := KialiTokenForHomeCluster
 	originalPath := DefaultServiceAccountPath
+	originalRemoteSecrets := RemoteClusterSecretsDir
 	t.Cleanup(func() {
 		KialiTokenForHomeCluster = originalToken
 		DefaultServiceAccountPath = originalPath
+		RemoteClusterSecretsDir = originalRemoteSecrets
 	})
+	RemoteClusterSecretsDir = t.TempDir()
 
 	DefaultServiceAccountPath = fmt.Sprintf("%s/kiali-testing-token-%s", t.TempDir(), time.Now())
 	if err := os.WriteFile(DefaultServiceAccountPath, []byte("test-token"), 0o644); err != nil {


### PR DESCRIPTION
### Describe the change

If you have a remote secret defined on the real path and you run the tests you will get test errors.

### Steps to test the PR

Have a remote secret at: `/kiali-remote-cluster-secrets/` and then run `make test`. Tests should pass.

### Automation testing

Unit testing included

### Issue reference

N/A
