### PR TITLE
Added HTTPRoute to InferencePool cross references.

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -654,10 +654,10 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 	case kubernetes.K8sHTTPRoutes:
 		httpRouteChecker := checkers.K8sHTTPRouteChecker{Conf: conf, Cluster: cluster, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices}
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, httpRouteChecker}
-		referenceChecker = references.K8sHTTPRouteReferences{Conf: conf, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: nsNames, K8sReferenceGrants: istioConfigList.K8sReferenceGrants}
+		referenceChecker = references.K8sHTTPRouteReferences{Conf: conf, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, Namespaces: nsNames, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, K8sInferencePools: istioConfigList.K8sInferencePools}
 	case kubernetes.K8sInferencePools:
 		// Validation on K8sInferencePools is not expected
-		referenceChecker = references.K8sInferencePoolReferences{Conf: conf, Namespaces: nsNames, K8sInferencePools: istioConfigList.K8sInferencePools, RegistryServices: registryServices, WorkloadsPerNamespace: workloadsPerNamespace}
+		referenceChecker = references.K8sInferencePoolReferences{Conf: conf, Namespaces: nsNames, K8sInferencePools: istioConfigList.K8sInferencePools, RegistryServices: registryServices, WorkloadsPerNamespace: workloadsPerNamespace, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes}
 	case kubernetes.K8sReferenceGrants:
 		objectCheckers = []checkers.ObjectChecker{
 			checkers.K8sReferenceGrantChecker{Cluster: cluster, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces},

--- a/business/references/k8s_gateway_references.go
+++ b/business/references/k8s_gateway_references.go
@@ -49,7 +49,11 @@ func (g K8sGatewayReferences) getConfigReferences(gw *k8s_networking_v1.Gateway)
 
 	for _, rt := range g.K8sHTTPRoutes {
 		for _, pr := range rt.Spec.ParentRefs {
-			if string(pr.Name) == gw.Name && string(*pr.Kind) == gvk.Kind && string(*pr.Group) == gvk.Group {
+			namespace := rt.Namespace
+			if pr.Namespace != nil && string(*pr.Namespace) != "" {
+				namespace = string(*pr.Namespace)
+			}
+			if string(pr.Name) == gw.Name && string(*pr.Kind) == gvk.Kind && string(*pr.Group) == gvk.Group && namespace == gw.Namespace {
 				ref := models.IstioReference{Name: rt.Name, Namespace: rt.Namespace, ObjectGVK: kubernetes.K8sHTTPRoutes}
 				result = append(result, ref)
 			}

--- a/business/references/k8s_inference_pool_references.go
+++ b/business/references/k8s_inference_pool_references.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	k8s_inference_v1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -16,6 +17,7 @@ import (
 type K8sInferencePoolReferences struct {
 	Conf                  *config.Config
 	Namespaces            []string
+	K8sHTTPRoutes         []*k8s_networking_v1.HTTPRoute
 	K8sInferencePools     []*k8s_inference_v1alpha2.InferencePool
 	RegistryServices      []*kubernetes.RegistryService
 	WorkloadsPerNamespace map[string]models.Workloads
@@ -34,6 +36,7 @@ func (r K8sInferencePoolReferences) References() models.IstioReferencesMap {
 		references := &models.IstioReferences{}
 		references.ServiceReferences = r.getServiceReferences(pool)
 		references.WorkloadReferences = r.getWorkloadReferences(pool)
+		references.ObjectReferences = r.getK8sHTTPRouteRefs(pool)
 		result.MergeReferencesMap(models.IstioReferencesMap{key: references})
 	}
 
@@ -71,4 +74,34 @@ func (r K8sInferencePoolReferences) getServiceReferences(pool *k8s_inference_v1a
 		result = append(result, models.ServiceReference{Name: string(pool.Spec.ExtensionRef.Name), Namespace: pool.Namespace})
 	}
 	return result
+}
+
+// getK8sHTTPRouteRefs finds the K8s  HTTPRoute objects which refer to InferencePool by their spec.rules.backendRefs
+func (r K8sInferencePoolReferences) getK8sHTTPRouteRefs(pool *k8s_inference_v1alpha2.InferencePool) []models.IstioReference {
+	result := make([]models.IstioReference, 0)
+
+routes:
+	for _, rt := range r.K8sHTTPRoutes {
+		for _, httpRoute := range rt.Spec.Rules {
+			for _, ref := range httpRoute.BackendRefs {
+				if ref.Kind == nil || string(*ref.Kind) != kubernetes.K8sInferencePoolsType || string(*ref.Group) != kubernetes.K8sInferencePools.Group {
+					continue
+				}
+				namespace := rt.Namespace
+				if ref.Namespace != nil && string(*ref.Namespace) != "" {
+					namespace = string(*ref.Namespace)
+				}
+				if pool.Name == string(ref.Name) && pool.Namespace == namespace {
+					result = append(result, getK8sHTTPRouteReference(rt.Name, rt.Namespace))
+					continue routes
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func getK8sHTTPRouteReference(name string, namespace string) models.IstioReference {
+	return models.IstioReference{Name: name, Namespace: namespace, ObjectGVK: kubernetes.K8sHTTPRoutes}
 }

--- a/business/references/k8shttproute_references_test.go
+++ b/business/references/k8shttproute_references_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	k8s_inference_v1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -14,11 +15,12 @@ import (
 	"github.com/kiali/kiali/tests/data"
 )
 
-func prepareTestForK8sHTTPRoute(route *k8s_networking_v1.HTTPRoute) models.IstioReferences {
+func prepareTestForK8sHTTPRoute(route *k8s_networking_v1.HTTPRoute, inferencePools []*k8s_inference_v1alpha2.InferencePool) models.IstioReferences {
 	routeReferences := K8sHTTPRouteReferences{
 		Conf:               config.Get(),
 		Namespaces:         []string{"bookinfo", "bookinfo2", "bookinfo3"},
 		K8sHTTPRoutes:      []*k8s_networking_v1.HTTPRoute{route},
+		K8sInferencePools:  inferencePools,
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("rg", route.Namespace, "bookinfo")},
 	}
 	return *routeReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: route.Namespace, Name: route.Name}]
@@ -30,7 +32,7 @@ func TestK8sHTTPRouteReferences(t *testing.T) {
 	config.Set(conf)
 
 	// Setup mocks
-	references := prepareTestForK8sHTTPRoute(data.AddBackendRefToHTTPRoute("reviews2", "bookinfo2", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route1", "bookinfo", "gatewayapi", []string{"bookinfo"}))))
+	references := prepareTestForK8sHTTPRoute(data.AddBackendRefToHTTPRoute("reviews2", "bookinfo2", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route1", "bookinfo", "gatewayapi", []string{"bookinfo"}))), nil)
 	assert.NotEmpty(references.ServiceReferences)
 
 	// Check Service references
@@ -51,12 +53,31 @@ func TestK8sHTTPRouteReferences(t *testing.T) {
 	assert.Equal(references.ObjectReferences[1].ObjectGVK.String(), kubernetes.K8sReferenceGrants.String())
 }
 
+func TestK8sHTTPRouteInferencePoolReferences(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Setup mocks
+	inferencePools := []*k8s_inference_v1alpha2.InferencePool{
+		fakeInferencePool("test-pool", "test-ns", map[k8s_inference_v1alpha2.LabelKey]k8s_inference_v1alpha2.LabelValue{"app": "vllm-llama3-8b-instruct"}, "my-service-epp"),
+		fakeInferencePool("test-pool2", "test-ns", map[k8s_inference_v1alpha2.LabelKey]k8s_inference_v1alpha2.LabelValue{"app": "vllm-llama3-8b-instruct"}, "my-service-epp"),
+	}
+	httpRoute := fakeHTTPRoute("route-to-pool", "test-ns", "test-pool")
+	references := prepareTestForK8sHTTPRoute(httpRoute, inferencePools)
+
+	assert.Len(references.ObjectReferences, 1)
+	assert.Equal(references.ObjectReferences[0].Name, "test-pool")
+	assert.Equal(references.ObjectReferences[0].Namespace, "test-ns")
+	assert.Equal(references.ObjectReferences[0].ObjectGVK.String(), kubernetes.K8sInferencePools.String())
+}
+
 func TestK8sHTTPRouteNoReferences(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	config.Set(conf)
 
 	// Setup mocks
-	references := prepareTestForK8sHTTPRoute(data.CreateEmptyHTTPRoute("route1", "bookinfo", []string{"details"}))
+	references := prepareTestForK8sHTTPRoute(data.CreateEmptyHTTPRoute("route1", "bookinfo", []string{"details"}), nil)
 	assert.Empty(references.ServiceReferences)
 }


### PR DESCRIPTION
### Describe the change

Added cross references between K8s HTTPRoute and InferencePool.

### Steps to test the PR

Make sure K8s Gateway API and Inference Extensions CRDs are installed.
`kubectl get crd gateways.gateway.networking.k8s.io || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.3.0" | kubectl apply -f -; }
`
`kubectl kustomize "github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=v0.4.0" | kubectl apply -f -;`

Create these objects.
```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: model-llama3-route
  namespace: default
spec:
  parentRefs:
    - name: my-gateway
      namespace: default
  hostnames:
    - "llama3.example.com"
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: llama3-pool
          kind: InferencePool
          namespace: default
          group: inference.networking.x-k8s.io
          port: 8000
          weight: 1
---
apiVersion: inference.networking.x-k8s.io/v1alpha2
kind: InferencePool
metadata:
  name: llama3-pool
  namespace: default
spec:
  targetPortNumber: 8000
  selector:
    app: vllm-llama3
  extensionRef:
    group: ''
    kind: Service
    name: vllm-llama3-8b-instruct-epp
    failureMode: FailClose
---
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: my-gateway
  namespace: default
spec:
  gatewayClassName: istio
  listeners:
  - name: host.com
    hostname: host.com
    port: 8080
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: All

```

Verify that cross references are shown.
<img width="1919" height="1041" alt="Screenshot From 2025-07-22 13-53-54" src="https://github.com/user-attachments/assets/fa6b674d-b206-4749-8d7a-f8aeb8b8d060" />
<img width="1919" height="1041" alt="Screenshot From 2025-07-22 13-53-49" src="https://github.com/user-attachments/assets/7c45c480-ae41-4150-ab7b-c82d9c6f3d9d" />

Currently there are no validations on InferencePool objects, so if the names are referring to non existing objects, then the links will not be shown without any validation warning.

### Automation testing

Added unit tests.

### Issue reference

https://github.com/kiali/kiali/issues/8555
