### PR TITLE
Fixed dataplane namespaces number

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -267,6 +267,16 @@ Then('user sees {string} node side panel', (name: string) => {
     });
 });
 
+Then('user does not see {string} in mesh body', (text: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-mesh-body')
+    .should('be.visible')
+    .within(() => {
+      cy.contains(text).should('not.exist');
+    });
+});
+
 Then('user sees tracing node side panel', () => {
   cy.waitForReact();
   cy.get('#loading_kiali_spinner').should('not.exist');

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -52,6 +52,7 @@ Feature: Kiali Mesh page
   Scenario: Test istio-system
     When user selects mesh node with label "istio-system"
     Then user sees "istio-system" namespace side panel
+    Then user does not see "dataplane namespaces: 0" in mesh body
 
   @bookinfo-app
   Scenario: User enables gateways

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -359,9 +359,8 @@ export const renderInfraSummary = (
     controlPlaneNodes = controlPlaneNodes.filter(
       n => n.getData().cluster === forCluster && (!forNamespace || n.getData().namespace === forNamespace)
     );
-    dataPlaneNodes = dataPlaneNodes.filter(
-      n => n.getData().cluster === forCluster && (!forNamespace || n.getData().namespace === forNamespace)
-    );
+    // 'infraType: dataplane' does not have a value for 'namespace', a filtering by 'revision' is used when displaying
+    dataPlaneNodes = dataPlaneNodes.filter(n => n.getData().cluster === forCluster);
     gatewayNodes = gatewayNodes.filter(
       n => n.getData().cluster === forCluster && (!forNamespace || n.getData().namespace === forNamespace)
     );
@@ -390,7 +389,7 @@ export const renderInfraSummary = (
         {controlPlaneNodes.map(infra => {
           const cpRev = infra.getData().infraData.revision ?? 'default';
           const dataPlaneNode = dataPlaneNodes.find(dpn => {
-            const dpRev = dpn.getData().infraData.revision ?? 'default';
+            const dpRev = dpn.getData().version ?? 'default';
             return cpRev === dpRev;
           });
           const dataPlaneNamespaceCount = dataPlaneNode?.getData().infraData?.length ?? 0;


### PR DESCRIPTION
### Describe the change

Fixed the number of dataplane namespaces shown for control plane namespace in Mesh page.

### Steps to test the PR

Before, showing 0:
<img width="1703" height="849" alt="Screenshot From 2025-07-16 16-25-34" src="https://github.com/user-attachments/assets/73d8f7a4-0038-4366-83b6-29198e0b4f50" />

After, showing the correct number:
<img width="1703" height="849" alt="Screenshot From 2025-07-16 16-24-36" src="https://github.com/user-attachments/assets/37d8bffd-9d7a-4be5-8090-c548e419497f" />


### Automation testing

added cypress check

### Issue reference
https://github.com/kiali/kiali/pull/8499
