### PR TITLE
[pf6] Fixed Overview page actions dropdown.

### DIFF
--- a/frontend/src/pages/Overview/OverviewNamespaceActions.tsx
+++ b/frontend/src/pages/Overview/OverviewNamespaceActions.tsx
@@ -32,8 +32,12 @@ type Props = {
 export const OverviewNamespaceActions: React.FC<Props> = (props: Props) => {
   const [isKebabOpen, setIsKebabOpen] = React.useState<boolean>(false);
 
-  const onKebabToggle = (isOpen: boolean) => {
+  const onKebabToggle = (isOpen: boolean): void => {
     setIsKebabOpen(isOpen);
+  };
+
+  const onKebabSelect = (): void => {
+    setIsKebabOpen(!isKebabOpen);
   };
 
   const namespaceActions = props.actions.map((action, i) => {
@@ -112,6 +116,7 @@ export const OverviewNamespaceActions: React.FC<Props> = (props: Props) => {
       )}
       isOpen={isKebabOpen}
       onOpenChange={(isOpen: boolean) => onKebabToggle(isOpen)}
+      onSelect={onKebabSelect}
       popperProps={{ position: 'right' }}
     >
       <DropdownList>{namespaceActions}</DropdownList>

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -41,21 +41,6 @@ export const globalStyle = kialiStyle({
     },
 
     /**
-     * Modal boxes should be above menus and dropdowns
-     */
-    '& .pf-v6-c-modal-box': {
-      zIndex: 300
-    },
-
-    /**
-     * Menus should be below modal boxes
-     * Override PatternFly's default z-index with !important
-     */
-    '& .pf-v6-c-menu': {
-      zIndex: '200 !important'
-    },
-
-    /**
      * Reduce padding of menu group title
      */
     '& .pf-v6-c-menu__group-title': {


### PR DESCRIPTION
This PR was a wrong fix suggestion: https://github.com/kiali/kiali/pull/8947
Dropdowns should be fixed now in all wizzards.