### PR TITLE
[CI] Attempt to fix tempo flake

### DIFF
--- a/hack/istio/tempo/install-tempo-env.sh
+++ b/hack/istio/tempo/install-tempo-env.sh
@@ -264,6 +264,12 @@ install_tempo_single_attempt() {
   echo -e "Waiting for cert-manager pods to be ready... \n"
   $CLIENT_EXE wait pods --all -n cert-manager --for=condition=Ready --timeout=5m
 
+  # There's some issue with the cert-manager webhook where it fails to add the https cert to the webhook
+  # before it is marked as ready. So we need to wait for a small period of time before installing the Tempo operator
+  # because the tempo manifests rely on the cert-manager webhook to be ready.
+  echo -e "Waiting for cert-manager webhook to be ready... \n"
+  sleep 10
+
   echo -e "Installing latest Tempo operator \n"
   ${CLIENT_EXE} apply -f https://github.com/grafana/tempo-operator/releases/latest/download/tempo-operator.yaml
   echo -e "Waiting for Tempo operator to be ready... \n"


### PR DESCRIPTION
### Describe the change

Adds a sleep before creating tempo operator. The thought here is that these kinds of failures in CI:

<img width="2117" height="505" alt="Screenshot from 2025-09-19 14-50-42" src="https://github.com/user-attachments/assets/0383d49a-e02d-4d90-b22e-d0d548be1e9d" />

are due to the [cert-manager webhook's dynamic cert](https://github.com/cert-manager/cert-manager/blob/e2aa55ced7cf3ef8878d8c81a73a0d132fa462e8/deploy/charts/cert-manager/templates/webhook-deployment.yaml#L103-L107) not being loaded in time before the Tempo operator manifest tries to create a cert-manager resource like `Certificate` and calls the webhook.

I searched around a bit and [this](https://github.com/cert-manager/cert-manager/issues/7687) might be a similar issue.

### Steps to test the PR

N/A

### Automation testing

N/A

### Issue reference
N/A
