### PR TITLE
[CI] ossmc tests

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -75,8 +75,8 @@ When('user selects a trace with at least {int} spans', (spans: number) => {
 Then('user sees span details', () => {
   cy.getBySel('trace-details-tabs').should('be.visible').contains('Span Details').click({ scrollBehavior: false });
 
-  cy.get('table')
-    .should('be.visible')
+  cy.get('table', { timeout: 5000 })
+    .should('exist')
     .find('tbody tr') // ignore thead rows
     .should('have.length.above', 1) // retries above cy.find() until we have a non head-row
     .eq(1) // take 1st  row
@@ -84,8 +84,8 @@ Then('user sees span details', () => {
     .eq(4) // take 5th cell (kebab)
     .should('exist');
 
-  cy.get('table')
-    .should('be.visible')
+  cy.get('table', { timeout: 5000 })
+    .should('exist')
     .find('tbody tr') // ignore thead rows
     .should('have.length.above', 1) // retries above cy.find() until we have a non head-row
     .eq(1) // take 1st  row

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -11,7 +11,13 @@ When('user graphs {string} namespaces', (namespaces: string) => {
   cy.visit({ url: `/console/graph/namespaces?refresh=0&namespaces=${namespaces}` });
 
   if (namespaces !== '') {
-    cy.wait('@graphNamespaces');
+    cy.url().then(url => {
+      // Only wait for API call in Kiali standalone, not in OpenShift
+      // Because OpenShift makes a redirection and the URL is never intercepted
+      if (!url.includes('/ossmconsole/')) {
+        cy.wait('@graphNamespaces');
+      }
+    });
   }
 
   ensureKialiFinishedLoading();

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -3,8 +3,8 @@ import { ensureKialiFinishedLoading } from './transition';
 
 enum detailType {
   App = 'app',
-  Deployments = 'deployments',
   Istio = 'istio',
+  Pods = 'pods',
   Service = 'service',
   Workload = 'workload'
 }
@@ -59,10 +59,10 @@ Given(
       let detailPage = '';
       // ossmc requires deployment as the pod name is different than the deployment name. Ex for waypoints, can be waypoint-fdsfdsfs
       if (
-        detail === detailType.Deployments &&
+        detail === detailType.Pods &&
         (currentURL.includes('openshift-console') || currentURL.includes('/ossmconsole/'))
       ) {
-        detailPage = detailType.Deployments;
+        detailPage = detailType.Pods;
       } else {
         detailPage = getPageDetail(detail);
       }

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -58,11 +58,12 @@ Given(
     cy.url().then(currentURL => {
       let detailPage = '';
       // ossmc requires deployment as the pod name is different than the deployment name. Ex for waypoints, can be waypoint-fdsfdsfs
-      if (
-        detail === detailType.Pods &&
-        (currentURL.includes('openshift-console') || currentURL.includes('/ossmconsole/'))
-      ) {
-        detailPage = detailType.Pods;
+      if (detail === detailType.Pods) {
+        if (currentURL.includes('openshift-console') || currentURL.includes('/ossmconsole/')) {
+          detailPage = detailType.Pods;
+        } else {
+          detailPage = 'workloads';
+        }
       } else {
         detailPage = getPageDetail(detail);
       }

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -150,3 +150,7 @@ Then(`user doesn't see the {string} menu`, menu => {
 Then(`user see the {string} menu`, menu => {
   cy.get('#page-sidebar').find(`#${menu}`).should('exist');
 });
+
+Given('wait for {string} does not exist', (element: string) => {
+  cy.get(`div[data-test="${element}"]`).should('not.exist');
+});

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -3,9 +3,10 @@ import { ensureKialiFinishedLoading } from './transition';
 
 enum detailType {
   App = 'app',
-  Workload = 'workload',
+  Deployments = 'deployments',
+  Istio = 'istio',
   Service = 'service',
-  Istio = 'istio'
+  Workload = 'workload'
 }
 
 Given('user is at the {string} list page', (page: string) => {
@@ -54,33 +55,45 @@ Given('autorefresh is enabled', () => {
 Given(
   'user is at the details page for the {string} {string} located in the {string} cluster',
   (detail: detailType, namespacedNamed: string, cluster: string) => {
-    const qs = {
-      // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
-      refresh: '0'
-    };
-    if (cluster !== '') {
-      qs['clusterName'] = cluster;
-    }
+    cy.url().then(currentURL => {
+      let detailPage = '';
+      // ossmc requires deployment as the pod name is different than the deployment name. Ex for waypoints, can be waypoint-fdsfdsfs
+      if (
+        detail === detailType.Deployments &&
+        (currentURL.includes('openshift-console') || currentURL.includes('/ossmconsole/'))
+      ) {
+        detailPage = detailType.Deployments;
+      } else {
+        detailPage = getPageDetail(detail);
+      }
+      const qs = {
+        // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
+        refresh: '0'
+      };
+      if (cluster !== '') {
+        qs['clusterName'] = cluster;
+      }
 
-    const namespaceAndName = namespacedNamed.split('/');
-    const namespace = namespaceAndName[0];
-    const pageDetail = getPageDetail(detail);
-    const name =
-      pageDetail === 'istio'
-        ? `${namespaceAndName[1]}/${namespaceAndName[2]}/${namespaceAndName[3]}/${namespaceAndName[4]}`
-        : namespaceAndName[1];
+      const namespaceAndName = namespacedNamed.split('/');
+      const namespace = namespaceAndName[0];
+      const pageDetail = detailPage;
+      const name =
+        pageDetail === 'istio'
+          ? `${namespaceAndName[1]}/${namespaceAndName[2]}/${namespaceAndName[3]}/${namespaceAndName[4]}`
+          : namespaceAndName[1];
 
-    if (pageDetail === 'services') {
-      cy.intercept({
-        pathname: '**/api/namespaces/bookinfo/services/productpage',
-        query: {
-          objects: ''
-        }
-      }).as('waitForCall');
-    }
+      if (pageDetail === 'services') {
+        cy.intercept({
+          pathname: '**/api/namespaces/bookinfo/services/productpage',
+          query: {
+            objects: ''
+          }
+        }).as('waitForCall');
+      }
 
-    cy.visit({ url: `${Cypress.config('baseUrl')}/console/namespaces/${namespace}/${pageDetail}/${name}`, qs });
-    ensureKialiFinishedLoading();
+      cy.visit({ url: `${Cypress.config('baseUrl')}/console/namespaces/${namespace}/${pageDetail}/${name}`, qs });
+      ensureKialiFinishedLoading();
+    });
   }
 );
 

--- a/frontend/cypress/integration/common/transition.ts
+++ b/frontend/cypress/integration/common/transition.ts
@@ -6,5 +6,5 @@ export const ensureKialiFinishedLoading = (): void => {
 };
 
 export const openTab = (tab: string): void => {
-  cy.get('#basic-tabs').should('be.visible').contains(tab).click();
+  cy.get('#basic-tabs', { timeout: 60000 }).should('be.visible').contains(tab).click(); // Can be very slow for OpenShift, specially in the UI
 };

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -38,6 +38,7 @@ Feature: Kiali App Details page
   @bookinfo-app
   @tracing
   @waypoint-tracing
+  @skip-ossmc
   Scenario: See tracing info after selecting a trace
     And user sees trace information
     When user selects a trace
@@ -52,6 +53,7 @@ Feature: Kiali App Details page
     And user can filter spans by app "productpage"
 
   @waypoint-tracing
+  @skip-ossmc
   Scenario: See span info after selecting app span
     And user sees trace information
     When user selects a trace

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -180,6 +180,7 @@ Feature: Kiali Services page
     Then the list is sorted by column "Cluster" in "descending" order
 
   @ambient
+  @skip-ossmc
   Scenario: Filter services table by health
     And user is at the "services" page
     When user selects the "bookinfo" namespace

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -14,6 +14,7 @@ Feature: Kiali Waypoint related features
     Then "bookinfo" namespace is labeled with the waypoint label
     And the graph page has enough data
 
+  @skip-ossmc
   Scenario: [Workload list] See the workload list of bookinfo with the correct info
     Given user is at the "workloads" list page
     When user selects the "bookinfo" namespace

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -324,7 +324,7 @@ Feature: Kiali Waypoint related features
     And validates waypoint Info data for "none"
 
   Scenario: [Waypoint details] The waypoint details for a waypoint for service are valid
-    Given user is at the details page for the "workload" "waypoint-forservice/curl-client" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-forservice/curl-client" located in the "" cluster
     And the user sees the L7 "waypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -334,7 +334,7 @@ Feature: Kiali Waypoint related features
     And validates waypoint Info data for "service"
 
   Scenario: [Waypoint details] The waypoint details for a waypoint in different ns are valid
-    Given user is at the details page for the "workload" "waypoint-differentns/curl-client" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-differentns/curl-client" located in the "" cluster
     And the user sees the L7 "egress-gateway" link
     And the link for the waypoint "egress-gateway" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -344,7 +344,7 @@ Feature: Kiali Waypoint related features
     And validates waypoint Info data for "service"
 
   Scenario: [Waypoint details] The waypoint details for a waypoint for all are valid
-    Given user is at the details page for the "workload" "waypoint-forall/curl-client" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-forall/curl-client" located in the "" cluster
     And the user sees the L7 "cgw" link
     And the link for the waypoint "cgw" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -356,7 +356,7 @@ Feature: Kiali Waypoint related features
     And validates waypoint Info data for "all"
 
   Scenario: [Waypoint details] The waypoint details for a waypoint for workload are valid
-    Given user is at the details page for the "workload" "waypoint-forworkload/echo-server" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-forworkload/echo-server" located in the "" cluster
     And the user sees the L7 "bwaypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -367,7 +367,7 @@ Feature: Kiali Waypoint related features
 
   Scenario: [Waypoint details] The waypoint details for a waypoint override are valid
   # TODO: This shouldn't be right
-    Given user is at the details page for the "workload" "waypoint-override/curl-client" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-override/curl-client" located in the "" cluster
     And the user sees the L7 "waypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -376,7 +376,7 @@ Feature: Kiali Waypoint related features
     Then user goes to the waypoint "Info" subtab
     And validates waypoint Info data for "service"
   # TODO: End-Todo
-    Then user is at the details page for the "workload" "waypoint-override/echo-server" located in the "" cluster
+    Then user is at the details page for the "pods" "waypoint-override/echo-server" located in the "" cluster
     And the user sees the L7 "use-this" link
     And the link for the waypoint "use-this" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
@@ -417,6 +417,7 @@ Feature: Kiali Waypoint related features
     Given user is at administrator perspective
     Given user is at the "overview" page
     And user filters "test-sidecar" namespace
+    And wait for "waypoint-fornone-EXPAND" does not exist
     And user opens the menu
     And the option "Add to Ambient" does not exist for "test-sidecar" namespace
     And the user clicks on "removes auto injection" for "test-sidecar" namespace

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -314,9 +314,9 @@ Feature: Kiali Waypoint related features
     Then 2 edges appear in the graph
 
   Scenario: [Waypoint details] The waypoint details for a waypoint for none are valid
-    Given user is at the details page for the "workload" "waypoint-fornone/curl-client" located in the "" cluster
+    Given user is at the details page for the "pods" "waypoint-fornone/curl-client" located in the "" cluster
     And the user doesn't see a L7 link
-    And user is at the details page for the "deployments" "waypoint-fornone/waypoint" located in the "" cluster
+    And user is at the details page for the "workload" "waypoint-fornone/waypoint" located in the "" cluster
     When the user goes to the "Waypoint" tab
     Then the "Services" subtab doesn't exist
     Then the "Workloads" subtab doesn't exist

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -316,7 +316,7 @@ Feature: Kiali Waypoint related features
   Scenario: [Waypoint details] The waypoint details for a waypoint for none are valid
     Given user is at the details page for the "workload" "waypoint-fornone/curl-client" located in the "" cluster
     And the user doesn't see a L7 link
-    And user is at the details page for the "workload" "waypoint-fornone/waypoint" located in the "" cluster
+    And user is at the details page for the "deployments" "waypoint-fornone/waypoint" located in the "" cluster
     When the user goes to the "Waypoint" tab
     Then the "Services" subtab doesn't exist
     Then the "Workloads" subtab doesn't exist

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -82,8 +82,8 @@ Feature: Kiali Waypoint related features
     When user graphs "bookinfo" namespaces
     Then user sees the "bookinfo" namespace
     Then user "opens" traffic menu
-    And user "enables" "ambientTotal" traffic option
     And user "enables" "ambient" traffic option
+    And user "enables" "ambientTotal" traffic option
     And user "closes" traffic menu
     Then 14 edges appear in the graph including Prometheus
 
@@ -95,6 +95,7 @@ Feature: Kiali Waypoint related features
     Then the display menu opens
     Then user "enables" "filterWaypoints" edge labels
     Then user "opens" traffic menu
+    And user "enables" "ambient" traffic option
     And user "enables" "ambientTotal" traffic option
     And user "closes" traffic menu
     Then 16 edges appear in the graph
@@ -105,10 +106,12 @@ Feature: Kiali Waypoint related features
     When user graphs "bookinfo" namespaces
     Then user sees the "bookinfo" namespace
     Then user "opens" traffic menu
+    And user "enables" "ambient" traffic option
     And user "enables" "ambientWaypoint" traffic option
     And user "closes" traffic menu
     Then 11 edges appear in the graph
 
+  @skip-ossmc
   Scenario: [Istio Config] Waypoint should not have validation errors
     Given user is at the "istio" page
     And user selects the "bookinfo" namespace
@@ -126,6 +129,7 @@ Feature: Kiali Waypoint related features
     Then user sees the "waypoint-differentns" namespace
     Then user "opens" traffic menu
     And user "enables" "ambient" traffic option
+    And user "enables" "ambientTotal" traffic option
     And user "enables" "http" traffic option
     And user "closes" traffic menu
     Then user "opens" display menu

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -156,6 +156,7 @@ Feature: Kiali Workloads page
     Then the list is sorted by column "Cluster" in "descending" order
 
   @ambient
+  @skip-ossmc
   Scenario: Out of mesh
     When user selects the "sleep" namespace
     Then user sees "Out of mesh" in the table

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -67,6 +67,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
       const link = isParentKiosk(props.kiosk) ? (
         <Link
           to=""
+          data-test="waypoint-link"
           onClick={() => {
             kioskContextMenuAction(href);
           }}

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -259,6 +258,7 @@ func WorkloadDashboard(
 }
 
 // ZtunnelDashboard is the API handler to fetch metrics to be displayed, related to a single control plane revision
+// It doesn't check if the namespace is a control plane, sometimes it is deployed in a different namespace (ex. OpenShift)
 func ZtunnelDashboard(
 	conf *config.Config,
 	cache cache.KialiCache,
@@ -285,11 +285,6 @@ func ZtunnelDashboard(
 
 		if err := extractIstioMetricsQueryParams(r, &params, oldestNs); err != nil {
 			RespondWithError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		if !discovery.IsControlPlane(r.Context(), cluster, namespace) {
-			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("namespace [%s] is not the control plane namespace", namespace))
 			return
 		}
 

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -178,6 +178,7 @@ func AggregateMetrics(conf *config.Config, cache cache.KialiCache, discovery *is
 }
 
 // ControlPlaneMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
+// It doesn't check if the namespace is from a control plane, it is also called for Ztunnel and Kiali, which sometimes are not deployed in a control plane namespace
 func ControlPlaneMetrics(
 	conf *config.Config,
 	cache cache.KialiCache,
@@ -201,11 +202,6 @@ func ControlPlaneMetrics(
 		controlPlane := vars["controlplane"]
 		conf := config.Get()
 		cluster := clusterNameFromQuery(conf, r.URL.Query())
-
-		if !discovery.HasControlPlane(r.Context(), cluster, namespace, controlPlane) {
-			RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("provided namespace [%s] and control plane [%s] are not found in the cluster [%s] ", namespace, controlPlane, cluster))
-			return
-		}
 
 		namespaceInfo, err := checkNamespaceAccessWithService(w, r, &layer.Namespace, namespace, cluster)
 		if err != nil {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -250,7 +250,7 @@ func ControlPlaneMetrics(
 	}
 }
 
-// ResourceUsageMetrics is the API handler to fetch metrics to be displayed, related to a single control plane revision
+// ResourceUsageMetrics is the API handler to fetch metrics to be displayed
 // It doesn't check if the namespace is from a control plane, it is called for Ztunnel and Kiali, which sometimes are not deployed in a control plane namespace
 func ResourceUsageMetrics(conf *config.Config, cache cache.KialiCache, discovery *istio.Discovery, clientFactory kubernetes.ClientFactory, prom prometheus.ClientInterface) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Describe the change

- OSSMC doesn't have a list of workloads/services, so skipping the tests for list related to `waypoints`
- Added timeout in get table and get - It was failing using tests in UI
- intercepting graph namespace was failing for ossmc due to the redirection
- Added pods for testing in details page for the pods that don't include a deployment (ossmc)
- Skipped tests for waypoint and list pages
- Required to enable traffic option "ambient" to have the other sub options available
- Removed control plane check in the handler for metrics and ztunnel dashboard. Resource usage metrics are used by Kiali and Ztunnel, they might not be deployed in the controlplane namespace. 
- Added data tests for detail description link when it is parent kiosk as well

### Steps to test the PR

- Use this PR: https://github.com/kiali/openshift-servicemesh-plugin/pull/483
- copy this code into ossmc
- Install Ambient in OpenShift cluster and ossmc
- Run `@waypoint` tests 

### Automation testing

e2e tests 

### Issue reference

Ref. https://github.com/kiali/kiali/issues/8723
