### PR TITLE
[hack-script] Use full name for sleep image

### DIFF
--- a/hack/istio/install-sleep-demo.sh
+++ b/hack/istio/install-sleep-demo.sh
@@ -95,11 +95,13 @@ if [ "${DELETE_SLEEP}" == "true" ]; then
   set +e
 
   echo "Deleting the 'sleep' app in the 'sleep' namespace..."
-  # s390x/ppc64le specific images for curl in sleep.yaml (OSSM-6012)
+  # s390x/ppc64le specific images for curl in sleep.yaml (OSSM-6012). Use 8.4 version since it is latest version for s390x!!!
   if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
-    sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
+    sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
+  # for other platforms, use the full name of the curl image since OCP 4.21+ doesn't allow using the short name of images (and it is bad practice)
   else
+    sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.16.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
     ${CLIENT_EXE} delete -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
   fi
 
@@ -160,9 +162,12 @@ metadata:
 NAD
   fi
 
+  # s390x/ppc64le specific images for curl in sleep.yaml (OSSM-6012). Use 8.4 version since it is latest version for s390x!!!
   if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
-    echo "Using s390x/ppc64le specific images for curl in sleep.yaml"
-    sed -i -E "s;curlimages/curl(:.*)?;quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
+    sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.4.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
+  # for other platforms, use the full name of the curl image since OCP 4.21+ doesn't allow using the short name of images (and it is bad practice)
+  else
+    sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.16.0;g" ${ISTIO_DIR}/samples/sleep/sleep.yaml
   fi
   ${CLIENT_EXE} apply -n sleep -f ${ISTIO_DIR}/samples/sleep/sleep.yaml
 


### PR DESCRIPTION
### Describe the change
Currently, the sleep image can be curlimages/curl ([istio 1.27 and lower](https://github.com/istio/istio/blob/release-1.27/samples/sleep/sleep.yaml)) or curlimages/curl:8.16.0 ([istio master branch](https://github.com/istio/istio/blob/master/samples/sleep/sleep.yaml))

However, using short name of images is permitted on OCP 4.21+. ( https://github.com/cri-o/cri-o/pull/9401) and it is not good practice https://www.redhat.com/en/blog/be-careful-when-pulling-images-short-name 
Until the full name of the image is in upstream, I have updated the hack script. ( and also to be able to work with older Istio versions (1.27 , 1.26, 1.24 ...)

The sed command can transform 
```
image: curlimages/curl
image: docker.io/curlimages/curl
image: curlimages/curl:8.16.0
image: docker.io/curlimages/curl:8.16.0
```
to 
```
image: quay.io/curl/curl:8.16.0
```

Fix: https://github.com/kiali/kiali/issues/8841

========================
Commands for verification:

Verification 1.27:
```
wget https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.27/samples/sleep/sleep.yaml -O sleep-27.yaml
cat sleep-27.yaml | grep image:
sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.16.0;g" sleep-27.yaml
cat sleep-27.yaml | grep image:
```

Verification master:
```
wget https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/sleep/sleep.yaml -O sleep-master.yaml
cat sleep-master.yaml | grep image:
sed -i -E "s;image:(.*)curlimages/curl(:.*)?;image: quay.io/curl/curl:8.16.0;g" sleep-master.yaml
cat sleep-master.yaml | grep image:
```