### PR TITLE
[ambient] avoid circular calling when fetching workloads with waypoint information

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -474,7 +474,7 @@ func (in *AppService) fetchNamespaceApps(ctx context.Context, namespace string, 
 
 	appNameSelectors := in.conf.GetAppVersionLabelSelectors(appName, "")
 	for _, appNameSelector := range appNameSelectors {
-		selectedWorkloads, err := in.businessLayer.Workload.fetchWorkloadsFromCluster(ctx, cluster, namespace, appNameSelector.LabelSelector)
+		selectedWorkloads, err := in.businessLayer.Workload.GetNamespaceWorkloads(ctx, cluster, namespace, appNameSelector.LabelSelector)
 		if err != nil {
 			return nil, err
 		}

--- a/business/health.go
+++ b/business/health.go
@@ -287,7 +287,7 @@ func (in *HealthService) GetNamespaceWorkloadHealth(ctx context.Context, criteri
 		return nil, err
 	}
 
-	wl, err := in.businessLayer.Workload.fetchWorkloadsFromCluster(ctx, cluster, namespace, "")
+	wl, err := in.businessLayer.Workload.GetNamespaceWorkloads(ctx, cluster, namespace, "")
 	if err != nil {
 		return nil, err
 	}

--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -182,7 +182,7 @@ func (iss *IstioStatusService) getComponentNamespacesWorkloads(ctx context.Conte
 				defer wg.Done()
 				var wls models.Workloads
 				var err error
-				wls, err = iss.workloads.fetchWorkloadsFromCluster(ctx, cluster, n, "")
+				wls, err = iss.workloads.GetNamespaceWorkloads(ctx, cluster, n, "")
 				wliChan <- wls
 				errChan <- err
 			}(ctx, n, wlChan, errChan)

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -87,7 +87,7 @@ func TestComponentNotRunning(t *testing.T) {
 			ds,
 		)
 		wl := &models.Workload{}
-		wl.ParseDeployment(d)
+		wl.ParseDeployment(d, config.Get())
 		assert.Equal(kubernetes.ComponentUnhealthy, GetWorkloadStatus(*wl))
 	}
 }
@@ -105,7 +105,7 @@ func TestComponentRunning(t *testing.T) {
 		})
 
 	wl := &models.Workload{}
-	wl.ParseDeployment(d)
+	wl.ParseDeployment(d, config.Get())
 
 	assert.Equal(kubernetes.ComponentHealthy, GetWorkloadStatus(*wl))
 }

--- a/business/services.go
+++ b/business/services.go
@@ -487,7 +487,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 		go func(ctx context.Context) {
 			defer wg.Done()
 			var err2 error
-			ws, err2 = in.businessLayer.Workload.fetchWorkloadsFromCluster(ctx, cluster, namespace, labelsSelector)
+			ws, err2 = in.businessLayer.Workload.GetNamespaceWorkloads(ctx, cluster, namespace, labelsSelector)
 			if err2 != nil {
 				log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err2)
 				errChan <- err2
@@ -724,7 +724,7 @@ func (in *SvcService) GetWaypointsForService(ctx context.Context, svc *models.Se
 
 	// then, get the waypoint workloads to filter out "forNone" waypoints
 	for _, waypoint := range waypoints {
-		waypointWorkload, err := in.businessLayer.Workload.fetchWorkload(ctx, WorkloadCriteria{Cluster: svc.Cluster, Namespace: waypoint.Namespace, WorkloadName: waypoint.Name, WorkloadGVK: schema.GroupVersionKind{}, IncludeWaypoints: false})
+		waypointWorkload, err := in.businessLayer.Workload.GetWorkload(ctx, WorkloadCriteria{Cluster: svc.Cluster, Namespace: waypoint.Namespace, WorkloadName: waypoint.Name, WorkloadGVK: schema.GroupVersionKind{}, IncludeWaypoints: false})
 		if err != nil {
 			log.Debugf("GetWaypointsForService: Error fetching waypoint workload %s", err.Error())
 			return nil

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1479,16 +1479,15 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 
 		if cnFound {
 			// Add the Proxy Status to the workload
+			addedWaypointsForWorkload := false
 			for _, pod := range w.Pods {
 				isWaypoint := w.IsWaypoint()
 				if in.conf.ExternalServices.Istio.IstioAPIEnabled && (pod.HasIstioSidecar() || isWaypoint) {
 					pod.ProxyStatus = in.businessLayer.ProxyStatus.GetPodProxyStatus(cluster, namespace, pod.Name, !isWaypoint)
 				}
-				// Add the Proxy Status to the workload
-				if pod.AmbientEnabled() {
+				if !addedWaypointsForWorkload && pod.AmbientEnabled() {
 					w.WaypointWorkloads = in.getWaypointsForWorkload(ctx, *w, false, waypoints)
-					// only need to do this work one time per workload
-					break
+					addedWaypointsForWorkload = true
 				}
 			}
 

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestParseDeploymentToWorkload(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewConfig()
-	cfg.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
+	conf := config.NewConfig()
+	conf.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
 		{
 			Annotation: "annotation-2",
 			Title:      "Annotation 2",
@@ -32,11 +32,11 @@ func TestParseDeploymentToWorkload(t *testing.T) {
 			Title:      "Annotation 4",
 		},
 	}
-	config.Set(cfg)
+	config.Set(conf)
 
 	w := Workload{}
 	d := fakeDeployment()
-	w.ParseDeployment(d)
+	w.ParseDeployment(d, conf)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -54,23 +54,23 @@ func TestParseDeploymentToWorkload(t *testing.T) {
 	// TODO: The parsing is actually clobbering the Deployment.Annotations if Template.Annotations
 	// is set but fixing it may cause unintended side effects so putting this test after the rest.
 	d.Spec.Template.Annotations = map[string]string{"food": "pizza", "drink": "soda"}
-	w.ParseDeployment(d)
+	w.ParseDeployment(d, conf)
 	assert.Equal(w.TemplateAnnotations, d.Spec.Template.Annotations)
 }
 
 func TestParseReplicaSetToWorkload(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewConfig()
-	cfg.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
+	conf := config.NewConfig()
+	conf.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
 		{
 			Annotation: "annotation",
 			Title:      "Annotation",
 		},
 	}
-	config.Set(cfg)
+	config.Set(conf)
 
 	w := Workload{}
-	w.ParseReplicaSet(fakeReplicaSet())
+	w.ParseReplicaSet(fakeReplicaSet(), conf)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -87,17 +87,17 @@ func TestParseReplicaSetToWorkload(t *testing.T) {
 
 func TestParseReplicationControllerToWorkload(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewConfig()
-	cfg.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
+	conf := config.NewConfig()
+	conf.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
 		{
 			Annotation: "annotation",
 			Title:      "Annotation",
 		},
 	}
-	config.Set(cfg)
+	config.Set(conf)
 
 	w := Workload{}
-	w.ParseReplicationController(fakeReplicationController())
+	w.ParseReplicationController(fakeReplicationController(), conf)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -114,17 +114,17 @@ func TestParseReplicationControllerToWorkload(t *testing.T) {
 
 func TestParseDeploymentConfigToWorkload(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewConfig()
-	cfg.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
+	conf := config.NewConfig()
+	conf.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
 		{
 			Annotation: "annotation",
 			Title:      "Annotation",
 		},
 	}
-	config.Set(cfg)
+	config.Set(conf)
 
 	w := Workload{}
-	w.ParseDeploymentConfig(fakeDeploymentConfig())
+	w.ParseDeploymentConfig(fakeDeploymentConfig(), conf)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -140,17 +140,17 @@ func TestParseDeploymentConfigToWorkload(t *testing.T) {
 
 func TestParsePodToWorkload(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewConfig()
-	cfg.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
+	conf := config.NewConfig()
+	conf.AdditionalDisplayDetails = []config.AdditionalDisplayItem{
 		{
 			Annotation: "annotation",
 			Title:      "Annotation",
 		},
 	}
-	config.Set(cfg)
+	config.Set(conf)
 
 	w := Workload{}
-	w.ParsePod(fakePod())
+	w.ParsePod(fakePod(), conf)
 
 	assert.Equal("reviews-v1", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -169,7 +169,7 @@ func TestParseWaypointPodToWorkload(t *testing.T) {
 	assert := assert.New(t)
 
 	w := Workload{}
-	w.ParsePod(fakeWaypointPod())
+	w.ParsePod(fakeWaypointPod(), config.Get())
 
 	assert.Equal("waypoint", w.Name)
 	assert.Equal("istio.io-mesh-controller", w.Labels["gateway.istio.io/managed"])
@@ -189,7 +189,7 @@ func TestParsePodsToWorkload(t *testing.T) {
 	config.Set(config.NewConfig())
 
 	w := Workload{}
-	w.ParsePods("workload-from-controller", schema.GroupVersionKind{Kind: "Controller"}, []core_v1.Pod{*fakePod()})
+	w.ParsePods("workload-from-controller", schema.GroupVersionKind{Kind: "Controller"}, []core_v1.Pod{*fakePod()}, config.NewConfig())
 
 	assert.Equal("workload-from-controller", w.Name)
 	assert.Equal("bar", w.Labels["foo"])
@@ -208,7 +208,7 @@ func TestParsePodWithoutLabelsToWorkload(t *testing.T) {
 	fakePod := fakePod()
 	fakePod.Labels = nil
 	w := Workload{}
-	w.ParsePod(fakePod)
+	w.ParsePod(fakePod, config.Get())
 
 	assert.Equal(map[string]string{}, w.Labels)
 }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/8657

Several WorkloadService functions, most notably `GetAllWorkloads`, had the potential for a circular call paths in ambient environments. The resulting recursion could cause OOM or perf issues.  The fundamental problem is that the required logic is a bit circular, where we want to decorate workloads with waypoint information, but waypoints themselves are workloads.

The updated approach is to ensure, when needed, that we first fetch all waypoint workloads, and then pass the waypoints down into the logic collecting the requested workloads. The prior logic fetched the waypoint workloads as needed, but that could end up calling the original entry points functions.

I considered gathering the Waypoints at in NewWorkloadService(), so they would always be available and wouldn't need to be passed around as function parameters. But, I wasn't sure about if it was appropriate given that it requires context, and we typically don't put this sort of information in a Service object.

Although this is a bug, we are fundamentally trying to address resource consumption at startup, and at other times. So, this PR is also replacing the per-namespace workload-fetch approach, with a cross-namespace fetch, with applicable filtering. It also removes a lot of config fetch/copy when parsing pods and workloads.

I pivoted away from this first approach, which had the benefit of maybe being more efficient but ended up being incomplete and also requiring more test wiring. This was the first idea:
  - remove redundant calls to GetWaypointsForWorkload
  - remove calls to GetAllWorkloads() in GetWaypoints()
    - replace with a straight fetch of just the Deployments
    - limit the workload information returned
