### PR TITLE
Check waypoint health before checking for icon

### DIFF
--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -9,6 +9,7 @@ Feature: Kiali Waypoint related features
 
   Background:
     Given user is at administrator perspective
+    And all waypoints are healthy
 
   Scenario: [Setup] namespace is labeled with waypoint label
     Then "bookinfo" namespace is labeled with the waypoint label
@@ -37,7 +38,6 @@ Feature: Kiali Waypoint related features
     And the link for the waypoint "waypoint" should redirect to a valid workload details
 
   Scenario: [Workload details - waypoint] The workload details for a waypoint are valid
-    Given the waypoint is healthy
     And user is at the details page for the "workload" "bookinfo/waypoint" located in the "" cluster
     Then the user sees the "L7" badge
     Then the user cannot see the "missing-sidecar" badge for "waypoint" workload in "bookinfo" namespace


### PR DESCRIPTION
### Describe the change

Try to address a flake in the waypoint tests by checking for the health of the waypoint workload before checking for the info icon. The health occasionaly is degraded but this is probably temporary.

### Steps to test the PR

Ambient CI passes.

### Automation testing

Ambient CI passes.

### Issue reference
N/A
