### PR TITLE
Fetch full history when creating release tag

### DIFF
--- a/.github/workflows/tag-bump-version.yml
+++ b/.github/workflows/tag-bump-version.yml
@@ -36,14 +36,14 @@ jobs:
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
-  create_tag:
+  bump_version:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
-    - name: Checkout Backend
+    - name: Checkout branch
       uses: actions/checkout@v4
       with:
         ref: ${{matrix.branch}}
@@ -70,10 +70,9 @@ jobs:
         print('.'.join(['v' + str(major), str(minor), str(patch)]))
         EOF
 
-    - name: Configure git backend
+    - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
-
         git config user.name 'kiali-bot'
 
     - name: Create Bump Version Tag in kiali/kiali
@@ -91,7 +90,7 @@ jobs:
         # Commit the changes
         git add Makefile frontend/package.json
         git commit -m "Bump to version $RELEASE_VERSION"
-        git push origin
+        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
 
         # Create the bump version tag
         git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -40,22 +40,23 @@ jobs:
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
-  create_tag:
+  release_tag:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
-    - name: Checkout Backend
+    - name: Checkout branch
       uses: actions/checkout@v4
       with:
         ref: ${{matrix.branch}}
+        # We need to fetch the full history to check if the commit exists
+        fetch-depth: 0
 
-    - name: Configure git backend
+    - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
-
         git config user.name 'kiali-bot'
 
     - name: Validate target commit


### PR DESCRIPTION
### Describe the change

There is a small error in `tag-release-creator.yaml` github workflow. actions/checkout@v4 only fetch the history of the latest commit, giving an error if you want to create a release tag of older commit.

Error action in my fork: 
<img width="1886" height="745" alt="image" src="https://github.com/user-attachments/assets/1507b946-e909-4380-a68c-ab50f6d69bb8" />

Using the parameter `fetch-depth: 0`, the workflow fetches the whole git history and now it is possible to create the release tag of older commits.

<img width="1893" height="724" alt="image" src="https://github.com/user-attachments/assets/13597e20-9864-46dd-b865-62f71109ba32" />

Additionally, I have done some small naming adjustments

