### PR TITLE
Update Istio metrics

### DIFF
--- a/business/metrics.go
+++ b/business/metrics.go
@@ -254,14 +254,9 @@ func createStatsMetricsLabelsBuilder(q *models.MetricsStatsQuery, conf *config.C
 	return lb
 }
 
-func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, pods models.Pods, scaler func(n string) float64) (models.MetricsMap, error) {
-	podRegex := ""
-	separator := ""
-	for _, pod := range pods {
-		podRegex = fmt.Sprintf("%s%s%s", podRegex, separator, pod.Name)
-		separator = "|"
-	}
-	podLabel := fmt.Sprintf(`{pod="%s"}`, podRegex)
+func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, controlPlane string) (models.MetricsMap, error) {
+
+	podLabel := fmt.Sprintf(`{pod=~"%s-.*"}`, controlPlane)
 
 	metrics := make(models.MetricsMap)
 	var err error
@@ -302,10 +297,7 @@ func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, pod
 	metrics["container_cpu_usage_seconds_total"] = append(metrics["container_cpu_usage_seconds_total"], converted...)
 
 	metric = in.prom.FetchRateRange("process_cpu_seconds_total", []string{podLabel}, "", &q.RangeQuery)
-	if metric.Matrix != nil {
-		// With more than one pod, the metric is empty
-		metric = in.prom.FetchRateRange("process_cpu_seconds_total", []string{"{pod=~\"istiod-.*\"}"}, "", &q.RangeQuery)
-	}
+
 	converted, err = models.ConvertMetric("process_cpu_seconds_total", metric, models.ConversionParams{Scale: 1})
 	if err != nil {
 		return nil, err
@@ -313,10 +305,6 @@ func (in *MetricsService) GetControlPlaneMetrics(q models.IstioMetricsQuery, pod
 	metrics["process_cpu_seconds_total"] = append(metrics["process_cpu_seconds_total"], converted...)
 
 	metric = in.prom.FetchRange("container_memory_working_set_bytes", podLabel, "", "", &q.RangeQuery)
-	if metrics["container_memory_working_set_bytes"] == nil {
-		// In Kind container_memory_working_set_bytes is missing
-		metric = in.prom.FetchRange("container_memory_working_set_bytes", "{pod=~\"istiod-.*\"}", "", "", &q.RangeQuery)
-	}
 	converted, err = models.ConvertMetric("container_memory_working_set_bytes", metric, models.ConversionParams{Scale: 0.000001})
 	if err != nil {
 		return nil, err

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -168,11 +168,6 @@ func getAggregateMetrics(w http.ResponseWriter, r *http.Request, promSupplier pr
 // ControlPlaneMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
 func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		layer, err := getBusiness(r)
-		if err != nil {
-			RespondWithError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
 
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
@@ -188,7 +183,7 @@ func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
 
-		err = extractIstioMetricsQueryParams(r, &params, oldestNs)
+		err := extractIstioMetricsQueryParams(r, &params, oldestNs)
 		if err != nil {
 			RespondWithError(w, http.StatusBadRequest, err.Error())
 			return
@@ -199,22 +194,9 @@ func ControlPlaneMetrics(promSupplier promClientSupplier) http.HandlerFunc {
 			return
 		}
 
-		cpWorkload, err := layer.Workload.GetWorkload(r.Context(), business.WorkloadCriteria{
-			Cluster:               cluster,
-			Namespace:             namespace,
-			WorkloadName:          controlPlane,
-			IncludeServices:       false,
-			IncludeIstioResources: false,
-			IncludeHealth:         false,
-		})
-		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
 		metrics := make(models.MetricsMap)
 
-		controlPlaneMetrics, err := metricsService.GetControlPlaneMetrics(params, cpWorkload.Pods, nil)
+		controlPlaneMetrics, err := metricsService.GetControlPlaneMetrics(params, controlPlane)
 		if err != nil {
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 			return


### PR DESCRIPTION
### Describe the change

This approach replaces the query by specific pods `{pod="istiod-6f67cdbfc9-4vd4w"}` by `{pod=~"istiod-.*"}` because: 

- It keeps stats along the time if the deployment is restarted
- Keeps consistency (E.x. kind doesn't provide stats by specific pod) 
- Istio query metrics are using the same regex in Grafana dashboards
- It doesn't need to get the control plane logs, so it can be a bit faster
- This change should remove flakes in the jenkins pipelines 

### Steps to test the PR

- Install Istio
- Go to the mesh page
- Stats should be available: 
![image](https://github.com/user-attachments/assets/3b79bf86-7fdb-4ead-92d1-effaae8ce5a3)


### Automation testing

CI should pass

### Issue reference
Fixes https://github.com/kiali/kiali/issues/8552 