### PR TITLE
[hack] update the resources that are purged, wait for CRDs to delete

### DIFF
--- a/hack/purge-kiali-from-cluster.sh
+++ b/hack/purge-kiali-from-cluster.sh
@@ -61,7 +61,7 @@ msg() {
   if [ "${DRY_RUN}" == "false" ]; then echo "$1"; else echo "DRY RUN: $1"; fi
 }
 
-msg "Deleting any and all Kiali resources that are found in the cluster..."
+msg "Deleting any and all Kiali and OSSMC resources that are found in the cluster..."
 
 delete_namespace_resources() {
   local selector_expression="$1"
@@ -84,7 +84,7 @@ delete_cluster_resources() {
 
   local openshift_resources=""
   if [[ "$CLIENT_EXE" = *"oc" ]]; then
-    openshift_resources=",oauthclients.oauth.openshift.io,consolelinks.console.openshift.io"
+    openshift_resources=",oauthclients.oauth.openshift.io,consolelinks.console.openshift.io,consoleplugins.console.openshift.io"
   fi
 
   for r in $(${CLIENT_EXE} get --ignore-not-found=true clusterroles,clusterrolebindings,customresourcedefinitions${openshift_resources} --selector="${selector_expression}" --all-namespaces -o custom-columns=K:.kind,N:.metadata.name --no-headers | sed 's/  */:/g')
@@ -110,11 +110,25 @@ do
   fi
 done
 
+msg "Deleting OSSMConsole CRs..."
+for o in $(${CLIENT_EXE} get ossmconsole --ignore-not-found=true --all-namespaces -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | sed 's/  */:/g')
+do
+  cr_namespace=$(echo $o | cut -d: -f1)
+  cr_name=$(echo $o | cut -d: -f2)
+  msg "Deleting OSSMConsole CR [${cr_name}] in namespace [${cr_namespace}]"
+  if [ "${DRY_RUN}" == "false" ]; then
+    ${CLIENT_EXE} patch ossmconsole ${cr_name} -n ${cr_namespace} -p '{"metadata":{"finalizers": []}}' --type=merge
+    ${CLIENT_EXE} delete ossmconsole ${cr_name} -n ${cr_namespace}
+  fi
+done
+
 # purge using the k8s labels
 delete_namespace_resources "app.kubernetes.io/name=kiali"
 delete_cluster_resources "app.kubernetes.io/name=kiali"
 delete_namespace_resources "app.kubernetes.io/name=kiali-operator"
 delete_cluster_resources "app.kubernetes.io/name=kiali-operator"
+delete_namespace_resources "app.kubernetes.io/name=ossmconsole"
+delete_cluster_resources "app.kubernetes.io/name=ossmconsole"
 
 # purge anything using the old labels
 delete_namespace_resources "app=kiali"
@@ -122,8 +136,8 @@ delete_cluster_resources "app=kiali"
 delete_namespace_resources "app=kiali-operator"
 delete_cluster_resources "app=kiali-operator"
 
-msg "Deleting Kiali CRDs..."
-for c in $(${CLIENT_EXE} get crds --ignore-not-found=true monitoringdashboards.monitoring.kiali.io kialis.kiali.io -o custom-columns=N:.metadata.name --no-headers)
+msg "Deleting Kiali and OSSMC CRDs..."
+for c in $(${CLIENT_EXE} get crds --ignore-not-found=true kialis.kiali.io ossmconsoles.kiali.io -o custom-columns=N:.metadata.name --no-headers)
 do
   msg "Deleting CRD [${c}]"
   if [ "${DRY_RUN}" == "false" ]; then
@@ -131,4 +145,25 @@ do
   fi
 done
 
-msg "Kiali has been completely purged from the cluster."
+if [ "${DRY_RUN}" == "false" ]; then
+  msg "Waiting for CRDs to be completely removed..."
+  timeout=60
+  elapsed=0
+  while [ ${elapsed} -lt ${timeout} ]; do
+    remaining_crds=$(${CLIENT_EXE} get crds --ignore-not-found=true kialis.kiali.io ossmconsoles.kiali.io -o custom-columns=N:.metadata.name --no-headers 2>/dev/null | wc -l)
+    if [ "${remaining_crds}" -eq 0 ]; then
+      msg "All Kiali and OSSMC CRDs have been removed."
+      break
+    fi
+    msg "Still waiting for ${remaining_crds} CRD(s) to be removed... (${elapsed}s elapsed)"
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  if [ ${elapsed} -ge ${timeout} ]; then
+    msg "WARNING: Timeout waiting for CRDs to be removed. Some CRDs may still be in deletion state."
+    ${CLIENT_EXE} get crds --ignore-not-found=true kialis.kiali.io ossmconsoles.kiali.io 2>/dev/null || true
+  fi
+fi
+
+msg "Kiali and OSSMC have been completely purged from the cluster."


### PR DESCRIPTION
this was mainly because when I ask Cursor to run molecule tests, sometimes it needs to purge kiali resources and when it does it seems like it goes so fast the CRD doesn't clean up and the test fails. I am not convinced this fixes the problem entirely, but it helps.