### PR TITLE
Unify the format of the configs in the Mesh page

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -282,11 +282,11 @@ type GrafanaVariablesConfig struct {
 }
 
 type TempoConfig struct {
-	CacheCapacity int    `yaml:"cache_capacity" json:"cache_capacity,omitempty"`
-	CacheEnabled  bool   `yaml:"cache_enabled" json:"cache_enabled,omitempty"`
-	DatasourceUID string `yaml:"datasource_uid" json:"datasource_uid,omitempty"`
-	OrgID         string `yaml:"org_id" json:"org_id,omitempty"`
-	URLFormat     string `yaml:"url_format" json:"url_format,omitempty"`
+	CacheCapacity int    `yaml:"cache_capacity"`
+	CacheEnabled  bool   `yaml:"cache_enabled"`
+	DatasourceUID string `yaml:"datasource_uid"`
+	OrgID         string `yaml:"org_id"`
+	URLFormat     string `yaml:"url_format"`
 }
 
 // TracingConfig describes configuration used for tracing links

--- a/config/config.go
+++ b/config/config.go
@@ -282,11 +282,11 @@ type GrafanaVariablesConfig struct {
 }
 
 type TempoConfig struct {
-	CacheCapacity int    `yaml:"cache_capacity"`
-	CacheEnabled  bool   `yaml:"cache_enabled"`
-	DatasourceUID string `yaml:"datasource_uid"`
-	OrgID         string `yaml:"org_id"`
-	URLFormat     string `yaml:"url_format"`
+	CacheCapacity int    `yaml:"cache_capacity" json:"cacheCapacity,omitempty"`
+	CacheEnabled  bool   `yaml:"cache_enabled" json:"cacheEnabled,omitempty"`
+	DatasourceUID string `yaml:"datasource_uid" json:"datasourceUID,omitempty"`
+	OrgID         string `yaml:"org_id" json:"orgID,omitempty"`
+	URLFormat     string `yaml:"url_format" json:"urlFormat,omitempty"`
 }
 
 // TracingConfig describes configuration used for tracing links

--- a/config/config.go
+++ b/config/config.go
@@ -248,7 +248,7 @@ type CustomDashboardsConfig struct {
 	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty"`
 	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty"`
 	Enabled                bool             `yaml:"enabled,omitempty"`
-	IsCore                 bool             `yaml:"is_core,omitempty"`
+	IsCore                 bool             `yaml:"is_core,omitempty" json:"isCore,omitempty"`
 	NamespaceLabel         string           `yaml:"namespace_label,omitempty"`
 	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty"`
 }
@@ -351,7 +351,7 @@ type ComponentStatuses struct {
 
 type ComponentStatus struct {
 	AppLabel       string `yaml:"app_label,omitempty"`
-	IsCore         bool   `yaml:"is_core,omitempty"`
+	IsCore         bool   `yaml:"is_core,omitempty" json:"isCore,omitempty"`
 	IsProxy        bool   `yaml:"is_proxy,omitempty"`
 	IsMultiCluster bool   `yaml:"is_multicluster,omitempty"`
 	Namespace      string `yaml:"namespace,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -320,7 +320,7 @@ type RegistryConfig struct {
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty" json:"componentStatus,omitempty"`
+	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty" json:"componentStatuses,omitempty"`
 	ConfigMapName                     string            `yaml:"config_map_name,omitempty" json:"configMapName,omitempty"`
 	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty" json:"envoyAdminLocalPort,omitempty"`
 	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty" json:"gatewayApiClasses,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -206,13 +206,13 @@ type Server struct {
 
 // Auth provides authentication data for external services
 type Auth struct {
-	CAFile             string `yaml:"ca_file"`
-	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
-	Password           string `yaml:"password"`
-	Token              string `yaml:"token"`
-	Type               string `yaml:"type"`
-	UseKialiToken      bool   `yaml:"use_kiali_token"`
-	Username           string `yaml:"username"`
+	CAFile             string `yaml:"ca_file" json:"caFile"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecureSkipVerify"`
+	Password           string `yaml:"password" json:"password"`
+	Token              string `yaml:"token" json:"token"`
+	Type               string `yaml:"type" json:"type"`
+	UseKialiToken      bool   `yaml:"use_kiali_token" json:"useKialiToken"`
+	Username           string `yaml:"username" json:"username"`
 }
 
 func (a *Auth) Obfuscate() {
@@ -224,23 +224,23 @@ func (a *Auth) Obfuscate() {
 
 // ThanosProxy describes configuration of the Thanos proxy component
 type ThanosProxy struct {
-	Enabled         bool   `yaml:"enabled,omitempty"`
-	RetentionPeriod string `yaml:"retention_period,omitempty"`
-	ScrapeInterval  string `yaml:"scrape_interval,omitempty"`
+	Enabled         bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	RetentionPeriod string `yaml:"retention_period,omitempty" json:"retentionPeriod,omitempty"`
+	ScrapeInterval  string `yaml:"scrape_interval,omitempty" json:"scrapeInterval,omitempty"`
 }
 
 // PrometheusConfig describes configuration of the Prometheus component
 type PrometheusConfig struct {
-	Auth            Auth              `yaml:"auth,omitempty"`
-	CacheDuration   int               `yaml:"cache_duration,omitempty"`   // Cache duration per query expressed in seconds
-	CacheEnabled    bool              `yaml:"cache_enabled,omitempty"`    // Enable cache for Prometheus queries
-	CacheExpiration int               `yaml:"cache_expiration,omitempty"` // Global cache expiration expressed in seconds
-	CustomHeaders   map[string]string `yaml:"custom_headers,omitempty"`
-	HealthCheckUrl  string            `yaml:"health_check_url,omitempty"`
-	IsCore          bool              `yaml:"is_core,omitempty"`
-	QueryScope      map[string]string `yaml:"query_scope,omitempty"`
-	ThanosProxy     ThanosProxy       `yaml:"thanos_proxy,omitempty"`
-	URL             string            `yaml:"url,omitempty"`
+	Auth            Auth              `yaml:"auth,omitempty" json:"auth,omitempty"`
+	CacheDuration   int               `yaml:"cache_duration,omitempty" json:"cacheDuration,omitempty"`     // Cache duration per query expressed in seconds
+	CacheEnabled    bool              `yaml:"cache_enabled,omitempty" json:"cacheEnabled,omitempty"`       // Enable cache for Prometheus queries
+	CacheExpiration int               `yaml:"cache_expiration,omitempty" json:"cacheExpiration,omitempty"` // Global cache expiration expressed in seconds
+	CustomHeaders   map[string]string `yaml:"custom_headers,omitempty" json:"customHeaders,omitempty"`
+	HealthCheckUrl  string            `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
+	IsCore          bool              `yaml:"is_core,omitempty" json:"isCore,omitempty"`
+	QueryScope      map[string]string `yaml:"query_scope,omitempty" json:"queryScope,omitempty"`
+	ThanosProxy     ThanosProxy       `yaml:"thanos_proxy,omitempty" json:"thanosProxy,omitempty"`
+	URL             string            `yaml:"url,omitempty" json:"url,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
@@ -255,21 +255,21 @@ type CustomDashboardsConfig struct {
 
 // GrafanaConfig describes configuration used for Grafana links
 type GrafanaConfig struct {
-	Auth           Auth                     `yaml:"auth"`
-	Dashboards     []GrafanaDashboardConfig `yaml:"dashboards"`
-	DatasourceUID  string                   `yaml:"datasource_uid,omitempty"`
-	Enabled        bool                     `yaml:"enabled"`      // Enable or disable Grafana support in Kiali
-	ExternalURL    string                   `yaml:"external_url"` // replaces the old url
-	HealthCheckUrl string                   `yaml:"health_check_url,omitempty"`
-	InternalURL    string                   `yaml:"internal_url"` // replaces the old in_cluster_url
-	IsCore         bool                     `yaml:"is_core,omitempty"`
+	Auth           Auth                     `yaml:"auth" json:"auth"`
+	Dashboards     []GrafanaDashboardConfig `yaml:"dashboards" json:"dashboards"`
+	DatasourceUID  string                   `yaml:"datasource_uid,omitempty" json:"datasourceUID,omitempty"`
+	Enabled        bool                     `yaml:"enabled" json:"enabled"`          // Enable or disable Grafana support in Kiali
+	ExternalURL    string                   `yaml:"external_url" json:"externalURL"` // replaces the old url
+	HealthCheckUrl string                   `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
+	InternalURL    string                   `yaml:"internal_url" json:"internalURL"` // replaces the old in_cluster_url
+	IsCore         bool                     `yaml:"is_core,omitempty" json:"isCore,omitempty"`
 	XInClusterURL  string                   `yaml:"in_cluster_url,omitempty" json:"InClusterURL,omitempty"` // DEPRECATED!
 	XURL           string                   `yaml:"url,omitempty" json:"URL,omitempty"`                     // DEPRECATED!
 }
 
 type GrafanaDashboardConfig struct {
-	Name      string                 `yaml:"name"`
-	Variables GrafanaVariablesConfig `yaml:"variables"`
+	Name      string                 `yaml:"name" json:"name"`
+	Variables GrafanaVariablesConfig `yaml:"variables" json:"variables"`
 }
 
 type GrafanaVariablesConfig struct {
@@ -291,22 +291,22 @@ type TempoConfig struct {
 
 // TracingConfig describes configuration used for tracing links
 type TracingConfig struct {
-	Auth                 Auth              `yaml:"auth"`
-	CustomHeaders        map[string]string `yaml:"custom_headers,omitempty"`
-	DisableVersionCheck  bool              `yaml:"disable_version_check,omitempty"`
-	Enabled              bool              `yaml:"enabled"`      // Enable Tracing in Kiali
-	ExternalURL          string            `yaml:"external_url"` // replaces the old url
-	HealthCheckUrl       string            `yaml:"health_check_url,omitempty"`
-	GrpcPort             int               `yaml:"grpc_port,omitempty"`
-	InternalURL          string            `yaml:"internal_url"` // replaces the old in_cluster_url
-	IsCore               bool              `yaml:"is_core,omitempty"`
-	Provider             TracingProvider   `yaml:"provider,omitempty"` // jaeger | tempo
-	TempoConfig          TempoConfig       `yaml:"tempo_config,omitempty"`
-	NamespaceSelector    bool              `yaml:"namespace_selector"`
-	QueryScope           map[string]string `yaml:"query_scope,omitempty"`
-	QueryTimeout         int               `yaml:"query_timeout,omitempty"`
-	UseGRPC              bool              `yaml:"use_grpc"`
-	WhiteListIstioSystem []string          `yaml:"whitelist_istio_system"`
+	Auth                 Auth              `yaml:"auth" json:"auth"`
+	CustomHeaders        map[string]string `yaml:"custom_headers,omitempty" json:"customHeaders,omitempty"`
+	DisableVersionCheck  bool              `yaml:"disable_version_check,omitempty" json:"disableVersionCheck,omitempty"`
+	Enabled              bool              `yaml:"enabled" json:"enabled"`
+	ExternalURL          string            `yaml:"external_url" json:"externalURL"`
+	HealthCheckUrl       string            `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
+	GrpcPort             int               `yaml:"grpc_port,omitempty" json:"grpcPort,omitempty"`
+	InternalURL          string            `yaml:"internal_url" json:"internalURL"`
+	IsCore               bool              `yaml:"is_core,omitempty" json:"isCore,omitempty"`
+	Provider             TracingProvider   `yaml:"provider,omitempty" json:"provider,omitempty"`
+	TempoConfig          TempoConfig       `yaml:"tempo_config,omitempty" json:"tempoConfig,omitempty"`
+	NamespaceSelector    bool              `yaml:"namespace_selector" json:"namespaceSelector"`
+	QueryScope           map[string]string `yaml:"query_scope,omitempty" json:"queryScope,omitempty"`
+	QueryTimeout         int               `yaml:"query_timeout,omitempty" json:"queryTimeout,omitempty"`
+	UseGRPC              bool              `yaml:"use_grpc" json:"useGRPC"`
+	WhiteListIstioSystem []string          `yaml:"whitelist_istio_system" json:"whiteListIstioSystem"`
 	XInClusterURL        string            `yaml:"in_cluster_url,omitempty" json:"InClusterURL,omitempty"` // DEPRECATED!
 	XURL                 string            `yaml:"url,omitempty" json:"URL,omitempty"`                     // DEPRECATED!
 }
@@ -314,39 +314,39 @@ type TracingConfig struct {
 // RegistryConfig contains configuration for connecting to an external istiod.
 // This is used when Kiali should connect to the istiod via a url instead of port forwarding.
 type RegistryConfig struct {
-	IstiodURL string `yaml:"istiod_url"`
+	IstiodURL string `yaml:"istiod_url" json:"istiodUrl"`
 	// TODO: Support auth options
 }
 
 // IstioConfig describes configuration used for istio links
 type IstioConfig struct {
-	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty"`
-	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
-	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
-	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
-	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty"`
-	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
-	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
-	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`
-	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
-	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty"`
-	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty"`
-	IstiodPodMonitoringPort           int               `yaml:"istiod_pod_monitoring_port,omitempty"`
+	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty" json:"componentStatus,omitempty"`
+	ConfigMapName                     string            `yaml:"config_map_name,omitempty" json:"configMapName,omitempty"`
+	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty" json:"envoyAdminLocalPort,omitempty"`
+	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty" json:"gatewayApiClasses,omitempty"`
+	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty" json:"gatewayApiClassesLabelSelector,omitempty"`
+	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled" json:"istioApiEnabled"`
+	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty" json:"istioIdentityDomain,omitempty"`
+	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty" json:"istioInjectionAnnotation,omitempty"`
+	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty" json:"istioSidecarInjectorConfigMapName,omitempty"`
+	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty" json:"istioSidecarAnnotation,omitempty"`
+	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty" json:"istiodDeploymentName,omitempty"`
+	IstiodPodMonitoringPort           int               `yaml:"istiod_pod_monitoring_port,omitempty" json:"istiodPodMonitoringPort,omitempty"`
 	// IstiodPollingIntervalSeconds is how often in seconds Kiali will poll istiod(s) for
 	// proxy status and registry services. Polling is not performed if IstioAPIEnabled is false.
-	IstiodPollingIntervalSeconds     int             `yaml:"istiod_polling_interval_seconds,omitempty"`
-	Registry                         *RegistryConfig `yaml:"registry,omitempty"`
-	RootNamespace                    string          `yaml:"root_namespace,omitempty"`
-	UrlServiceVersion                string          `yaml:"url_service_version"`
-	ValidationChangeDetectionEnabled bool            `yaml:"validation_change_detection_enabled,omitempty"`
+	IstiodPollingIntervalSeconds     int             `yaml:"istiod_polling_interval_seconds,omitempty" json:"istiodPollingIntervalSeconds,omitempty"`
+	Registry                         *RegistryConfig `yaml:"registry,omitempty" json:"registry,omitempty"`
+	RootNamespace                    string          `yaml:"root_namespace,omitempty" json:"rootNamespace,omitempty"`
+	UrlServiceVersion                string          `yaml:"url_service_version" json:"urlServiceVersion"`
+	ValidationChangeDetectionEnabled bool            `yaml:"validation_change_detection_enabled,omitempty" json:"validationChangeDetectionEnabled,omitempty"`
 	// ValidationReconcileInterval sets how often Kiali will validate Istio configuration.
 	// Validations can be disabled setting the interval to 0
-	ValidationReconcileInterval *time.Duration `yaml:"validation_reconcile_interval,omitempty"`
+	ValidationReconcileInterval *time.Duration `yaml:"validation_reconcile_interval,omitempty" json:"validationReconcileInterval,omitempty"`
 }
 
 type ComponentStatuses struct {
-	Enabled    bool              `yaml:"enabled,omitempty"`
-	Components []ComponentStatus `yaml:"components,omitempty"`
+	Enabled    bool              `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Components []ComponentStatus `yaml:"components,omitempty" json:"components,omitempty"`
 }
 
 type ComponentStatus struct {

--- a/config/config.go
+++ b/config/config.go
@@ -245,12 +245,12 @@ type PrometheusConfig struct {
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
 type CustomDashboardsConfig struct {
-	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty"`
-	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty"`
-	Enabled                bool             `yaml:"enabled,omitempty"`
+	DiscoveryEnabled       string           `yaml:"discovery_enabled,omitempty" json:"discoveryEnabled,omitempty"`
+	DiscoveryAutoThreshold int              `yaml:"discovery_auto_threshold,omitempty" json:"discoveryAutoThreshold,omitempty"`
+	Enabled                bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	IsCore                 bool             `yaml:"is_core,omitempty" json:"isCore,omitempty"`
-	NamespaceLabel         string           `yaml:"namespace_label,omitempty"`
-	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty"`
+	NamespaceLabel         string           `yaml:"namespace_label,omitempty" json:"namespaceLabel,omitempty"`
+	Prometheus             PrometheusConfig `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
 }
 
 // GrafanaConfig describes configuration used for Grafana links
@@ -350,11 +350,11 @@ type ComponentStatuses struct {
 }
 
 type ComponentStatus struct {
-	AppLabel       string `yaml:"app_label,omitempty"`
+	AppLabel       string `yaml:"app_label,omitempty" json:"appLabel,omitempty"`
 	IsCore         bool   `yaml:"is_core,omitempty" json:"isCore,omitempty"`
-	IsProxy        bool   `yaml:"is_proxy,omitempty"`
-	IsMultiCluster bool   `yaml:"is_multicluster,omitempty"`
-	Namespace      string `yaml:"namespace,omitempty"`
+	IsProxy        bool   `yaml:"is_proxy,omitempty" json:"isProxy,omitempty"`
+	IsMultiCluster bool   `yaml:"is_multicluster,omitempty" json:"isMulticluster,omitempty"`
+	Namespace      string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
 type GatewayAPIClass struct {

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -372,7 +372,7 @@ When('user changes the provider in the Tester tab', () => {
         }
       }
       let val: string = editor.getValue();
-      val = val.replace(`Provider: ${provider}`, `Provider: ${replacer}`);
+      val = val.replace(`provider: ${provider}`, `provider: ${replacer}`);
       editor.setValue(val);
     });
   });

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -125,7 +125,6 @@ Feature: Kiali Mesh page
     And user sees "mode: REGISTRY_ONLY" in the "shared" configuration tab
     And user does not see "mode: REGISTRY_ONLY" in the "standard" configuration tab
 
-  @selected
   Scenario: User opens and interacts with the Trace Configuration modal
     When user selects tracing mesh node
     And user opens the Trace Configuration modal

--- a/frontend/src/components/IstioStatus/IstioComponentStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioComponentStatus.tsx
@@ -70,7 +70,7 @@ export const IstioComponentStatus: React.FC<Props> = (props: Props) => {
 
     return [
       <Split key={`cell-status-icon-${comp.name}`} hasGutter={true} className={splitItemStyle}>
-        <SplitItem>{renderIcon(props.componentStatus.status, props.componentStatus.is_core)}</SplitItem>
+        <SplitItem>{renderIcon(props.componentStatus.status, props.componentStatus.isCore)}</SplitItem>
         <SplitItem isFilled={true}>{comp.name}</SplitItem>
         <SplitItem>{t(statusMsg[comp.status])}</SplitItem>
       </Split>

--- a/frontend/src/components/IstioStatus/IstioStatus.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatus.tsx
@@ -150,7 +150,7 @@ export const IstioStatusComponent: React.FC<Props> = (props: Props) => {
       ...components.map(
         cs =>
           statusSeverity[cs.status] +
-          (cs.is_core && statusSeverity[cs.status] !== statusSeverity[Status.Healthy] ? 10 : 0)
+          (cs.isCore && statusSeverity[cs.status] !== statusSeverity[Status.Healthy] ? 10 : 0)
       )
     ); // non health core component has much higher severity
 
@@ -197,11 +197,11 @@ export const IstioStatusComponent: React.FC<Props> = (props: Props) => {
     const values = Object.values(props.statusMap).flat();
 
     Object.keys(values ?? {}).forEach((compKey: string) => {
-      const { status, is_core } = values[compKey];
+      const { status, isCore } = values[compKey];
       const isNotReady: boolean = status === Status.NotReady;
       const isUnhealthy: boolean = status !== Status.Healthy && !isNotReady;
 
-      if (is_core) {
+      if (isCore) {
         coreUnhealthy = coreUnhealthy || isUnhealthy;
       } else {
         addonUnhealthy = addonUnhealthy || isUnhealthy;

--- a/frontend/src/components/IstioStatus/IstioStatusList.tsx
+++ b/frontend/src/components/IstioStatus/IstioStatusList.tsx
@@ -24,11 +24,11 @@ export const IstioStatusList: React.FC<Props> = (props: Props) => {
   };
 
   const coreComponentsStatus = (): ComponentStatus[] => {
-    return nonhealthyComponents().filter((s: ComponentStatus) => s.is_core);
+    return nonhealthyComponents().filter((s: ComponentStatus) => s.isCore);
   };
 
   const addonComponentsStatus = (): ComponentStatus[] => {
-    return nonhealthyComponents().filter((s: ComponentStatus) => !s.is_core);
+    return nonhealthyComponents().filter((s: ComponentStatus) => !s.isCore);
   };
 
   const renderComponentList = (): React.ReactNode => {

--- a/frontend/src/components/IstioStatus/__tests__/IstioComponentStatus.test.tsx
+++ b/frontend/src/components/IstioStatus/__tests__/IstioComponentStatus.test.tsx
@@ -15,7 +15,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'isito-ingress',
       status: Status.Healthy,
-      is_core: true
+      isCore: true
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -27,7 +27,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'isito-ingress',
       status: Status.Unhealthy,
-      is_core: true
+      isCore: true
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -39,7 +39,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'isito-ingress',
       status: Status.NotFound,
-      is_core: true
+      isCore: true
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -51,7 +51,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'prometheus',
       status: Status.Healthy,
-      is_core: false
+      isCore: false
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -63,7 +63,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'prometheus',
       status: Status.Unhealthy,
-      is_core: false
+      isCore: false
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -75,7 +75,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'prometheus',
       status: Status.NotFound,
-      is_core: false
+      isCore: false
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -87,7 +87,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'core',
       status: Status.NotReady,
-      is_core: true
+      isCore: true
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();
@@ -99,7 +99,7 @@ describe('IstioComponentStatus renders', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'addon',
       status: Status.NotReady,
-      is_core: false
+      isCore: false
     });
 
     expect(shallowToJson(wrapper)).toBeDefined();

--- a/frontend/src/components/IstioStatus/__tests__/IstioStatus.test.tsx
+++ b/frontend/src/components/IstioStatus/__tests__/IstioStatus.test.tsx
@@ -68,13 +68,13 @@ describe('When core component has a problem', () => {
         cluster: CLUSTER_DEFAULT,
         name: 'grafana',
         status: Status.Healthy,
-        is_core: false
+        isCore: false
       },
       {
         cluster: CLUSTER_DEFAULT,
         name: 'istio-egressgateway',
         status: Status.Unhealthy,
-        is_core: true
+        isCore: true
       }
     ]);
 
@@ -91,13 +91,13 @@ describe('When addon component has a problem', () => {
         cluster: CLUSTER_DEFAULT,
         name: 'grafana',
         status: Status.Unhealthy,
-        is_core: false
+        isCore: false
       },
       {
         cluster: CLUSTER_DEFAULT,
         name: 'istio-egressgateway',
         status: Status.Healthy,
-        is_core: true
+        isCore: true
       }
     ]);
 
@@ -115,13 +115,13 @@ describe('When both core and addon component have problems', () => {
           cluster: CLUSTER_DEFAULT,
           name: 'grafana',
           status: Status.Unhealthy,
-          is_core: false
+          isCore: false
         },
         {
           cluster: CLUSTER_DEFAULT,
           name: 'istio-egressgateway',
           status: Status.Unhealthy,
-          is_core: true
+          isCore: true
         }
       ]);
 
@@ -141,13 +141,13 @@ describe('When there are not-ready components', () => {
             cluster: CLUSTER_DEFAULT,
             name: 'istio-egressgateway',
             status: Status.Unhealthy,
-            is_core: true
+            isCore: true
           },
           {
             cluster: CLUSTER_DEFAULT,
             name: 'istio-ingressgateway',
             status: Status.NotReady,
-            is_core: true
+            isCore: true
           }
         ]);
 
@@ -164,13 +164,13 @@ describe('When there are not-ready components', () => {
             cluster: CLUSTER_DEFAULT,
             name: 'grafana',
             status: Status.Unhealthy,
-            is_core: false
+            isCore: false
           },
           {
             cluster: CLUSTER_DEFAULT,
             name: 'jaeger',
             status: Status.NotReady,
-            is_core: false
+            isCore: false
           }
         ]);
 
@@ -187,25 +187,25 @@ describe('When there are not-ready components', () => {
             cluster: CLUSTER_DEFAULT,
             name: 'grafana',
             status: Status.Unhealthy,
-            is_core: false
+            isCore: false
           },
           {
             cluster: CLUSTER_DEFAULT,
             name: 'jaeger',
             status: Status.NotReady,
-            is_core: false
+            isCore: false
           },
           {
             cluster: CLUSTER_DEFAULT,
             name: 'istio-egressgateway',
             status: Status.Unhealthy,
-            is_core: true
+            isCore: true
           },
           {
             cluster: CLUSTER_DEFAULT,
             name: 'istio-ingressgateway',
             status: Status.NotReady,
-            is_core: true
+            isCore: true
           }
         ]);
 
@@ -224,7 +224,7 @@ describe('When there are not-ready components', () => {
             cluster: CLUSTER_DEFAULT,
             name: 'jaeger',
             status: Status.NotReady,
-            is_core: false
+            isCore: false
           }
         ]);
 
@@ -241,7 +241,7 @@ describe('When there are not-ready components', () => {
             cluster: CLUSTER_DEFAULT,
             name: 'istiod',
             status: Status.NotReady,
-            is_core: true
+            isCore: true
           }
         ]);
 
@@ -260,13 +260,13 @@ describe('When all components are good', () => {
         cluster: CLUSTER_DEFAULT,
         name: 'grafana',
         status: Status.Healthy,
-        is_core: false
+        isCore: false
       },
       {
         cluster: CLUSTER_DEFAULT,
         name: 'istio-egressgateway',
         status: Status.Healthy,
-        is_core: true
+        isCore: true
       }
     ]);
 

--- a/frontend/src/components/IstioStatus/__tests__/IstioStatusList.test.tsx
+++ b/frontend/src/components/IstioStatus/__tests__/IstioStatusList.test.tsx
@@ -11,25 +11,25 @@ it('lists all the components grouped', () => {
       cluster: CLUSTER_DEFAULT,
       name: 'grafana',
       status: Status.NotFound,
-      is_core: false
+      isCore: false
     },
     {
       cluster: CLUSTER_DEFAULT,
       name: 'prometheus',
       status: Status.Unhealthy,
-      is_core: false
+      isCore: false
     },
     {
       cluster: CLUSTER_DEFAULT,
       name: 'istiod',
       status: Status.NotFound,
-      is_core: true
+      isCore: true
     },
     {
       cluster: CLUSTER_DEFAULT,
       name: 'istio-egressgateway',
       status: Status.Unhealthy,
-      is_core: true
+      isCore: true
     }
   ];
 

--- a/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatus.test.tsx.snap
+++ b/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatus.test.tsx.snap
@@ -49,13 +49,13 @@ exports[`When addon component has a problem the Icon shows is displayed in orang
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "grafana",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-egressgateway",
                   "status": "Healthy",
                 },
@@ -149,13 +149,13 @@ exports[`When both core and addon component have problems any component is in no
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "grafana",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-egressgateway",
                   "status": "Unhealthy",
                 },
@@ -249,13 +249,13 @@ exports[`When core component has a problem the Icon shows is displayed in Red 1`
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "grafana",
                   "status": "Healthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-egressgateway",
                   "status": "Unhealthy",
                 },
@@ -349,13 +349,13 @@ exports[`When there are not-ready components mixed with other not healthy compon
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "grafana",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "jaeger",
                   "status": "NotReady",
                 },
@@ -449,25 +449,25 @@ exports[`When there are not-ready components mixed with other not healthy compon
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "grafana",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "jaeger",
                   "status": "NotReady",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-egressgateway",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-ingressgateway",
                   "status": "NotReady",
                 },
@@ -561,13 +561,13 @@ exports[`When there are not-ready components mixed with other not healthy compon
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-egressgateway",
                   "status": "Unhealthy",
                 },
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istio-ingressgateway",
                   "status": "NotReady",
                 },
@@ -661,7 +661,7 @@ exports[`When there are not-ready components not mixed with other unhealthy comp
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": true,
+                  "isCore": true,
                   "name": "istiod",
                   "status": "NotReady",
                 },
@@ -755,7 +755,7 @@ exports[`When there are not-ready components not mixed with other unhealthy comp
               Array [
                 Object {
                   "cluster": "Kubernetes",
-                  "is_core": false,
+                  "isCore": false,
                   "name": "jaeger",
                   "status": "NotReady",
                 },

--- a/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatusList.test.tsx.snap
+++ b/frontend/src/components/IstioStatus/__tests__/__snapshots__/IstioStatusList.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`lists all the components grouped 1`] = `
     componentStatus={
       Object {
         "cluster": "Kubernetes",
-        "is_core": true,
+        "isCore": true,
         "name": "istiod",
         "status": "NotFound",
       }
@@ -21,7 +21,7 @@ exports[`lists all the components grouped 1`] = `
     componentStatus={
       Object {
         "cluster": "Kubernetes",
-        "is_core": true,
+        "isCore": true,
         "name": "istio-egressgateway",
         "status": "Unhealthy",
       }
@@ -32,7 +32,7 @@ exports[`lists all the components grouped 1`] = `
     componentStatus={
       Object {
         "cluster": "Kubernetes",
-        "is_core": false,
+        "isCore": false,
         "name": "grafana",
         "status": "NotFound",
       }
@@ -43,7 +43,7 @@ exports[`lists all the components grouped 1`] = `
     componentStatus={
       Object {
         "cluster": "Kubernetes",
-        "is_core": false,
+        "isCore": false,
         "name": "prometheus",
         "status": "Unhealthy",
       }

--- a/frontend/src/components/Mesh/TraceConfigurationModal.tsx
+++ b/frontend/src/components/Mesh/TraceConfigurationModal.tsx
@@ -56,7 +56,7 @@ export const validateExternalUrl = (
   }
 
   if (isTempoService(svc)) {
-    if (svc.tempoConfig?.url_format === TempoUrlFormat.JAEGER) {
+    if (svc.tempoConfig?.urlFormat === TempoUrlFormat.JAEGER) {
       const urlProvider = new JaegerUrlProvider(svc);
       if (!urlProvider.HomeUrl() || !urlProvider.valid) {
         return '"View in Tracing" is hidden because external_url is empty';

--- a/frontend/src/types/IstioStatus.ts
+++ b/frontend/src/types/IstioStatus.ts
@@ -26,7 +26,7 @@ export const statusSeverity: Record<Status, number> = {
 
 export interface ComponentStatus {
   cluster: string;
-  is_core: boolean;
+  isCore: boolean;
   name: string;
   status: Status;
 }

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -14,9 +14,9 @@ export enum TempoUrlFormat {
 export type Status = { [K in StatusKey]?: string };
 
 export type TempoConfig = {
-  datasource_uid: string;
-  org_id: string;
-  url_format: TempoUrlFormat;
+  datasourceUID: string;
+  orgID: string;
+  urlFormat: TempoUrlFormat;
 };
 
 export interface ExternalServiceInfo {

--- a/frontend/src/utils/tracing/UrlProviders/Tempo.ts
+++ b/frontend/src/utils/tracing/UrlProviders/Tempo.ts
@@ -41,11 +41,11 @@ export class TempoUrlProvider implements TracingUrlProvider {
     let frontendProvider: TracingUrlProvider | undefined = undefined;
     const svc = externalServices.find(s => [GRAFANA, JAEGER].includes(s.name.toLowerCase()));
     if (svc && svc.name.toLowerCase() === GRAFANA && svc.url !== undefined) {
-      if (service.tempoConfig?.datasource_uid !== undefined) {
+      if (service.tempoConfig?.datasourceUID !== undefined) {
         // Grafana 10+
         frontendProvider = new GrafanaUrlProvider(svc.url, {
-          datasource_uid: service.tempoConfig.datasource_uid,
-          orgID: service.tempoConfig.org_id
+          datasource_uid: service.tempoConfig.datasourceUID,
+          orgID: service.tempoConfig.orgID
         });
       } else {
         // Fallback to older Grafana URL schema

--- a/frontend/src/utils/tracing/UrlProviders/index.ts
+++ b/frontend/src/utils/tracing/UrlProviders/index.ts
@@ -22,7 +22,7 @@ export function GetTracingUrlProvider(
   // the wanted url provider
   let urlProvider: TracingUrlProvider | undefined = undefined;
   if (isTempoService(svc)) {
-    if (svc.tempoConfig?.url_format === TempoUrlFormat.JAEGER) {
+    if (svc.tempoConfig?.urlFormat === TempoUrlFormat.JAEGER) {
       urlProvider = new JaegerUrlProvider(svc);
     } else {
       urlProvider = new TempoUrlProvider(svc, externalServices);

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -54,7 +54,7 @@ type ComponentStatus struct {
 	//
 	// example:  true
 	// required: true
-	IsCore bool `json:"is_core"`
+	IsCore bool `json:"isCore"`
 }
 
 type IstioComponentStatus []ComponentStatus

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -93,22 +93,19 @@
         "nodeType" : "infra",
         "healthData" : "Healthy",
         "infraData" : {
-          "Auth" : {
-            "CAFile" : "xxx",
-            "InsecureSkipVerify" : false,
-            "Password" : "xxx",
-            "Token" : "xxx",
-            "Type" : "none",
-            "UseKialiToken" : false,
-            "Username" : "xxx"
+          "auth" : {
+            "caFile" : "xxx",
+            "insecureSkipVerify" : false,
+            "password" : "xxx",
+            "token" : "xxx",
+            "type" : "none",
+            "useKialiToken" : false,
+            "username" : "xxx"
           },
-          "Dashboards" : null,
-          "DatasourceUID" : "",
-          "Enabled" : true,
-          "ExternalURL" : "",
-          "HealthCheckUrl" : "",
-          "InternalURL" : "http://grafana.istio-system:3000",
-          "IsCore" : false
+          "dashboards" : null,
+          "enabled" : true,
+          "externalURL" : "",
+          "internalURL" : "http://grafana.istio-system:3000"
         },
         "isExternal" : true,
         "isInaccessible" : true
@@ -124,28 +121,23 @@
         "nodeType" : "infra",
         "healthData" : "Healthy",
         "infraData" : {
-          "Auth" : {
-            "CAFile" : "xxx",
-            "InsecureSkipVerify" : false,
-            "Password" : "xxx",
-            "Token" : "xxx",
-            "Type" : "none",
-            "UseKialiToken" : false,
-            "Username" : "xxx"
+          "auth" : {
+            "caFile" : "xxx",
+            "insecureSkipVerify" : false,
+            "password" : "xxx",
+            "token" : "xxx",
+            "type" : "none",
+            "useKialiToken" : false,
+            "username" : "xxx"
           },
-          "CacheDuration" : 7,
-          "CacheEnabled" : true,
-          "CacheExpiration" : 300,
-          "CustomHeaders" : { },
-          "HealthCheckUrl" : "",
-          "IsCore" : false,
-          "QueryScope" : { },
-          "ThanosProxy" : {
-            "Enabled" : false,
-            "RetentionPeriod" : "7d",
-            "ScrapeInterval" : "30s"
+          "cacheDuration" : 7,
+          "cacheEnabled" : true,
+          "cacheExpiration" : 300,
+          "thanosProxy" : {
+            "retentionPeriod" : "7d",
+            "scrapeInterval" : "30s"
           },
-          "URL" : "http://prometheus.istio-system:9090"
+          "url" : "http://prometheus.istio-system:9090"
         },
         "isExternal" : true,
         "isInaccessible" : true
@@ -161,33 +153,28 @@
         "nodeType" : "infra",
         "healthData" : "Healthy",
         "infraData" : {
-          "Auth" : {
-            "CAFile" : "xxx",
-            "InsecureSkipVerify" : false,
-            "Password" : "xxx",
-            "Token" : "xxx",
-            "Type" : "none",
-            "UseKialiToken" : false,
-            "Username" : "xxx"
+          "auth" : {
+            "caFile" : "xxx",
+            "insecureSkipVerify" : false,
+            "password" : "xxx",
+            "token" : "xxx",
+            "type" : "none",
+            "useKialiToken" : false,
+            "username" : "xxx"
           },
-          "CustomHeaders" : { },
-          "DisableVersionCheck" : false,
-          "Enabled" : true,
-          "ExternalURL" : "",
-          "HealthCheckUrl" : "",
-          "GrpcPort" : 9095,
-          "InternalURL" : "http://tracing.istio-system:16685/jaeger",
-          "IsCore" : false,
-          "Provider" : "jaeger",
-          "TempoConfig" : {
-            "cache_capacity" : 200,
-            "cache_enabled" : true
+          "enabled" : true,
+          "externalURL" : "",
+          "grpcPort" : 9095,
+          "internalURL" : "http://tracing.istio-system:16685/jaeger",
+          "provider" : "jaeger",
+          "tempoConfig" : {
+            "cacheCapacity" : 200,
+            "cacheEnabled" : true
           },
-          "NamespaceSelector" : true,
-          "QueryScope" : { },
-          "QueryTimeout" : 5,
-          "UseGRPC" : true,
-          "WhiteListIstioSystem" : [ "jaeger-query", "istio-ingressgateway" ]
+          "namespaceSelector" : true,
+          "queryTimeout" : 5,
+          "useGRPC" : true,
+          "whiteListIstioSystem" : [ "jaeger-query", "istio-ingressgateway" ]
         },
         "isExternal" : true,
         "isInaccessible" : true
@@ -260,27 +247,20 @@
         "nodeType" : "infra",
         "healthData" : "Healthy",
         "infraData" : {
-          "ComponentStatuses" : {
-            "Enabled" : true,
-            "Components" : [ ]
+          "componentStatus" : {
+            "enabled" : true
           },
-          "ConfigMapName" : "",
-          "EnvoyAdminLocalPort" : 15000,
-          "GatewayAPIClasses" : [ ],
-          "GatewayAPIClassesLabelSelector" : "",
-          "IstioAPIEnabled" : true,
-          "IstioIdentityDomain" : "svc.cluster.local",
-          "IstioInjectionAnnotation" : "sidecar.istio.io/inject",
-          "IstioSidecarInjectorConfigMapName" : "",
-          "IstioSidecarAnnotation" : "sidecar.istio.io/status",
-          "IstiodDeploymentName" : "",
-          "IstiodPodMonitoringPort" : 15014,
-          "IstiodPollingIntervalSeconds" : 20,
-          "Registry" : null,
-          "RootNamespace" : "istio-system",
-          "UrlServiceVersion" : "",
-          "ValidationChangeDetectionEnabled" : true,
-          "ValidationReconcileInterval" : 60000000000
+          "envoyAdminLocalPort" : 15000,
+          "istioApiEnabled" : true,
+          "istioIdentityDomain" : "svc.cluster.local",
+          "istioInjectionAnnotation" : "sidecar.istio.io/inject",
+          "istioSidecarAnnotation" : "sidecar.istio.io/status",
+          "istiodPodMonitoringPort" : 15014,
+          "istiodPollingIntervalSeconds" : 20,
+          "rootNamespace" : "istio-system",
+          "urlServiceVersion" : "",
+          "validationChangeDetectionEnabled" : true,
+          "validationReconcileInterval" : 60000000000
         }
       }
     }, {

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -247,7 +247,7 @@
         "nodeType" : "infra",
         "healthData" : "Healthy",
         "infraData" : {
-          "componentStatus" : {
+          "componentStatuses" : {
             "enabled" : true
           },
           "envoyAdminLocalPort" : 15000,


### PR DESCRIPTION
### Describe the change

Unify the format of the configs in the Mesh page using lower camel case:

![image](https://github.com/user-attachments/assets/db630d7e-85bb-46c4-a1ff-ae8b32db1245)
![image](https://github.com/user-attachments/assets/7a26b059-29c3-4436-a6ee-f4d6f5169938)
![image](https://github.com/user-attachments/assets/aad7a3e7-cc77-406e-bf7a-745d4ee1f9d3)


### Steps to test the PR

- Validate configs are in the same format (lower camel case)
- Regression test

### Automation testing

Updated required tests

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8493
