### PR TITLE
[2.17][test] Fix open/close traffic menu logic

### DIFF
--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -20,8 +20,17 @@ When('user closes graph tour', () => {
   cy.get('div[role="dialog"]').find('button[aria-label="Close"]').click();
 });
 
-When('user {string} traffic menu', (_action: string) => {
-  cy.get('button#graph-traffic-dropdown').click();
+When('user {string} traffic menu', (action: string) => {
+  cy.get('button#graph-traffic-dropdown').then($button => {
+    const currentState = $button.attr('aria-expanded');
+    const isCurrentlyOpen = currentState === 'true';
+    const shouldBeOpen = action.includes('open');
+
+    // Only click if the current state is different from the desired state
+    if (isCurrentlyOpen !== shouldBeOpen) {
+      cy.wrap($button).click();
+    }
+  });
 });
 
 When('user {string} {string} traffic option', (action: string, option: string) => {


### PR DESCRIPTION
### Describe the change

Currently, the cucumber steps
```
When user "opens" traffic menu
When user "closes" traffic menu
```
just switching the previous state of the traffic menu (clicking on the button), not doing what a user expects to do.
So when I run 
```
When user "opens" traffic menu   ## (opens menu)
When user "opens" traffic menu   ## (closes menu)
When user "closes" traffic menu   ## (opens menu)
```
the menu will be opened at the end.

That can break the other tests as well, because after the failure of the first test, the traffic menu remains open, and the next test will try to open it again, which causes the menu to be closed instead.