### PR TITLE
[GH Action] Option to bump to the next version after the tag release creation

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -1,14 +1,20 @@
-name: Tag Bump Version
+name: Bump release version
 
 on:
   workflow_dispatch:
     inputs:
-      tag_branch:
-        description: Branch to bump version (Separate branches by commas. Ex v1.73,v2.4)
+      tag_branches:
+        description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73
+        default: v1.73,v2.4,v2.11
         type: string
-
+  workflow_call:
+    inputs:
+      tag_branches:
+        description: Branches to bump version (Separate branches by commas)
+        required: true
+        default: v1.73,v2.4,v2.11
+        type: string
 jobs:
   initialize:
     name: Initialize
@@ -31,7 +37,7 @@ jobs:
     - name: Set Branch
       id: branches
       env:
-        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branches }}
       run: |
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
@@ -75,22 +81,29 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Create Bump Version Tag in kiali/kiali
+    - name: Bump to next version
       env:
         BRANCH: ${{matrix.branch}}
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
+        # Check if the latest tag is the ossm tag (meaning no release tag of current version exists)
+        LATEST_TAG=$(git describe --tags --abbrev=0)
+        if [[ "$LATEST_TAG" == "$RAW_VERSION-ossm" ]]; then
+          echo "Error: Cannot bump release version because the ossm tag $RAW_VERSION-ossm exists"
+          exit 1
+        else
+          RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
-        # Update the version in Kiali repository
-        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
-        sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'",/' frontend/package.json
+          # Update the version in Kiali repository
+          sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+          sed -i -r 's/"version": (.*)/"version": "'${RELEASE_VERSION:1}'",/' frontend/package.json
 
-        # Commit the changes
-        git add Makefile frontend/package.json
-        git commit -m "Bump to version $RELEASE_VERSION"
-        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+          # Commit the changes
+          git add Makefile frontend/package.json
+          git commit -m "Bump to version $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
 
-        # Create the bump version tag
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+          # Create the ossm version tag
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+        fi

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -53,6 +53,8 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
+        # We need to fetch all the history to determine the latest tag
+        fetch-depth: 0
 
     - name: Prepare scripts
       run: |
@@ -90,7 +92,7 @@ jobs:
         # Check if the latest tag is the ossm tag (meaning no release tag of current version exists)
         LATEST_TAG=$(git describe --tags --abbrev=0)
         if [[ "$LATEST_TAG" == "$RAW_VERSION-ossm" ]]; then
-          echo "Error: Cannot bump release version because the ossm tag $RAW_VERSION-ossm exists"
+          echo "Error: Cannot bump release version because the latest tag is not the release tag $RAW_VERSION"
           exit 1
         else
           RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -46,7 +46,7 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
-      # Allow other branches to bump to next version even if one of the branches failed
+      # Allow other branches to continue even if one of the branches failed
       fail-fast: false
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
-        # We need to fetch all the history to determine the latest tag
+        # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 
     - name: Prepare scripts

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -1,4 +1,4 @@
-name: Bump release version
+name: Bump Release Version
 
 on:
   workflow_dispatch:
@@ -46,6 +46,8 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
+      # Allow other branches to bump to next version even if one of the branches failed
+      fail-fast: false
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
@@ -89,12 +91,10 @@ jobs:
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        # Check if the latest tag is the ossm tag (meaning no release tag of current version exists)
         LATEST_TAG=$(git describe --tags --abbrev=0)
-        if [[ "$LATEST_TAG" == "$RAW_VERSION-ossm" ]]; then
-          echo "Error: Cannot bump release version because the latest tag is not the release tag $RAW_VERSION"
-          exit 1
-        else
+
+        # Check if the latest tag is the current release version tag
+        if [[ "$LATEST_TAG" == "$RAW_VERSION" ]]; then
           RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
           # Update the version in Kiali repository
@@ -108,4 +108,7 @@ jobs:
 
           # Create the ossm version tag
           git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+        else
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RAW_VERSION tag"
+          exit 1
         fi

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,4 +1,4 @@
-name: Tag Release Creator
+name: Release Tag Creator
 
 on:
   workflow_dispatch:
@@ -45,6 +45,8 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
+      # Allow other branches to continue even if one of the branches failed
+      fail-fast: false
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
@@ -64,8 +66,9 @@ jobs:
       run: |
         RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        # Check if the latest tag is the ossm tag (meaning no release tag of current version exists)
         LATEST_TAG=$(git describe --tags --abbrev=0)
+
+        # Check if the latest tag is the current ossm version tag
         if [[ "$LATEST_TAG" == "$RELEASE_VERSION-ossm" ]]; then
           # Delete the ossm version tag
           echo "Deleting existing ossm version tag: $RELEASE_VERSION-ossm"
@@ -82,7 +85,8 @@ jobs:
   bump_version:
     name: Bump to Next Version
     needs: [initialize, release_tag]
-    if: ${{ inputs.bump_next_version }}
-    uses: ./.github/workflows/tag-bump-version.yml
+    # Allow other branches to bump to next version even if one of the branches failed to create the release tag
+    if: ${{ inputs.bump_next_version && always() }}
+    uses: ./.github/workflows/bump-release-version.yml
     with:
       tag_branches: ${{ inputs.tag_branches }}

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
-        # We need to fetch all the history to determine the latest tag
+        # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 
     - name: Configure git
@@ -85,7 +85,7 @@ jobs:
   bump_version:
     name: Bump to Next Version
     needs: [initialize, release_tag]
-    # Allow other branches to bump to next version even if one of the branches failed to create the release tag
+    # Allow other branches to bump to the next version even if one of the branches failed to create the release tag
     if: ${{ inputs.bump_next_version && always() }}
     uses: ./.github/workflows/bump-release-version.yml
     with:

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -52,6 +52,8 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
+        # We need to fetch all the history to determine the latest tag
+        fetch-depth: 0
 
     - name: Configure git
       run: |
@@ -73,7 +75,7 @@ jobs:
           echo "Creating release tag $RELEASE_VERSION"
           git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
         else
-          echo "Error: Expected ossm version tag refs/tags/$RELEASE_VERSION-ossm does not exist"
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RELEASE_VERSION-ossm tag"
           exit 1
         fi
 

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -3,15 +3,16 @@ name: Tag Release Creator
 on:
   workflow_dispatch:
     inputs:
-      tag_branch:
-        description: Branch to tag (Separate branches by commas. Ex v1.73,v2.4)
+      tag_branches:
+        description: Branches to tag (Separate branches by commas)
         required: true
-        default: v1.73
+        default: v1.73,v2.4,v2.11
         type: string
-      target_commit:
-        description: Commit hash to tag (if empty, uses HEAD of each branch; if specified, requires single branch)
-        required: false
-        type: string
+      bump_next_version:
+        description: Bump to next version after creating release tag
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   initialize:
@@ -35,7 +36,7 @@ jobs:
     - name: Set Branch
       id: branches
       env:
-        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branches }}
       run: |
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
@@ -51,52 +52,35 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
-        # We need to fetch the full history to check if the commit exists
-        fetch-depth: 0
 
     - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Validate target commit
-      run: |
-        # Validate that only single branch is specified when target_commit is provided
-        if [ -n "${{ inputs.target_commit }}" ]; then
-          if [[ "${{ inputs.tag_branch }}" == *","* ]]; then
-            echo "Error: When target_commit is specified, only a single branch is allowed in tag_branch"
-            echo "Provided: ${{ inputs.tag_branch }}"
-            echo "Remove commas and specify only one branch when using a specific commit"
-            exit 1
-          fi
-        fi
-
-        # Set target commit to HEAD if empty
-        if [ -z "${{ inputs.target_commit }}" ]; then
-          TARGET_COMMIT=$(git rev-parse HEAD)
-          echo "No target commit specified, using HEAD: $TARGET_COMMIT"
-        else
-          TARGET_COMMIT="${{ inputs.target_commit }}"
-          echo "Using specified target commit: $TARGET_COMMIT"
-        fi
-
-        # Check if commit exists in the specified branch
-        if ! git merge-base --is-ancestor $TARGET_COMMIT HEAD 2>/dev/null; then
-          echo "Error: Commit $TARGET_COMMIT not found in branch ${{ matrix.branch }}"
-          exit 1
-        fi
-
-        echo "Commit $TARGET_COMMIT is valid and exists in branch ${{ matrix.branch }}"
-        echo "TARGET_COMMIT=$TARGET_COMMIT" >> $GITHUB_ENV
-
     - name: Create Release Tag in kiali/kiali
       run: |
         RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        echo "Creating release tag $RELEASE_VERSION for commit $TARGET_COMMIT"
+        # Check if the latest tag is the ossm tag (meaning no release tag of current version exists)
+        LATEST_TAG=$(git describe --tags --abbrev=0)
+        if [[ "$LATEST_TAG" == "$RELEASE_VERSION-ossm" ]]; then
+          # Delete the ossm version tag
+          echo "Deleting existing ossm version tag: $RELEASE_VERSION-ossm"
+          git push origin --delete refs/tags/$RELEASE_VERSION-ossm
 
-        # Create the release tag
-        git push origin $TARGET_COMMIT:refs/tags/$RELEASE_VERSION
+          # Create the release tag
+          echo "Creating release tag $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        else
+          echo "Error: Expected ossm version tag refs/tags/$RELEASE_VERSION-ossm does not exist"
+          exit 1
+        fi
 
-        # Delete the bump version tag if it exists
-        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true
+  bump_version:
+    name: Bump to Next Version
+    needs: [initialize, release_tag]
+    if: ${{ inputs.bump_next_version }}
+    uses: ./.github/workflows/tag-bump-version.yml
+    with:
+      tag_branches: ${{ inputs.tag_branches }}


### PR DESCRIPTION
### Describe the change

This PR enhances the tag release creation workflow by adding functionality to automatically bump to the next version after creating a release tag. Additionally, the latest tag of the branch is analyzed to verify if it is the expected one to avoid errors during the workflow.