### PR TITLE
Show local mode Kiali in Mesh

### DIFF
--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -190,3 +190,7 @@ Feature: Kiali Mesh page
     And user sees 0 "dataplane" nodes on the "mgmt" cluster
     And user sees 0 "istiod" nodes on the "mgmt" cluster
     And user sees the "kiali" node connected to the 1 "istiod" nodes
+
+  @smoke
+  Scenario: Local-kiali: see kiali node in local mode
+    And user sees the "kiali" node connected to the 1 "istiod" nodes

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -155,7 +155,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 
 		// add any Kiali instances
 		for _, ki := range cp.Cluster.KialiInstances {
-			kiali, _, err := addInfra(meshMap, mesh.InfraTypeKiali, cp.Cluster.Name, ki.Namespace, ki.ServiceName, es.Istio, ki.Version, true, "")
+			kiali, _, err := addInfra(meshMap, mesh.InfraTypeKiali, cp.Cluster.Name, ki.Namespace, ki.ServiceName, es.Istio, ki.Version, false, "")
 			mesh.CheckError(err)
 
 			if es.Istio.IstioAPIEnabled {


### PR DESCRIPTION
### Describe the change
Added Kiali local mode in Mesh page.
For simplicity and escaping further fixes with metrics load and other side panel items loading, showing Kiali in current cluster.

### Steps to test the PR
Start Kiali in local mode: Steps here https://github.com/kiali/kiali/pull/8274
Make sure that Kiali is shown in Mesh page:
<img width="1709" height="955" alt="Screenshot From 2025-09-24 10-50-51" src="https://github.com/user-attachments/assets/43c0935e-e729-453f-95d5-bd574f535ff9" />

### Automation testing
Added new cypress test.

### Issue reference
https://github.com/kiali/kiali/issues/8668
