### PR TITLE
[PF6] Fixed Menu and Modal boxes z-index

### DIFF
--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -41,6 +41,21 @@ export const globalStyle = kialiStyle({
     },
 
     /**
+     * Modal boxes should be above menus and dropdowns
+     */
+    '& .pf-v6-c-modal-box': {
+      zIndex: 300
+    },
+
+    /**
+     * Menus should be below modal boxes
+     * Override PatternFly's default z-index with !important
+     */
+    '& .pf-v6-c-menu': {
+      zIndex: '200 !important'
+    },
+
+    /**
      * Reduce padding of menu group title
      */
     '& .pf-v6-c-menu__group-title': {


### PR DESCRIPTION
In Overview page naemspace actions dropdown kebeb menu was staying over any action.
Before:
<img width="1104" height="803" alt="Screenshot From 2025-12-05 10-06-31" src="https://github.com/user-attachments/assets/bf5d0d58-d151-4d97-918a-bf949cda0e8d" />

Now:
<img width="1731" height="821" alt="Screenshot From 2025-12-05 10-21-46" src="https://github.com/user-attachments/assets/68f4fdc3-1593-411f-be4a-b0f422977666" />


https://github.com/kiali/kiali/issues/8946
