### PR TITLE
Add apps to the same ns and Ambient option to graph generator

### DIFF
--- a/tools/generator/options.go
+++ b/tools/generator/options.go
@@ -25,6 +25,12 @@ type Options struct {
 
 	// PopulationStrategy determines how many connections from ingress i.e. dense or sparse.
 	PopulationStrategy *string
+
+	// AmbientMode enables ambient mesh mode with waypoint proxies.
+	AmbientMode *bool
+
+	// SingleNamespace puts all apps in the same namespace instead of random namespaces.
+	SingleNamespace *string
 }
 
 // PopStratValue implements flag.Value interface so pop strategy can be used


### PR DESCRIPTION
### Describe the change

Add apps to the same ns and Ambient option to graph generator

### Steps to test the PR


    Run `go run ./tools/cmd/proxy http://localhost:8000 --ambient --namespace test-ns --apps 100`
    in package.json add proxy setting: `"proxy": "http://localhost:10201",`


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/9005 (Separate script from code changes) 
