### PR TITLE
[pf6] Update tooltip styles for annotation in aceEditor

### DIFF
--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -49,7 +49,7 @@ import { isParentKiosk, kioskContextMenuAction } from '../../components/Kiosk/Ki
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { basicTabStyle } from 'styles/TabStyles';
-import { istioAceEditorStyle } from 'styles/AceEditorStyle';
+import { drawerPanelStyle, istioAceEditorStyle } from 'styles/AceEditorStyle';
 import { Theme } from 'types/Common';
 import { ApiError, ApiResponse } from 'types/Api';
 import { dump, loadAll } from 'js-yaml';
@@ -572,7 +572,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
     ) : null;
 
     return (
-      <div className={`object-drawer ${editorDrawer}`}>
+      <div className={`object-drawer ${editorDrawer} ${drawerPanelStyle}`}>
         {showCards ? (
           <Drawer isExpanded={this.state.isExpanded} isInline={true}>
             <DrawerContent panelContent={showCards ? panelContent : undefined}>

--- a/frontend/src/styles/AceEditorStyle.ts
+++ b/frontend/src/styles/AceEditorStyle.ts
@@ -35,6 +35,15 @@ export const istioAceEditorStyle = kialiStyle({
   }
 } as NestedCSSProperties);
 
+// Specific z-index for drawer panel for the context tooltip
+export const drawerPanelStyle = kialiStyle({
+  $nest: {
+    '& .pf-v6-c-drawer__panel': {
+      zIndex: 90
+    }
+  }
+} as NestedCSSProperties);
+
 export const istioValidationErrorStyle = kialiStyle({
   position: 'absolute'
   // Removing colors due PF6 dark mode changes


### PR DESCRIPTION
### Describe the change

<img width="1883" height="651" alt="image" src="https://github.com/user-attachments/assets/bb800e3e-a656-47d9-aec6-39684f0b60bf" />

<img width="1883" height="651" alt="image" src="https://github.com/user-attachments/assets/007e8b03-6833-4841-87d5-99bbc615f4af" />


### Steps to test the PR

- Open an Istio Config, like the bookinfo-gateway
- Create an error, like removing the hosts
- Hover over the message 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9020 
