### PR TITLE
[Ambient] Identify idle nodes before removing them from the graph

### DIFF
--- a/graph/telemetry/istio/appender/ambient.go
+++ b/graph/telemetry/istio/appender/ambient.go
@@ -81,14 +81,13 @@ func (a AmbientAppender) handleWaypoints(trafficMap graph.TrafficMap) {
 
 		// If not showing waypoints then delete edges going to a waypoint
 		if !a.ShowWaypoints {
-			// Make a copy to differentiate the idle nodes
-			edges := sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
+			n.Edges = sliceutil.Filter(n.Edges, func(edge *graph.Edge) bool {
 				return waypointNodes[edge.Dest.ID] == nil
 			})
-			if len(edges) == 0 && len(n.Edges) != 0 {
+
+			if n.Metadata[graph.IsIdle] != true && len(n.Edges) == 0 {
 				potentialOrphans[n.ID] = true
 			}
-			n.Edges = edges
 			continue
 		}
 


### PR DESCRIPTION
### Describe the change

Identify the idle nodes before removing them from the traffic map in the Ambient appender. 

### Steps to test the PR

- Install Istio and Ambient
- Install bookinfo
- Click in idle nodes > Should appear
- Click in Waypoint proxy to validate it works as well

<img width="773" height="687" alt="image" src="https://github.com/user-attachments/assets/06d36376-126a-4656-94df-d6082fd48c20" />


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/9009
