### PR TITLE
[2.17] fix setup-envtest version so it doesn't require go 1.25 (#8799)

### DIFF
--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -138,7 +138,7 @@ lint:
 ## Download setup-envtest locally if necessary.
 .ensure-envtest-exists:
 	@if [ ! -x envtest ]; then \
-	  ${GO} install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest; \
+	  ${GO} install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20; \
 	fi
 
 YQ := $(shell command -v yq 2> /dev/null)


### PR DESCRIPTION
Backport from https://github.com/kiali/kiali/pull/8799
