### PR TITLE
Fix Grafana URL

### DIFF
--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -69,7 +69,7 @@ func (s *Service) discover(ctx context.Context) string {
 	// Try to get service and namespace from in-cluster URL, to discover route
 	routeURL := ""
 	var err error
-	if internalURL := s.conf.ExternalServices.Perses.InternalURL; internalURL != "" {
+	if internalURL := s.conf.ExternalServices.Grafana.InternalURL; internalURL != "" {
 		routeURL, err = ParseUrl(ctx, internalURL, s.homeClusterSAClient)
 		if err == nil {
 			s.routeURL = &routeURL


### PR DESCRIPTION
### Describe the change

#8583 swapped the Grafana URL used for versioning. 

I don't think it was intentional and breaks the UI version display of Grafana sources. 

This PR restores it.


