### PR TITLE
Use prom client interface for getting build info

### DIFF
--- a/handlers/mesh.go
+++ b/handlers/mesh.go
@@ -80,7 +80,7 @@ func MeshGraph(
 			o.MeshName = meshId
 		}
 
-		code, payload := api.GraphMesh(r.Context(), business, o, clientFactory, cache, conf, grafana, perses, discovery)
+		code, payload := api.GraphMesh(r.Context(), business, o, clientFactory, cache, conf, grafana, perses, prom, discovery)
 		respond(w, code, payload)
 	}
 }

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +122,14 @@ func TestGetMeshGraph(t *testing.T) {
 	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 	prom.Inject(xapi)
+
+	// Add mock expectation for Buildinfo to fix the test
+	xapi.On("Buildinfo", mock.AnythingOfType("*context.valueCtx")).Return(prom_v1.BuildinfoResult{
+		Version:   "2.35.0",
+		BuildDate: "2023-01-01T00:00:00Z",
+		Revision:  "abcdef123456",
+	}, nil)
+
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := func() tracing.ClientInterface { return nil }
 

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/perses"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/status"
 )
 
@@ -19,8 +20,8 @@ func Healthz(w http.ResponseWriter, r *http.Request) {
 }
 
 // Root provides basic status of the server.
-func Root(conf *config.Config, clientFactory kubernetes.ClientFactory, cache cache.KialiCache, grafana *grafana.Service, perses *perses.Service) http.HandlerFunc {
+func Root(conf *config.Config, clientFactory kubernetes.ClientFactory, cache cache.KialiCache, grafana *grafana.Service, perses *perses.Service, prom prometheus.ClientInterface) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		RespondWithJSONIndent(w, http.StatusOK, status.Get(r.Context(), conf, clientFactory, cache, grafana, perses))
+		RespondWithJSONIndent(w, http.StatusOK, status.Get(r.Context(), conf, clientFactory, cache, grafana, perses, prom))
 	}
 }

--- a/mesh/api/api.go
+++ b/mesh/api/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kiali/kiali/mesh/generator"
 	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/perses"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/prometheus/internalmetrics"
 )
 
@@ -33,6 +34,7 @@ func GraphMesh(
 	conf *config.Config,
 	grafana *grafana.Service,
 	perses *perses.Service,
+	prom prometheus.ClientInterface,
 	discovery *istio.Discovery,
 ) (code int, config interface{}) {
 	var end observability.EndFunc
@@ -50,6 +52,7 @@ func GraphMesh(
 	globalInfo.Grafana = grafana
 	globalInfo.IstioStatusGetter = &business.IstioStatus
 	globalInfo.KialiCache = kialiCache
+	globalInfo.PromClient = prom
 	globalInfo.Perses = perses
 
 	promtimer := internalmetrics.GetGraphGenerationTimePrometheusTimer("mesh", "mesh", false)

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kiali/kiali/mesh"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/perses"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/status"
 	"github.com/kiali/kiali/tests/data"
 )
@@ -265,7 +266,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 func mockMeshGraph(t *testing.T) (*mesh.GlobalInfo, error) {
 	globalInfo := setupMocks(t)
 
-	mesh.StatusGetter = func(context.Context, *config.Config, kubernetes.ClientFactory, cache.KialiCache, *grafana.Service, *perses.Service) status.StatusInfo {
+	mesh.StatusGetter = func(context.Context, *config.Config, kubernetes.ClientFactory, cache.KialiCache, *grafana.Service, *perses.Service, prometheus.ClientInterface) status.StatusInfo {
 		return status.StatusInfo{
 			ExternalServices: []models.ExternalServiceInfo{},
 		}

--- a/mesh/appender.go
+++ b/mesh/appender.go
@@ -28,7 +28,7 @@ type GlobalInfo struct {
 	IstioStatusGetter IstioStatusGetter
 	KialiCache        cache.KialiCache
 	Perses            *perses.Service
-	PromClient        *prometheus.Client
+	PromClient        prometheus.ClientInterface
 
 	Vendor VendorInfo // telemetry vendor's global info
 }

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -76,7 +76,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 	if gi.Perses != nil && healthData[persesHealthKey] == kubernetes.ComponentHealthy {
 		persesService = gi.Perses
 	}
-	kialiStatus := mesh.StatusGetter(ctx, gi.Conf, gi.ClientFactory, gi.KialiCache, grafanaService, persesService)
+	kialiStatus := mesh.StatusGetter(ctx, gi.Conf, gi.ClientFactory, gi.KialiCache, grafanaService, persesService, gi.PromClient)
 	esVersions := make(map[string]string)
 	for _, es := range kialiStatus.ExternalServices {
 		esVersions[es.Name] = es.Version

--- a/mesh/util.go
+++ b/mesh/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/perses"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/status"
 )
 
@@ -18,7 +19,7 @@ type Response struct {
 }
 
 // StatusGetter var allows test code to mock out this function with a mock
-var StatusGetter func(context.Context, *config.Config, kubernetes.ClientFactory, cache.KialiCache, *grafana.Service, *perses.Service) status.StatusInfo = status.Get
+var StatusGetter func(context.Context, *config.Config, kubernetes.ClientFactory, cache.KialiCache, *grafana.Service, *perses.Service, prometheus.ClientInterface) status.StatusInfo = status.Get
 
 // Error panics with InternalServerError (500) and the provided message
 func Error(message string) {

--- a/prometheus/prometheustest/fake.go
+++ b/prometheus/prometheustest/fake.go
@@ -1,0 +1,95 @@
+package prometheustest
+
+import (
+	"context"
+	"time"
+
+	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"github.com/kiali/kiali/prometheus"
+)
+
+// FakeClient implements prometheus.ClientInterface for testing purposes
+// All methods return empty values
+type FakeClient struct{}
+
+// API returns nil API for testing
+func (f *FakeClient) API() prom_v1.API {
+	return nil
+}
+
+// FetchDelta returns empty Metric
+func (f *FakeClient) FetchDelta(metricName, labels, grouping string, queryTime time.Time, duration time.Duration) prometheus.Metric {
+	return prometheus.Metric{}
+}
+
+// FetchHistogramRange returns empty Histogram
+func (f *FakeClient) FetchHistogramRange(metricName, labels, grouping string, q *prometheus.RangeQuery) prometheus.Histogram {
+	return prometheus.Histogram{}
+}
+
+// FetchHistogramValues returns empty map and nil error
+func (f *FakeClient) FetchHistogramValues(metricName, labels, grouping, rateInterval string, avg bool, quantiles []string, queryTime time.Time) (map[string]model.Vector, error) {
+	return map[string]model.Vector{}, nil
+}
+
+// FetchRange returns empty Metric
+func (f *FakeClient) FetchRange(metricName, labels, grouping, aggregator string, q *prometheus.RangeQuery) prometheus.Metric {
+	return prometheus.Metric{}
+}
+
+// FetchRateRange returns empty Metric
+func (f *FakeClient) FetchRateRange(metricName string, labels []string, grouping string, q *prometheus.RangeQuery) prometheus.Metric {
+	return prometheus.Metric{}
+}
+
+// GetAllRequestRates returns empty Vector and nil error
+func (f *FakeClient) GetAllRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return model.Vector{}, nil
+}
+
+// GetAppRequestRates returns empty Vectors and nil error
+func (f *FakeClient) GetAppRequestRates(namespace, cluster, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
+	return model.Vector{}, model.Vector{}, nil
+}
+
+// GetBuildInfo returns empty BuildinfoResult and nil error
+func (f *FakeClient) GetBuildInfo(ctx context.Context) (*prom_v1.BuildinfoResult, error) {
+	return &prom_v1.BuildinfoResult{}, nil
+}
+
+// GetConfiguration returns empty ConfigResult and nil error
+func (f *FakeClient) GetConfiguration() (prom_v1.ConfigResult, error) {
+	return prom_v1.ConfigResult{}, nil
+}
+
+// GetExistingMetricNames returns empty slice and nil error
+func (f *FakeClient) GetExistingMetricNames(metricNames []string) ([]string, error) {
+	return []string{}, nil
+}
+
+// GetMetricsForLabels returns empty slice and nil error
+func (f *FakeClient) GetMetricsForLabels(metricNames []string, labels string) ([]string, error) {
+	return []string{}, nil
+}
+
+// GetNamespaceServicesRequestRates returns empty Vector and nil error
+func (f *FakeClient) GetNamespaceServicesRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return model.Vector{}, nil
+}
+
+// GetServiceRequestRates returns empty Vector and nil error
+func (f *FakeClient) GetServiceRequestRates(namespace, cluster, service, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return model.Vector{}, nil
+}
+
+// GetRuntimeinfo returns empty RuntimeinfoResult and nil error
+func (f *FakeClient) GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error) {
+	return prom_v1.RuntimeinfoResult{}, nil
+}
+
+// GetWorkloadRequestRates returns empty Vectors and nil error
+func (f *FakeClient) GetWorkloadRequestRates(namespace, cluster, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
+	return model.Vector{}, model.Vector{}, nil
+}

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -17,6 +17,10 @@ type PromAPIMock struct {
 	mock.Mock
 }
 
+func (o *PromAPIMock) API() prom_v1.API {
+	return o
+}
+
 func (o *PromAPIMock) Alerts(ctx context.Context) (prom_v1.AlertsResult, error) {
 	args := o.Called(ctx)
 	return args.Get(0).(prom_v1.AlertsResult), nil
@@ -274,6 +278,10 @@ type PromClientMock struct {
 	mock.Mock
 }
 
+func (o *PromClientMock) API() prom_v1.API {
+	return o.Called().Get(0).(prom_v1.API)
+}
+
 // MockAllRequestRates mocks GetAllRequestRates for given namespace, rateInverval and queryTime, returning out vector
 func (o *PromClientMock) MockAllRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time, out model.Vector) {
 	o.On("GetAllRequestRates", namespace, cluster, ratesInterval, queryTime).Return(out, nil)
@@ -307,6 +315,14 @@ func (o *PromClientMock) MockMetricsForLabels(metrics []string) {
 func (o *PromClientMock) GetAllRequestRates(namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
 	args := o.Called(namespace, cluster, ratesInterval, queryTime)
 	return args.Get(0).(model.Vector), args.Error(1)
+}
+
+func (o *PromClientMock) GetBuildInfo(ctx context.Context) (*prom_v1.BuildinfoResult, error) {
+	args := o.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*prom_v1.BuildinfoResult), args.Error(1)
 }
 
 func (o *PromClientMock) GetConfiguration() (prom_v1.ConfigResult, error) {
@@ -372,11 +388,6 @@ func (o *PromClientMock) GetMetricsForLabels(metricNames []string, labels string
 func (o *PromClientMock) GetRuntimeinfo() (prom_v1.RuntimeinfoResult, error) {
 	args := o.Called()
 	return args.Get(0).(prom_v1.RuntimeinfoResult), args.Error(1)
-}
-
-func (o *PromClientMock) API() prom_v1.API {
-	args := o.Called()
-	return args.Get(0).(prom_v1.API)
 }
 
 func (o *PromClientMock) MockMetric(name string, labels string, q *prometheus.RangeQuery, value float64) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -86,7 +86,7 @@ func NewRoutes(
 			log.StatusLogName,
 			"GET",
 			"/api",
-			handlers.Root(conf, clientFactory, kialiCache, grafana, perses),
+			handlers.Root(conf, clientFactory, kialiCache, grafana, perses, prom),
 			conf.Server.RequireAuth,
 		},
 		// swagger:route GET /authenticate auth authenticate
@@ -189,7 +189,7 @@ func NewRoutes(
 			log.StatusLogName,
 			"GET",
 			"/api/status",
-			handlers.Root(conf, clientFactory, kialiCache, grafana, perses),
+			handlers.Root(conf, clientFactory, kialiCache, grafana, perses, prom),
 			true,
 		},
 		// swagger:route GET /tracing/diagnose tracing tracingDiagnose

--- a/status/status.go
+++ b/status/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/perses"
+	"github.com/kiali/kiali/prometheus"
 )
 
 const (
@@ -64,7 +65,7 @@ type StatusInfo struct {
 // }
 
 // Get returns a copy of the current status info.
-func Get(ctx context.Context, conf *config.Config, clientFactory kubernetes.ClientFactory, cache cache.KialiCache, grafana *grafana.Service, perses *perses.Service) StatusInfo {
+func Get(ctx context.Context, conf *config.Config, clientFactory kubernetes.ClientFactory, cache cache.KialiCache, grafana *grafana.Service, perses *perses.Service, prom prometheus.ClientInterface) StatusInfo {
 	buildInfo := cache.GetBuildInfo()
 	info := StatusInfo{
 		ExternalServices: []models.ExternalServiceInfo{},
@@ -82,7 +83,7 @@ func Get(ctx context.Context, conf *config.Config, clientFactory kubernetes.Clie
 		WarningMessages: []string{},
 	}
 
-	info.ExternalServices = getVersions(ctx, conf, clientFactory, grafana, perses)
+	info.ExternalServices = getVersions(ctx, conf, clientFactory, grafana, perses, prom)
 
 	return info
 }


### PR DESCRIPTION
### Describe the change

Uses `BuildInfo` from the prom client rather than fetching it directly.

### Steps to test the PR

Regression

### Automation testing

Regression

### Issue reference

Split out from #8543 