### PR TITLE
Hack script for installing Kiali on RHDH as a dynamic plugin

### DIFF
--- a/hack/backstage/install-kiali-rhdh.sh
+++ b/hack/backstage/install-kiali-rhdh.sh
@@ -56,7 +56,7 @@ log "Channel: ${CHANNEL} | Source: ${SOURCE}"
 log "Kiali URL: ${KIALI_URL}"
 log "Plugin tags -> frontend: ${FRONTEND_TAG} | backend: ${BACKEND_TAG}"
 log "Backstage BASE_URL: ${BASE_URL}"
-log "Skip subscription: ${SKIP_SUSCRIPTION}"
+log "Skip subscription: ${SKIP_SUBSCRIPTION}"
 
 # 0) Namespaces
 log "Ensuring namespaces exist..."


### PR DESCRIPTION
Follow up PR for https://github.com/kiali/kiali/pull/8587

As @aljesusg commented, the idea was also to have an script to install Kiali as a dynamic plugin in RHDH on OpenShift.

This script does that, but just that, it assumes:

* You have an OpenShift cluster
* You have Istio and Kiali installed

The result will be a RHDH instance (Backstage) with the Kiali dynamic plugin installed (frontend and backend). It also will pre load the entities that we have in https://github.com/backstage/community-plugins/blob/main/workspaces/kiali/examples/kialiEntities.yaml

The nice thing of this method is that is just configuration as code and there is no need to recompile and rebuild Backstage as in upstream.