### PR TITLE
Add lock for GetRootNamespace

### DIFF
--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -345,6 +345,9 @@ func (in *Discovery) HasControlPlane(ctx context.Context, cluster string, ns str
 
 // GetRootNamespace returns the Istio root namespace for the control plane managing the given namespace
 func (in *Discovery) GetRootNamespace(ctx context.Context, cluster, namespace string) string {
+	defer in.meshMutex.Unlock()
+	in.meshMutex.Lock()
+
 	cp := in.namespaceMap[in.namespaceMapKey(cluster, namespace)]
 	if cp != nil {
 		return cp.RootNamespace


### PR DESCRIPTION
### Describe the change

Fixes data race in `GetRootNamespace`.

### Steps to test the PR

N/A

### Automation testing

Included already in current automation. I failed at coming up with a unit test to cover this.

### Issue reference

Fixes #8759 