### PR TITLE
Remove netobserv service links because Netobserv frequently does not …

### DIFF
--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -138,7 +138,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     const shouldRenderApp = app && ![NodeType.APP, NodeType.UNKNOWN].includes(nodeType) && !nodeData.isWaypoint;
     const shouldRenderWorkload = workload && ![NodeType.WORKLOAD, NodeType.UNKNOWN].includes(nodeType);
     const shouldRenderNetobservWorkload = hasNetobserv && (nodeType === NodeType.WORKLOAD || shouldRenderWorkload);
-    const shouldRenderNetobservService = hasNetobserv && (nodeType === NodeType.SERVICE || shouldRenderService);
     const shouldRenderTraces =
       !isServiceEntry &&
       !nodeData.isInaccessible &&
@@ -252,7 +251,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}
             {shouldRenderApp && <div>{renderBadgedLink(nodeData, NodeType.APP)}</div>}
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
-            {shouldRenderNetobservService && this.renderNetobservLink(nodeData, NodeType.SERVICE)}
             {shouldRenderNetobservWorkload && this.renderNetobservLink(nodeData, NodeType.WORKLOAD)}
           </div>
         </div>


### PR DESCRIPTION
Remove netobserv service links because Netobserv frequently does not supply a "Network Traffic" tab for services, and the console does not handle it well when trying to link to a non-existent tab.

Relates-to https://github.com/kiali/openshift-servicemesh-plugin/issues/507