### PR TITLE
Align Style of PeerAuth Select Components

### DIFF
--- a/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/frontend/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -190,15 +190,6 @@ export class PeerAuthenticationForm extends React.Component<Props, PeerAuthentic
     this.props.onChange(this.state);
   };
 
-  onMutualTlsChange = (_event: React.FormEvent, value: string): void => {
-    this.setState(
-      {
-        mtls: value
-      },
-      () => this.onPeerAuthenticationChange()
-    );
-  };
-
   onAddPortNumber = (_event: React.FormEvent, value: string): void => {
     this.setState(
       prevState => {


### PR DESCRIPTION
### Describe the change
I changed the Style to the Select Component from FormSelect

Before:
<img width="1070" height="614" alt="Screenshot From 2025-11-26 13-39-35" src="https://github.com/user-attachments/assets/d40ee3eb-c5df-452b-aa6d-e12fded29360" />

After: 
<img width="1067" height="620" alt="Screenshot From 2025-11-26 14-00-28" src="https://github.com/user-attachments/assets/9c075d9e-a065-41ed-8fbd-60a00cb64663" />


### Issue reference

Issue: https://github.com/kiali/kiali/issues/7277
