### PR TITLE
[cy] Ambient overview flake

### DIFF
--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -374,7 +374,7 @@ Then('Control Plane metrics should be visible for cluster {string}', (cluster: s
 
 Then('badge for {string} is visible in the LIST view in the namespace {string}', (label: string, ns: string) => {
   getClusterForSingleCluster().then(cluster => {
-    cy.getBySel(`VirtualItem_Cluster${cluster}_${ns}`).contains(label).should('be.visible');
+    cy.getBySel(`VirtualItem_Cluster${cluster}_${ns}`).contains(label).should('exist');
   });
 });
 


### PR DESCRIPTION
### Describe the change

Fix for flake: 

Kiali.Kiali Overview page.See ambient badge in the LIST view (from Root Suite.Kiali Overview page)
Failing for the past 1 build 
Error Message

`Timed out retrying after 40000ms: expected '<span.pf-v5-c-label__text>' to be 'visible'  This element `<span.pf-v5-c-label__text>` is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: `hidden`, `scroll` or `auto``

### Steps to test the PR

When there are many namespaces and istio-system is hidden, the following error occurs.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
