### PR TITLE
[CI] ossmc failure for hidden element 

### DIFF
--- a/frontend/cypress/integration/common/transition.ts
+++ b/frontend/cypress/integration/common/transition.ts
@@ -6,5 +6,5 @@ export const ensureKialiFinishedLoading = (): void => {
 };
 
 export const openTab = (tab: string): void => {
-  cy.get('#basic-tabs', { timeout: 60000 }).should('be.visible').contains(tab).click(); // Can be very slow for OpenShift, specially in the UI
+  cy.get('#basic-tabs', { timeout: 60000 }).should('exist').contains(tab).click(); // Can be very slow for OpenShift, specially in the UI
 };


### PR DESCRIPTION
### Describe the change

Should fix a failure for OSSMC tests where an element can't be clicked because it is hidden due to scroll: 

<img width="738" height="425" alt="image" src="https://github.com/user-attachments/assets/0748b002-cbb2-41d9-bef1-96728e934894" />

```
  1) Kiali Waypoint related features
       [Workload details - waypoint] The workload details for a waypoint are valid:
     AssertionError: Timed out retrying after 40000ms: expected '<div#basic-tabs.pf-v5-c-tabs.ossmconsole__f57izmj.ossmconsole__fgcjg5b>' to be 'visible'

This element `<div#basic-tabs.pf-v5-c-tabs.ossmconsole__f57izmj.ossmconsole__fgcjg5b>` is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: `hidden`, `scroll` or `auto`

```

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
