### PR TITLE
Refactor out global vars from biz package

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -18,9 +18,10 @@ import (
 	"github.com/kiali/kiali/tests/data"
 )
 
-func setupAppService(clients map[string]kubernetes.UserClientInterface) *AppService {
+func setupAppService(t testing.TB, clients map[string]kubernetes.UserClientInterface) *AppService {
 	prom := new(prometheustest.PromClientMock)
-	layer := NewWithBackends(clients, kubernetes.ConvertFromUserClients(clients), prom, nil)
+	conf := config.Get()
+	layer := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build()
 	return &layer.App
 }
 
@@ -46,12 +47,8 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(objects...)
 	k8s.OpenShift = true
 	k8s.Token = "token" // Not needed a result, just to not send an error to test this usecase
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	appList, err := svc.GetClusterAppList(context.TODO(), criteria)
@@ -93,12 +90,8 @@ func TestGetAppListFromWorkloadGroups(t *testing.T) {
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
 	k8s.Token = "token" // Not needed a result, just to not send an error to test this usecase
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: true, IncludeHealth: false}
 	appList, err := svc.GetClusterAppList(context.TODO(), criteria)
@@ -139,12 +132,8 @@ func TestGetAppFromDeployments(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(objects...)
 	k8s.OpenShift = true
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Namespace: "Namespace", AppName: "httpbin", Cluster: conf.KubernetesConfig.ClusterName}
 	appDetails, appDetailsErr := svc.GetAppDetails(context.TODO(), criteria)
@@ -183,12 +172,8 @@ func TestGetAppFromDeploymentsNoAppVerLabelNames(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(objects...)
 	k8s.OpenShift = true
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Namespace: "Namespace", AppName: "httpbin", Cluster: conf.KubernetesConfig.ClusterName}
 	appDetails, appDetailsErr := svc.GetAppDetails(context.TODO(), criteria)
@@ -233,12 +218,8 @@ func TestGetAppFromWorkloadGroups(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
 	k8s.OpenShift = true
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Namespace: "Namespace", AppName: "ratings-vm", Cluster: conf.KubernetesConfig.ClusterName}
 	appDetails, appDetailsErr := svc.GetAppDetails(context.TODO(), criteria)
@@ -271,12 +252,8 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(objects...)
 	k8s.OpenShift = true
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
 	appList, _ := svc.GetClusterAppList(context.TODO(), criteria)
@@ -312,12 +289,8 @@ func TestGetAppFromReplicaSets(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(objects...)
 	k8s.OpenShift = true
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
 
-	SetupBusinessLayer(t, k8s, *conf)
-
-	svc := setupAppService(mockClientFactory.Clients)
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
 
 	criteria := AppCriteria{Namespace: "Namespace", AppName: "httpbin", Cluster: conf.KubernetesConfig.ClusterName}
 	appDetails, _ := svc.GetAppDetails(context.TODO(), criteria)

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -55,10 +55,6 @@ func TestGetDashboard(t *testing.T) {
 	prom.MockMetric("my_metric_1_1", expectedLabels, &query.RangeQuery, 10)
 	prom.MockHistogram("my_metric_1_2", expectedLabels, &query.RangeQuery, 11, 12)
 
-	k8s := kubetest.NewFakeK8sClient()
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	SetWithBackends(mockClientFactory, nil)
-
 	dashboard, err := service.GetDashboard(context.Background(), query, "dashboard1")
 
 	assert.Nil(err)

--- a/business/layer.go
+++ b/business/layer.go
@@ -32,49 +32,6 @@ type Layer struct {
 	Workload       WorkloadService
 }
 
-// Global clientfactory and prometheus clients.
-var (
-	clientFactory    kubernetes.ClientFactory
-	discovery        istio.MeshDiscovery
-	grafanaService   *grafana.Service
-	kialiCache       cache.KialiCache
-	poller           ControlPlaneMonitor
-	prometheusClient prometheus.ClientInterface
-)
-
-// Start sets the globals necessary for the business layer.
-// TODO: Refactor out global vars.
-func Start(
-	cf kubernetes.ClientFactory,
-	controlPlaneMonitor ControlPlaneMonitor,
-	cache cache.KialiCache,
-	disc istio.MeshDiscovery,
-	prom prometheus.ClientInterface,
-	traceClientLoader func() tracing.ClientInterface,
-	grafana *grafana.Service,
-) {
-	clientFactory = cf
-	discovery = disc
-	grafanaService = grafana
-	kialiCache = cache
-	poller = controlPlaneMonitor
-	prometheusClient = prom
-}
-
-// SetWithBackends allows for specifying the ClientFactory and Prometheus clients to be used.
-// Mock friendly. Used only with tests.
-func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterface) {
-	clientFactory = cf
-	prometheusClient = prom
-}
-
-// NewWithBackends creates the business layer using the passed k8sClients and prom clients.
-// Note that the client passed here should *not* be the Kiali ServiceAccount client.
-// It should be the user client based on the logged in user's token.
-func NewWithBackends(userClients map[string]kubernetes.UserClientInterface, kialiSAClients map[string]kubernetes.ClientInterface, prom prometheus.ClientInterface, traceClient tracing.ClientInterface) *Layer {
-	return newLayer(userClients, kialiSAClients, prom, traceClient, kialiCache, config.Get(), grafanaService, discovery, poller)
-}
-
 func newLayer(
 	userClients map[string]kubernetes.UserClientInterface,
 	kialiSAClients map[string]kubernetes.ClientInterface,

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -17,14 +17,11 @@ import (
 func TestGetMeshConfig(t *testing.T) {
 	check := assert.New(t)
 
-	k8s := kubetest.NewFakeK8sClient()
 	conf := config.NewConfig()
-
-	config.Set(conf)
 
 	// Create a MeshService and invoke IsMeshConfigured
 	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
+	k8sclients[conf.KubernetesConfig.ClusterName] = kubetest.NewFakeK8sClient()
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -40,9 +37,7 @@ func TestGetMeshConfig(t *testing.T) {
 		},
 	}
 
-	business.WithDiscovery(discovery)
-	layer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
-	meshSvc := layer.Mesh
+	meshSvc := business.NewMeshService(conf, discovery, kubernetes.ConvertFromUserClients(k8sclients))
 
 	meshConfig := meshSvc.GetMeshConfig()
 

--- a/business/testing.go
+++ b/business/testing.go
@@ -10,63 +10,104 @@ import (
 
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
-	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus"
+	"github.com/kiali/kiali/tracing"
 )
 
-// SetWithBackends allows for specifying the ClientFactory and Prometheus clients to be used.
-// Mock friendly. Used only with tests.
-func setWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterface, cache cache.KialiCache, cpm ControlPlaneMonitor, d istio.MeshDiscovery) {
-	clientFactory = cf
-	discovery = d
-	kialiCache = cache
-	poller = cpm
-	prometheusClient = prom
+// layerBuilder is a helper for building a Layer for testing.
+// It is used to create a Layer with the necessary dependencies for testing.
+// It is not meant to be used outside of unit tests.
+// You must call either WithClient or WithClients to set the clients but everything else is optional.
+// You can chain the methods to set the dependencies and call Build() at the end to create the Layer.
+// Example:
+//
+//	layer := NewLayerBuilder(t, conf).WithClient(k8s).Build()
+//
+//	layer := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build()
+type layerBuilder struct {
+	t              testing.TB
+	userClients    map[string]kubernetes.UserClientInterface
+	kialiSAClients map[string]kubernetes.ClientInterface
+	prom           prometheus.ClientInterface
+	tracingLoader  func() tracing.ClientInterface
+	cache          cache.KialiCache
+	conf           *config.Config
+	grafana        *grafana.Service
+	discovery      istio.MeshDiscovery
+	cpm            ControlPlaneMonitor
 }
 
-// SetupBusinessLayer mocks out some global variables in the business package
-// such as the kiali cache and the prometheus client.
-func SetupBusinessLayer(t testing.TB, k8s kubernetes.UserClientInterface, config config.Config) cache.KialiCache {
-	t.Helper()
-
-	originalClientFactory := clientFactory
-	originalPrometheusClient := prometheusClient
-	originalKialiCache := kialiCache
-	originalDiscovery := discovery
-	t.Cleanup(func() {
-		clientFactory = originalClientFactory
-		prometheusClient = originalPrometheusClient
-		kialiCache = originalKialiCache
-		discovery = originalDiscovery
-	})
-
-	cf := kubetest.NewK8SClientFactoryMock(k8s)
-	cache := cache.NewTestingCacheWithFactory(t, cf, config)
-	cpm := &FakeControlPlaneMonitor{}
-	d := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), cache, &config)
-
-	setWithBackends(cf, nil, cache, cpm, d)
-	return cache
+// NewLayerBuilder creates a new layerBuilder with the given config.
+func NewLayerBuilder(t testing.TB, conf *config.Config) *layerBuilder {
+	return &layerBuilder{
+		t:             t,
+		conf:          conf,
+		tracingLoader: func() tracing.ClientInterface { return nil },
+	}
 }
 
-// WithProm is a testing func that lets you replace the global prom client var.
-func WithProm(prom prometheus.ClientInterface) {
-	prometheusClient = prom
+// WithClient sets the user client for the layer. Use this for single cluster.
+func (lb *layerBuilder) WithClient(k8s kubernetes.UserClientInterface) *layerBuilder {
+	clients := map[string]kubernetes.UserClientInterface{lb.conf.KubernetesConfig.ClusterName: k8s}
+	lb.userClients = clients
+	lb.kialiSAClients = kubernetes.ConvertFromUserClients(clients)
+	return lb
 }
 
-// WithKialiCache is a testing func that lets you replace the global cache var.
-func WithKialiCache(cache cache.KialiCache) {
-	kialiCache = cache
+// WithClients sets both user and SA clients for the layer. Use this for multi-cluster.
+func (lb *layerBuilder) WithClients(clients map[string]kubernetes.UserClientInterface) *layerBuilder {
+	lb.userClients = clients
+	lb.kialiSAClients = kubernetes.ConvertFromUserClients(clients)
+	return lb
 }
 
-// WithControlPlaneMonitor is a testing func that lets you replace the global cpm var.
-func WithControlPlaneMonitor(cpm ControlPlaneMonitor) {
-	poller = cpm
+// WithCache sets the cache for the layer.
+func (lb *layerBuilder) WithCache(cache cache.KialiCache) *layerBuilder {
+	lb.cache = cache
+	return lb
 }
 
-// WithDiscovery is a testing func that lets you replace the global discovery var.
-func WithDiscovery(disc istio.MeshDiscovery) {
-	discovery = disc
+// WithDiscovery sets the discovery for the layer.
+func (lb *layerBuilder) WithDiscovery(discovery istio.MeshDiscovery) *layerBuilder {
+	lb.discovery = discovery
+	return lb
+}
+
+// WithTraceLoader sets the trace loader for the layer.
+func (lb *layerBuilder) WithTraceLoader(traceLoader func() tracing.ClientInterface) *layerBuilder {
+	lb.tracingLoader = traceLoader
+	return lb
+}
+
+// WithProm sets the prometheus client for the layer.
+func (lb *layerBuilder) WithProm(prom prometheus.ClientInterface) *layerBuilder {
+	lb.prom = prom
+	return lb
+}
+
+// Build creates a new Layer with the given dependencies.
+// If you did not call WithClient or WithClients, the layerBuilder will fail the test.
+func (lb *layerBuilder) Build() *Layer {
+	lb.t.Helper()
+	if lb.userClients == nil && lb.kialiSAClients == nil {
+		lb.t.Fatalf("You must call either WithClient or WithClients to set the clients")
+		return nil
+	}
+
+	if lb.cache == nil {
+		lb.cache = cache.NewTestingCacheWithClients(lb.t, lb.kialiSAClients, *lb.conf)
+	}
+	if lb.cpm == nil {
+		lb.cpm = &FakeControlPlaneMonitor{}
+	}
+	if lb.discovery == nil {
+		lb.discovery = istio.NewDiscovery(lb.kialiSAClients, lb.cache, lb.conf)
+	}
+	if lb.grafana == nil {
+		lb.grafana = grafana.NewService(lb.conf, lb.userClients[lb.conf.KubernetesConfig.ClusterName])
+	}
+	return newLayer(lb.userClients, lb.kialiSAClients, lb.prom, lb.tracingLoader(), lb.cache, lb.conf, lb.grafana, lb.discovery, lb.cpm)
 }

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -56,7 +56,6 @@ func TestMeshStatusEnabled(t *testing.T) {
 	objs = append(objs, kubernetes.ToRuntimeObjects(dr)...)
 
 	k8s := kubetest.NewFakeK8sClient(objs...)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -67,12 +66,7 @@ func TestMeshStatusEnabled(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -98,7 +92,6 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 	objs = append(objs, kubernetes.ToRuntimeObjects(dr)...)
 
 	k8s := kubetest.NewFakeK8sClient(objs...)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -109,12 +102,7 @@ func TestMeshStatusEnabledAutoMtls(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -143,7 +131,6 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 	objs = append(objs, kubernetes.ToRuntimeObjects(dr)...)
 
 	k8s := kubetest.NewFakeK8sClient(objs...)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -154,12 +141,7 @@ func TestMeshStatusPartiallyEnabled(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -184,7 +166,6 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 	objs = append(objs, kubernetes.ToRuntimeObjects(dr)...)
 
 	k8s := kubetest.NewFakeK8sClient(objs...)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -195,12 +176,7 @@ func TestMeshStatusNotEnabled(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -228,7 +204,6 @@ func TestMeshStatusDisabled(t *testing.T) {
 	objs = append(objs, kubernetes.ToRuntimeObjects(dr)...)
 
 	k8s := kubetest.NewFakeK8sClient(objs...)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -239,12 +214,7 @@ func TestMeshStatusDisabled(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -259,7 +229,6 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 
 	ns := kubetest.FakeNamespaceWithLabels("test", injectionEnabledLabel)
 	k8s := kubetest.NewFakeK8sClient(ns)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -270,12 +239,7 @@ func TestMeshStatusNotEnabledAutoMtls(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.MeshWidemTLSStatus(context.TODO(), conf.KubernetesConfig.ClusterName, "default")
 
 	assert.NoError(err)
@@ -399,7 +363,6 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Deployment.ClusterWideAccess = true
 	kubernetes.SetConfig(t, *conf)
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -410,11 +373,7 @@ func TestNamespaceHasDestinationRuleEnabledDifferentNs(t *testing.T) {
 			}},
 		},
 	}
-	WithDiscovery(discovery)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)
@@ -446,7 +405,6 @@ func testNamespaceScenario(exStatus string, drs []*networking_v1.DestinationRule
 
 	k8sclients := make(map[string]kubernetes.UserClientInterface)
 	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	SetupBusinessLayer(t, k8s, *conf)
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
@@ -457,9 +415,8 @@ func testNamespaceScenario(exStatus string, drs []*networking_v1.DestinationRule
 			}},
 		},
 	}
-	WithDiscovery(discovery)
 
-	tlsService := NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil).TLS
+	tlsService := NewLayerBuilder(t, conf).WithClient(k8s).WithDiscovery(discovery).Build().TLS
 	status, err := tlsService.NamespaceWidemTLSStatus(context.TODO(), "bookinfo", conf.KubernetesConfig.ClusterName)
 
 	assert.NoError(err)

--- a/business/tracing_test.go
+++ b/business/tracing_test.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tracing/jaeger/model"
@@ -16,7 +15,6 @@ import (
 )
 
 func getLayer(t *testing.T, conf *config.Config) *Layer {
-
 	config.Set(conf)
 	s1 := kubetest.FakeService("Namespace", "reviews")
 	s2 := kubetest.FakeService("Namespace", "httpbin")
@@ -27,10 +25,7 @@ func getLayer(t *testing.T, conf *config.Config) *Layer {
 	}
 
 	k8s := kubetest.NewFakeK8sClient(objects...)
-	SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	return NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
+	return NewLayerBuilder(t, conf).WithClient(k8s).Build()
 }
 
 var trace1 = jaegerModels.Trace{
@@ -238,7 +233,6 @@ func TestTracesToSpanWaypointWithWorkloadFilter(t *testing.T) {
 }
 
 func TestValidateConfiguration(t *testing.T) {
-
 	assert := assert.New(t)
 	conf := config.NewConfig()
 	conf.ExternalServices.Tracing.Enabled = true
@@ -258,5 +252,4 @@ func TestValidateConfiguration(t *testing.T) {
 	assert.NotNil(validConfig)
 	assert.NotNil(validConfig.Error)
 	assert.Contains(validConfig.Error, "Error creating tracing client")
-
 }

--- a/cache/testing.go
+++ b/cache/testing.go
@@ -47,7 +47,7 @@ func NewTestingCacheWithFactory(t testing.TB, cf kubernetes.ClientFactory, conf 
 }
 
 // NewTestingCacheWithClients allows you to pass in a map of clients instead of creating a client factory. Good for testing multicluster.
-func NewTestingCacheWithClients(t *testing.T, clients map[string]kubernetes.ClientInterface, conf config.Config) KialiCache {
+func NewTestingCacheWithClients(t testing.TB, clients map[string]kubernetes.ClientInterface, conf config.Config) KialiCache {
 	t.Helper()
 	return newTestingCache(t, clients, conf)
 }

--- a/graph/api/api_perf_test.go
+++ b/graph/api/api_perf_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"flag"
 	"fmt"
-
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -949,12 +948,9 @@ func setupMockedPerf(b *testing.B, numNs int) (*prometheus.Client, *prometheuste
 	}
 	client.Inject(api)
 
-	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	business.SetWithBackends(mockClientFactory, nil)
+	mockClientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
 	testingCache := cache.NewTestingCache(b, k8s, *conf)
-	business.WithKialiCache(testingCache)
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(mockClientFactory.Clients), testingCache, conf)
-	business.WithDiscovery(discovery)
 
 	biz, err := business.NewLayer(conf, testingCache, mockClientFactory, client, nil, nil, nil, discovery, authInfo)
 	require.NoError(b, err)

--- a/graph/telemetry/istio/appender/ambient_test.go
+++ b/graph/telemetry/istio/appender/ambient_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -30,11 +29,7 @@ func setupMocks(t *testing.T) *business.Layer {
 	conf.KubernetesConfig.ClusterName = defaultCluster
 	config.Set(conf)
 
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[defaultCluster] = k8s
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
-	return businessLayer
+	return business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 }
 
 func workloadEntriesTrafficMap() map[string]*graph.Node {
@@ -124,7 +119,8 @@ func TestRemoveWaypoint(t *testing.T) {
 				Name:    appNamespace,
 			},
 		},
-		ShowWaypoints: false}
+		ShowWaypoints: false,
+	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 
 	assert.Equal(4, len(trafficMap))
@@ -154,7 +150,8 @@ func TestIsWaypointExcludedNs(t *testing.T) {
 				Name:    appNamespace,
 			},
 		},
-		ShowWaypoints: true}
+		ShowWaypoints: true,
+	}
 
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 

--- a/graph/telemetry/istio/appender/dead_node_test.go
+++ b/graph/telemetry/istio/appender/dead_node_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -98,12 +97,7 @@ func setupWorkloads(t *testing.T) *business.Layer {
 		},
 	)
 
-	business.SetupBusinessLayer(t, k8s, *conf)
-
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[config.DefaultClusterID] = k8s
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
-	return businessLayer
+	return business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 }
 
 func TestDeadNode(t *testing.T) {

--- a/graph/telemetry/istio/appender/extensions_test.go
+++ b/graph/telemetry/istio/appender/extensions_test.go
@@ -175,11 +175,8 @@ func setupMockedExt(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMo
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)
-	business.SetWithBackends(mockClientFactory, nil)
 	cache := cache.NewTestingCache(t, k8s, *conf)
-	business.WithKialiCache(cache)
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(mockClientFactory.Clients), cache, conf)
-	business.WithDiscovery(discovery)
 
 	businessLayer, err := business.NewLayer(conf, cache, mockClientFactory, promClient, nil, nil, nil, discovery, authInfo)
 	require.NoError(t, err)

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -67,13 +66,7 @@ func TestCBAll(t *testing.T) {
 		},
 	}
 	k8s := kubetest.NewFakeK8sClient(dRule, kubetest.FakeNamespace("testNamespace"))
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := map[string]kubernetes.UserClientInterface{
-		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("testNamespace"),
-		),
-	}
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, _, _ := setupTrafficMap()
 
 	assert.Equal(7, len(trafficMap))
@@ -132,14 +125,11 @@ func TestCBSubset(t *testing.T) {
 			},
 		},
 	}
-	k8s := kubetest.NewFakeK8sClient(dRule, kubetest.FakeNamespace("testNamespace"))
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := map[string]kubernetes.UserClientInterface{
-		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("testNamespace"),
-		),
-	}
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
+	k8s := kubetest.NewFakeK8sClient(
+		dRule,
+		kubetest.FakeNamespace("testNamespace"),
+	)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, _, _ := setupTrafficMap()
 
 	assert.Equal(7, len(trafficMap))
@@ -201,7 +191,7 @@ func TestCBSubset(t *testing.T) {
 //	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
 //	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{{}}, nil)
 //
-//	businessLayer := business.NewWithBackends(k8s, nil, nil)
+//	businessLayer := business.NewWithBackends(t, k8s, nil, nil)
 //	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, fooSvcNodeId := setupTrafficMap()
 //
 //	assert.Equal(7, len(trafficMap))
@@ -276,7 +266,7 @@ func TestCBSubset(t *testing.T) {
 //	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
 //	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{{}}, nil)
 //
-//	businessLayer := business.NewWithBackends(k8s, nil, nil)
+//	businessLayer := business.NewWithBackends(t, k8s, nil, nil)
 //	trafficMap, _, _, _, _, _, fooSvcNodeId := setupTrafficMap()
 //
 //	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
@@ -310,13 +300,7 @@ func TestSEInAppBox(t *testing.T) {
 		},
 	}
 	k8s := kubetest.NewFakeK8sClient(svc, kubetest.FakeNamespace("testNamespace"))
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := map[string]kubernetes.UserClientInterface{
-		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("testNamespace"),
-		),
-	}
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 
 	trafficMap := graph.NewTrafficMap()
 	serviceEntryNode, _ := graph.NewNode(config.DefaultClusterID, "testNamespace", "ratings", "", "", "", "", graph.GraphTypeVersionedApp)

--- a/graph/telemetry/istio/appender/labeler_test.go
+++ b/graph/telemetry/istio/appender/labeler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -100,14 +99,7 @@ func setupLabelerK8S(t *testing.T) *business.Layer {
 		},
 	)
 
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := map[string]kubernetes.UserClientInterface{
-		config.DefaultClusterID: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("testNamespace"),
-		),
-	}
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
-	return businessLayer
+	return business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 }
 
 func TestLabeler(t *testing.T) {

--- a/graph/telemetry/istio/appender/workload_entry_test.go
+++ b/graph/telemetry/istio/appender/workload_entry_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry/istio/appender"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -31,11 +30,7 @@ func setupBusinessLayer(t *testing.T, istioObjects ...runtime.Object) *business.
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	config.Set(conf)
 
-	business.SetupBusinessLayer(t, k8s, *conf)
-	k8sclients := make(map[string]kubernetes.UserClientInterface)
-	k8sclients[conf.KubernetesConfig.ClusterName] = k8s
-	businessLayer := business.NewWithBackends(k8sclients, kubernetes.ConvertFromUserClients(k8sclients), nil, nil)
-	return businessLayer
+	return business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
 }
 
 func setupWorkloadEntries(t *testing.T) *business.Layer {
@@ -137,7 +132,8 @@ func TestWorkloadEntry(t *testing.T) {
 				Cluster:           testCluster,
 				CreationTimestamp: time.Now(),
 				Name:              appNamespace,
-			}},
+			},
+		},
 	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 
@@ -215,7 +211,8 @@ func TestWorkloadEntryAppLabelNotMatching(t *testing.T) {
 				Cluster:           testCluster,
 				CreationTimestamp: time.Now(),
 				Name:              appNamespace,
-			}},
+			},
+		},
 	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 
@@ -301,7 +298,8 @@ func TestMultipleWorkloadEntryForSameWorkload(t *testing.T) {
 				Cluster:           testCluster,
 				CreationTimestamp: time.Now(),
 				Name:              appNamespace,
-			}},
+			},
+		},
 	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 
@@ -369,7 +367,8 @@ func TestWorkloadWithoutWorkloadEntries(t *testing.T) {
 				Cluster:           testCluster,
 				CreationTimestamp: time.Now(),
 				Name:              appNamespace,
-			}},
+			},
+		},
 	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 
@@ -417,7 +416,8 @@ func TestWEKiali7305(t *testing.T) {
 				Cluster:           testCluster,
 				CreationTimestamp: time.Now(),
 				Name:              appNamespace,
-			}},
+			},
+		},
 	}
 	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
 

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -113,9 +113,6 @@ func TestGetMeshGraph(t *testing.T) {
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	grafana := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
-	business.SetupBusinessLayer(t, clients[conf.KubernetesConfig.ClusterName], *conf)
-	business.WithKialiCache(cache)
-	business.WithDiscovery(discovery)
 
 	xapi := new(prometheustest.PromAPIMock)
 	prom, err := prometheus.NewClient()

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -222,15 +222,10 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 		conf.KubernetesConfig.ClusterName: primaryClient,
 		"cluster-remote":                  remoteClient,
 	}
-	factory := kubetest.NewK8SClientFactoryMock(nil)
-	factory.SetClients(clients)
 
-	cache := cache.NewTestingCacheWithFactory(t, factory, *conf)
+	cache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(clients), *conf)
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
-	business.WithDiscovery(discovery)
-	business.WithKialiCache(cache)
-	business.SetWithBackends(factory, nil)
-	layer := business.NewWithBackends(clients, kubernetes.ConvertFromUserClients(clients), nil, nil)
+	layer := business.NewLayerBuilder(t, conf).WithClients(clients).WithCache(cache).WithDiscovery(discovery).Build()
 
 	meshDef, err := discovery.Mesh(context.TODO())
 	require.NoError(err)

--- a/server/server.go
+++ b/server/server.go
@@ -26,17 +26,10 @@ import (
 )
 
 type Server struct {
-	conf                *config.Config
-	controlPlaneMonitor business.ControlPlaneMonitor
-	clientFactory       kubernetes.ClientFactory
-	discovery           *istio.Discovery
-	grafana             *grafana.Service
-	httpServer          *http.Server
-	kialiCache          cache.KialiCache
-	prom                prometheus.ClientInterface
-	router              *mux.Router
-	tracer              *sdktrace.TracerProvider
-	traceClientLoader   func() tracing.ClientInterface
+	conf       *config.Config
+	httpServer *http.Server
+	router     *mux.Router
+	tracer     *sdktrace.TracerProvider
 }
 
 // NewServer creates a new server configured with the given settings.
@@ -109,16 +102,9 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 
 	// return our new Server
 	s := &Server{
-		conf:                conf,
-		clientFactory:       clientFactory,
-		controlPlaneMonitor: controlPlaneMonitor,
-		discovery:           discovery,
-		grafana:             grafana,
-		httpServer:          httpServer,
-		kialiCache:          cache,
-		prom:                prom,
-		router:              router,
-		traceClientLoader:   traceClientLoader,
+		conf:       conf,
+		httpServer: httpServer,
+		router:     router,
 	}
 	if conf.Server.Observability.Tracing.Enabled && tracingProvider != nil {
 		s.tracer = tracingProvider
@@ -128,8 +114,6 @@ func NewServer(controlPlaneMonitor business.ControlPlaneMonitor,
 
 // Start HTTP server asynchronously. TLS may be active depending on the global configuration.
 func (s *Server) Start() {
-	business.Start(s.clientFactory, s.controlPlaneMonitor, s.kialiCache, s.discovery, s.prom, s.traceClientLoader, s.grafana)
-
 	log.Infof("Server endpoint will start at [%v%v]", s.httpServer.Addr, s.conf.Server.WebRoot)
 
 	go func() {


### PR DESCRIPTION
### Describe the change

Removes all global variables from the business package. Gets rid of a lot of boilerplate in the unit tests. Adds a "layerBuilder" for unit tests that follows the builder pattern and makes it easy to create a `business.Layer` in the tests with variable dependencies.

### Steps to test the PR

N/A

### Automation testing

Unit test refactor

### Issue reference

fixes #6923 
