### PR TITLE
[ci] fix molecule test nightly test - checkout missing files

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -48,6 +48,13 @@ jobs:
       with:
         sparse-checkout: |
           hack/ci-kind-molecule-tests.sh
+          hack/install-hydra-kind.sh
+          hack/start-kind.sh
+          hack/ory-hydra/scripts/gencert.sh
+          hack/ory-hydra/scripts/install-hydra.sh
+          hack/ory-hydra/scripts/setup-clients.sh
+          hack/ory-hydra/manifests/postgresql.yaml
+          hack/ory-hydra/manifests/hydra-ui-simple.yaml
     - name: Install Helm
       uses: Azure/setup-helm@v4.3.1
       with:


### PR DESCRIPTION
The molecule nightly tests are failing because the workflow is not checking out new files that it now needs.

(this PR can be merged now, no need to wait for CI tests because this only changes the molecule.yml workflow so doesn't affect any production code or any other CI tests - so the PR ci tests are irrelevant for this)