### PR TITLE
Add support for explicit OpenID Connect endpoints configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -488,7 +488,10 @@ type OpenIdConfig struct {
 	HTTPSProxy              string            `yaml:"https_proxy,omitempty"`
 	InsecureSkipVerifyTLS   bool              `yaml:"insecure_skip_verify_tls,omitempty"`
 	IssuerUri               string            `yaml:"issuer_uri,omitempty"`
+	JwksUri                 string            `yaml:"jwks_uri,omitempty"`
 	Scopes                  []string          `yaml:"scopes,omitempty"`
+	TokenEndpoint           string            `yaml:"token_endpoint,omitempty"`
+	UserInfoEndpoint        string            `yaml:"userinfo_endpoint,omitempty"`
 	UsernameClaim           string            `yaml:"username_claim,omitempty"`
 }
 
@@ -756,7 +759,10 @@ func NewConfig() (c *Config) {
 				DisableRBAC:             false,
 				InsecureSkipVerifyTLS:   false,
 				IssuerUri:               "",
+				JwksUri:                 "",
 				Scopes:                  []string{"openid", "profile", "email"},
+				TokenEndpoint:           "",
+				UserInfoEndpoint:        "",
 				UsernameClaim:           "sub",
 			},
 			OpenShift: OpenShiftConfig{


### PR DESCRIPTION
- Add TokenEndpoint, UserInfoEndpoint, and JwksUri fields to OpenIdConfig
- Enable explicit OIDC endpoint configuration to bypass auto-discovery
- Skip auto-discovery when explicit authorization_endpoint and token_endpoint are provided
- Use explicit endpoints for token exchange and validation when configured
- Fixes authentication issues when OIDC discovery endpoint is restricted

This allows Kiali to work with OIDC providers that restrict access to the /.well-known/openid-configuration endpoint by providing explicit endpoint URLs in the configuration instead of relying on auto-discovery.

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
