### PR TITLE
[CI] OSSMC - Workload logs tab failure -- Update test selectors

### DIFF
--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -159,10 +159,10 @@ Then('I click a json log line', () => {
 });
 
 Then('I click on the parsed json tab', () => {
-  cy.get('[role="dialog"]')
+  cy.get('[data-test="json-modal"]')
     .should('be.visible')
     .within(() => {
-      cy.get('[role="tab"]').eq(1).click();
+      cy.get('[data-test="json-table-tab"]').click();
     });
 });
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -1036,7 +1036,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
     );
 
     const tableTab = (
-      <Tab eventKey={1} title={t('Table')} key="table">
+      <Tab eventKey={1} title={t('Table')} key="table" data-test="json-table-tab">
         {this.state.jsonModalContent && this.renderTableFromJson(JSON.parse(this.state.jsonModalContent))}
       </Tab>
     );
@@ -1047,6 +1047,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
   private getJSONLogModal = (): React.ReactNode => {
     return (
       <Modal
+        data-test="json-modal"
         className={modalStyle}
         disableFocusTrap={true}
         title={t('JSON Log Entry')}


### PR DESCRIPTION
### Describe the change

Update test selectors in Workload logs tab test

![image](https://github.com/user-attachments/assets/25018a5a-e288-4010-bb28-80d81f86e003)


### Steps to test the PR

- Run Workload logs tab test
- cy passes

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8540 
