### PR TITLE
[CI] cypress test coverage for tracing tool 

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -350,29 +350,29 @@ When('user switches to the Tester tab', () => {
   });
 });
 
-When('user sets the provider in the Tester tab', () => {
+When('user changes the provider in the Tester tab', () => {
   cy.get('div[data-test="modal-configuration-tester"]').within(() => {
     cy.window().then((win: any) => {
-      const editor = win.ace.edit('ace-editor');
+      const editor = win.ace.edit('ace-editor-tester');
       const session = editor.getSession();
       const linesCount = session.getLength();
       const searchText = 'provider';
       let replacer = 'tempo';
+      let provider = 'jaeger';
 
-      let lineNumber = -1;
       for (let i = 0; i < linesCount; i++) {
         const line = session.getLine(i);
-        if (line.includes(searchText)) {
-          lineNumber = i;
+        if (line.toString().toLowerCase().includes(searchText)) {
           if (line.includes('tempo')) {
             replacer = 'jaeger';
+            provider = 'tempo';
           }
           break;
         }
       }
-      console.log(editor.session);
-      const range = editor.session.getLineRange(lineNumber);
-      editor.session.replace(range, `Provider: ${replacer}`);
+      let val: string = editor.getValue();
+      val = val.replace(`Provider: ${provider}`, `Provider: ${replacer}`);
+      editor.setValue(val);
     });
   });
 });
@@ -384,11 +384,11 @@ When('user clicks the Test Configuration button', () => {
 });
 
 Then('user sees the Tester result {string}', (result: string) => {
-  cy.get('#modal-configuration.tester').within(() => {
+  cy.get('div[data-test="modal-configuration-tester"]').within(() => {
     if (result === 'incorrect') {
-      cy.get('div[data-test="icon-error-validation"]').should('exist');
+      cy.get('span[data-test="icon-error-validation"]').should('exist');
     } else {
-      cy.get('div[data-test="icon-correct-validation"]').should('exist');
+      cy.get('span[data-test="icon-correct-validation"]').should('exist');
     }
   });
 });

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -124,3 +124,21 @@ Feature: Kiali Mesh page
     And user sees "mode: REGISTRY_ONLY" in the "effective" configuration tab
     And user sees "mode: REGISTRY_ONLY" in the "shared" configuration tab
     And user does not see "mode: REGISTRY_ONLY" in the "standard" configuration tab
+
+  @selected
+  Scenario: User opens and interacts with the Trace Configuration modal
+    When user selects tracing mesh node
+    And user opens the Trace Configuration modal
+    Then user sees the Trace Configuration modal
+    And user sees the Discovery and Tester tabs
+    And user sees the action buttons fixed at the bottom
+    And user verifies the Discovery information is correct
+    When user clicks the Rediscover button in the Discovery tab
+    And user verifies the Discovery information is correct
+    When user switches to the Tester tab
+    And user sets the provider in the Tester tab
+    And user clicks the Test Configuration button
+    Then user sees the Tester result "incorrect"
+    And user sets the provider in the Tester tab
+    And user clicks the Test Configuration button
+    Then user sees the Tester result "correct"

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -136,9 +136,9 @@ Feature: Kiali Mesh page
     When user clicks the Rediscover button in the Discovery tab
     And user verifies the Discovery information is correct
     When user switches to the Tester tab
-    And user sets the provider in the Tester tab
+    And user changes the provider in the Tester tab
     And user clicks the Test Configuration button
     Then user sees the Tester result "incorrect"
-    And user sets the provider in the Tester tab
+    And user changes the provider in the Tester tab
     And user clicks the Test Configuration button
     Then user sees the Tester result "correct"

--- a/frontend/src/components/Mesh/CheckerTracingConfig.tsx
+++ b/frontend/src/components/Mesh/CheckerTracingConfig.tsx
@@ -109,6 +109,7 @@ export const CheckerTracingConfig: React.FC<CheckerTracingConfigProps> = (props:
       <div style={{ flexGrow: 1, overflowY: 'auto' }}>
         <span>{t('external_services.tracing configuration:')}</span>
         <AceEditor
+          name="ace-editor-tester"
           ref={aceEditorRef}
           mode="yaml"
           theme={theme === Theme.DARK ? 'twilight' : 'eclipse'}

--- a/frontend/src/components/Mesh/DiscoveryTracingConfig.tsx
+++ b/frontend/src/components/Mesh/DiscoveryTracingConfig.tsx
@@ -111,7 +111,10 @@ export const CheckConfigComp: React.FC<CheckModalProps> = (props: CheckModalProp
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '600px', paddingTop: '1em' }}>
+    <div
+      id="discovery-tab-content"
+      style={{ display: 'flex', flexDirection: 'column', height: '600px', paddingTop: '1em' }}
+    >
       <div style={{ flexGrow: 1, overflowY: 'auto' }}>
         {props.tracingDiagnose && (
           <>
@@ -133,7 +136,7 @@ export const CheckConfigComp: React.FC<CheckModalProps> = (props: CheckModalProp
                 {props.tracingDiagnose?.validConfig.length === 0 && <>No configurations found. See logs for details</>}
               </span>
             </div>
-            <div>
+            <div id="valid-configurations">
               {props.tracingDiagnose?.validConfig?.map((item, i) => (
                 <>
                   <div className={configStyle}>
@@ -168,7 +171,7 @@ export const CheckConfigComp: React.FC<CheckModalProps> = (props: CheckModalProp
               <Title headingLevel="h4" size="lg" style={{ paddingBottom: '10px' }}>
                 {t('Logs')}:
               </Title>
-              <div className={containerStyle}>
+              <div className={containerStyle} id={'configuration-logs'}>
                 {props.tracingDiagnose.logLine.map(log => (
                   <>
                     <div>
@@ -186,10 +189,15 @@ export const CheckConfigComp: React.FC<CheckModalProps> = (props: CheckModalProp
         )}
       </div>
       <div>
-        <Button onClick={handleCheckService} disabled={loading} variant={ButtonVariant.secondary}>
+        <Button
+          onClick={handleCheckService}
+          disabled={loading}
+          variant={ButtonVariant.secondary}
+          style={{ marginRight: '5px' }}
+        >
           {t('Rediscover')}
         </Button>
-        {loading && <Spinner size="sm" />}
+        {loading && <Spinner id="discover-spinner" size="sm" />}
       </div>
     </div>
   );

--- a/frontend/src/components/Mesh/TraceConfigurationModal.tsx
+++ b/frontend/src/components/Mesh/TraceConfigurationModal.tsx
@@ -158,6 +158,7 @@ export const TraceConfigurationModalComp: React.FC<TraceConfigurationModalProps>
       variant={ModalVariant.medium}
       isOpen={props.isOpen}
       onClose={props.onClose}
+      data-test="modal-configuration-tester"
       title={t('Configuration Tester')}
       actions={[
         <Button key="close" onClick={props.onClose}>


### PR DESCRIPTION
### Describe the change

cypress test coverage for tracing tool 

### Steps to test the PR

You can mark `Scenario: User opens and interacts with the Trace Configuration modal` with `@selected` and run 
`kiali/frontend$ yarn cypress:selected`

### Automation testing

e2e

### Issue reference

Fixes #8528 
