### PR TITLE
Overview page: Load controlplanes before namespaces

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -230,8 +230,15 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
   load = (): void => {
     this.promises.cancelAll();
 
+    // First fetch control planes, then fetch namespaces
     this.promises
-      .register('namespaces', API.getNamespaces())
+      .register('controlPlanes', API.getControlPlanes())
+      .then(controlPlanesResponse => {
+        this.setState({
+          controlPlanes: controlPlanesResponse.data
+        });
+        return this.promises.register('namespaces', API.getNamespaces());
+      })
       .then(namespacesResponse => {
         const nameFilters = FilterSelected.getSelected().filters.filter(
           f => f.category === Filters.nameFilter.category
@@ -284,7 +291,6 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
             this.fetchHealth(isAscending, sortField, type);
             this.fetchTLS(isAscending, sortField);
             this.fetchValidations(isAscending, sortField);
-            this.fetchControlPlanes();
 
             if (displayMode !== OverviewDisplayMode.COMPACT) {
               this.fetchMetrics(direction);
@@ -292,9 +298,9 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
           }
         );
       })
-      .catch(namespacesError => {
-        if (!namespacesError.isCanceled) {
-          this.handleApiError('Could not fetch namespace list', namespacesError);
+      .catch(error => {
+        if (!error.isCanceled) {
+          this.handleApiError('Could not fetch Overview cards', error);
         }
       });
   };
@@ -633,18 +639,6 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
           type: MessageType.INFO,
           showNotification: false
         });
-      });
-  };
-
-  private fetchControlPlanes = async (): Promise<void> => {
-    return API.getControlPlanes()
-      .then(response => {
-        this.setState({
-          controlPlanes: response.data
-        });
-      })
-      .catch(error => {
-        AlertUtils.addError('Error fetching controlplanes.', error, 'default', MessageType.ERROR);
       });
   };
 
@@ -1397,9 +1391,12 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
             Istio API disabled
           </Label>
         )}
-        
+
         {serverConfig.ambientEnabled && !isControlPlane && ns.labels && ns.isAmbient && (
-          <AmbientBadge tooltip={tooltip ? 'labeled as part of Ambient Mesh' : undefined} data-test="ambient-badge"></AmbientBadge>
+          <AmbientBadge
+            tooltip={tooltip ? 'labeled as part of Ambient Mesh' : undefined}
+            data-test="ambient-badge"
+          ></AmbientBadge>
         )}
       </>
     );


### PR DESCRIPTION
### Describe the change

In Overview page, ControlPlanes is necessary for putting badges on cards, make sure it loads first before Namespaces.
POC

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/8627
