### PR TITLE
[CI] Remove support in testing for Istio 1.23

### DIFF
--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -246,7 +246,6 @@ Feature: Kiali Waypoint related features
     And user "disables" "http" traffic option
     Then 2 edges appear in the graph
 
-  @skip-istio-1-23
   Scenario: [Traffic] Waypoint for workload
     Given user is at the "graph" page
     When user graphs "waypoint-forworkload" namespaces
@@ -261,7 +260,6 @@ Feature: Kiali Waypoint related features
     And the "unknown" service "does" exists
     And the "curl-client" node "does" exists
 
-  @skip-istio-1-23
   Scenario: [Traffic] Waypoint for workload with waypoints
     Given user is at the "graph" page
     When user graphs "waypoint-forworkload" namespaces
@@ -387,7 +385,6 @@ Feature: Kiali Waypoint related features
     When the user goes to the "Logs" tab
     Then the user updates the log level to "Debug"
 
-  @skip-istio-1-23
   Scenario: [Traffic] Sidecar Ambient traffic
     Given user is at the "graph" page
     When user graphs "test-ambient,test-sidecar" namespaces

--- a/hack/istio/functions.sh
+++ b/hack/istio/functions.sh
@@ -41,29 +41,3 @@ is_istio_version_eq_greater_than() {
   fi
 
 }
-
-# Returns 0 if the istio version is greater than specified, 0 otherwise, using two arguments
-is_istio_version_eq_greater_than_expected() {
-  local expected_version=$1
-  local istio_version=$2
-
-  istio_expected_version=$(echo "$expected_version" | cut -d'-' -f1)
-
-  IFS='.' read -r major minor patch <<< "$istio_version"
-  IFS='.' read -r major_expected minor_expected patch_expected <<< "$istio_expected_version"
-  IFS=' '
-  if [ "${major}" -lt "${major_expected}" ]; then
-    return 1
-  else
-    if [ "${major}" -eq "${major_expected}" ]; then
-      if [ "${minor}" -lt "${minor_expected}" ]; then
-        return 0
-      else
-        return 1
-      fi
-    else
-      return 0
-    fi
-  fi
-
-}

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -175,7 +175,6 @@ fi
 
 # Determine where this script is and make it the cwd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-source ${SCRIPT_DIR}/istio/functions.sh
 
 # This is used in multiple places and you need to call 'setKialiURL' first.
 KIALI_URL=""
@@ -411,7 +410,6 @@ elif [ "${TEST_SUITE}" == "${FRONTEND}" ]; then
   yarn run cypress:run
   detectRaceConditions
 elif [ "${TEST_SUITE}" == "${FRONTEND_AMBIENT}" ]; then
-
   ensureCypressInstalled
   ensureKialiTracesReady "true"
 
@@ -435,25 +433,8 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_AMBIENT}" ]; then
   fi
 
   cd "${SCRIPT_DIR}"/../frontend
-
-  # TODO: Remove when no support for Istio 1.23 is required
-  # Replace by "yarn run cypress:run:ambient"
-  if [ "${ISTIO_VERSION}" != "" ]; then
-    set +e
-    is_istio_version_eq_greater_than_expected "1.24.0" "${ISTIO_VERSION}"
-    status=$?
-    if [ "$status" -eq 0 ]; then
-      yarn run cypress:run:ambient123
-    else
-      yarn run cypress:run:ambient
-    fi
-    set -e
-  else
-    yarn run cypress:run:ambient
-  fi
-
+  yarn run cypress:run:ambient
   detectRaceConditions
-
 elif [ "${TEST_SUITE}" == "${FRONTEND_PRIMARY_REMOTE}" ]; then
   ensureCypressInstalled
   


### PR DESCRIPTION
This reverts commit e3d2c4c7345071f0718f50685e9c164e0c955212.

### Describe the change

As istio 1.23 is no longer supported, remove the code for testing handling this version

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
