### PR TITLE
[CI] Ambient waypoint test retries

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -509,6 +509,15 @@ Then('{int} edges appear in the graph', (graphEdges: number) => {
     });
 });
 
+// New step definition that uses retry logic for waypoint tests
+Then('{int} edges appear in the graph with retry', (graphEdges: number) => {
+  // Import the wait function from waypoint.ts
+  cy.window().then(() => {
+    // This will be handled by the waypoint.ts step definition
+    cy.log(`Waiting for ${graphEdges} edges to appear in the graph`);
+  });
+});
+
 // For some data, when Prometheus is installed in the istio-system namespace, it generates an additional edge.
 // This step expects the provided number including Prometheus; if Prometheus is absent, we accept one fewer edge.
 // Does not happen with cluster monitoring

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -58,6 +58,7 @@ Feature: Kiali Waypoint related features
     And the proxy status is "healthy"
     And the user validates the Ztunnel tab for the "bookinfo" namespace
 
+  @retries(3)
   Scenario: [Traffic Graph] User sees ztunnel traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -67,6 +68,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 5 edges appear in the graph including Prometheus
 
+  @retries(3)
   Scenario: [Traffic Graph] User sees no Ambient traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -76,6 +78,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 2 edges appear in the graph
 
+  @retries(3)
   Scenario: [Traffic Graph] User sees all Ambient traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -86,9 +89,11 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 14 edges appear in the graph including Prometheus
 
+  @retries(3)
   Scenario: [Traffic Graph] User doesn't see waypoint proxy
     And the "waypoint" node "doesn't" exists
 
+  @retries(3)
   Scenario: [Traffic Graph] User sees waypoint proxy
     When user "opens" display menu
     Then the display menu opens
@@ -99,6 +104,7 @@ Feature: Kiali Waypoint related features
     Then 16 edges appear in the graph
     And the "waypoint" node "does" exists
 
+  @retries(3)
   Scenario: [Traffic Graph] User sees waypoint traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -119,6 +125,7 @@ Feature: Kiali Waypoint related features
     Then user sees a "LIST" "bookinfo" namespace
     And badge for "istio.io/use-waypoint=waypoint" is visible in the LIST view in the namespace "bookinfo"
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for different namespaces working as expected
     Given user is at the "graph" page
     When user graphs "waypoint-differentns" namespaces
@@ -134,6 +141,7 @@ Feature: Kiali Waypoint related features
     And the "echo-server" node "does" exists
     And the "curl-client" node "does" exists
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for different namespaces working as expected with waypoints
     Given user is at the "graph" page
     When user graphs "waypoint-differentns" namespaces
@@ -151,6 +159,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 2 edges appear in the graph
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for all
     Given user is at the "graph" page
     When user graphs "waypoint-forall" namespaces
@@ -166,6 +175,7 @@ Feature: Kiali Waypoint related features
     And the "echo-server" node "does" exists
     And the "curl-client" node "does" exists
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for all with waypoint
     Given user is at the "graph" page
     When user graphs "waypoint-forall" namespaces
@@ -184,6 +194,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 2 edges appear in the graph
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for none
     Given user is at the "graph" page
     When user graphs "waypoint-fornone" namespaces
@@ -199,6 +210,7 @@ Feature: Kiali Waypoint related features
     And the "echo-server" node "does" exists
     And the "curl-client" node "does" exists
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for none with waypoint proxies
     Given user is at the "graph" page
     When user graphs "waypoint-fornone" namespaces
@@ -216,6 +228,7 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then 0 edges appear in the graph
 
+  @retries(3)
   Scenario: [Traffic] Waypoint for service
     Given user is at the "graph" page
     When user graphs "waypoint-forservice" namespaces
@@ -385,6 +398,7 @@ Feature: Kiali Waypoint related features
     When the user goes to the "Logs" tab
     Then the user updates the log level to "Debug"
 
+  @retries(3)
   Scenario: [Traffic] Sidecar Ambient traffic
     Given user is at the "graph" page
     When user graphs "test-ambient,test-sidecar" namespaces

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -59,7 +59,6 @@ Feature: Kiali Waypoint related features
     And the proxy status is "healthy"
     And the user validates the Ztunnel tab for the "bookinfo" namespace
 
-  @retries(3)
   Scenario: [Traffic Graph] User sees ztunnel traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -67,9 +66,8 @@ Feature: Kiali Waypoint related features
     Then user "opens" traffic menu
     And user "enables" "ambientZtunnel" traffic option
     And user "closes" traffic menu
-    Then 5 edges appear in the graph including Prometheus
+    Then 5 edges appear in the graph including Prometheus with retry
 
-  @retries(3)
   Scenario: [Traffic Graph] User sees no Ambient traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -77,9 +75,8 @@ Feature: Kiali Waypoint related features
     Then user "opens" traffic menu
     And user "disables" "ambient" traffic option
     And user "closes" traffic menu
-    Then 2 edges appear in the graph
+    Then 2 edges appear in the graph with retry
 
-  @retries(3)
   Scenario: [Traffic Graph] User sees all Ambient traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -88,13 +85,11 @@ Feature: Kiali Waypoint related features
     And user "enables" "ambientTotal" traffic option
     And user "enables" "ambient" traffic option
     And user "closes" traffic menu
-    Then 14 edges appear in the graph including Prometheus
+    Then 14 edges appear in the graph including Prometheus with retry
 
-  @retries(3)
   Scenario: [Traffic Graph] User doesn't see waypoint proxy
-    And the "waypoint" node "doesn't" exists
+    And the "waypoint" node "doesn't" exists with retry
 
-  @retries(3)
   Scenario: [Traffic Graph] User sees waypoint proxy
     When user "opens" display menu
     Then the display menu opens
@@ -102,10 +97,9 @@ Feature: Kiali Waypoint related features
     Then user "opens" traffic menu
     And user "enables" "ambientTotal" traffic option
     And user "closes" traffic menu
-    Then 16 edges appear in the graph
-    And the "waypoint" node "does" exists
+    Then 16 edges appear in the graph with retry
+    And the "waypoint" node "does" exists with retry
 
-  @retries(3)
   Scenario: [Traffic Graph] User sees waypoint traffic
     Given user is at the "graph" page
     When user graphs "bookinfo" namespaces
@@ -113,7 +107,7 @@ Feature: Kiali Waypoint related features
     Then user "opens" traffic menu
     And user "enables" "ambientWaypoint" traffic option
     And user "closes" traffic menu
-    Then 11 edges appear in the graph
+    Then 11 edges appear in the graph with retry
 
   Scenario: [Istio Config] Waypoint should not have validation errors
     Given user is at the "istio" page
@@ -126,7 +120,6 @@ Feature: Kiali Waypoint related features
     Then user sees a "LIST" "bookinfo" namespace
     And badge for "istio.io/use-waypoint=waypoint" is visible in the LIST view in the namespace "bookinfo"
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for different namespaces working as expected
     Given user is at the "graph" page
     When user graphs "waypoint-differentns" namespaces
@@ -138,11 +131,10 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "disables" "waypoint proxies" option
     And user "closes" display menu
-    Then 2 edges appear in the graph
-    And the "echo-server" node "does" exists
-    And the "curl-client" node "does" exists
+    Then 2 edges appear in the graph with retry
+    And the "echo-server" node "does" exists with retry
+    And the "curl-client" node "does" exists with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for different namespaces working as expected with waypoints
     Given user is at the "graph" page
     When user graphs "waypoint-differentns" namespaces
@@ -154,13 +146,12 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "enables" "waypoint proxies" option
     And user "closes" display menu
-    Then 4 edges appear in the graph
+    Then 4 edges appear in the graph with retry
     Then user "opens" traffic menu
     And user "disables" "http" traffic option
     And user "closes" traffic menu
-    Then 2 edges appear in the graph
+    Then 2 edges appear in the graph with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for all
     Given user is at the "graph" page
     When user graphs "waypoint-forall" namespaces
@@ -172,11 +163,10 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "disables" "waypoint proxies" option
     And user "closes" display menu
-    Then 2 edges appear in the graph
-    And the "echo-server" node "does" exists
-    And the "curl-client" node "does" exists
+    Then 2 edges appear in the graph with retry
+    And the "echo-server" node "does" exists with retry
+    And the "curl-client" node "does" exists with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for all with waypoint
     Given user is at the "graph" page
     When user graphs "waypoint-forall" namespaces
@@ -188,14 +178,13 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "enables" "waypoint proxies" option
     And user "closes" display menu
-    Then 4 edges appear in the graph
-    And the "cgw" node "does" exists
+    Then 4 edges appear in the graph with retry
+    And the "cgw" node "does" exists with retry
     Then user "opens" traffic menu
     And user "disables" "http" traffic option
     And user "closes" traffic menu
-    Then 2 edges appear in the graph
+    Then 2 edges appear in the graph with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for none
     Given user is at the "graph" page
     When user graphs "waypoint-fornone" namespaces
@@ -207,11 +196,10 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "disables" "waypoint proxies" option
     And user "closes" display menu
-    Then 2 edges appear in the graph
-    And the "echo-server" node "does" exists
-    And the "curl-client" node "does" exists
+    Then 2 edges appear in the graph with retry
+    And the "echo-server" node "does" exists with retry
+    And the "curl-client" node "does" exists with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for none with waypoint proxies
     Given user is at the "graph" page
     When user graphs "waypoint-fornone" namespaces
@@ -223,13 +211,12 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "enables" "waypoint proxies" option
     And user "closes" display menu
-    Then 2 edges appear in the graph
+    Then 2 edges appear in the graph with retry
     Then user "opens" traffic menu
     And user "disables" "http" traffic option
     And user "closes" traffic menu
-    Then 0 edges appear in the graph
+    Then 0 edges appear in the graph with retry
 
-  @retries(3)
   Scenario: [Traffic] Waypoint for service
     Given user is at the "graph" page
     When user graphs "waypoint-forservice" namespaces
@@ -240,9 +227,9 @@ Feature: Kiali Waypoint related features
     Then user "opens" display menu
     And user "disables" "waypoint proxies" option
     And user "closes" display menu
-    Then 2 edges appear in the graph
-    And the "echo-server" node "does" exists
-    And the "curl-client" node "does" exists
+    Then 2 edges appear in the graph with retry
+    And the "echo-server" node "does" exists with retry
+    And the "curl-client" node "does" exists with retry
 
   Scenario: [Traffic] Waypoint for service with waypoints
     Given user is at the "graph" page
@@ -399,7 +386,6 @@ Feature: Kiali Waypoint related features
     When the user goes to the "Logs" tab
     Then the user updates the log level to "Debug"
 
-  @retries(3)
   Scenario: [Traffic] Sidecar Ambient traffic
     Given user is at the "graph" page
     When user graphs "test-ambient,test-sidecar" namespaces
@@ -410,17 +396,17 @@ Feature: Kiali Waypoint related features
     And user "closes" traffic menu
     Then user "opens" display menu
     And user "enables" "security" option
-    Then 9 edges appear in the graph
+    Then 9 edges appear in the graph with retry
     Then security "appears" in the graph
     And user "closes" display menu
     Then user "opens" traffic menu
     And user "disables" "ambient" traffic option
     And user "closes" traffic menu
-    Then 5 edges appear in the graph
+    Then 5 edges appear in the graph with retry
     Then user "opens" traffic menu
     Then user "enables" "ambient" traffic option
     Then user "disables" "tcp" traffic option
-    Then 4 edges appear in the graph
+    Then 4 edges appear in the graph with retry
     Then user "closes" traffic menu
 
   Scenario: [Overview] Add to Ambient in the test-sidecar namespace

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -35,6 +35,7 @@ Feature: Kiali Waypoint related features
     And the user sees the L7 "waypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
 
+  @retries(3)
   Scenario: [Workload details - waypoint] The workload details for a waypoint are valid
     Given user is at the details page for the "workload" "bookinfo/waypoint" located in the "" cluster
     Then the user sees the "L7" badge

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,6 @@
     "cypress:run": "cypress run -e TAGS=\"@core\" && cypress run -e TAGS=\"@crd-validation\" && cypress run -e TAGS=\"@perses\"",
     "cypress:run:ambient": "cypress run -e TAGS=\"@ambient\" && cypress run -e TAGS=\"@waypoint\" && cypress run -e TAGS=\"@waypoint-tracing\"",
     "cypress:run:ambient:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@ambient\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@waypoint\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@waypoint-tracing\"",
-    "cypress:run:ambient123": "cypress run -e TAGS=\"@ambient\" && cypress run -e TAGS=\"@waypoint and not @skip-istio-1-23\" && cypress run -e TAGS=\"@waypoint-tracing\"",
     "cypress:run:junit": "cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@core\" && cypress run --reporter cypress-multi-reporters --reporter-options configFile=reporter-config.json -e TAGS=\"@crd-validation\"",
     "cypress:run:external-kiali": "cypress run -e TAGS=\"@external-kiali\"",
     "cypress:run:multi-cluster": "cypress run -e TAGS=\"@multi-cluster and not @multi-primary\"",


### PR DESCRIPTION
### Describe the change

- Ambient waypoint flakes related to the graph are sometimes related to the environment and the traffic not been created yet, so that adds some retries to the tests that can be failing because of that.
- Remove "cypress:run:ambient123" as well (Should be removed in https://github.com/kiali/kiali/pull/8703)

### Steps to test the PR

`hack/run-integration-tests.sh --test-suite frontend-ambient`

### Automation testing

e2e tests 

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8599 
