### PR TITLE
Include Ambient mode in service spawner demo

### DIFF
--- a/hack/istio/install-service-spawner-demo.sh
+++ b/hack/istio/install-service-spawner-demo.sh
@@ -12,9 +12,26 @@
 : ${AUTO_INJECTION_LABEL:="istio-injection=enabled"}
 : ${CLIENT_EXE:=oc}
 : ${DELETE_DEMOS:=false}
+: ${NAMESPACE:=}
 : ${SSPAWNER:=service-spawner}
 : ${BASE_URL:=https://raw.githubusercontent.com/kiali/demos/master}
 : ${NUM_SPAWNS:=10}
+: ${MODE:=sidecar}
+
+# Find istioctl (needed for ambient mode waypoint)
+find_istioctl() {
+  if [ -z "${ISTIOCTL:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+    ISTIO_DIR=$(ls -dt1 ${SCRIPT_DIR}/../../_output/istio-* 2>/dev/null | head -n1)
+    if [ -n "${ISTIO_DIR}" ] && [ -x "${ISTIO_DIR}/bin/istioctl" ]; then
+      ISTIOCTL="${ISTIO_DIR}/bin/istioctl"
+    elif command -v istioctl &> /dev/null; then
+      ISTIOCTL="istioctl"
+    else
+      ISTIOCTL=""
+    fi
+  fi
+}
 
 apply_network_attachment() {
   NAME=$1
@@ -45,15 +62,20 @@ SCC
 install_service_spawner_demo() {
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-    ${CLIENT_EXE} new-project ${SSPAWNER}
-    apply_network_attachment ${SSPAWNER}
-    $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${SSPAWNER}
+    ${CLIENT_EXE} new-project ${NAMESPACE}
+    apply_network_attachment ${NAMESPACE}
+    $CLIENT_EXE adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE}
   else
-    ${CLIENT_EXE} create ns ${SSPAWNER}
+    ${CLIENT_EXE} create ns ${NAMESPACE}
   fi
 
-  if [ "${AUTO_INJECTION}" == "true" ]; then
-    ${CLIENT_EXE} label namespace ${SSPAWNER} ${AUTO_INJECTION_LABEL} --overwrite=true
+  # Label namespace based on mode
+  if [ "${MODE}" == "ambient" ]; then
+    echo "Configuring namespace for Istio Ambient mode..."
+    ${CLIENT_EXE} label namespace ${NAMESPACE} istio.io/dataplane-mode=ambient --overwrite=true
+  elif [ "${AUTO_INJECTION}" == "true" ]; then
+    echo "Configuring namespace for Istio Sidecar mode with auto-injection..."
+    ${CLIENT_EXE} label namespace ${NAMESPACE} ${AUTO_INJECTION_LABEL} --overwrite=true
   fi
 
   for (( c=0; c<$NUM_SPAWNS; c++ ))
@@ -66,16 +88,43 @@ install_service_spawner_demo() {
     cat deployment-tpl.yaml \
           | sed -e "s:this-service:service-$c:g" \
           | sed -e "s:target-service:http\://service-$next:g" \
-          | sed -e "s:this-namespace:$SSPAWNER:g" \
+          | sed -e "s:this-namespace:${NAMESPACE}:g" \
           | sed -e "s:quay.io/jotak/nginx-hello:nginxdemos/nginx-hello:g" \
           > tmp-$c.yaml
-    ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${SSPAWNER}
+    ${CLIENT_EXE} apply -f tmp-${c}.yaml -n ${NAMESPACE}
   done
   rm deployment-tpl.yaml
   for (( c=0; c<$NUM_SPAWNS; c++ ))
   do
       rm tmp-${c}.yaml
   done
+
+  # Create waypoint for ambient mode
+  if [ "${MODE}" == "ambient" ]; then
+    echo "Creating waypoint proxy for ambient mode..."
+    find_istioctl
+    if [ -n "${ISTIOCTL}" ]; then
+      echo "Using istioctl: ${ISTIOCTL}"
+      if ${ISTIOCTL} waypoint apply -n ${NAMESPACE} --enroll-namespace; then
+        echo "Waypoint proxy created successfully"
+        echo "Waiting for waypoint to be ready..."
+        sleep 5
+        for i in {1..30}; do
+          WAYPOINT_POD=$(${CLIENT_EXE} get pods -n ${NAMESPACE} -l gateway.istio.io/managed=istio.io-waypoint -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+          if [ -n "${WAYPOINT_POD}" ]; then
+            echo "Waypoint pod found: ${WAYPOINT_POD}"
+            ${CLIENT_EXE} wait --for=condition=Ready pod/${WAYPOINT_POD} -n ${NAMESPACE} --timeout=60s && break || true
+          fi
+          sleep 2
+        done
+      else
+        echo "WARNING: Failed to create waypoint proxy. Traffic will still flow but without L7 processing."
+      fi
+    else
+      echo "WARNING: istioctl not found. Cannot create waypoint proxy for ambient mode."
+      echo "Please install istioctl or set ISTIOCTL environment variable."
+    fi
+  fi
 }
 
 while [ $# -gt 0 ]; do
@@ -93,6 +142,18 @@ while [ $# -gt 0 ]; do
       CLIENT_EXE="$2"
       shift;shift
       ;;
+    -m|--mode)
+      MODE="$2"
+      if [ "${MODE}" != "sidecar" -a "${MODE}" != "ambient" ]; then
+        echo "ERROR: --mode must be either 'sidecar' or 'ambient'"
+        exit 1
+      fi
+      shift;shift
+      ;;
+    -ns|--namespace)
+      NAMESPACE="$2"
+      shift;shift
+      ;;
     -n|-spawns)
       NUM_SPAWNS="$2"
       shift;shift
@@ -104,12 +165,30 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<HELPMSG
 Valid command line arguments:
-  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true).
-  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled).
+  -ai|--auto-injection <true|false>: If you want sidecars to be auto-injected (default: true). Only applies to sidecar mode.
+  -ail|--auto-injection-label <name=value>: If auto-injection is enabled, this is the label added to the namespace. For revision-based installs, you can use something like "istio.io/rev=default-v1-23-0". default: istio-injection=enabled). Only applies to sidecar mode.
   -c|--client: either 'oc' or 'kubectl'
+  -m|--mode <sidecar|ambient>: Istio dataplane mode (default: sidecar)
+    - sidecar: Uses traditional sidecar injection with istio-injection label
+    - ambient: Uses Istio Ambient mode with istio.io/dataplane-mode=ambient label and waypoint proxy
+  -ns|--namespace <name>: Namespace to use (default: service-spawner)
   -n|--spawns: Number of spawns. Default: 10
   -d|--delete: if 'true' demos will be deleted; otherwise, they will be installed
   -h|--help: this text
+
+Examples:
+  # Install with sidecar mode (default)
+  ./install-service-spawner-demo.sh -n 10 -c kubectl
+
+  # Install with ambient mode in custom namespace
+  ./install-service-spawner-demo.sh -n 10 -c kubectl --mode ambient --namespace my-ambient-test
+
+  # Compare sidecar vs ambient side-by-side
+  ./install-service-spawner-demo.sh -n 5 -c kubectl --mode sidecar --namespace spawner-sidecar
+  ./install-service-spawner-demo.sh -n 5 -c kubectl --mode ambient --namespace spawner-ambient
+
+  # Delete
+  ./install-service-spawner-demo.sh -d true -c kubectl --namespace my-ambient-test
 HELPMSG
       exit 1
       ;;
@@ -120,28 +199,44 @@ HELPMSG
   esac
 done
 
+# Use default namespace if not specified
+if [ -z "${NAMESPACE}" ]; then
+  NAMESPACE="${SSPAWNER}"
+fi
+
 IS_OPENSHIFT="false"
 if [[ "${CLIENT_EXE}" = *"oc" ]]; then
   IS_OPENSHIFT="true"
 fi
 
+echo "=== SETTINGS ==="
 echo "CLIENT_EXE=${CLIENT_EXE}"
 echo "IS_OPENSHIFT=${IS_OPENSHIFT}"
+echo "NAMESPACE=${NAMESPACE}"
+echo "MODE=${MODE}"
+echo "NUM_SPAWNS=${NUM_SPAWNS}"
+if [ "${MODE}" == "sidecar" ]; then
+  echo "AUTO_INJECTION=${AUTO_INJECTION}"
+  if [ "${AUTO_INJECTION}" == "true" ]; then
+    echo "AUTO_INJECTION_LABEL=${AUTO_INJECTION_LABEL}"
+  fi
+fi
+echo "================"
 
 if [ "${DELETE_DEMOS}" != "true" ]; then
-  echo "Installing the ${SSPAWNER} app in the ${SSPAWNER} namespace..."
+  echo "Installing service-spawner app in the '${NAMESPACE}' namespace..."
   install_service_spawner_demo
 else
-  echo "Deleting the '${SSPAWNER}' app in the '${SSPAWNER}' namespace..."
+  echo "Deleting service-spawner app in the '${NAMESPACE}' namespace..."
 
-  ${CLIENT_EXE} delete all -l project=service-spawner
+  ${CLIENT_EXE} delete all -l project=service-spawner -n ${NAMESPACE}
 
   if [ "${IS_OPENSHIFT}" == "true" ]; then
-    $CLIENT_EXE delete network-attachment-definition istio-cni -n ${SSPAWNER}
-    $CLIENT_EXE delete scc ${SSPAWNER}-scc
+    $CLIENT_EXE delete network-attachment-definition istio-cni -n ${NAMESPACE}
+    $CLIENT_EXE delete scc ${NAMESPACE}-scc
 
-    ${CLIENT_EXE} delete project ${SSPAWNER}
+    ${CLIENT_EXE} delete project ${NAMESPACE}
   else
-    ${CLIENT_EXE} delete ns ${SSPAWNER} --ignore-not-found=true
+    ${CLIENT_EXE} delete ns ${NAMESPACE} --ignore-not-found=true
   fi
 fi


### PR DESCRIPTION
### Describe the change

Modify the service spawner demo to be able to run Ambient. It is helpful to compare performance between Ambient and non Ambient namespaces. 


<img width="1909" height="922" alt="image" src="https://github.com/user-attachments/assets/49a36d25-5786-4d13-a464-6665eb22211d" />

### Steps to test the PR

```
./install-service-spawner-demo.sh -n 50 -c oc --mode ambient --namespace test-ambient
./install-service-spawner-demo.sh -n 50 -c oc --namespace test-sidecar
```

To be removed: 

```
./install-service-spawner-demo.sh -d true -c oc --namespace test-ambient
./install-service-spawner-demo.sh -d true -c oc --namespace test-sidecar
```

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

REf. #8975 
