### PR TITLE
[v2.17] Add lpinterop tag

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -16,12 +16,14 @@ Feature: Kiali App Details page
   @bookinfo-app
   @core-1
   @offline
+  @lpinterop
   Scenario: See details for app.
     Then user sees details information for the "details" app
     But no cluster badge for the "app" should be visible
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: See app Traffic information
     Then user sees inbound and outbound traffic information
     And the "Cluster" column "disappears"

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -13,6 +13,7 @@ Feature: Kiali Apps List page
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: See all Apps objects in the bookinfo namespace.
     Then user sees all the Apps in the bookinfo namespace
     And user sees Health information for Apps
@@ -25,6 +26,7 @@ Feature: Kiali Apps List page
   @bookinfo-app
   @core-1
   @offline
+  @lpinterop
   Scenario: See all Apps toggles
     Then user sees all the Apps toggles
 
@@ -114,7 +116,6 @@ Feature: Kiali Apps List page
 
   @bookinfo-app
   @error-rates-app
-  @skip-lpinterop
   @core-1
   Scenario: The degraded status of a logical mesh application is reported in the list of applications
     Given a degraded application in the mesh

--- a/frontend/cypress/integration/featureFiles/graph_display.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display.feature
@@ -16,6 +16,7 @@ Feature: Kiali Graph page - Display menu
   @error-rates-app
   @core-1
   @offline
+  @lpinterop
   Scenario: Graph no namespaces
     When user graphs "" namespaces
     Then user sees no namespace selected
@@ -23,6 +24,7 @@ Feature: Kiali Graph page - Display menu
   # default should show empty graph
   # TODO: default namespace does not exist in offline mode
   @core-1
+  @lpinterop
   Scenario: Show empty graph
     When user graphs "default" namespaces
     Then user sees empty graph
@@ -30,6 +32,7 @@ Feature: Kiali Graph page - Display menu
   @error-rates-app
   @core-1
   @offline
+  @lpinterop
   Scenario: Show idle nodes
     When user graphs "istio-system" namespaces
     And user "opens" display menu
@@ -41,6 +44,7 @@ Feature: Kiali Graph page - Display menu
   @error-rates-app
   @core-1
   @offline
+  @lpinterop
   Scenario: User disables idle nodes
     When user "opens" display menu
     And user "disables" "idle nodes" option
@@ -50,6 +54,7 @@ Feature: Kiali Graph page - Display menu
   @error-rates-app
   @core-1
   @offline
+  @lpinterop
   Scenario: Graph alpha and beta namespaces
     When user graphs "alpha,beta" namespaces
     Then user sees the "alpha" namespace

--- a/frontend/cypress/integration/featureFiles/graph_find_hide.feature
+++ b/frontend/cypress/integration/featureFiles/graph_find_hide.feature
@@ -17,6 +17,7 @@ Feature: Kiali Graph page - Find/Hide
 
   @error-rates-app
   @core-1
+  @lpinterop
   Scenario: Find unhealthy workloads
     Then user sees nothing highlighted on the graph
     When user finds unhealthy workloads
@@ -24,6 +25,7 @@ Feature: Kiali Graph page - Find/Hide
 
   @error-rates-app
   @core-1
+  @lpinterop
   Scenario: Hide unhealthy workloads
     When user hides unhealthy workloads
     Then user sees no unhealthy workloads on the graph

--- a/frontend/cypress/integration/featureFiles/graph_side_panel.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel.feature
@@ -11,6 +11,7 @@ Feature: Kiali Graph page - Side panel menu actions
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Actions in kebab menu of the side panel for a service node with existing traffic routing
     Given user graphs "bookinfo" namespaces
     And user clicks the "productpage" "service" node

--- a/frontend/cypress/integration/featureFiles/graph_toolbar_legend.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar_legend.feature
@@ -14,6 +14,7 @@ Feature: Kiali Graph page - Graph toolbar and legend sidebar
 
   @error-rates-app
   @core-1
+  @lpinterop
   Scenario Outline: Check if the <id> button is usable
     Then the toggle button "<id>" is enabled
     Examples:

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -14,6 +14,7 @@ Feature: Kiali Istio Config page
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: See all Istio Config objects in the bookinfo namespace.
     Then user sees all the Istio Config objects in the bookinfo namespace
     And the "Cluster" column "disappears"
@@ -24,11 +25,13 @@ Feature: Kiali Istio Config page
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: See all Istio Config toggles
     Then user sees all the Istio Config toggles
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Toggle Istio Config configuration toggle
     When user "unchecks" toggle "configuration"
     Then the "Configuration" column "disappears"
@@ -56,17 +59,20 @@ Feature: Kiali Istio Config page
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create an AuthorizationPolicy object
     Then the user can create a "security.istio.io" "v1" "AuthorizationPolicy" Istio object
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a Gateway object
     Then the user can create a "networking.istio.io" "v1" "Gateway" Istio object
 
   @gateway-api
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "gateway.networking.k8s.io" "v1" "Gateway" K8s Istio object
 
@@ -83,21 +89,25 @@ Feature: Kiali Istio Config page
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a PeerAuthentication object
     Then the user can create a "security.istio.io" "v1" "PeerAuthentication" Istio object
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a RequestAuthentication object
     Then the user can create a "security.istio.io" "v1" "RequestAuthentication" Istio object
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a ServiceEntry object
     Then the user can create a "networking.istio.io" "v1" "ServiceEntry" Istio object
 
   @bookinfo-app
   @core-1
+  @lpinterop
   Scenario: Ability to create a Sidecar object
     Then the user can create a "networking.istio.io" "v1" "Sidecar" Istio object
 

--- a/frontend/cypress/integration/featureFiles/kiali_about.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_about.feature
@@ -8,6 +8,7 @@ Feature: Kiali help about verify
 
   @smoke
   @core-2
+  @lpinterop
   Scenario: Open Kiali about page
     And user clicks on Help Button
     And user clicks on About Button

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -26,18 +26,21 @@ Feature: Kiali Mesh page
     Then user "does not see" mesh tour
 
   @core-2
+  @lpinterop
   # TODO: offline - number of infra nodes don't match up because no grafana/tracing.
   Scenario: See mesh
     When user sees mesh side panel
     Then user sees expected mesh infra
 
   @core-2
+  @lpinterop
   # TODO: offline - no metrics for side panel yet.
   Scenario: Test istiod
     When user selects mesh node with label "istiod"
     Then user sees control plane side panel
 
   @core-2
+  @lpinterop
   # TODO: offline - no grafana.
   Scenario: Grafana Infra
     When user selects mesh node with label "Grafana"
@@ -55,12 +58,14 @@ Feature: Kiali Mesh page
     Then user sees tracing node side panel
 
   @core-2
+  @lpinterop
   Scenario: Prometheus Infra
     When user selects mesh node with label "Prometheus"
     Then user sees "Prometheus" node side panel
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Test DataPlane
     When user selects mesh node with label "Data Plane"
     Then user sees data plane side panel

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -19,6 +19,7 @@ Feature: Kiali Overview page
 
   @core-2
   @offline
+  @lpinterop
   Scenario: See "alpha" and "beta" namespaces
     Then user sees the "alpha" namespace card
     And user does not see any cluster badge in the "alpha" namespace card
@@ -27,23 +28,27 @@ Feature: Kiali Overview page
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Doesn't see a "bad" namespace
     Then user does not see the "bad" namespace card in any cluster
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Select the COMPACT view
     When user clicks in the "COMPACT" view
     Then user sees a "COMPACT" "alpha" namespace
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Select the EXPAND view
     When user clicks in the "EXPAND" view
     Then user sees a "EXPAND" "beta" namespace
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Select the LIST view
     When user clicks in the "LIST" view
     Then user sees a "LIST" "beta" namespace
@@ -66,18 +71,21 @@ Feature: Kiali Overview page
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Health for Apps
     When user selects Health for "Apps"
     Then user sees the "alpha" namespace with "Applications"
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Health for Workloads
     When user selects Health for "Workloads"
     Then user sees the "alpha" namespace with "Workloads"
 
   @core-2
   @offline
+  @lpinterop
   Scenario: Health for Services
     When user selects Health for "Services"
     Then user sees the "alpha" namespace with "Services"
@@ -100,6 +108,7 @@ Feature: Kiali Overview page
   @error-rates-app
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: The healthy status of a logical mesh application is reported in the overview of a namespace
     Given a healthy application in the cluster
     When I fetch the overview of the cluster
@@ -124,7 +133,6 @@ Feature: Kiali Overview page
     And the "failure" application indicator should list the application
 
   @error-rates-app
-  @skip-lpinterop
   @core-2
   Scenario: The degraded status of a logical mesh application is reported in the overview of a namespace
     Given a degraded application in the mesh

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -14,6 +14,7 @@ Feature: Kiali Service Details page
   # TODO: offline - no tracing details yet
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See details for productpage
     Then sd::user sees a list with content "Overview"
     Then sd::user sees a list with content "Traffic"
@@ -24,6 +25,7 @@ Feature: Kiali Service Details page
   # TODO: offline - no "Hostname" found but this doesn't exist in regular runs either?
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See details for service
     Then sd::user sees "productpage" details information for service "v1"
     Then sd::user sees Network card

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -11,6 +11,7 @@ Feature: Kiali Services page
   # TODO: offline - no bookinfo VirtualService?
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See services table with correct info
     And user is at the "services" page
     When user applies kiali api "rest" annotations
@@ -31,6 +32,7 @@ Feature: Kiali Services page
 
   @smoke
   @core-2
+  @lpinterop
   Scenario: See all Services toggles
     And user is at the "services" list page
     Then user sees all the Services toggles
@@ -152,7 +154,6 @@ Feature: Kiali Services page
 
   # TODO: offline - no service health
   @error-rates-app
-  @skip-lpinterop
   @core-2
   Scenario: The degraded status of a service is reported in the list of services
     And user is at the "services" page

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -14,6 +14,7 @@ Feature: Kiali Istio Config wizard
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: Dropdown for cluster selection should not be visible in single cluster setup
     When user clicks in the "Gateway" Istio config actions
     Then user sees the "Create Gateway" config wizard
@@ -21,6 +22,7 @@ Feature: Kiali Istio Config wizard
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: Create an Sidecar with labels and annotations
     When user deletes sidecar named "mysidecarwithlabels" and the resource is no longer available
     And user clicks in the "Sidecar" Istio config actions
@@ -40,6 +42,7 @@ Feature: Kiali Istio Config wizard
   @gateway-api
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: Create a K8s Gateway scenario
     When user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
     And user clicks in the "K8sGateway" Istio config actions

--- a/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
@@ -10,6 +10,7 @@ Feature: Service Details Wizard: Request Routing
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: Create a Request Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Request Routing" actions
@@ -34,6 +35,7 @@ Feature: Service Details Wizard: Request Routing
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See a DestinationRule generated
     When user clicks in the "Istio Config" table "DR" badge "reviews" name row link
     Then user sees the "kind: DestinationRule" regex in the editor
@@ -45,6 +47,7 @@ Feature: Service Details Wizard: Request Routing
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See a VirtualService generated
     When user clicks in the "bookinfo" "reviews" "VirtualService" reference
     Then user sees the "kind: VirtualService" regex in the editor

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -14,6 +14,7 @@ Feature: Workload logs tab
   @bookinfo-app
   @core-2
   @offline
+  @lpinterop
   Scenario: The logs tab should show the logs of a pod
     Given I am on the "ratings-v1" workload detail page of the "bookinfo" namespace
     When I go to the Logs tab of the workload detail page

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -12,6 +12,7 @@ Feature: Kiali Workloads page
   @bookinfo-app
   @core-2
   @offline
+  @lpinterop
   Scenario: See workloads table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
@@ -121,6 +122,7 @@ Feature: Kiali Workloads page
   @bookinfo-app
   @core-2
   @offline
+  @lpinterop
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
     When user selects the "bookinfo" namespace
@@ -144,7 +146,6 @@ Feature: Kiali Workloads page
     And the health status of the workload should be "Failure"
 
   @error-rates-app
-  @skip-lpinterop
   @core-2
   Scenario: The degraded status of a workload is reported in the list of workloads
     Given a degraded workload in the mesh

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -14,6 +14,7 @@ Feature: Kiali Workload Details page
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See details for workload
     Then user sees details information for workload
     But no cluster badge for the "workload" should be visible
@@ -21,12 +22,14 @@ Feature: Kiali Workload Details page
   # TODO: offline - workload health.
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See workload traffic information
     Then user sees workload inbound and outbound traffic information
     And the "Cluster" column "disappears"
 
   @bookinfo-app
   @core-2
+  @lpinterop
   Scenario: See workload Inbound Metrics
     Then user sees workload inbound metrics information
 


### PR DESCRIPTION
### Describe the change
Picked only some tests for lpinterop.
The complete test suite is currently being executed. However, since the job runs twice daily, running the entire suite is time-consuming and can occasionally be unreliable. For the scheduled runs, I have selected a subset of tests.
