### PR TITLE
Kiali version bumping and release tag creator

### DIFF
--- a/.github/workflows/tag-bump-version.yml
+++ b/.github/workflows/tag-bump-version.yml
@@ -1,12 +1,12 @@
-name: Tag Creator
+name: Tag Bump Version
 
 on:
   workflow_dispatch:
     inputs:
       tag_branch:
-        description: Branch to tag, (Separate branches by commas. Ex v1.65,v1.73)
+        description: Branch to bump version (Separate branches by commas. Ex v2.4,v2.11)
         required: true
-        default: v1.73
+        default: v2.4
         type: string
 
 jobs:
@@ -35,6 +35,7 @@ jobs:
       run: |
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
+
   create_tag:
     needs: [initialize]
     runs-on: ubuntu-latest
@@ -46,6 +47,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{matrix.branch}}
+
     - name: Prepare scripts
       run: |
         cat <<-EOF > bump.py
@@ -73,22 +75,23 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
 
         git config user.name 'kiali-bot'
-    - name: Create Tag in kiali/kiali
-      id: tag_kiali
+
+    - name: Create Bump Version Tag in kiali/kiali
       env:
         BRANCH: ${{matrix.branch}}
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        # Remove any pre release identifier (ie: "-SNAPSHOT")
-        RELEASE_VERSION=${RAW_VERSION%-*}
-        RELEASE_VERSION=$(python bump.py patch $RELEASE_VERSION)
+        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
-        echo "release_version=$RELEASE_VERSION" >> $GITHUB_ENV
-
+        # Update the version in Kiali repository
         sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
         sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'",/' frontend/package.json
 
+        # Commit the changes
         git add Makefile frontend/package.json
         git commit -m "Bump to version $RELEASE_VERSION"
-        git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-rc
+        git push origin
+
+        # Create the bump version tag
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,0 +1,49 @@
+name: Tag Release Creator
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to tag
+        required: true
+        default: v2.4
+        type: string
+      target_commit:
+        description: Commit hash to tag
+        required: true
+        type: string
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Backend
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag_branch }}
+
+    - name: Configure git backend
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+
+        git config user.name 'kiali-bot'
+
+    - name: Validate target commit
+      run: |
+        # Check if commit exists
+        if ! git cat-file -e ${{ inputs.target_commit }}^{commit} 2>/dev/null; then
+          echo "Error: Commit ${{ inputs.target_commit }} not found in branch ${{ inputs.tag_branch }}"
+          exit 1
+        fi
+
+        echo "Commit ${{ inputs.target_commit }} is valid and exists in branch ${{ inputs.tag_branch }}"
+
+    - name: Create Release Tag in kiali/kiali
+      run: |
+        RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+        # Create the release tag
+        git push origin ${{ inputs.target_commit }}:refs/tags/$RELEASE_VERSION
+
+        # Delete the bump version tag if it exists
+        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true


### PR DESCRIPTION
### Describe the change

This PR removes previous tag-creator workflow and introduces two GitHub workflows that streamline the Kiali version bumping and tagging process:

- `tag-bump-version.yaml`
  -  Bump the patch version of release branch
  - Creates the tag `<patch-version>-ossm`

- `tag-release-creator.yaml`
  - Creates the tag `<patch-version>` to specific commit within the release branch
  - Removes the tag `<patch-version>-ossm`

### Steps to test the PR

Testing GitHub workflows in a fork requires some setup and careful planning. Here's a comprehensive guide to test these workflows safely:

1. **Fork Repository & Enable Actions**
```bash
# Fork the repository on GitHub, then clone your fork
git clone https://github.com/YOUR_USERNAME/kiali.git
cd kiali

# Add upstream remote
git remote add upstream https://github.com/kiali/kiali.git
```

2. **Enable GitHub Actions in Your Fork**
- Go to your fork on GitHub
- Navigate to **Settings** → **Actions** → **General**
- Enable "Allow all actions and reusable workflows"

3. **Create Test Branches**
```bash
# Create test branches from existing release branches
git checkout -b test-v2.4 origin/v2.4
git push origin test-v2.4

git checkout -b test-v2.11 origin/v2.11  
git push origin test-v2.11
```
### Testing the Tag Bump Version Workflow

**Test Case 1: Single Branch**
1. Go to **Actions** → **Tag Bump Version** → **Run workflow**
2. Fill inputs:
   ```
   Branch to bump version: test-v2.4
   ```
3. **Expected Results:**
   - New commit with version bump (e.g., v2.4.1)
   - Tag created: `v2.4.1-ossm`
   - `Makefile` and `frontend/package.json` updated

**Test Case 2: Multiple Branches**
1. Run workflow with:
   ```
   Branch to bump version: test-v2.4,test-v2.11
   ```
2. **Expected Results:**
   - Both branches get version bumps
   - Two tags created: `v2.4.1-ossm`, `v2.11.1-ossm`

**Test Case 3: Error Handling**
1. Run with non-existent branch:
   ```
   Branch to bump version: nonexistent-branch
   ```
2. **Expected Results:**
   - Workflow fails with checkout error
   - No tags created

---

### Testing the Tag Release Creator Workflow

**Test Case 1: Valid Commit**
1. First, get a recent commit hash from your test branch:
   ```bash
   git log --oneline test-v2.4 -n 5
   ```
2. Run **Tag Release Creator** workflow:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: [copy a recent commit hash]
   ```
3. **Expected Results:**
   - Clean release tag created (e.g., `v2.4.1`)
   - Corresponding `-ossm` tag removed (if exists)

**Test Case 2: Invalid Commit**
1. Run workflow with:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: invalid123abc
   ```
2. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit

**Test Case 3: Commit from Different Branch**
1. Get commit hash from `main` branch
2. Try to tag it using `test-v2.4` branch
3. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit in that branch

### Cleanup After Testing

**Remove Test Tags**
```bash
# Remove specific tags
git push origin --delete refs/tags/v2.4.1-ossm
git push origin --delete refs/tags/v2.4.1

# Remove all test tags (if following naming pattern)
git ls-remote --tags origin | grep -E "v[0-9]+\.[0-9]+\.[0-9]+" | \
while read hash ref; do
    tag=${ref##*/}
    git push origin --delete refs/tags/$tag
done
```

**Clean Up Test Branches**
```bash
# Remove test branches
git push origin --delete test-v2.4
git push origin --delete test-v2.11

# Clean up local branches
git branch -D test-v2.4 test-v2.11
```