### PR TITLE
[CI] fix hack to pass args correctly

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -663,7 +663,7 @@ setup_kind_multicluster() {
     kubectl rollout status deployment prometheus -n istio-system --context kind-east
     kubectl rollout status deployment prometheus -n istio-system --context kind-west
   elif [ "${MULTICLUSTER}" == "${PRIMARY_REMOTE}" ]; then
-    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --kiali-enabled false --manage-kind true -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
+    "${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh --kiali-enabled false --manage-kind true -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" "${kind_node_image[@]}" "${hub_arg[@]}" "${istio_version_arg[@]}"
     cluster1_context="kind-east"
     cluster2_context="kind-west"
     cluster1_name="east"
@@ -676,7 +676,7 @@ setup_kind_multicluster() {
     if [ -n "${certs_dir}" ]; then
       external_certs_dir_arg="--certs-dir ${certs_dir}"
     fi
-    "${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh --kiali-enabled false --manage-kind true ${external_certs_dir_arg} -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
+    "${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh --kiali-enabled false --manage-kind true ${external_certs_dir_arg} -dorp docker -te ${TEMPO} --istio-dir "${istio_dir}" "${kind_node_image[@]}" "${hub_arg[@]}" "${istio_version_arg[@]}"
     cluster1_context="kind-mgmt"
     cluster2_context="kind-mesh"
     cluster1_name="mgmt"
@@ -684,7 +684,7 @@ setup_kind_multicluster() {
     ignore_home_cluster="true"
     kubectl rollout status deployment prometheus -n istio-system --context kind-mesh
   elif [ "${MULTICLUSTER}" == "${EXTERNAL_CONTROLPLANE}" ]; then
-    "${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh ${kind_node_image:-} ${istio_version_arg}
+    "${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh "${kind_node_image[@]}" "${istio_version_arg[@]}"
     cluster1_context="kind-controlplane"
     cluster2_context="kind-dataplane"
     cluster1_name="controlplane"


### PR DESCRIPTION
# Fix Summary: Multicluster Integration Test Failures

## Problem Description

The backend multicluster external-controlplane integration tests were failing with:
```
/home/runner/work/kiali/kiali/hack/istio/multicluster/env.sh: line 399: $2: unbound variable
```

## Root Cause

The issue was in `hack/setup-kind-in-ci.sh` at lines 666, 679, and 687.

### The Bug

The script defines bash arrays for arguments:
```bash
local kind_node_image=()
if [ -n "${KIND_NODE_IMAGE}" ]; then
  kind_node_image=(--kind-node-image "${KIND_NODE_IMAGE}")
fi

local istio_version_arg=()
if [ -n "${ISTIO_VERSION}" ]; then
  istio_version_arg=(--istio-version "${ISTIO_VERSION}")
fi
```

But when passing these arrays to other scripts, it used **incorrect array expansion**:

**Line 666 (PRIMARY_REMOTE):**
```bash
# WRONG: Only expands first element of each array
"${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh ... ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
```

**Line 679 (EXTERNAL_KIALI):**
```bash
# WRONG: Only expands first element of each array
"${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh ... ${kind_node_image:-} ${hub_arg:-} ${istio_version_arg}
```

**Line 687 (EXTERNAL_CONTROLPLANE):**
```bash
# WRONG: Only expands first element of each array
"${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh ${kind_node_image:-} ${istio_version_arg}
```

### What Happened

When `istio_version_arg=(--istio-version "1.27-latest")`:
- Using `${istio_version_arg}` only expands the **first element**: `--istio-version`
- The **value is lost**: `1.27-latest` is never passed
- The called script receives `--istio-version` with no value
- When `env.sh` tries to access `$2` for the value, it's **unbound**
- With `set -u` in env.sh, this causes the script to **exit with an error**

## The Fix

Changed all three lines to use **correct array expansion** with `"${array[@]}"`:

**Line 666:**
```bash
# FIXED: Properly expands all elements of each array
"${SCRIPT_DIR}"/istio/multicluster/install-primary-remote.sh ... "${kind_node_image[@]}" "${hub_arg[@]}" "${istio_version_arg[@]}"
```

**Line 679:**
```bash
# FIXED: Properly expands all elements of each array
"${SCRIPT_DIR}"/istio/multicluster/install-external-kiali.sh ... "${kind_node_image[@]}" "${hub_arg[@]}" "${istio_version_arg[@]}"
```

**Line 687:**
```bash
# FIXED: Properly expands all elements of each array
"${SCRIPT_DIR}"/istio/multicluster/setup-external-controlplane.sh "${kind_node_image[@]}" "${istio_version_arg[@]}"
```

### Why This Works

With the correct syntax `"${array[@]}"`:
- Empty array expands to **nothing** (0 arguments)
- Array `(--istio-version "1.27-latest")` expands to **2 separate arguments**: `--istio-version` and `1.27-latest`
- All array elements are preserved and passed correctly

## Verification

Test confirming the fix:
```bash
# Test array expansion
kind_node_image=()
istio_version_arg=(--istio-version "1.27-latest")

# Using fixed syntax
set -- "${kind_node_image[@]}" "${istio_version_arg[@]}"
echo "Arguments: $@"
# Output: Arguments: --istio-version 1.27-latest ✓
```

## Files Modified

- `hack/setup-kind-in-ci.sh` (lines 666, 679, 687)

## Testing

The script passes bash syntax validation:
```bash
bash -n hack/setup-kind-in-ci.sh
# Exit code: 0 ✓
```

## Impact

This fix resolves the failures in:
- Backend multicluster external-controlplane integration tests
- Frontend multicluster tests using similar configurations
- Any CI job that uses the external-controlplane multicluster setup with an istio-version parameter

