### PR TITLE
Enable schedule for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         weeks_mod3 = int(weeks_elapsed % 3)
 
         # Only release when weeks_elapsed >= 0 (past the base date) and weeks_mod3 == 0
-        print (weeks_elapsed >= 0 and weeks_mod3 == 0) # True in case of release
+        print(weeks_elapsed >= 0 and weeks_mod3 == 0) # True in case of release
         EOF
 
     - name: Determine release type
@@ -87,7 +87,7 @@ jobs:
         if [ -z ${{ github.event.inputs.release_type }} ];
         then
           DO_RELEASE=$(python minor.py)
-          if [[ $DO_RELEASE == "1" ]]
+          if [[ $DO_RELEASE == "True" ]]
           then
             echo "release_type=minor" >> $GITHUB_ENV
           else


### PR DESCRIPTION
### Describe the change

Enable schedule for automatic releases again, setting the base date is set so that releases occur every 3 weeks starting from January 26, 2026.

Additionally, I have switched the order of release type options so that the default option is `patch`, the most common release type used for manual releases.
