### PR TITLE
Don't add GH actor if it is empty

### DIFF
--- a/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+++ b/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_backend:

--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -17,7 +17,8 @@ on:
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
   # BUILD_BRANCH is used by setup-kind-in-ci.sh to locate a matching helm-charts branch.
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  # If build_branch is empty, fallback to target_branch
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_backend:

--- a/.github/workflows/integration-tests-frontend-ambient.yml
+++ b/.github/workflows/integration-tests-frontend-ambient.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_frontend:

--- a/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_frontend_multicluster_multi_primary:

--- a/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_frontend_multicluster:

--- a/.github/workflows/integration-tests-frontend-tempo.yml
+++ b/.github/workflows/integration-tests-frontend-tempo.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_frontend:

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
-  BUILD_BRANCH: ${{ inputs.build_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
 
 jobs:
   integration_tests_frontend:

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -156,7 +156,12 @@ if [ -z "${HELM_CHARTS_DIR}" ]; then
   # that branch does not exist in the helm-charts repo, gracefully fall back to
   # TARGET_BRANCH, and finally to 'master'.
   CANDIDATE_BRANCHES=("${BUILD_BRANCH}" "${GITHUB_HEAD_REF}" "${TARGET_BRANCH}" "master")
-  CANDIDATE_OWNERS=("${GITHUB_ACTOR}" "kiali")
+  # Only add GITHUB_ACTOR if it's not empty to avoid malformed URLs
+  CANDIDATE_OWNERS=()
+  if [ -n "${GITHUB_ACTOR}" ]; then
+    CANDIDATE_OWNERS+=("${GITHUB_ACTOR}")
+  fi
+  CANDIDATE_OWNERS+=("kiali")
 
   HELM_CHARTS_BRANCH=""
   for b in "${CANDIDATE_BRANCHES[@]}"; do

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -156,12 +156,6 @@ if [ -z "${HELM_CHARTS_DIR}" ]; then
   # that branch does not exist in the helm-charts repo, gracefully fall back to
   # TARGET_BRANCH, and finally to 'master'.
   CANDIDATE_BRANCHES=("${BUILD_BRANCH}" "${GITHUB_HEAD_REF}" "${TARGET_BRANCH}" "master")
-  # Only add GITHUB_ACTOR if it's not empty to avoid malformed URLs
-  CANDIDATE_OWNERS=()
-  if [ -n "${GITHUB_ACTOR}" ]; then
-    CANDIDATE_OWNERS+=("${GITHUB_ACTOR}")
-  fi
-  CANDIDATE_OWNERS+=("kiali")
 
   HELM_CHARTS_BRANCH=""
   for b in "${CANDIDATE_BRANCHES[@]}"; do
@@ -171,6 +165,25 @@ if [ -z "${HELM_CHARTS_DIR}" ]; then
       infomsg " -> branch skipped (empty)"
       continue
     fi
+
+    # For master branch, prioritize the official kiali repo over forks
+    # For other branches, try the PR author's fork first, then fall back to kiali repo
+    # Only add GITHUB_ACTOR if it's not empty to avoid malformed URLs
+    CANDIDATE_OWNERS=()
+    if [ "${b}" = "master" ]; then
+      # For master, prioritize kiali repo first
+      CANDIDATE_OWNERS+=("kiali")
+      if [ -n "${GITHUB_ACTOR}" ]; then
+        CANDIDATE_OWNERS+=("${GITHUB_ACTOR}")
+      fi
+    else
+      # For feature branches, try author's fork first
+      if [ -n "${GITHUB_ACTOR}" ]; then
+        CANDIDATE_OWNERS+=("${GITHUB_ACTOR}")
+      fi
+      CANDIDATE_OWNERS+=("kiali")
+    fi
+
     for owner in "${CANDIDATE_OWNERS[@]}"; do
       repo_url="https://github.com/${owner}/helm-charts.git"
       infomsg "Evaluating helm-charts branch [${b}] of owner [${owner}]: ${repo_url}"


### PR DESCRIPTION
### Describe the change

Running from master I've go the error: 

```
=== SETTINGS ===
[INFO] Running backend-external-controlplane integration tests
Istio install script: ~/kiali_sources/kiali/hack/istio/install-istio-via-sail.sh
[INFO] Evaluating helm-charts branch candidate: []
[INFO]  -> branch skipped (empty)
[INFO] Evaluating helm-charts branch candidate: []
[INFO]  -> branch skipped (empty)
[INFO] Evaluating helm-charts branch candidate: [master]
[INFO] Evaluating helm-charts branch [master] of owner []: https://github.com//helm-charts.git
Username for 'https://github.com': 
```

Git this change, just kiali is set (Not empty string) 

Also, use TARGET_BRANCH when BUILD_BRANCH is empty

### Steps to test the PR

Run any test suite, for example: 

`hack/run-integration-tests.sh --test-suite backend-external-controlplane`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/8545 
