### PR TITLE
Modify tag-creator to create release candidate tags

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -90,5 +90,5 @@ jobs:
         sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'",/' frontend/package.json
 
         git add Makefile frontend/package.json
-        git commit -m "Release $RELEASE_VERSION"
-        git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        git commit -m "Bump to version $RELEASE_VERSION"
+        git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-rc


### PR DESCRIPTION
This PR modify the tag-creator github workflow to create rc (release candidate) tags. In a follow-up PR we will create the possibility to create release candidate tags or final release tags
