### PR TITLE
Hardcode Istio version in download-istio hack script

### DIFF
--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -103,10 +103,12 @@ Then('user should only see workloads with a version label', () => {
     const regex = new RegExp(`version=|service.istio.io/canonical-revision=|app.kubernetes.io/version=`);
 
     cy.get('tr').each($item => {
-      cy.wrap($item).find('td').eq(4).as('labelCell');
-      cy.get('@labelCell').within(() => {
-        cy.get('span').children().contains(regex);
-      });
+      cy.wrap($item)
+        .find('td')
+        .eq(4)
+        .within(() => {
+          cy.get('span').children().contains(regex);
+        });
     });
   });
 });


### PR DESCRIPTION
### Describe the change

I removed the 2 hour stalling when there API rate limits, making the hack script fail faster. I also added the istio version to be hardcoded for a fallback if the Github API's do not work/ or not found. 

### Steps to test the PR
Have crc running
run until you get 403's:
```
for i in {1..61}; do
    echo "Request $i..."
    curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/istio/istio/releases
    echo
done
```
Rerun `./download-istio.sh `


### Issue reference

Closes https://github.com/kiali/kiali/issues/8530#issuecomment-3424918136
