### PR TITLE
Autodetect the istiod monitoring port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -328,18 +328,17 @@ type RegistryConfig struct {
 //
 //	a multi-control-plane deployment.
 type IstioConfig struct {
-	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty"`
-	ConfigMapName                     string            `yaml:"config_map_name,omitempty"`
-	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty"`
-	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty"`
-	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty"`
-	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled"`
-	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty"`
-	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty"`
-	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty"`
-	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty"`
-	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty"`
-	IstiodPodMonitoringPort           int               `yaml:"istiod_pod_monitoring_port,omitempty"`
+	ComponentStatuses                 ComponentStatuses `yaml:"component_status,omitempty" json:"componentStatuses,omitempty"`
+	ConfigMapName                     string            `yaml:"config_map_name,omitempty" json:"configMapName,omitempty"`
+	EnvoyAdminLocalPort               int               `yaml:"envoy_admin_local_port,omitempty" json:"envoyAdminLocalPort,omitempty"`
+	GatewayAPIClasses                 []GatewayAPIClass `yaml:"gateway_api_classes,omitempty" json:"gatewayApiClasses,omitempty"`
+	GatewayAPIClassesLabelSelector    string            `yaml:"gateway_api_classes_label_selector,omitempty" json:"gatewayApiClassesLabelSelector,omitempty"`
+	IstioAPIEnabled                   bool              `yaml:"istio_api_enabled" json:"istioApiEnabled"`
+	IstioIdentityDomain               string            `yaml:"istio_identity_domain,omitempty" json:"istioIdentityDomain,omitempty"`
+	IstioInjectionAnnotation          string            `yaml:"istio_injection_annotation,omitempty" json:"istioInjectionAnnotation,omitempty"`
+	IstioSidecarInjectorConfigMapName string            `yaml:"istio_sidecar_injector_config_map_name,omitempty" json:"istioSidecarInjectorConfigMapName,omitempty"`
+	IstioSidecarAnnotation            string            `yaml:"istio_sidecar_annotation,omitempty" json:"istioSidecarAnnotation,omitempty"`
+	IstiodDeploymentName              string            `yaml:"istiod_deployment_name,omitempty" json:"istiodDeploymentName,omitempty"`
 	// IstiodPollingIntervalSeconds is how often in seconds Kiali will poll istiod(s) for
 	// proxy status and registry services. Polling is not performed if IstioAPIEnabled is false.
 	IstiodPollingIntervalSeconds     int             `yaml:"istiod_polling_interval_seconds,omitempty" json:"istiodPollingIntervalSeconds,omitempty"`
@@ -791,7 +790,6 @@ func NewConfig() (c *Config) {
 				IstioSidecarInjectorConfigMapName: "",
 				IstioSidecarAnnotation:            "sidecar.istio.io/status",
 				IstiodDeploymentName:              "",
-				IstiodPodMonitoringPort:           15014,
 				IstiodPollingIntervalSeconds:      20,
 				RootNamespace:                     IstioNamespaceDefault,
 				UrlServiceVersion:                 "",

--- a/istio/constants.go
+++ b/istio/constants.go
@@ -1,0 +1,23 @@
+package istio
+
+// These are used across files in this package and elsewhere.
+
+const (
+	AmbientDataplaneModeLabelValue = "ambient"
+	IstioDataplaneModeLabelKey     = "istio.io/dataplane-mode"
+)
+
+const (
+	istioControlPlaneClustersLabel        = "topology.istio.io/controlPlaneClusters"
+	istiodAppLabelValue                   = "istiod"
+	istiodClusterIDEnvKey                 = "CLUSTER_ID"
+	istiodExternalEnvKey                  = "EXTERNAL_ISTIOD"
+	istiodScopeGatewayEnvKey              = "PILOT_SCOPE_GATEWAY_TO_NAMESPACE"
+	istiodSharedMeshConfigEnvKey          = "SHARED_MESH_CONFIG"
+	baseIstioConfigMapName                = "istio"                  // As of 1.19 this is hardcoded in the helm charts.
+	baseIstioSidecarInjectorConfigMapName = "istio-sidecar-injector" // As of 1.19 this is hardcoded in the helm charts.
+	certificatesConfigMapName             = "istio-ca-root-cert"
+	certificateName                       = "root-cert.pem"
+	monitoringPortName                    = "http-monitoring"
+	defaultMonitoringPort                 = 15014 // Default monitoring port for istiod
+)

--- a/mesh/api/testdata/test_mesh_graph.expected
+++ b/mesh/api/testdata/test_mesh_graph.expected
@@ -25,6 +25,7 @@
           "nodeType": "box",
           "healthData": "Healthy",
           "infraData": {
+            "accessible": true,
             "apiEndpoint": "http://127.0.0.2:9443",
             "isKialiHome": true,
             "kialiInstances": [
@@ -37,8 +38,7 @@
               }
             ],
             "name": "cluster-primary",
-            "secretName": "",
-            "accessible": true
+            "secretName": ""
           },
           "isBox": "cluster",
           "version": "Unknown"
@@ -54,12 +54,12 @@
           "nodeType": "box",
           "healthData": "Healthy",
           "infraData": {
+            "accessible": true,
             "apiEndpoint": "",
             "isKialiHome": false,
             "kialiInstances": null,
             "name": "cluster-remote",
-            "secretName": "",
-            "accessible": true
+            "secretName": ""
           },
           "isBox": "cluster"
         }
@@ -266,20 +266,14 @@
           "nodeType": "infra",
           "healthData": "Healthy",
           "infraData": {
-            "ComponentStatuses": {
+            "componentStatuses": {
               "enabled": true
             },
-            "ConfigMapName": "",
-            "EnvoyAdminLocalPort": 15000,
-            "GatewayAPIClasses": [],
-            "GatewayAPIClassesLabelSelector": "",
-            "IstioAPIEnabled": true,
-            "IstioIdentityDomain": "svc.cluster.local",
-            "IstioInjectionAnnotation": "sidecar.istio.io/inject",
-            "IstioSidecarInjectorConfigMapName": "",
-            "IstioSidecarAnnotation": "sidecar.istio.io/status",
-            "IstiodDeploymentName": "",
-            "IstiodPodMonitoringPort": 15014,
+            "envoyAdminLocalPort": 15000,
+            "istioApiEnabled": true,
+            "istioIdentityDomain": "svc.cluster.local",
+            "istioInjectionAnnotation": "sidecar.istio.io/inject",
+            "istioSidecarAnnotation": "sidecar.istio.io/status",
             "istiodPollingIntervalSeconds": 20,
             "rootNamespace": "istio-system",
             "urlServiceVersion": "",
@@ -329,6 +323,7 @@
           "healthData": "Healthy",
           "infraData": {
             "cluster": {
+              "accessible": true,
               "apiEndpoint": "http://127.0.0.2:9443",
               "isKialiHome": true,
               "kialiInstances": [
@@ -341,8 +336,7 @@
                 }
               ],
               "name": "cluster-primary",
-              "secretName": "",
-              "accessible": true
+              "secretName": ""
             },
             "config": {
               "certificates": [
@@ -388,6 +382,7 @@
             "istiodNamespace": "istio-system",
             "managedClusters": [
               {
+                "accessible": true,
                 "apiEndpoint": "http://127.0.0.2:9443",
                 "isKialiHome": true,
                 "kialiInstances": [
@@ -400,16 +395,15 @@
                   }
                 ],
                 "name": "cluster-primary",
-                "secretName": "",
-                "accessible": true
+                "secretName": ""
               },
               {
+                "accessible": true,
                 "apiEndpoint": "",
                 "isKialiHome": false,
                 "kialiInstances": null,
                 "name": "cluster-remote",
-                "secretName": "",
-                "accessible": true
+                "secretName": ""
               }
             ],
             "managesExternal": true,
@@ -459,6 +453,7 @@
                 "revision": "default"
               }
             ],
+            "monitoringPort": 15014,
             "resources": {},
             "revision": "default",
             "status": "",

--- a/models/mesh.go
+++ b/models/mesh.go
@@ -112,6 +112,10 @@ type ControlPlane struct {
 	// and user configmap. This field is just for the backend to use. The frontend should use the Config field.
 	MeshConfig *MeshConfig `json:"-"`
 
+	// MonitoringPort is the port used for monitoring metrics, parsed from the --monitoringAddr argument.
+	// Defaults to 15014 if not specified or in invalid format.
+	MonitoringPort int `json:"monitoringPort"`
+
 	// Resources are the resources that the controlplane is using.
 	Resources corev1.ResourceRequirements `json:"resources"`
 


### PR DESCRIPTION
### Describe the change

- Autodetects the monitoring port instead of assuming it is the default `15014`.
  - Does this by parsing the istiod args for what is passed in the `--monitoringAddr` cmd line flag. This could have come from the deployment's ports but there's no guarantee that what is set there matches what gets passed as an arg.
- Removes the `IstiodPodMonitoringPort` config setting as part of https://github.com/kiali/kiali/issues/8576
- Adds structured logging to the control plane monitor and properly passes context through
  ```
  2025-07-28T19:06:32Z DBG Getting proxy status from istiod cluster=cluster-default component=controlplane-monitor revision=default
  E0728 19:06:32.081872       1 portforward.go:424] "Unhandled Error" err="an error occurred forwarding 14052 -> 15014: error forwarding port 15014 to pod e923ef14bb694b71d6af119137700f972920ae12f0f69893a91cf3234073659a, uid : failed to execute portforward in network namespace \"/var/run/netns/cni-ea075663-99be-51d7-b4c0-8b1bafc23559\": failed to connect to localhost:15014 inside namespace \"e923ef14bb694b71d6af119137700f972920ae12f0f69893a91cf3234073659a\", IPv4: dial tcp4 127.0.0.1:15014: connect: connection refused IPv6 dial tcp6 [::1]:15014: connect: connection refused " logger="UnhandledError"
  2025-07-28T19:06:32Z ERR Failed to call Istiod endpoint /debug/syncz error: Error fetching the proxy-status in the following pods: istiod-5547bc8d48-z89xg: Get "http://localhost:14052/debug/syncz": EOF cluster=cluster-default component=controlplane-monitor revision=default
  ```

### Steps to test the PR

Somewhat convoluted testing instructions since the sail operator doesn't support overlay manifests yet.

1. Build / deploy PR in test environment
  ```
  make build-ui build && ./hack/run-integration-tests.sh --test-suite backend --setup-only true
  ```

2. Scale down Sail Operator replicas to 0 (otherwise the operator will overwrite changes)
  ```
  kubectl scale deployment -n sail-operator --replicas=0 sail-operator
  ```
3. Update the monitoring port to something other than default on both the istiod service and the istiod deployment
4. Ensure no error logs in Kiali

### Automation testing

Unit tests included

### Issue reference

Fixes #8553 