### PR TITLE
[PF6] Align toolbar metrics items

### DIFF
--- a/frontend/src/components/Metrics/CustomMetrics.tsx
+++ b/frontend/src/components/Metrics/CustomMetrics.tsx
@@ -7,8 +7,7 @@ import {
   Card,
   CardBody,
   EmptyState,
-  EmptyStateVariant,
-  
+  EmptyStateVariant
 } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
 import { router, HistoryManager, URLParam, location } from '../../app/History';
@@ -247,8 +246,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
   renderFetchMetrics = (title: string): React.ReactNode => {
     return (
       <div className={emptyStyle}>
-        <EmptyState  headingLevel="h5"   titleText={<>{title}</>} variant={EmptyStateVariant.sm}>
-          </EmptyState>
+        <EmptyState headingLevel="h5" titleText={<>{title}</>} variant={EmptyStateVariant.sm}></EmptyState>
       </div>
     );
   };
@@ -349,7 +347,7 @@ class CustomMetricsComponent extends React.Component<Props, MetricsState> {
             </ToolbarItem>
 
             {this.props.tracingIntegration && (
-              <ToolbarItem style={{ alignSelf: 'center' }}>
+              <ToolbarItem>
                 <TraceSpansLimit
                   label="Spans"
                   onChange={this.onTraceSpansChange}

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -428,7 +428,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
     return (
       <div ref={this.toolbarRef}>
         <Toolbar style={{ padding: 0, marginBottom: '1.25rem' }}>
-          <ToolbarGroup>
+          <ToolbarGroup style={{ alignItems: 'center' }}>
             <ToolbarItem>
               <MetricsSettingsDropdown
                 onChanged={this.onMetricsSettingsChanged}
@@ -450,7 +450,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
             </ToolbarItem>
 
             {this.props.tracingIntegration && (
-              <ToolbarItem style={{ alignSelf: 'center' }}>
+              <ToolbarItem>
                 <TraceSpansLimit
                   label="Spans"
                   onChange={this.onTraceSpansChange}
@@ -460,7 +460,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
               </ToolbarItem>
             )}
 
-            <ToolbarItem style={{ alignSelf: 'center' }}>
+            <ToolbarItem>
               <Checkbox
                 id="trendlines-show-"
                 isChecked={this.state.showTrendlines}


### PR DESCRIPTION
<img width="1908" height="477" alt="image" src="https://github.com/user-attachments/assets/7ba8594e-a624-4b72-978a-3c76a5bbaa3e" />

Fix: 

<img width="1908" height="477" alt="image" src="https://github.com/user-attachments/assets/b6d20d97-305f-4d99-a5fc-f30fbc6ee782" />

Fixes: https://github.com/kiali/kiali/issues/8939 
