### PR TITLE
Pass prom as interface and pass SA token into constructor

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -405,7 +405,7 @@ func (in *AppService) GetAppDetails(ctx context.Context, criteria AppCriteria) (
 		}
 	}
 
-	appInstance.Runtimes = NewDashboardsService(in.conf, in.grafana, ns, nil).GetCustomDashboardRefs(criteria.Namespace, criteria.AppName, "", pods)
+	appInstance.Runtimes = NewDashboardsService(in.conf, in.grafana, in.prom, ns, nil).GetCustomDashboardRefs(criteria.Namespace, criteria.AppName, "", pods)
 	if criteria.IncludeHealth {
 		appInstance.Health, err = in.businessLayer.Health.GetAppHealth(ctx, criteria.Namespace, criteria.Cluster, criteria.AppName, criteria.RateInterval, criteria.QueryTime, appDetails)
 		if err != nil {
@@ -522,7 +522,8 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 // If the app has any Waypoint, the information is included, as it will be the search name used by the tracing backend
 func (in *AppService) GetAppTracingName(ctx context.Context, cluster, namespace, app string) models.TracingName {
 	criteria := AppCriteria{
-		Namespace: namespace, AppName: app, IncludeIstioResources: false, IncludeHealth: false, Cluster: cluster}
+		Namespace: namespace, AppName: app, IncludeIstioResources: false, IncludeHealth: false, Cluster: cluster,
+	}
 
 	tracingName := models.TracingName{App: app, Lookup: app}
 	// Fetch and build app

--- a/business/metrics_test.go
+++ b/business/metrics_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 func setupMocked() (*MetricsService, *prometheustest.PromAPIMock, error) {
-	config.Set(config.NewConfig())
+	conf := config.NewConfig()
+	config.Set(conf)
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*conf, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -241,7 +241,7 @@ func TestMultiClusterGetServiceDetails(t *testing.T) {
 			&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-west-cluster", Namespace: "bookinfo"}},
 		),
 	}
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 
 	promMock := new(prometheustest.PromAPIMock)
@@ -304,7 +304,7 @@ func TestGetServiceRouteURL(t *testing.T) {
 	)
 	k8s.OpenShift = true
 
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, k8s.GetToken())
 	require.NoError(err)
 
 	promMock := new(prometheustest.PromAPIMock)
@@ -382,7 +382,7 @@ func TestGetServiceDetailsValidations(t *testing.T) {
 		),
 	}
 
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 
 	promMock := new(prometheustest.PromAPIMock)
@@ -421,7 +421,7 @@ func TestGetServiceDetailsValidationErrors(t *testing.T) {
 		),
 	}
 
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 
 	promMock := new(prometheustest.PromAPIMock)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -481,7 +481,7 @@ func (in *WorkloadService) GetWorkload(ctx context.Context, criteria WorkloadCri
 		verLabelName, _ := conf.GetVersionLabelName(workload.Labels)
 		app := workload.Labels[appLabelName]
 		version := workload.Labels[verLabelName]
-		runtimes = NewDashboardsService(in.conf, in.grafana, ns, workload).GetCustomDashboardRefs(criteria.Namespace, app, version, workload.Pods)
+		runtimes = NewDashboardsService(in.conf, in.grafana, in.prom, ns, workload).GetCustomDashboardRefs(criteria.Namespace, app, version, workload.Pods)
 	}()
 
 	// WorkloadGroup.Labels can be empty

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -31,6 +31,8 @@ import (
 func setupWorkloadService(t testing.TB, k8s kubernetes.UserClientInterface, conf *config.Config) WorkloadService {
 	// config needs to be set by other services since those rely on the global.
 	prom := new(prometheustest.PromClientMock)
+	// Mocking out for the dashboards service. Maybe this should be set to something real?
+	prom.MockMetricsForLabels([]string{})
 	return NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Workload
 }
 

--- a/graph/api/api.go
+++ b/graph/api/api.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GraphNamespaces generates a namespaces graph using the provided options
-func GraphNamespaces(ctx context.Context, business *business.Layer, o graph.Options) (code int, graphConfig interface{}) {
+func GraphNamespaces(ctx context.Context, business *business.Layer, prom prometheus.ClientInterface, o graph.Options) (code int, graphConfig interface{}) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(
 		ctx,
@@ -42,8 +42,6 @@ func GraphNamespaces(ctx context.Context, business *business.Layer, o graph.Opti
 
 	switch o.TelemetryVendor {
 	case graph.VendorIstio:
-		prom, err := prometheus.NewClient()
-		graph.CheckError(err)
 		code, graphConfig = graphNamespacesIstio(ctx, business, prom, o)
 	default:
 		graph.Error(fmt.Sprintf("TelemetryVendor [%s] not supported", o.TelemetryVendor))
@@ -59,8 +57,7 @@ func GraphNamespaces(ctx context.Context, business *business.Layer, o graph.Opti
 }
 
 // graphNamespacesIstio provides a test hook that accepts mock clients
-func graphNamespacesIstio(ctx context.Context, business *business.Layer, prom *prometheus.Client, o graph.Options) (code int, graphConfig interface{}) {
-
+func graphNamespacesIstio(ctx context.Context, business *business.Layer, prom prometheus.ClientInterface, o graph.Options) (code int, graphConfig interface{}) {
 	// Create a 'global' object to store the business. Global only to the request.
 	globalInfo := graph.NewGlobalInfo(business, prom, config.Get())
 
@@ -71,7 +68,7 @@ func graphNamespacesIstio(ctx context.Context, business *business.Layer, prom *p
 }
 
 // GraphNode generates a node graph using the provided options
-func GraphNode(ctx context.Context, business *business.Layer, o graph.Options) (code int, graphConfig interface{}) {
+func GraphNode(ctx context.Context, business *business.Layer, prom prometheus.ClientInterface, o graph.Options) (code int, graphConfig interface{}) {
 	if len(o.Namespaces) != 1 {
 		graph.Error("Node graph does not support the 'namespaces' query parameter or the 'all' namespace")
 	}
@@ -92,8 +89,6 @@ func GraphNode(ctx context.Context, business *business.Layer, o graph.Options) (
 
 	switch o.TelemetryVendor {
 	case graph.VendorIstio:
-		prom, err := prometheus.NewClient()
-		graph.CheckError(err)
 		code, graphConfig = graphNodeIstio(ctx, business, prom, o)
 	default:
 		graph.Error(fmt.Sprintf("TelemetryVendor [%s] not supported", o.TelemetryVendor))
@@ -109,8 +104,7 @@ func GraphNode(ctx context.Context, business *business.Layer, o graph.Options) (
 }
 
 // graphNodeIstio provides a test hook that accepts mock clients
-func graphNodeIstio(ctx context.Context, business *business.Layer, prom *prometheus.Client, o graph.Options) (code int, graphConfig interface{}) {
-
+func graphNodeIstio(ctx context.Context, business *business.Layer, prom prometheus.ClientInterface, o graph.Options) (code int, graphConfig interface{}) {
 	// Create a 'global' object to store the business. Global only to the request.
 	globalInfo := graph.NewGlobalInfo(business, prom, config.Get())
 	globalInfo.Business = business

--- a/graph/api/api_perf_test.go
+++ b/graph/api/api_perf_test.go
@@ -942,7 +942,7 @@ func setupMockedPerf(b *testing.B, numNs int) (*prometheus.Client, *prometheuste
 	authInfo := map[string]*cmdapi.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*config.NewConfig(), k8s.GetToken())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/graph/api/api_test.go
+++ b/graph/api/api_test.go
@@ -47,7 +47,7 @@ func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock,
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*conf, k8s.GetToken())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func setupMockedWithIstioComponentNamespaces(t *testing.T, meshId string, userCl
 	authInfo := map[string]*api.AuthInfo{testConfig.KubernetesConfig.ClusterName: {Token: "test"}}
 
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*testConfig, userClients[testConfig.KubernetesConfig.ClusterName].GetToken())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -4160,7 +4160,7 @@ func TestAmbientGraph(t *testing.T) {
 	businessLayer := ambientWorkloads(t)
 
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*config.Get(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/graph/appender.go
+++ b/graph/appender.go
@@ -17,7 +17,7 @@ type VendorInfo map[string]interface{}
 type GlobalInfo struct {
 	Business   *business.Layer
 	Conf       *config.Config
-	PromClient *prometheus.Client
+	PromClient prometheus.ClientInterface
 	Vendor     VendorInfo // telemetry vendor's global info
 }
 
@@ -34,12 +34,13 @@ func NewVendorInfo() VendorInfo {
 	return make(map[string]interface{})
 }
 
-func NewGlobalInfo(business *business.Layer, prom *prometheus.Client, conf *config.Config) *GlobalInfo {
+func NewGlobalInfo(business *business.Layer, prom prometheus.ClientInterface, conf *config.Config) *GlobalInfo {
 	return &GlobalInfo{
 		Business:   business,
 		Conf:       conf,
 		PromClient: prom,
-		Vendor:     NewVendorInfo()}
+		Vendor:     NewVendorInfo(),
+	}
 }
 
 func NewAppenderNamespaceInfo(namespace string) *AppenderNamespaceInfo {

--- a/graph/telemetry/istio/appender/aggregate_node.go
+++ b/graph/telemetry/istio/appender/aggregate_node.go
@@ -58,12 +58,6 @@ func (a AggregateNodeAppender) AppendGraph(ctx context.Context, trafficMap graph
 		return
 	}
 
-	if globalInfo.PromClient == nil {
-		var err error
-		globalInfo.PromClient, err = prometheus.NewClient()
-		graph.CheckError(err)
-	}
-
 	if a.AggregateValue == "" {
 		a.appendGraph(ctx, trafficMap, namespaceInfo.Namespace, globalInfo.PromClient, globalInfo.Conf)
 	} else {
@@ -71,7 +65,7 @@ func (a AggregateNodeAppender) AppendGraph(ctx context.Context, trafficMap graph
 	}
 }
 
-func (a AggregateNodeAppender) appendGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client *prometheus.Client, conf *config.Config) {
+func (a AggregateNodeAppender) appendGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client prometheus.ClientInterface, conf *config.Config) {
 	log.FromContext(ctx).Trace().Msgf("Resolving request aggregates for namespace=[%s], aggregate=[%s]", namespace, a.Aggregate)
 	duration := a.Namespaces[namespace].Duration
 
@@ -111,7 +105,7 @@ func (a AggregateNodeAppender) appendGraph(ctx context.Context, trafficMap graph
 	a.injectAggregates(ctx, trafficMap, &vector, conf)
 }
 
-func (a AggregateNodeAppender) appendNodeGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client *prometheus.Client, conf *config.Config) {
+func (a AggregateNodeAppender) appendNodeGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client prometheus.ClientInterface, conf *config.Config) {
 	log.FromContext(ctx).Trace().Msgf("Resolving node request aggregates for namespace=[%s], aggregate=[%s=%s]", namespace, a.Aggregate, a.AggregateValue)
 	duration := a.Namespaces[namespace].Duration
 

--- a/graph/telemetry/istio/appender/extensions.go
+++ b/graph/telemetry/istio/appender/extensions.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util/sliceutil"
 )
 
@@ -54,12 +53,6 @@ func (a ExtensionsAppender) IsFinalizer() bool {
 func (a ExtensionsAppender) AppendGraph(ctx context.Context, trafficMap graph.TrafficMap, globalInfo *graph.GlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	if len(globalInfo.Conf.Extensions) == 0 {
 		return
-	}
-
-	if globalInfo.PromClient == nil {
-		var err error
-		globalInfo.PromClient, err = prometheus.NewClient()
-		graph.CheckError(err)
 	}
 
 	a.globalInfo = globalInfo

--- a/graph/telemetry/istio/appender/extensions_test.go
+++ b/graph/telemetry/istio/appender/extensions_test.go
@@ -161,17 +161,16 @@ func setupMockedExt(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMo
 	conf.KubernetesConfig.ClusterName = rootCluster
 	config.Set(conf)
 
-	promApi := new(prometheustest.PromAPIMock)
-	promClient, err := prometheus.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	promClient.Inject(promApi)
-
 	k8s := kubetest.NewFakeK8sClient(
 		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: rootNamespace}},
 		&core_v1.Service{ObjectMeta: meta_v1.ObjectMeta{Name: extName, Namespace: rootNamespace, Annotations: map[string]string{"extension.kiali.io/ui-url": extUrl}}},
 	)
+	promApi := new(prometheustest.PromAPIMock)
+	promClient, err := prometheus.NewClient(*config.NewConfig(), k8s.GetToken())
+	if err != nil {
+		t.Fatal(err)
+	}
+	promClient.Inject(promApi)
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 
 	mockClientFactory := kubetest.NewK8SClientFactoryMock(k8s)

--- a/graph/telemetry/istio/appender/response_time.go
+++ b/graph/telemetry/istio/appender/response_time.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/prometheus"
 )
 
 const (
@@ -56,12 +55,6 @@ func (a ResponseTimeAppender) AppendGraph(ctx context.Context, trafficMap graph.
 	// Response times only apply to request traffic (not TCP or gRPC-message traffic)
 	if a.Rates.Grpc != graph.RateRequests && a.Rates.Http != graph.RateRequests {
 		return
-	}
-
-	if globalInfo.PromClient == nil {
-		var err error
-		globalInfo.PromClient, err = prometheus.NewClient()
-		graph.CheckError(err)
 	}
 
 	a.appendGraph(ctx, trafficMap, a.Namespaces[namespaceInfo.Namespace], globalInfo)

--- a/graph/telemetry/istio/appender/security_policy.go
+++ b/graph/telemetry/istio/appender/security_policy.go
@@ -48,16 +48,10 @@ func (a SecurityPolicyAppender) AppendGraph(ctx context.Context, trafficMap grap
 		return
 	}
 
-	if globalInfo.PromClient == nil {
-		var err error
-		globalInfo.PromClient, err = prometheus.NewClient()
-		graph.CheckError(err)
-	}
-
 	a.appendGraph(ctx, trafficMap, namespaceInfo.Namespace, globalInfo.PromClient, globalInfo.Conf)
 }
 
-func (a SecurityPolicyAppender) appendGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client *prometheus.Client, conf *config.Config) {
+func (a SecurityPolicyAppender) appendGraph(ctx context.Context, trafficMap graph.TrafficMap, namespace string, client prometheus.ClientInterface, conf *config.Config) {
 	zl := log.FromContext(ctx)
 
 	zl.Trace().Msgf("Resolving security policy for namespace [%v], rates [%+v]", namespace, a.Rates)

--- a/graph/telemetry/istio/appender/throughput.go
+++ b/graph/telemetry/istio/appender/throughput.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kiali/kiali/graph"
 	"github.com/kiali/kiali/graph/telemetry/istio/util"
 	"github.com/kiali/kiali/log"
-	"github.com/kiali/kiali/prometheus"
 )
 
 const (
@@ -53,12 +52,6 @@ func (a ThroughputAppender) AppendGraph(ctx context.Context, trafficMap graph.Tr
 	// HTTP Throughput only apply to HTTP request traffic
 	if a.Rates.Http != graph.RateRequests {
 		return
-	}
-
-	if globalInfo.PromClient == nil {
-		var err error
-		globalInfo.PromClient, err = prometheus.NewClient()
-		graph.CheckError(err)
 	}
 
 	a.appendGraph(ctx, trafficMap, namespaceInfo.Namespace, globalInfo)

--- a/graph/telemetry/istio/appender/util_test.go
+++ b/graph/telemetry/istio/appender/util_test.go
@@ -24,7 +24,7 @@ func setupMockedWithQueryScope(meshId string) (*prometheus.Client, *prometheuste
 	}
 	config.Set(testConfig)
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*config.NewConfig(), "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -70,7 +70,7 @@ func CustomDashboard(
 			}
 		}
 
-		svc := business.NewDashboardsService(conf, grafana, info, wkd)
+		svc := business.NewDashboardsService(conf, grafana, prom, info, wkd)
 		if !svc.CustomEnabled {
 			RespondWithError(w, http.StatusServiceUnavailable, "Custom dashboards are disabled in config")
 			return
@@ -156,7 +156,7 @@ func AppDashboard(
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
-		dashboard := business.NewDashboardsService(conf, grafana, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
+		dashboard := business.NewDashboardsService(conf, grafana, prom, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
 		RespondWithJSON(w, http.StatusOK, dashboard)
 	}
 }
@@ -216,7 +216,7 @@ func ServiceDashboard(
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
-		dashboard := business.NewDashboardsService(conf, grafana, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
+		dashboard := business.NewDashboardsService(conf, grafana, prom, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
 		RespondWithJSON(w, http.StatusOK, dashboard)
 	}
 }
@@ -253,7 +253,7 @@ func WorkloadDashboard(
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
-		dashboard := business.NewDashboardsService(conf, grafana, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
+		dashboard := business.NewDashboardsService(conf, grafana, prom, namespaceInfo, nil).BuildIstioDashboard(metrics, params.Direction)
 		RespondWithJSON(w, http.StatusOK, dashboard)
 	}
 }
@@ -301,7 +301,7 @@ func ZtunnelDashboard(
 			return
 		}
 		ns := namespaceInfo[0]
-		dashboard := business.NewDashboardsService(conf, grafana, &ns, nil).BuildZtunnelDashboard(ztunnelMetrics)
+		dashboard := business.NewDashboardsService(conf, grafana, prom, &ns, nil).BuildZtunnelDashboard(ztunnelMetrics)
 		RespondWithJSON(w, http.StatusOK, dashboard)
 	}
 }

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -69,7 +69,7 @@ func GraphNamespaces(
 
 		o := graph.NewOptions(r, business)
 
-		code, payload := api.GraphNamespaces(r.Context(), business, o)
+		code, payload := api.GraphNamespaces(r.Context(), business, prom, o)
 		respond(w, code, payload)
 	}
 }
@@ -93,7 +93,7 @@ func GraphNode(
 
 		o := graph.NewOptions(r, business)
 
-		code, payload := api.GraphNode(r.Context(), business, o)
+		code, payload := api.GraphNode(r.Context(), business, prom, o)
 		respond(w, code, payload)
 	}
 }

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -115,7 +115,7 @@ func TestGetMeshGraph(t *testing.T) {
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
 
 	xapi := new(prometheustest.PromAPIMock)
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 	prom.Inject(xapi)
 	cpm := &business.FakeControlPlaneMonitor{}

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -67,7 +67,7 @@ func setupMocked(t *testing.T) (*prometheus.Client, *prometheustest.PromAPIMock,
 	k.OpenShift = true
 
 	api := new(prometheustest.PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*config.NewConfig(), k.GetToken())
 	if err != nil {
 		t.Fatal(err)
 		return nil, nil, nil

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -335,7 +335,7 @@ func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustes
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), cache, conf)
 
 	xapi := new(prometheustest.PromAPIMock)
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*config.NewConfig(), k.GetToken())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func setupServiceMetricsEndpointWithClient(t *testing.T, client kubernetes.Clien
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), cache, conf)
 
 	xapi := new(prometheustest.PromAPIMock)
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*config.NewConfig(), client.GetToken())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kiali.go
+++ b/kiali.go
@@ -186,7 +186,7 @@ func main() {
 	cpm := business.NewControlPlaneMonitor(cache, clientFactory, conf, discovery)
 
 	// Create shared prometheus client shared by all prometheus requests in the business layer.
-	prom, err := prometheus.NewClient()
+	prom, err := prometheus.NewClient(*conf, clientFactory.GetSAHomeClusterClient().GetToken())
 	if err != nil {
 		log.Fatalf("Error creating Prometheus client: %s", err)
 	}

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -121,7 +121,6 @@ func NewK8SClientMock() *K8SClientMock {
 	k8s.On("IsGatewayAPI").Return(false)
 	k8s.On("IsInferenceAPI").Return(false)
 	k8s.On("IsIstioAPI").Return(true)
-	k8s.On("GetKialiTokenForHomeCluster").Return("", "")
 	return k8s
 }
 

--- a/prometheus/prometheustest/client_test.go
+++ b/prometheus/prometheustest/client_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 func setupMocked() (*prometheus.Client, *PromAPIMock, error) {
-	config.Set(config.NewConfig())
+	conf := config.NewConfig()
+	config.Set(conf)
 	api := new(PromAPIMock)
-	client, err := prometheus.NewClient()
+	client, err := prometheus.NewClient(*conf, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -31,7 +32,7 @@ func TestGetAllRequestRates(t *testing.T) {
 		return
 	}
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 0o1, 15, 0, 0, 0, 0, time.UTC)
 
 	vectorQ1 := model.Vector{
 		&model.Sample{
@@ -46,7 +47,8 @@ func TestGetAllRequestRates(t *testing.T) {
 		&model.Sample{
 			Timestamp: model.Now(),
 			Value:     model.SampleValue(2),
-			Metric:    model.Metric{"foo": "bar"}},
+			Metric:    model.Metric{"foo": "bar"},
+		},
 	}
 	api.OnQueryTime(`rate(istio_requests_total{source_workload_namespace="ns",source_cluster="east"}[5m]) > 0`, &queryTime, vectorQ2)
 
@@ -63,7 +65,7 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 		return
 	}
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 0o1, 15, 0, 0, 0, 0, time.UTC)
 
 	vectorQ1 := model.Vector{
 		&model.Sample{
@@ -78,7 +80,8 @@ func TestGetAllRequestRatesIstioSystem(t *testing.T) {
 		&model.Sample{
 			Timestamp: model.Now(),
 			Value:     model.SampleValue(2),
-			Metric:    model.Metric{"foo": "bar"}},
+			Metric:    model.Metric{"foo": "bar"},
+		},
 	}
 	api.OnQueryTime(`rate(istio_requests_total{source_workload_namespace="istio-system",source_cluster="east"}[5m]) > 0`, &queryTime, vectorQ2)
 
@@ -95,7 +98,7 @@ func TestGetNamespaceServicesRequestRates(t *testing.T) {
 		return
 	}
 
-	queryTime := time.Date(2017, 01, 15, 0, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2017, 0o1, 15, 0, 0, 0, 0, time.UTC)
 
 	vectorQ1 := model.Vector{
 		&model.Sample{

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -374,6 +374,11 @@ func (o *PromClientMock) GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error) {
 	return args.Get(0).(prom_v1.RuntimeinfoResult), args.Error(1)
 }
 
+func (o *PromClientMock) API() prom_v1.API {
+	args := o.Called()
+	return args.Get(0).(prom_v1.API)
+}
+
 func (o *PromClientMock) MockMetric(name string, labels string, q *prometheus.RangeQuery, value float64) {
 	o.On("FetchRateRange", name, []string{labels}, "", q).Return(fakeMetric(value))
 }

--- a/server/metrics_server.go
+++ b/server/metrics_server.go
@@ -14,8 +14,7 @@ import (
 var metricsServer *http.Server
 
 // StartMetricsServer starts a new HTTP server forthat exposes Kiali internal metrics in Prometheus format
-func StartMetricsServer() {
-	conf := config.Get()
+func StartMetricsServer(conf *config.Config) {
 	log.Infof("Starting Metrics Server on [%v:%v]", conf.Server.Address, conf.Server.Observability.Metrics.Port)
 	metricsServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", conf.Server.Address, conf.Server.Observability.Metrics.Port),

--- a/server/server.go
+++ b/server/server.go
@@ -132,7 +132,7 @@ func (s *Server) Start() {
 
 	// Start the Metrics Server
 	if s.conf.Server.Observability.Metrics.Enabled {
-		StartMetricsServer()
+		StartMetricsServer(s.conf)
 	}
 }
 


### PR DESCRIPTION
### Describe the change

Updates the prom client interface so the interface can be used in the graph handlers. Passes the home cluster service account token into the prom client constructor rather than trying to read it from the local service account file.

### Steps to test the PR

Regression test

### Automation testing

N/A

### Issue reference

Relates to #8262 and #8274. This is probably 95% of what's needed for being able to choose which cluster to pass the service account token from.
