### PR TITLE
Fixed cypress flake: select a trace with 2 spans

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -59,6 +59,6 @@ Feature: Kiali App Details page
   @skip-ossmc
   Scenario: See span info after selecting app span
     And user sees trace information
-    When user selects a trace
+    When user selects a trace with at least 2 spans
     Then user sees span details
     And user can filter spans by app "waypoint"

--- a/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/service_details_multicluster.feature
@@ -42,7 +42,7 @@ Feature: Kiali Service Details page for remote cluster
 
   Scenario: See span info after selecting service span
     And user sees trace information
-    When user selects a trace
+    When user selects a trace with at least 2 spans
     Then user sees span details
 
   Scenario: Don't see tracing info

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -61,7 +61,7 @@ Feature: Kiali Workload Details page
   # TODO: offline - ambient.
   Scenario: See workload span info after selecting a span
     And user sees trace information
-    When user selects a trace
+    When user selects a trace with at least 2 spans
     And user sees span details
     And user can filter spans by workload "waypoint"
 

--- a/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details_multicluster.feature
@@ -29,7 +29,7 @@ Feature: Kiali Workload Details page
 
   Scenario: See workload span info after selecting a span
     And user sees trace information
-    When user selects a trace
+    When user selects a trace with at least 2 spans
     And user sees span details
     And user can filter spans by workload "details-v1"
 


### PR DESCRIPTION
### Describe the change

In Cypress tests, the check 'user sees span details' requires a Trace with more than one Span.
So make sure that 'user selects a trace with at least 2 spans' before this check.

### Issue reference
https://github.com/kiali/kiali/issues/8754
