### PR TITLE
[v2.11] [CI] cypress: fixed wrong deployment name in tag

### DIFF
--- a/frontend/cypress/integration/common/masthead.ts
+++ b/frontend/cypress/integration/common/masthead.ts
@@ -31,5 +31,5 @@ When(
 
 After({ tags: '@component-health-upscale' }, () => {
   cy.exec(`kubectl scale -n istio-system --replicas=1 deployment/grafana`);
-  cy.exec(`kubectl rollout status deployment prometheus -n istio-system`);
+  cy.exec(`kubectl rollout status deployment grafana -n istio-system`);
 });


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/8560