### PR TITLE
Fixed perf cypress tests config

### DIFF
--- a/frontend/cypress-perf.config.ts
+++ b/frontend/cypress-perf.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import { getAuthStrategy } from './cypress/plugins/setup';
+import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
 
 /* eslint-disable import/no-default-export*/
 export default defineConfig({
@@ -15,6 +16,8 @@ export default defineConfig({
       config: Cypress.PluginConfigOptions
     ): Promise<Cypress.PluginConfigOptions> {
       config.env.cookie = false;
+
+      on('file:preprocessor', createBundler());
 
       // This name is non-standard and might change based on your environment hence the separate
       // env variable.

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "inlineSourceMap": false,
+    "sourceMap": false,
     "target": "es5",
     "lib": ["es2019", "dom"],
     "resolveJsonModule": true,


### PR DESCRIPTION
### Describe the change

Perf tests are failing after TS5 update:
```
[tsl] ERROR
      TS5053: Option 'sourceMap' cannot be specified with option 'inlineSourceMap'.
```
Updated pref test configs, aligned cypress-perf.config.ts to cypress.config.ts
