### PR TITLE
[hack] update CRC to 4.19

### DIFF
--- a/hack/crc-openshift.sh
+++ b/hack/crc-openshift.sh
@@ -509,10 +509,10 @@ SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPT_ROOT}
 
 # The default version of the crc tool to be downloaded
-DEFAULT_CRC_DOWNLOAD_VERSION="2.49.0"
+DEFAULT_CRC_DOWNLOAD_VERSION="2.53.0"
 
 # The default version of the crc bundle - this is typically the version included with the CRC download
-DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.18.2"
+DEFAULT_CRC_LIBVIRT_DOWNLOAD_VERSION="4.19.3"
 
 # The default virtual CPUs assigned to the CRC VM
 DEFAULT_CRC_CPUS="6"


### PR DESCRIPTION
to test:

`hack/crc-openshift.sh start -p <location of your pull secret file>`

This should start OpenShift 4.19 on your local machine.

`oc version` results in something like:

```
$ oc version
Client Version: 4.19.0-202507011209.p0.g298429b.assembly.stream.el9-298429b
Kustomize Version: v5.5.0
Server Version: 4.19.3
Kubernetes Version: v1.32.5
```

Check your "oc" client - it might be time for you to upgrade :) You can download the 4.19 oc directly from the CRC instance that you started up --> https://console-openshift-console.apps-crc.testing/command-line-tools