### PR TITLE
Update sleep image for P/Z

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -97,7 +97,7 @@ if [ "${DELETE_SLEEP}" == "true" ]; then
   echo "Deleting the 'sleep' app in the 'sleep' namespace..."
   # s390x/ppc64le specific images for curl in sleep.yaml (OSSM-6012)
   if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
-    sed -i "s;curlimages/curl;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
+    sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
   else
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
@@ -162,7 +162,7 @@ NAD
 
   if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
     echo "Using s390x/ppc64le specific images for curl in sleep.yaml"
-    sed -i "s;curlimages/curl;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
+    sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
   fi
   ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
 


### PR DESCRIPTION
### Describe the change
Currently, the sleep image can be `curlimages/curl` ([istio 1.27 and lower](https://github.com/istio/istio/blob/release-1.27/samples/sleep/sleep.yaml)) or `curlimages/curl:8.16.0` ([istio master branch](https://github.com/istio/istio/blob/master/samples/sleep/sleep.yaml))

Updated `sed` command to handle both cases and replace with IBM P/Z variant.

========================
Commands for verification:

Verification 1.27:
```
wget https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.27/samples/sleep/sleep.yaml -O sleep-27.yaml
cat sleep-27.yaml | grep image:
sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" sleep-27.yaml
cat sleep-27.yaml | grep image:
```

Verification master:
```
wget https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/sleep/sleep.yaml -O sleep-master.yaml
cat sleep-master.yaml | grep image:
sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" sleep-master.yaml
cat sleep-master.yaml | grep image:
```