### PR TITLE
Cleanup the run make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # The compiled binary
 /kiali
 
+# This gets added by air when running make run-backend.
+tmp/
+
 # Files specific to our build process
 _output
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ DORP ?= docker
 # Set this to 'minikube' if you want images to be tagged/pushed for minikube as opposed to OpenShift/AWS. Set to 'local' if the image should not be pushed to any remote cluster (requires the cluster to be able to pull from your local image repository).
 CLUSTER_TYPE ?= openshift
 
+# Set this to the URL of the Kiali server that you want to use for local development.
+YARN_START_URL ?= http://localhost:20001
+
 # Find the client executable (either oc or kubectl). If minikube or kind, only look for kubectl (though we might not need be so strict)
 ifeq ($(CLUSTER_TYPE),minikube)
 OC ?= $(shell which kubectl 2>/dev/null || echo "MISSING-KUBECTL-FROM-PATH")


### PR DESCRIPTION
### Describe the change

Adds `tmp/` to `.gitignore` and makes the default `YARN_START_URL` = the default `make run-backend` url so that you don't need to provide it anymore.

### Steps to test the PR

1. Deploy istio
2. Run make targets
    ```
    make run-backend
    make run-frontend
    ```
3. `tmp` should not appear when you do `git status` and the `proxy` field should get automatically cleaned up when you exit `make run-frontend`.

### Automation testing

N/A

### Issue reference

None