### PR TITLE
[CI] Wait for traces for Ambient workload traces

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -23,13 +23,13 @@ const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
 Then('user sees trace information', () => {
   openTab('Traces');
 
-  cy.getBySel('tracing-scatterplot');
+  cy.getBySel('tracing-scatterplot', { timeout: 120000 }).should('be.visible');
 
   // Ensures a trace hasn't been clicked on yet.
   cy.getBySel('trace-details-tabs').should('not.exist');
 
-  // Ensures traces have loaded.
-  cy.getBySel('tracing-scatterplot').contains('Traces');
+  // Ensures traces have loaded
+  cy.getBySel('tracing-scatterplot', { timeout: 120000 }).contains('Traces', { timeout: 120000 });
 });
 
 Then('user see no traces', () => {

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -43,6 +43,7 @@ Feature: Kiali Waypoint related features
     Then the user cannot see the "missing-sidecar" badge for "waypoint" workload in "bookinfo" namespace
     And the proxy status is "info" with "RDS: IGNORED" details
     And the user can see the "K8sGateway-bookinfo-waypoint" istio config and badge "pfbadge-G"
+    And traces are available for waypoint workload "waypoint" in namespace "bookinfo"
     And user sees trace information
     When user selects a trace
     Then user sees trace details


### PR DESCRIPTION
### Describe the change

Fix for Ambient test (Waypoint workload with no traces):

```
  1 failing

  1) Kiali Waypoint related features
       [Workload details - waypoint] The workload details for a waypoint are valid:
     AssertionError: Timed out retrying after 40000ms: Expected to find element: `[data-test="tracing-scatterplot"]`, but never found it.
      at Context.eval (http://172.18.255.70/__cypress/tests?p=cypress/support/index.ts:560:62)

```

### Steps to test the PR

`hack/run-integration-tests.sh --test-suite frontend-ambient`

### Automation testing
e2e tests updated

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
