### PR TITLE
[2.17][test] Get ambient mode info dynamically from config

### DIFF
--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -82,8 +82,18 @@ Then('user {string} graph tour', (action: string) => {
   }
 });
 
-Then('user sees {string} graph traffic menu', (menu: string) => {
+Then('user sees graph traffic menu', () => {
   cy.get('button#graph-traffic-dropdown').invoke('attr', 'aria-expanded').should('eq', 'true');
+
+  let menu = 'default';
+  cy.request({ url: '/api/config' }).then(response => {
+    cy.wrap(response.isOkStatusCode).should('be.true');
+
+    const ambientEnabled = response.body.ambientEnabled;
+    if (ambientEnabled) {
+      menu = 'ambient';
+    }
+  });
 
   cy.get('div#graph-traffic-menu').within(() => {
     if (menu === 'ambient') {

--- a/frontend/cypress/integration/featureFiles/graph_toolbar.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar.feature
@@ -48,7 +48,7 @@ Feature: Kiali Graph page - Toolbar (various)
   @core-1
   Scenario: Open traffic dropdown
     When user "opens" traffic menu
-    Then user sees "default" graph traffic menu
+    Then user sees graph traffic menu
 
   @offline
   @error-rates-app
@@ -82,7 +82,7 @@ Feature: Kiali Graph page - Toolbar (various)
   Scenario: User resets to factory default
     When user resets to factory default
     And user "opens" traffic menu
-    Then user sees "default" graph traffic menu
+    Then user sees graph traffic menu
 
   @offline
   @error-rates-app
@@ -159,7 +159,7 @@ Feature: Kiali Graph page - Toolbar (various)
   Scenario: Open traffic dropdown for ambient
     When user graphs "" namespaces
     And user "opens" traffic menu
-    Then user sees "ambient" graph traffic menu
+    Then user sees graph traffic menu
 
   # TODO: offline - ambient support.
   @ambient


### PR DESCRIPTION
### Describe the change
Get info about ambient mode dynamically from the server config. 
So we can run graph test in mixed environment (when istio data plane is in ambient mode) 
