### PR TITLE
Fixed failing Test Configurations cypress test.

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -438,6 +438,46 @@ When('user changes the provider in the Tester tab', () => {
   });
 });
 
+When('user changes the useGRPC in the Tester tab', () => {
+  cy.get('div[data-test="modal-configuration-tester"]').within(() => {
+    cy.window().then((win: any) => {
+      const editor = win.ace.edit('ace-editor-tester');
+      const session = editor.getSession();
+      const linesCount = session.getLength();
+      const searchText = 'useGRPC';
+      let currentValue: string | null = null;
+      let targetValue = 'true';
+
+      // Find the line containing useGRPC and determine current value
+      for (let i = 0; i < linesCount; i++) {
+        const line = session.getLine(i);
+        const lowerLine = line.toLowerCase();
+        if (lowerLine.includes(searchText.toLowerCase())) {
+          // Check for both true and false patterns
+          if (line.match(/:\s*(true|false)/i)) {
+            if (line.match(/:\s*true/i)) {
+              currentValue = 'true';
+              targetValue = 'false';
+            } else if (line.match(/:\s*false/i)) {
+              currentValue = 'false';
+              targetValue = 'true';
+            }
+          }
+          break;
+        }
+      }
+
+      // Replace the value using regex to handle various formats (with/without spaces, quotes, etc.)
+      let val: string = editor.getValue();
+      if (currentValue !== null) {
+        // Replace useGRPC with various formats: "useGRPC: true", "useGRPC:false", "useGRPC: true", etc.
+        val = val.replace(new RegExp(`(useGRPC\\s*:\\s*)${currentValue}`, 'gi'), `$1${targetValue}`);
+        editor.setValue(val);
+      }
+    });
+  });
+});
+
 When('user clicks the Test Configuration button', () => {
   cy.get('div[data-test="modal-configuration-tester"]').within(() => {
     cy.contains('Test Configuration').click();

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -173,9 +173,11 @@ Feature: Kiali Mesh page
     And user verifies the Discovery information is correct
     When user switches to the Tester tab
     And user changes the provider in the Tester tab
+    And user changes the useGRPC in the Tester tab
     And user clicks the Test Configuration button
     Then user sees the Tester result "incorrect"
     And user changes the provider in the Tester tab
+    And user changes the useGRPC in the Tester tab
     And user clicks the Test Configuration button
     Then user sees the Tester result "correct"
 


### PR DESCRIPTION
Cypress test "User opens and interacts with the Trace Configuration modal" can fail in environments where "useGRPC: false" tracing config with "provider: tempo".
So after the step "user changes the provider in the Tester tab" where the "provider" value is changed to an opposite, a new step is added to change the "useGRPC" to opposite as well.