### PR TITLE
Disable scheduled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  schedule:
+  # schedule:
   # Every Monday at 07:00 (UTC)
-  - cron: "00 7 * * MON"
+  # - cron: "00 7 * * MON"
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
### Describe the change

Due to the upcoming Christmas holidays, the release schedule for Kiali will be modified slightly. For this reason, the three-week schedule for the cron job has been disabled in the Release GitHub Action
