### PR TITLE
Fix sporadic null reference in SummaryPanelClusterBox

### DIFF
--- a/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -72,7 +72,7 @@ export class SummaryPanelClusterBox extends React.Component<SummaryPanelPropType
     const data = clusterBox.getData();
     const boxed = descendents(clusterBox);
     const cluster = data[NodeAttr.cluster];
-    const kialiInstances = serverConfig.clusters[cluster] ? serverConfig.clusters[cluster].kialiInstances : [];
+    const kialiInstances: KialiInstance[] = serverConfig.clusters?.[cluster]?.kialiInstances ?? [];
 
     const { numApps, numVersions } = this.countApps(boxed);
     const {


### PR DESCRIPTION
Fixes #8903

I have a lot of clusters meshed and when viewing a few namespaces with services spanning multiple clusters in the Traffic Graph, I will sporadically get a full frontend crash due to: `TypeError: can't access property "map", v is null` in `renderKialiLinks()`.

From what I can see, the backend `/api/config` returns `null` for `cluster.kialiInstances` when:
- Kube cache/service listing errors during discovery (`istio/discovery.go:430-433`)
- No Kiali services found with label `app.kubernetes.io/part-of: kiali`
- `getKialiInstances()` fails and loop continues without setting field

The original code checked if cluster exists but not if `kialiInstances` is null:
```ts
serverConfig.clusters[cluster] ? serverConfig.clusters[cluster].kialiInstances : []
```

The fix is to use optional chaining/nullish coalescing to guarantee array:
```ts
serverConfig.clusters?.[cluster]?.kialiInstances ?? []
```

Tests pass.

<details>
<summary>Stack Trace</summary>

```
React Router caught the following error during render TypeError: can't access property "map", v is null
    renderKialiLinks https://kiali.internal/static/js/main.caad5af4.js:2
    renderCluster https://kiali.internal/static/js/main.caad5af4.js:2
    render https://kiali.internal/static/js/main.caad5af4.js:2
    Ai https://kiali.internal/static/js/main.caad5af4.js:2
    zi https://kiali.internal/static/js/main.caad5af4.js:2
    rk https://kiali.internal/static/js/main.caad5af4.js:2
    qk https://kiali.internal/static/js/main.caad5af4.js:2
    pk https://kiali.internal/static/js/main.caad5af4.js:2
    ik https://kiali.internal/static/js/main.caad5af4.js:2
    Yj https://kiali.internal/static/js/main.caad5af4.js:2
    ng https://kiali.internal/static/js/main.caad5af4.js:2
    unstable_runWithPriority https://kiali.internal/static/js/main.caad5af4.js:2
    kg https://kiali.internal/static/js/main.caad5af4.js:2
    ng https://kiali.internal/static/js/main.caad5af4.js:2
    mg https://kiali.internal/static/js/main.caad5af4.js:2
    Jb https://kiali.internal/static/js/main.caad5af4.js:2
    id https://kiali.internal/static/js/main.caad5af4.js:2

Object { componentStack: "\nSummaryPanelClusterBox@https://kiali.internal/static/js/main.caad5af4.js:2:4364336\ndiv\ndiv\nTourStopComponent@https://kiali.internal/static/js/main.caad5af4.js:2:3159342\nConnectFunction@https://kiali.internal/static/js/main.caad5af4.js:2:2244951\nSummaryPanelComponent@https://kiali.internal/static/js/main.caad5af4.js:2:4381328\nConnectFunction@https://kiali.internal/static/js/main.caad5af4.js:2:2244951\ndiv\nFlexView@https://kiali.internal/static/js/main.caad5af4.js:2:1131527\ndiv\nFlexView@https://kiali.internal/static/js/main.caad5af4.js:2:1131527\nGraphPageComponent@https://kiali.internal/static/js/main.caad5af4.js:2:4391707\nConnectFunction@https://kiali.internal/static/js/main.caad5af4.js:2:2244951\nconnectRefresh/<@https://kiali.internal/static/js/main.caad5af4.js:2:2945096\nRenderedRoute@https://kiali.internal/static/js/main.caad5af4.js:2:1412845\nRenderErrorBoundary@https://kiali.internal/static/js/main.caad5af4.js:2:1411746\nOutlet@https://kiali.internal/static/js/main.caad5af4.js:2:1416099\ndiv\nRenderPage@https://kiali.internal/static/js/main.caad5af4.js:2:4410666\nsection\nPageSection@https://kiali.internal/static/js/main.caad5af4.js:2:4426488\nmain\ndiv\nPage@https://kiali.internal/static/js/main.caad5af4.js:2:4420672\nNavigationComponent@https://kiali.internal/static/js/main.caad5af4.js:2:4453523\nConnectFunction@https://kiali.internal/static/js/main.caad5af4.js:2:2244951\nAuthenticationControllerComponent@https://kiali.internal/static/js/main.caad5af4.js:2:4456612\nConnectFunction@https://kiali.internal/static/js/main.caad5af4.js:2:2244951\nPersistGate@https://kiali.internal/static/js/main.caad5af4.js:2:1165582\nProvider_Provider@https://kiali.internal/static/js/main.caad5af4.js:2:2242546\nSuspense\nApp@https://kiali.internal/static/js/main.caad5af4.js:2:4476993\nRenderedRoute@https://kiali.internal/static/js/main.caad5af4.js:2:1412845\nRenderErrorBoundary@https://kiali.internal/static/js/main.caad5af4.js:2:1411746\ndist_DataRoutes@https://kiali.internal/static/js/main.caad5af4.js:2:1425371\ndist_Router@https://kiali.internal/static/js/main.caad5af4.js:2:1416140\ndist_RouterProvider@https://kiali.internal/static/js/main.caad5af4.js:2:1421539" }
```
</details>