### PR TITLE
Fix scroll in IstioConfigNewPage (#8751)

### DIFF
--- a/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/frontend/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -497,7 +497,7 @@ const IstioConfigNewPageComponent: React.FC<Props> = (props: Props) => {
         <DefaultSecondaryMasthead showClusterSelector={false} hideNamespaceSelector={true} />
       </div>
 
-      <div style={{ flex: 1, overflow: 'auto' }}>
+       <div style={{ flexGrow: 1, overflowY: 'auto' }}>
         <RenderContent>
           <Form className={formPadding} isHorizontal={true}>
             <FormGroup label={t('Namespaces')} isRequired={true} fieldId="namespaces">


### PR DESCRIPTION
### Describe the change

I proposed a fix for issue (#8751). It's just a reference fix. I hope someone helps me to rewrite it for kiali code style.

### Steps to test the PR

Creating an AuthorizationPolicy and selecting RULES policy will result in content height overflow:
<img width="1200" height="814" alt="Image" src="https://github.com/user-attachments/assets/556f5b04-ec3e-48cb-9664-161f219b5588" />

### Automation testing

None

### Issue reference

The issue: https://github.com/kiali/kiali/issues/8751