### PR TITLE
Migrate to keycloak operator from helm chart

### DIFF
--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd ${SCRIPT_DIR}/..
+
+# Not exposed as a flag yet but could be.
+KEYCLOAK_VERSION="26.3.4"
+
 KEYCLOAK_CERTS_DIR=""
 KEYCLOAK_EXTERNAL_IP=""
 SET_LIMIT_MEMORY=""
@@ -116,7 +122,7 @@ EOF
     -extensions v3_req -extfile "${KEYCLOAK_CERTS_DIR}"/req.cnf
   
   # create kube secret from the certs
-  kubectl create secret tls keycloak-tls --cert="${KEYCLOAK_CERTS_DIR}"/cert.pem --key="${KEYCLOAK_CERTS_DIR}"/key.pem -n keycloak
+  kubectl get secret keycloak-tls -n keycloak || kubectl create secret tls keycloak-tls --cert="${KEYCLOAK_CERTS_DIR}"/cert.pem --key="${KEYCLOAK_CERTS_DIR}"/key.pem -n keycloak
 
   HELM_MEMORY_ARGS=""
   if [ -n "$SET_LIMIT_MEMORY" ]; then
@@ -125,28 +131,24 @@ EOF
   if [ -n "$SET_REQUESTS_MEMORY" ]; then
     HELM_MEMORY_ARGS="$HELM_MEMORY_ARGS --set resources.requests.memory=$SET_REQUESTS_MEMORY"
   fi
-  helm upgrade --install --wait --timeout 15m \
-  --namespace keycloak \
-  keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --version 24.3.2 \
-  $HELM_MEMORY_ARGS \
-  --reuse-values --values - <<EOF
-auth:
-  createAdminUser: true
-  adminUser: admin
-  adminPassword: admin
-  managementUser: manager
-  managementPassword: manager
-proxyAddressForwarding: true
-postgresql:
-  enabled: true
-tls:
-  enabled: true
-  usePem: true
-  existingSecret: keycloak-tls
-service:
-  type: LoadBalancer
-EOF
 
+  kubectl apply -n keycloak -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+  kubectl apply -n keycloak -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+  kubectl apply -n keycloak -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml
+
+  kubectl apply -n keycloak -f "${SCRIPT_DIR}/keycloak/postgresql.yaml"
+  kubectl apply -n keycloak -f "${SCRIPT_DIR}/keycloak/keycloak-service.yaml"
+  kubectl apply -n keycloak -f "${SCRIPT_DIR}/keycloak/keycloak-secrets.yaml"
+  keycloak_yaml=$(cat "${SCRIPT_DIR}/keycloak/keycloak-cr.yaml" | yq ".spec.hostname.hostname = \"${KEYCLOAK_EXTERNAL_ADDRESS}\"")
+  if [ -n "$SET_REQUESTS_MEMORY" ]; then
+    keycloak_yaml=$(echo "${keycloak_yaml}" | yq ".spec.resources.requests.memory = \"${SET_REQUESTS_MEMORY}\"")
+  fi
+  if [ -n "$SET_LIMIT_MEMORY" ]; then
+    keycloak_yaml=$(echo "${keycloak_yaml}" | yq ".spec.resources.limits.memory = \"${SET_LIMIT_MEMORY}\"")
+  fi
+  kubectl apply -n keycloak -f - <<< "${keycloak_yaml}"
+
+  kubectl wait --for=condition=Ready keycloak/keycloak -n keycloak --timeout=600s
   echo "Keycloak deployed. Waiting for the keycloak ingress to be ready..."
   kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' -n keycloak service/keycloak
 fi

--- a/hack/keycloak/keycloak-cr.yaml
+++ b/hack/keycloak/keycloak-cr.yaml
@@ -1,0 +1,34 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  hostname:
+    hostname: <Replace with the external IP of the keycloak service>
+  instances: 1
+  db:
+    vendor: postgres
+    host: keycloak-postgresql
+    database: keycloak
+    usernameSecret:
+      name: keycloak-db-secret
+      key: username
+    passwordSecret:
+      name: keycloak-db-secret
+      key: password
+
+  http:
+    tlsSecret: keycloak-tls
+
+  bootstrapAdmin:
+    user:
+      secret: keycloak-admin
+
+  # Disable ingress since we're using LoadBalancer service with MetalLB
+  ingress:
+    enabled: false
+
+  additionalOptions:
+  - name: proxy-address-forwarding
+    value: "true"

--- a/hack/keycloak/keycloak-secrets.yaml
+++ b/hack/keycloak/keycloak-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin
+  namespace: keycloak
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-secret
+  namespace: keycloak
+type: Opaque
+stringData:
+  username: keycloak
+  password: keycloak

--- a/hack/keycloak/keycloak-service.yaml
+++ b/hack/keycloak/keycloak-service.yaml
@@ -1,0 +1,19 @@
+# Service to expose Keycloak as LoadBalancer.
+# We could use ingress but we'd also need to deploy a separate ingress controller.
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: keycloak
+  labels:
+    app: keycloak
+spec:
+  type: LoadBalancer
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app.kubernetes.io/managed-by: keycloak-operator
+    app.kubernetes.io/component: server

--- a/hack/keycloak/postgresql.yaml
+++ b/hack/keycloak/postgresql.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql-db
+spec:
+  serviceName: postgresql-db-service
+  selector:
+    matchLabels:
+      app: postgresql-db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgresql-db
+    spec:
+      containers:
+      - name: postgresql-db
+        image: postgres:15
+        volumeMounts:
+        - mountPath: /data
+          name: cache-volume
+        env:
+        - name: POSTGRES_USER
+          value: keycloak
+        - name: POSTGRES_PASSWORD
+          value: keycloak
+        - name: PGDATA
+          value: /data/pgdata
+        - name: POSTGRES_DB
+          value: keycloak
+      volumes:
+      - name: cache-volume
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+spec:
+  selector:
+    app: postgresql-db
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432


### PR DESCRIPTION
### Describe the change

Installs the keycloak operator and the keycloak CR rather than using the bitnami keycloak helm chart.

### Steps to test the PR

CI passes.

### Automation testing

N/A

### Issue reference

~Fixes https://github.com/kiali/kiali/issues/6455~
Fixes https://github.com/kiali/kiali/issues/8742

