### PR TITLE
[PF6] Migrate datepicker to PF6

### DIFF
--- a/frontend/src/components/Time/DateTimePicker.module.scss
+++ b/frontend/src/components/Time/DateTimePicker.module.scss
@@ -301,8 +301,9 @@
     }
 
     .react-datepicker__month {
-      margin: 0.4rem;
+      padding: 0.4rem;
       text-align: center;
+      background-color: var(--pf-t--global--background--color--primary--default);
     }
 
     .react-datepicker__month .react-datepicker__month-text,
@@ -449,7 +450,7 @@
       .react-datepicker__time-box
       ul.react-datepicker__time-list
       li.react-datepicker__time-list-item--disabled {
-      color: var(--pf-t--color--gray--30);
+      color: var(--pf-t--global--text--color--disabled);
     }
 
     .react-datepicker__time-container
@@ -462,7 +463,7 @@
     }
 
     .react-datepicker__week-number {
-      color: var(--pf-t--color--gray--30);
+      color: var(--pf-t--global--text--color--disabled);
       display: inline-block;
       width: 1.7rem;
       line-height: 1.7rem;
@@ -517,7 +518,7 @@
 
     .react-datepicker__month--disabled,
     .react-datepicker__quarter--disabled {
-      color: var(--pf-t--color--gray--30);
+      color: var(--pf-t--global--text--color--disabled);
       pointer-events: none;
     }
 
@@ -648,7 +649,7 @@
     .react-datepicker__quarter-text--disabled,
     .react-datepicker__year-text--disabled {
       cursor: default;
-      color: var(--pf-t--color--gray--30);
+      color: var(--pf-t--global--text--color--disabled);
     }
 
     .react-datepicker__day--disabled:hover,


### PR DESCRIPTION
### Describe the change

Migrate datepicker component used in Replay feature to PF6

<img width="1900" height="901" alt="image" src="https://github.com/user-attachments/assets/aa9057d2-2f87-4bbc-be2c-4f6f34387354" />

@Joeyyubo For the moment I will keep datepicker as-is for the main PF6 migration. The final goal is to replace this component by the Patternfly datepicker in the future - https://www.patternfly.org/components/date-and-time/date-picker
