### PR TITLE
Run External kiali CI with openid auth strategy

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -69,45 +69,45 @@ jobs:
     with:
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_backend:
-  #   name: Run backend integration tests
-  #   uses: ./.github/workflows/integration-tests-backend.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_backend:
+    name: Run backend integration tests
+    uses: ./.github/workflows/integration-tests-backend.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_backend_multicluster_external_controlplane:
-  #   name: Run backend multicluster external-controlplane integration tests
-  #   uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_backend_multicluster_external_controlplane:
+    name: Run backend multicluster external-controlplane integration tests
+    uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_frontend:
-  #   name: Run frontend integration tests
-  #   uses: ./.github/workflows/integration-tests-frontend.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_frontend:
+    name: Run frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_frontend_multicluster_primary_remote:
-  #   name: Run frontend multicluster primary-remote integration tests
-  #   uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_frontend_multicluster_primary_remote:
+    name: Run frontend multicluster primary-remote integration tests
+    uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_frontend_multicluster_multi_primary:
-  #   name: Run frontend multicluster multi-primary integration tests
-  #   uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_frontend_multicluster_multi_primary:
+    name: Run frontend multicluster multi-primary integration tests
+    uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
   integration_tests_frontend_multicluster_external_kiali:
     name: Run frontend multicluster external-kiali integration tests
@@ -117,18 +117,18 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_frontend_ambient:
-  #   name: Run Ambient frontend integration tests
-  #   uses: ./.github/workflows/integration-tests-frontend-ambient.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_frontend_ambient:
+    name: Run Ambient frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend-ambient.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  # integration_tests_frontend_tempo:
-  #   name: Run tracing frontend integration tests
-  #   uses: ./.github/workflows/integration-tests-frontend-tempo.yml
-  #   needs: [initialize, build_backend]
-  #   with:
-  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
-  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  integration_tests_frontend_tempo:
+    name: Run tracing frontend integration tests
+    uses: ./.github/workflows/integration-tests-frontend-tempo.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -69,45 +69,45 @@ jobs:
     with:
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_backend:
-    name: Run backend integration tests
-    uses: ./.github/workflows/integration-tests-backend.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_backend:
+  #   name: Run backend integration tests
+  #   uses: ./.github/workflows/integration-tests-backend.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_backend_multicluster_external_controlplane:
-    name: Run backend multicluster external-controlplane integration tests
-    uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_backend_multicluster_external_controlplane:
+  #   name: Run backend multicluster external-controlplane integration tests
+  #   uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_frontend:
-    name: Run frontend integration tests
-    uses: ./.github/workflows/integration-tests-frontend.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_frontend:
+  #   name: Run frontend integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_frontend_multicluster_primary_remote:
-    name: Run frontend multicluster primary-remote integration tests
-    uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_frontend_multicluster_primary_remote:
+  #   name: Run frontend multicluster primary-remote integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_frontend_multicluster_multi_primary:
-    name: Run frontend multicluster multi-primary integration tests
-    uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_frontend_multicluster_multi_primary:
+  #   name: Run frontend multicluster multi-primary integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
   integration_tests_frontend_multicluster_external_kiali:
     name: Run frontend multicluster external-kiali integration tests
@@ -117,18 +117,18 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_frontend_ambient:
-    name: Run Ambient frontend integration tests
-    uses: ./.github/workflows/integration-tests-frontend-ambient.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_frontend_ambient:
+  #   name: Run Ambient frontend integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend-ambient.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  integration_tests_frontend_tempo:
-    name: Run tracing frontend integration tests
-    uses: ./.github/workflows/integration-tests-frontend-tempo.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
+  # integration_tests_frontend_tempo:
+  #   name: Run tracing frontend integration tests
+  #   uses: ./.github/workflows/integration-tests-frontend-tempo.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -325,11 +325,12 @@ subjects:
   name: oidc:kiali
 EOF
 
-      # Role to access bookinfo
-      kubectl apply --context "${CLUSTER1_CONTEXT}" -f ${SCRIPT_DIR}/roleBookinfo.yaml
+      # Role to access bookinfo - only if bookinfo namespace exists
+      if kubectl get namespace bookinfo --context "${CLUSTER1_CONTEXT}" >/dev/null 2>&1; then
+        kubectl apply --context "${CLUSTER1_CONTEXT}" -f ${SCRIPT_DIR}/roleBookinfo.yaml
 
-      # Create a rolebinding
-      kubectl apply --context "${CLUSTER1_CONTEXT}" -f - <<EOF
+        # Create a rolebinding
+        kubectl apply --context "${CLUSTER1_CONTEXT}" -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -343,6 +344,9 @@ subjects:
 - kind: User
   name: oidc:bookinfouser
 EOF
+      else
+        echo "Skipping bookinfo role setup - bookinfo namespace does not exist on cluster ${CLUSTER1_NAME}"
+      fi
 
     fi
 

--- a/hack/istio/multicluster/install-external-kiali.sh
+++ b/hack/istio/multicluster/install-external-kiali.sh
@@ -32,9 +32,6 @@ fi
 IGNORE_HOME_CLUSTER="true"
 SINGLE_KIALI="true"
 
-# TODO: need to see this work with openshift auth
-KIALI_AUTH_STRATEGY="anonymous"
-
 create_crossnetwork_gateway() {
   local clustername="${1}"
   local network="${2}"
@@ -169,8 +166,21 @@ if [ "${MANAGE_KIND}" == "true" ]; then
       --keycloak-certs-dir "${KEYCLOAK_CERTS_DIR}" \
       --keycloak-issuer-uri https://"${KEYCLOAK_ADDRESS}"/realms/kube \
       --image "${KIND_NODE_IMAGE}"
-
-    "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" -kip "${KEYCLOAK_ADDRESS}" deploy
+    
+    # Optional: keycloak memory limits
+    KEYCLOAK_LIMIT_MEMORY="${KEYCLOAK_LIMIT_MEMORY:-}"
+    KEYCLOAK_REQUESTS_MEMORY="${KEYCLOAK_REQUESTS_MEMORY:-}"
+    if [ -n "$KEYCLOAK_LIMIT_MEMORY" ]; then
+      MEMORY_LIMIT_ARG="-slm $KEYCLOAK_LIMIT_MEMORY"
+    else
+      MEMORY_LIMIT_ARG=""
+    fi
+    if [ -n "$KEYCLOAK_REQUESTS_MEMORY" ]; then
+      MEMORY_REQUEST_ARG="-srm $KEYCLOAK_REQUESTS_MEMORY"
+    else
+      MEMORY_REQUEST_ARG=""
+    fi
+    "${SCRIPT_DIR}/../../keycloak.sh" -kcd "${KEYCLOAK_CERTS_DIR}" -kip "${KEYCLOAK_ADDRESS}" $MEMORY_LIMIT_ARG $MEMORY_REQUEST_ARG deploy
 
     echo "==== START KIND FOR CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
     "${SCRIPT_DIR}"/../../start-kind.sh \

--- a/hack/istio/multicluster/install-external-kiali.sh
+++ b/hack/istio/multicluster/install-external-kiali.sh
@@ -33,7 +33,7 @@ IGNORE_HOME_CLUSTER="true"
 SINGLE_KIALI="true"
 
 # TODO: need to see this work with openshift auth
-KIALI_AUTH_STRATEGY="openid"
+KIALI_AUTH_STRATEGY="anonymous"
 
 create_crossnetwork_gateway() {
   local clustername="${1}"

--- a/hack/istio/multicluster/install-external-kiali.sh
+++ b/hack/istio/multicluster/install-external-kiali.sh
@@ -32,8 +32,8 @@ fi
 IGNORE_HOME_CLUSTER="true"
 SINGLE_KIALI="true"
 
-# TODO: just use anonymous auth until we have this working...
-KIALI_AUTH_STRATEGY="anonymous"
+# TODO: need to see this work with openshift auth
+KIALI_AUTH_STRATEGY="openid"
 
 create_crossnetwork_gateway() {
   local clustername="${1}"

--- a/hack/istio/multicluster/install-external-kiali.sh
+++ b/hack/istio/multicluster/install-external-kiali.sh
@@ -9,6 +9,10 @@
 #
 ##############################################################################
 
+infomsg() {
+  echo "[INFO] ${1}"
+}
+
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source ${SCRIPT_DIR}/env.sh $*
 

--- a/hack/istio/multicluster/install-multi-primary.sh
+++ b/hack/istio/multicluster/install-multi-primary.sh
@@ -11,6 +11,10 @@
 #
 ##############################################################################
 
+infomsg() {
+  echo "[INFO] ${1}"
+}
+
 SCRIPT_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source ${SCRIPT_DIR}/env.sh $*
 

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -521,8 +521,19 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_MULTI_PRIMARY}" ]; then
 elif [ "${TEST_SUITE}" == "${FRONTEND_EXTERNAL_KIALI}" ]; then
   ensureCypressInstalled
 
+  if [ -n "$KEYCLOAK_LIMIT_MEMORY" ]; then
+      MEMORY_LIMIT_ARG="-klm $KEYCLOAK_LIMIT_MEMORY"
+  else
+      MEMORY_LIMIT_ARG=""
+  fi
+  if [ -n "$KEYCLOAK_REQUESTS_MEMORY" ]; then
+     MEMORY_REQUEST_ARG="-krm $KEYCLOAK_REQUESTS_MEMORY"
+  else
+     MEMORY_REQUEST_ARG=""
+  fi
+
   if [ "${TESTS_ONLY}" == "false" ]; then
-    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "external-kiali" ${ISTIO_VERSION_ARG} --tempo ${TEMPO} ${HELM_CHARTS_DIR_ARG}
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --multicluster "external-kiali" ${ISTIO_VERSION_ARG} --auth-strategy openid --tempo ${TEMPO} ${HELM_CHARTS_DIR_ARG} $MEMORY_LIMIT_ARG $MEMORY_REQUEST_ARG
   fi
 
   ensureKialiServerReady

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -481,7 +481,7 @@ setup_kind_multicluster() {
     kubectl rollout status deployment prometheus -n istio-system --context kind-east
     kubectl rollout status deployment prometheus -n istio-system --context kind-west
   elif [ "${MULTICLUSTER}" == "${EXTERNAL_KIALI}" ]; then
-    "${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh --kiali-enabled false --manage-kind true -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
+    "${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh --kiali-enabled false --manage-kind true --certs-dir "${certs_dir}" -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
     cluster1_context="kind-mgmt"
     cluster2_context="kind-mesh"
     cluster1_name="mgmt"


### PR DESCRIPTION
Closes #8612 

Currently running with `anonymous`, but for upstream production we need to support `openid`.  This PR:

- changes the auth strategy for the external-kiali CI from `anonymous` to `openid`
- adds some missing keycloak support in the `install-external-kiali.sh` hack script
- protects `deploy-kiali.sh` from an assumption that bookinfo will always exist
- adds some missing `infomsg` support in a couple of hack scripts