### PR TITLE
Fixed Workload Validations style

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -49,6 +49,11 @@ const iconStyle = kialiStyle({
   display: 'inline-block'
 });
 
+const blockElementStyle = kialiStyle({
+  display: 'block',
+  marginTop: '0.125rem'
+});
+
 const workloadInfoStyle = kialiStyle({
   verticalAlign: '-0.125rem'
 });
@@ -232,7 +237,7 @@ export const WorkloadDescription: React.FC<WorkloadDescriptionProps> = (props: W
         <WorkloadConfigValidation
           validations={workload.validations!['workload'][validationKey(workload.name, workload.namespace)]}
           namespace={props.namespace}
-          className={classes(workloadInfoStyle)}
+          className={classes(workloadInfoStyle, blockElementStyle)}
           iconSize={'md'}
           detailed={true}
         />


### PR DESCRIPTION
### Describe the change

In a case when cluster name was shown in Workload Details page, the Validations icon was on the same line with it,
fixed now to be on a new line:
<img width="571" height="374" alt="Screenshot From 2025-08-18 09-02-05" src="https://github.com/user-attachments/assets/fa0db272-6e63-4a3d-9fe5-d82d81a890ec" />


### Steps to test the PR

Multicluster env.

### Automation testing

n/a

### Issue reference
https://github.com/kiali/kiali/issues/8648
