### PR TITLE
Disabling "Show Virtual Services" now disables the "istio_details" appender

### DIFF
--- a/frontend/src/components/Nav/NavUtils.tsx
+++ b/frontend/src/components/Nav/NavUtils.tsx
@@ -28,6 +28,7 @@ export type GraphUrlParams = {
   showOperationNodes: boolean;
   showServiceNodes: boolean;
   showWaypoints: boolean;
+  showVirtualServices: boolean;
   trafficRates: TrafficRate[];
 };
 

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -416,6 +416,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
           (prev.refreshInterval !== curr.refreshInterval && curr.refreshInterval !== RefreshIntervalPause) ||
           prev.replayQueryTime !== curr.replayQueryTime ||
           prev.showSecurity !== curr.showSecurity ||
+          prev.showVirtualServices !== curr.showVirtualServices ||
           prev.trafficRates !== curr.trafficRates))
     ) {
       this.loadGraphDataFromBackend();
@@ -762,6 +763,7 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
       showOperationNodes: this.props.showOperationNodes,
       showSecurity: this.props.showSecurity,
       showWaypoints: this.props.showWaypoints,
+      showVirtualServices: this.props.showVirtualServices,
       trafficRates: this.props.trafficRates
     });
   };

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -47,6 +47,7 @@ type ReduxStateProps = {
   showIdleNodes: boolean;
   showRank: boolean;
   showSecurity: boolean;
+  showVirtualServices: boolean;
 };
 
 type ReduxDispatchProps = {
@@ -55,6 +56,7 @@ type ReduxDispatchProps = {
   setHideValue: (val: string) => void;
   toggleFindHelp: () => void;
   toggleGraphSecurity: () => void;
+  toggleGraphVirtualServices: () => void;
   toggleIdleNodes: () => void;
   toggleRank: () => void;
 };
@@ -1090,11 +1092,21 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
       //
       case 'cb':
       case 'circuitbreaker':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return { target: 'node', selector: { prop: NodeAttr.hasCB, op: isNegation ? 'falsy' : 'truthy' } };
       case 'dead':
         return { target: 'node', selector: { prop: NodeAttr.isDead, op: isNegation ? 'falsy' : 'truthy' } };
       case 'fi':
       case 'faultinjection':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return {
           target: 'node',
           selector: { prop: NodeAttr.hasFaultInjection, op: isNegation ? 'falsy' : 'truthy' }
@@ -1122,6 +1134,11 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
         }
         return { target: 'node', selector: { prop: NodeAttr.isIdle, op: isNegation ? 'falsy' : 'truthy' } };
       case 'mirroring':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return { target: 'node', selector: { prop: NodeAttr.hasMirroring, op: isNegation ? 'falsy' : 'truthy' } };
       case 'outside':
       case 'outsider':
@@ -1149,12 +1166,22 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
         return { target: 'node', selector: { prop: NodeAttr.isOutOfMesh, op: isNegation ? 'falsy' : 'truthy' } };
       case 'tcpts':
       case 'tcptrafficshifting':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return {
           target: 'node',
           selector: { prop: NodeAttr.hasTCPTrafficShifting, op: isNegation ? 'falsy' : 'truthy' }
         };
       case 'ts':
       case 'trafficshifting':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return {
           target: 'node',
           selector: { prop: NodeAttr.hasTrafficShifting, op: isNegation ? 'falsy' : 'truthy' }
@@ -1164,6 +1191,11 @@ export class GraphFindComponent extends React.Component<GraphFindProps, GraphFin
         return { target: 'node', selector: { prop: NodeAttr.isRoot, op: isNegation ? 'falsy' : 'truthy' } };
       case 'vs':
       case 'virtualservice':
+        if (!this.props.showVirtualServices) {
+          AlertUtils.addSuccess('Enabling "Virtual Services" display option for graph find/hide expression');
+          this.props.toggleGraphVirtualServices();
+        }
+
         return { target: 'node', selector: { prop: NodeAttr.hasVS, op: isNegation ? 'falsy' : 'truthy' } };
       case 'we':
       case 'workloadentry':
@@ -1204,7 +1236,8 @@ const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   showFindHelp: state.graph.toolbarState.showFindHelp,
   showIdleNodes: state.graph.toolbarState.showIdleNodes,
   showRank: state.graph.toolbarState.showRank,
-  showSecurity: state.graph.toolbarState.showSecurity
+  showSecurity: state.graph.toolbarState.showSecurity,
+  showVirtualServices: state.graph.toolbarState.showVirtualServices
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
@@ -1215,7 +1248,8 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
     toggleFindHelp: bindActionCreators(GraphToolbarActions.toggleFindHelp, dispatch),
     toggleGraphSecurity: bindActionCreators(GraphToolbarActions.toggleGraphSecurity, dispatch),
     toggleIdleNodes: bindActionCreators(GraphToolbarActions.toggleIdleNodes, dispatch),
-    toggleRank: bindActionCreators(GraphToolbarActions.toggleRank, dispatch)
+    toggleRank: bindActionCreators(GraphToolbarActions.toggleRank, dispatch),
+    toggleGraphVirtualServices: bindActionCreators(GraphToolbarActions.toggleGraphVirtualServices, dispatch)
   };
 };
 

--- a/frontend/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
@@ -22,11 +22,13 @@ describe('Parse find value test', () => {
         showRank={true}
         showSecurity={false}
         showIdleNodes={false}
+        showVirtualServices={true}
         setEdgeLabels={testSetter}
         setFindValue={testSetter}
         setHideValue={testSetter}
         toggleFindHelp={testHandler}
         toggleGraphSecurity={testHandler}
+        toggleGraphVirtualServices={testHandler}
         toggleIdleNodes={testHandler}
         toggleRank={testHandler}
       />

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -413,6 +413,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
       showIdleNodes: this.props.dataSource.fetchParameters.showIdleNodes,
       showOperationNodes: this.props.dataSource.fetchParameters.showOperationNodes,
       showServiceNodes: true,
+      showVirtualServices: true,
       showWaypoints: this.props.dataSource.fetchParameters.showWaypoints,
       trafficRates: this.props.dataSource.fetchParameters.trafficRates
     };

--- a/frontend/src/pages/Graph/components/stylesComponentFactory.tsx
+++ b/frontend/src/pages/Graph/components/stylesComponentFactory.tsx
@@ -284,6 +284,7 @@ const handleGraphNav = (fromNode: GraphElement, kiosk: string): void => {
     showIdleNodes: state.graph.toolbarState.showIdleNodes,
     showOperationNodes: state.graph.toolbarState.showOperationNodes,
     showServiceNodes: state.graph.toolbarState.showServiceNodes,
+    showVirtualServices: state.graph.toolbarState.showVirtualServices,
     showWaypoints: state.graph.toolbarState.showWaypoints,
     trafficRates: graphData.fetchParams.trafficRates
   };

--- a/frontend/src/services/GraphDataSource.ts
+++ b/frontend/src/services/GraphDataSource.ts
@@ -73,6 +73,7 @@ export interface FetchParams {
   showIdleNodes: boolean;
   showOperationNodes: boolean;
   showSecurity: boolean;
+  showVirtualServices: boolean;
   showWaypoints: boolean;
   trafficRates: TrafficRate[];
 }
@@ -135,6 +136,7 @@ export class GraphDataSource {
       showOperationNodes: false,
       showSecurity: false,
       showWaypoints: true,
+      showVirtualServices: true,
       trafficRates: []
     };
     this._isError = this._isLoading = false;
@@ -185,10 +187,14 @@ export class GraphDataSource {
     }
 
     // Some appenders are expensive so only specify an appender if needed.
-    let appenders: AppenderString = 'deadNode,istio,serviceEntry,meshCheck,workloadEntry';
+    let appenders: AppenderString = 'deadNode,serviceEntry,meshCheck,workloadEntry';
 
     if (fetchParams.includeHealth) {
       appenders += ',health';
+    }
+
+    if (fetchParams.showVirtualServices) {
+      appenders += ',istio';
     }
 
     if (fetchParams.showOperationNodes) {
@@ -521,6 +527,7 @@ export class GraphDataSource {
       showIdleNodes: false,
       showOperationNodes: false,
       showSecurity: false,
+      showVirtualServices: true,
       showWaypoints: true,
       trafficRates: DefaultTrafficRates
     };

--- a/frontend/src/services/__tests__/GraphDataSource.test.ts
+++ b/frontend/src/services/__tests__/GraphDataSource.test.ts
@@ -26,6 +26,7 @@ const FETCH_PARAMS = {
   showIdleNodes: false,
   showOperationNodes: false,
   showSecurity: false,
+  showVirtualServices: false,
   showWaypoints: false,
   trafficRates: DefaultTrafficRates
 };


### PR DESCRIPTION
Closes #8732 

Disabling "Show Virtual Services" now disables the "istio_details" appender in the backend graph-gen. This can touch a few more things than just VS nodes, but can be necessary of the appender is running too slowly.

To Test:
Enable/Disable the `Show Virtual Services` graph display option. Using the browser debugger Network tab, examine the outgoing graph requests. The "appender=" query param should or should not include ",istio" depending on the setting.
