### PR TITLE
[pf6] Fix proxy logs color icon

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -291,6 +291,17 @@ const logInfoStyle = kialiStyle({
   fontSize: '0.75rem'
 });
 
+const getLogInfoWithMessageColorStyle = (messageColor: string): string => {
+  const messageColorStyle = kialiStyle({
+    $nest: {
+      '& .pf-v6-c-icon__content': {
+        color: messageColor
+      }
+    }
+  });
+  return classes(logInfoStyle, messageColorStyle);
+};
+
 const logMessageStyle = kialiStyle({
   fontSize: '0.75rem',
   paddingRight: '1rem'
@@ -804,7 +815,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
               icon={<KialiIcon.Info key={`jod-i-${index}`} className={alInfoIcon} color={messageColor} />}
               key={`jod-b-${index}`}
               variant={ButtonVariant.plain}
-              className={logInfoStyle}
+              className={getLogInfoWithMessageColorStyle(messageColor)}
               hasNoPadding={true}
               onClick={() => this.openJSONModal(e)}
             />
@@ -832,7 +843,7 @@ export class WorkloadPodLogsComponent extends React.Component<WorkloadPodLogsPro
             icon={<KialiIcon.Info key={`al-i-${index}`} className={alInfoIcon} color={messageColor} />}
             key={`al-b-${index}`}
             variant={ButtonVariant.plain}
-            className={logInfoStyle}
+            className={getLogInfoWithMessageColorStyle(messageColor)}
             hasNoPadding={true}
             onClick={() => {
               this.addAccessLogModal(le.message, le.accessLog!);


### PR DESCRIPTION
### Describe the change

Fix icon in for sidecar log: 
<img width="1882" height="574" alt="image" src="https://github.com/user-attachments/assets/4b3e8a7c-9365-44cd-87d0-69eea78cd1b5" />

Fix: 
<img width="1882" height="574" alt="image" src="https://github.com/user-attachments/assets/36bf989c-6f6d-476f-9984-4f7ff8f9c2d2" />


### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
