### PR TITLE
[pf6] Update the workload log buttons and test selector

### DIFF
--- a/frontend/cypress/integration/common/workload_logs.ts
+++ b/frontend/cypress/integration/common/workload_logs.ts
@@ -98,7 +98,7 @@ Then('the log pane should only show log lines not containing {string}', (filterT
 
 Then('the log pane should only show json log lines', () => {
   cy.get('#logsText').within(() => {
-    cy.get('button').find('svg.pf-v6-svg').should('exist');
+    cy.getBySel('json-log-info-button').should('exist');
   });
 });
 
@@ -153,8 +153,7 @@ Then('the log pane should show spans', () => {
 
 Then('I click a json log line', () => {
   cy.get('#logsText').within(() => {
-    cy.get('button').find('svg.pf-6-svg').should('exist');
-    cy.get('button').first().click();
+    cy.getBySel('json-log-info-button').first().should('exist').click();
   });
 });
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -278,6 +278,7 @@ const noLogsStyle = kialiStyle({
 
 const logLineStyle = kialiStyle({
   display: 'flex',
+  alignItems: 'center',
   height: '1.5rem',
   lineHeight: '1.5rem',
   paddingLeft: '0.75rem'
@@ -285,8 +286,7 @@ const logLineStyle = kialiStyle({
 
 const logInfoStyle = kialiStyle({
   paddingLeft: 0,
-  width: '0.75rem',
-  height: '0.75rem',
+  paddingRight: '0.5rem',
   fontFamily: 'monospace',
   fontSize: '0.75rem'
 });
@@ -774,6 +774,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
               key={`s-b-${index}`}
               variant={ButtonVariant.plain}
               className={logInfoStyle}
+              hasNoPadding={true}
               onClick={() => {
                 this.gotoSpan(e.span!);
               }}
@@ -799,15 +800,17 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             content="Click for JSON object details"
           >
             <Button
+              data-test="json-log-info-button"
               icon={<KialiIcon.Info key={`jod-i-${index}`} className={alInfoIcon} color={messageColor} />}
               key={`jod-b-${index}`}
               variant={ButtonVariant.plain}
               className={logInfoStyle}
+              hasNoPadding={true}
               onClick={() => this.openJSONModal(e)}
             />
           </Tooltip>
         )}
-        <p key={`le-${index}`} className={logMessageStyle} style={{ color: messageColor }}>
+        <p key={`le-${index}`} className={logMessageStyle} style={{ color: messageColor, paddingBottom: '2px' }}>
           {this.entryToString(e)}
         </p>
       </div>
@@ -830,6 +833,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             key={`al-b-${index}`}
             variant={ButtonVariant.plain}
             className={logInfoStyle}
+            hasNoPadding={true}
             onClick={() => {
               this.addAccessLogModal(le.message, le.accessLog!);
             }}


### PR DESCRIPTION
### Describe the change

Adds a `data-test` attribute to the info icon so it can be easily selected in the test.

### Steps to test the PR

Go to workload logs page and click the json loggers app.

### Automation testing

N/A

### Issue reference

Fixes #8950 
