### PR TITLE
Support custom GVKs in UI observability feature gating

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -672,13 +672,14 @@ type KialiURL struct {
 
 // KialiFeatureFlags available from the CR
 type KialiFeatureFlags struct {
-	Clustering            FeatureFlagClustering `yaml:"clustering,omitempty" json:"clustering,omitempty"`
-	DisabledFeatures      []string              `yaml:"disabled_features,omitempty" json:"disabledFeatures,omitempty"`
-	IstioAnnotationAction bool                  `yaml:"istio_annotation_action,omitempty" json:"istioAnnotationAction"`
-	IstioInjectionAction  bool                  `yaml:"istio_injection_action,omitempty" json:"istioInjectionAction"`
-	IstioUpgradeAction    bool                  `yaml:"istio_upgrade_action,omitempty" json:"istioUpgradeAction"`
-	UIDefaults            UIDefaults            `yaml:"ui_defaults,omitempty" json:"uiDefaults,omitempty"`
-	Validations           Validations           `yaml:"validations,omitempty" json:"validations,omitempty"`
+	Clustering            FeatureFlagClustering     `yaml:"clustering,omitempty" json:"clustering,omitempty"`
+	CustomWorkloadTypes   []metav1.GroupVersionKind `yaml:"custom_workload_types,omitempty" json:"customWorkloadTypes,omitempty"`
+	DisabledFeatures      []string                  `yaml:"disabled_features,omitempty" json:"disabledFeatures,omitempty"`
+	IstioAnnotationAction bool                      `yaml:"istio_annotation_action,omitempty" json:"istioAnnotationAction"`
+	IstioInjectionAction  bool                      `yaml:"istio_injection_action,omitempty" json:"istioInjectionAction"`
+	IstioUpgradeAction    bool                      `yaml:"istio_upgrade_action,omitempty" json:"istioUpgradeAction"`
+	UIDefaults            UIDefaults                `yaml:"ui_defaults,omitempty" json:"uiDefaults,omitempty"`
+	Validations           Validations               `yaml:"validations,omitempty" json:"validations,omitempty"`
 }
 
 // Tolerance config

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -92,6 +92,7 @@ const defaultServerConfig: ComputedServerConfig = {
     versionLabelName: ''
   },
   kialiFeatureFlags: {
+    customWorkloadTypes: [],
     disabledFeatures: [],
     istioInjectionAction: true,
     istioAnnotationAction: true,

--- a/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -279,10 +279,12 @@ const workloadTypeFilter: FilterType = {
       }
     ]
       .concat(
-        (serverConfig.kialiFeatureFlags.customWorkloadTypes || []).map(gvk => ({
-          id: gvk.kind,
-          title: gvk.kind
-        }))
+        (serverConfig.kialiFeatureFlags.customWorkloadTypes || [])
+          .filter(gvk => gvk.kind && gvk.kind.trim() !== '')
+          .map(gvk => ({
+            id: gvk.kind,
+            title: gvk.kind
+          }))
       )
       .sort((a, b) => a.title.localeCompare(b.title));
   }

--- a/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/frontend/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -235,48 +235,57 @@ const workloadTypeFilter: FilterType = {
   placeholder: 'Filter by Workload Type',
   filterType: AllFilterTypes.typeAhead,
   action: FILTER_ACTION_APPEND,
-  filterValues: [
-    {
-      id: dicTypeToGVK.CronJob.Kind,
-      title: dicTypeToGVK.CronJob.Kind
-    },
-    {
-      id: dicTypeToGVK.DaemonSet.Kind,
-      title: dicTypeToGVK.DaemonSet.Kind
-    },
-    {
-      id: dicTypeToGVK.Deployment.Kind,
-      title: dicTypeToGVK.Deployment.Kind
-    },
-    {
-      id: dicTypeToGVK.DeploymentConfig.Kind,
-      title: dicTypeToGVK.DeploymentConfig.Kind
-    },
-    {
-      id: dicTypeToGVK.Job.Kind,
-      title: dicTypeToGVK.Job.Kind
-    },
-    {
-      id: dicTypeToGVK.Pod.Kind,
-      title: dicTypeToGVK.Pod.Kind
-    },
-    {
-      id: dicTypeToGVK.ReplicaSet.Kind,
-      title: dicTypeToGVK.ReplicaSet.Kind
-    },
-    {
-      id: dicTypeToGVK.ReplicationController.Kind,
-      title: dicTypeToGVK.ReplicationController.Kind
-    },
-    {
-      id: dicTypeToGVK.StatefulSet.Kind,
-      title: dicTypeToGVK.StatefulSet.Kind
-    },
-    {
-      id: dicTypeToGVK.WorkloadGroup.Kind,
-      title: dicTypeToGVK.WorkloadGroup.Kind
-    }
-  ]
+  get filterValues() {
+    return [
+      {
+        id: dicTypeToGVK.CronJob.Kind,
+        title: dicTypeToGVK.CronJob.Kind
+      },
+      {
+        id: dicTypeToGVK.DaemonSet.Kind,
+        title: dicTypeToGVK.DaemonSet.Kind
+      },
+      {
+        id: dicTypeToGVK.Deployment.Kind,
+        title: dicTypeToGVK.Deployment.Kind
+      },
+      {
+        id: dicTypeToGVK.DeploymentConfig.Kind,
+        title: dicTypeToGVK.DeploymentConfig.Kind
+      },
+      {
+        id: dicTypeToGVK.Job.Kind,
+        title: dicTypeToGVK.Job.Kind
+      },
+      {
+        id: dicTypeToGVK.Pod.Kind,
+        title: dicTypeToGVK.Pod.Kind
+      },
+      {
+        id: dicTypeToGVK.ReplicaSet.Kind,
+        title: dicTypeToGVK.ReplicaSet.Kind
+      },
+      {
+        id: dicTypeToGVK.ReplicationController.Kind,
+        title: dicTypeToGVK.ReplicationController.Kind
+      },
+      {
+        id: dicTypeToGVK.StatefulSet.Kind,
+        title: dicTypeToGVK.StatefulSet.Kind
+      },
+      {
+        id: dicTypeToGVK.WorkloadGroup.Kind,
+        title: dicTypeToGVK.WorkloadGroup.Kind
+      }
+    ]
+      .concat(
+        (serverConfig.kialiFeatureFlags.customWorkloadTypes || []).map(gvk => ({
+          id: gvk.kind,
+          title: gvk.kind
+        }))
+      )
+      .sort((a, b) => a.title.localeCompare(b.title));
+  }
 };
 
 export const availableFilters: FilterType[] = [

--- a/frontend/src/types/ServerConfig.ts
+++ b/frontend/src/types/ServerConfig.ts
@@ -79,7 +79,14 @@ interface UIDefaults {
   tracing: TracingDefaults;
 }
 
+interface CustomWorkloadType {
+  group: string;
+  version: string;
+  kind: string;
+}
+
 interface KialiFeatureFlags {
+  customWorkloadTypes?: CustomWorkloadType[];
   disabledFeatures: string[];
   istioAnnotationAction: boolean;
   istioInjectionAction: boolean;

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -257,10 +257,16 @@ export function isGVKSupported(gvk?: GroupVersionKind): boolean {
     return false;
   }
 
-  // Check built-in workload types.
+
+  // WorkloadGroup is not supported
+  if (gvk.Kind === gvkType.WorkloadGroup) {
+    return false;
+  }
+
+  // Check built-in workload types
   const builtIn = dicTypeToGVK[gvk.Kind as gvkType];
-  if (builtIn && builtIn.Group === gvk.Group && builtIn.Version === gvk.Version && builtIn.Kind === gvk.Kind) {
-    return true;
+  if (builtIn) {
+    return getGVKTypeString(gvk) === getGVKTypeString(builtIn);
   }
 
   // Check custom (user-configured) workload types.


### PR DESCRIPTION
I'm in the process of evaluating and rolling out Kiali and I have noticed the UI hides certain useful observability features (logs, metrics, traces) for workloads with unknown GVKs.

For me specifically this affects the Argo `Rollout` resources which we favor internally almost exclusively over `Deployment` but I presume it affects other custom controllers that also manage pods.

There is a whitelist in the Kiali product that couples these observability features to controller recognition.

However, AFAIK these restricted observability features operate at pod/mesh level and require no controller understanding.

### Describe the change

I could not find an existing configuration property to augment the whitelist so this PR adds one allowing users to enumerate custom GVKs to be considered during the UI feature evaluation.

A user would make Kiali aware of new kinds like so:

```yaml
kiali_feature_flags:
  custom_workload_types:
    - group: "argoproj.io"
      version: "v1alpha1" 
      kind: "Rollout"
    - group: "apps.kruise.io"
      version: "v1alpha1"
      kind: "CloneSet"
   ...
```

And the existing `isGVKSupported` function has been extended to consider these user-provided custom GVKs during display.

PTAL and let me know if this is something useful to the core product or if I have missed something obvious.