### PR TITLE
[Tracing] Add OpenShift tempo url provider

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -308,7 +308,10 @@ type TempoConfig struct {
 	CacheCapacity int    `yaml:"cache_capacity" json:"cacheCapacity,omitempty"`
 	CacheEnabled  bool   `yaml:"cache_enabled" json:"cacheEnabled,omitempty"`
 	DatasourceUID string `yaml:"datasource_uid" json:"datasourceUID,omitempty"`
+	Name          string `yaml:"name" json:"name,omitempty"`
+	Namespace     string `yaml:"namespace" json:"namespace,omitempty"`
 	OrgID         string `yaml:"org_id" json:"orgID,omitempty"`
+	Tenant        string `yaml:"tenant" json:"tenant,omitempty"`
 	URLFormat     string `yaml:"url_format" json:"urlFormat,omitempty"`
 }
 
@@ -856,6 +859,9 @@ func NewConfig() (c *Config) {
 				TempoConfig: TempoConfig{
 					CacheCapacity: 200,
 					CacheEnabled:  true,
+					Name:          "sample",
+					Namespace:     "tempo",
+					Tenant:        "default",
 				},
 				UseGRPC:              true,
 				WhiteListIstioSystem: []string{"jaeger-query", "istio-ingressgateway"},

--- a/frontend/src/components/Mesh/TraceConfigurationModal.tsx
+++ b/frontend/src/components/Mesh/TraceConfigurationModal.tsx
@@ -61,10 +61,15 @@ export const validateExternalUrl = (
       if (!urlProvider.HomeUrl() || !urlProvider.valid) {
         return '"View in Tracing" is hidden because external_url is empty';
       }
+    } else if (svc.tempoConfig?.urlFormat === TempoUrlFormat.OPENSHIFT) {
+      const urlProvider = new TempoUrlProvider(svc, externalServices);
+      if (!urlProvider.HomeUrl() || !urlProvider.valid) {
+        return '"View in Tracing" is hidden because external_url is empty or invalid for OpenShift console';
+      }
     } else {
       const urlProvider = new TempoUrlProvider(svc, externalServices);
       if (!urlProvider.HomeUrl() || !urlProvider.valid) {
-        return "\"View in Tracing\" link is hidden because Grafana is not enabled. To use external_url as 'View in tracing' link, tempo_config.url_format must be set to 'jaeger'";
+        return "\"View in Tracing\" link is hidden because Grafana is not enabled. To use external_url as 'View in tracing' link, tempo_config.url_format must be set to 'jaeger' or 'openshift'";
       }
     }
   }

--- a/frontend/src/types/StatusState.ts
+++ b/frontend/src/types/StatusState.ts
@@ -8,14 +8,18 @@ export enum StatusKey {
 
 export enum TempoUrlFormat {
   JAEGER = 'jaeger',
-  GRAFANA = 'grafana'
+  GRAFANA = 'grafana',
+  OPENSHIFT = 'openshift'
 }
 
 export type Status = { [K in StatusKey]?: string };
 
 export type TempoConfig = {
   datasourceUID: string;
+  name: string;
+  namespace: string;
   orgID: string;
+  tenant: string;
   urlFormat: TempoUrlFormat;
 };
 

--- a/frontend/src/utils/tracing/UrlProviders/OpenShift.ts
+++ b/frontend/src/utils/tracing/UrlProviders/OpenShift.ts
@@ -1,0 +1,122 @@
+import { ConcreteService, TracingUrlProvider } from 'types/Tracing';
+import { ExternalServiceInfo, TempoConfig } from 'types/StatusState';
+import { BoundsInMilliseconds } from 'types/Common';
+import { SpanData, TraceData } from '../../../types/TracingInfo';
+
+interface OpenShiftExternalService extends ConcreteService {
+  name: string;
+  tempoConfig?: TempoConfig;
+}
+
+export function isOpenShiftService(svc: ExternalServiceInfo): svc is OpenShiftExternalService {
+  return svc.name.toLowerCase().includes('openshift') || svc.name.toLowerCase().includes('console');
+}
+
+export class OpenShiftUrlProvider implements TracingUrlProvider {
+  private service: OpenShiftExternalService;
+  readonly valid: boolean = true;
+
+  constructor(service: OpenShiftExternalService) {
+    this.service = service;
+  }
+
+  private buildBaseUrl(): string {
+    // Ensure the URL ends with a slash for proper path joining
+    const baseUrl = this.service.url.endsWith('/') ? this.service.url : `${this.service.url}/`;
+    return `${baseUrl}observe/traces`;
+  }
+
+  private buildQueryParams(bounds: BoundsInMilliseconds, tags: Record<string, string>, limit: number): string {
+    const params = new URLSearchParams();
+
+    // Add configurable parameters for OpenShift console
+    const namespace = this.service.tempoConfig?.namespace || 'tempo';
+    const name = this.service.tempoConfig?.name || 'sample';
+    const tenant = this.service.tempoConfig?.tenant || 'default';
+
+    params.append('namespace', namespace);
+    params.append('name', name);
+    params.append('tenant', tenant);
+    params.append('limit', limit.toString());
+
+    // Add time range parameters
+    if (bounds.from) {
+      params.append('start', (bounds.from * 1000).toString());
+    }
+    if (bounds.to && bounds.from) {
+      const duration = bounds.to - bounds.from;
+      // Convert duration to hours for the duration parameter
+      const durationHours = Math.max(1, Math.ceil(duration / 3600));
+      params.append('duration', `${durationHours}h`);
+    }
+
+    // Add tags as query parameter
+    if (tags && Object.keys(tags).length > 0) {
+      params.append('tags', encodeURIComponent(JSON.stringify(tags)));
+    } else {
+      params.append('tags', encodeURIComponent(JSON.stringify({})));
+    }
+
+    return params.toString();
+  }
+
+  private buildServiceQuery(serviceName: string): string {
+    // Build the query parameter for service name
+    const query = `{ resource.service.name = "${serviceName}" }`;
+    return encodeURIComponent(query);
+  }
+
+  TraceUrl(trace: TraceData<any>): string {
+    const baseUrl = this.buildBaseUrl();
+    const traceId = trace.traceID;
+
+    // For trace URLs, we need to include the trace ID in the path and add query parameters
+    // Use current time as fallback since TraceData doesn't have startTime/duration
+    const now = Date.now() / 1000;
+    const queryParams = this.buildQueryParams(
+      { from: now - 3600, to: now }, // Default to last hour
+      {},
+      100
+    );
+    return `${baseUrl}/${traceId}?${queryParams}`;
+  }
+
+  SpanUrl(span: SpanData): string {
+    const baseUrl = this.buildBaseUrl();
+    const traceId = span.traceID;
+
+    // For span URLs, we include the trace ID in the path and add query parameters
+    // OpenShift console will handle highlighting the specific span
+    const queryParams = this.buildQueryParams({ from: span.startTime, to: span.startTime + span.duration }, {}, 100);
+    return `${baseUrl}/${traceId}?${queryParams}`;
+  }
+
+  ComparisonUrl(traceID: string, ...traces: string[]): string | undefined {
+    // OpenShift console doesn't seem to have a direct comparison feature
+    // Return the first trace URL as a fallback with query parameters
+    if (traces.length > 0) {
+      return this.TraceUrl({
+        traceID: traces[0],
+        processes: {},
+        spans: []
+      } as TraceData<any>);
+    }
+    return this.TraceUrl({
+      traceID,
+      processes: {},
+      spans: []
+    } as TraceData<any>);
+  }
+
+  AppSearchUrl(serviceName: string, bounds: BoundsInMilliseconds, tags: Record<string, string>, limit: number): string {
+    const baseUrl = this.buildBaseUrl();
+    const queryParams = this.buildQueryParams(bounds, tags, limit);
+    const serviceQuery = this.buildServiceQuery(serviceName);
+
+    return `${baseUrl}?${queryParams}&q=${serviceQuery}`;
+  }
+
+  HomeUrl(): string {
+    return this.buildBaseUrl();
+  }
+}

--- a/frontend/src/utils/tracing/UrlProviders/index.ts
+++ b/frontend/src/utils/tracing/UrlProviders/index.ts
@@ -25,6 +25,7 @@ export function GetTracingUrlProvider(
     if (svc.tempoConfig?.urlFormat === TempoUrlFormat.JAEGER) {
       urlProvider = new JaegerUrlProvider(svc);
     } else {
+      // Handle GRAFANA, OPENSHIFT, and other formats through TempoUrlProvider
       urlProvider = new TempoUrlProvider(svc, externalServices);
     }
   }


### PR DESCRIPTION
### Describe the change

Adds OpenShift tempo url provider

### Steps to test the PR
- Install Tempo, Kiali, and the observability UI Plugin with a distributed tracing instance in OpenShift
- Create a Kiali CR with the config: 
(Use the Tempo instance namespace, name and tenant)

```
      tracing:
        ...
        external_url: 'https://console-openshift-console.server.com'
        tempo_config:
          name: 'sample'
          namespace: 'tempo'
          tenant: 'default'
          url_format: openshift
```

Validate that the Trancing URL redirect correctly: 
<img width="1902" height="789" alt="image" src="https://github.com/user-attachments/assets/2a599b80-79df-4375-a516-13528d471bb7" />

<img width="1902" height="901" alt="image" src="https://github.com/user-attachments/assets/06ff4da5-efc5-4318-aeb1-ef1f7ef603f4" />


<img width="1902" height="901" alt="image" src="https://github.com/user-attachments/assets/fb9ca312-1b81-4d0d-b351-3f1066dc39ea" />

<img width="1902" height="646" alt="image" src="https://github.com/user-attachments/assets/e9a8edfd-cfaa-41a0-b61c-6a77f56fbd6c" />


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Closes https://github.com/kiali/kiali/issues/8762 
