### PR TITLE
Add support for explicit OpenID Connect endpoints configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -541,7 +541,7 @@ type OpenShiftConfig struct {
 type DiscoveryOverrideConfig struct {
 	AuthorizationEndpoint string `yaml:"authorization_endpoint,omitempty"`
 	TokenEndpoint         string `yaml:"token_endpoint,omitempty"`
-	UserInfoEndpoint      string `yaml:"userinfo_endpoint,omitempty"`
+	UserinfoEndpoint      string `yaml:"userinfo_endpoint,omitempty"`
 	JwksUri               string `yaml:"jwks_uri,omitempty"`
 }
 
@@ -840,7 +840,7 @@ func NewConfig() (c *Config) {
 				DiscoveryOverride: DiscoveryOverrideConfig{
 					AuthorizationEndpoint: "",
 					TokenEndpoint:         "",
-					UserInfoEndpoint:      "",
+					UserinfoEndpoint:      "",
 					JwksUri:               "",
 				},
 				InsecureSkipVerifyTLS: false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -983,7 +983,7 @@ func TestOpenIdDiscoveryOverrideDefaults(t *testing.T) {
 	// Test that DiscoveryOverride fields are initialized to empty strings
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
-	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint)
+	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.JwksUri)
 }
 
@@ -1010,7 +1010,7 @@ auth:
 	assert.Equal(t, "kiali-client", conf.Auth.OpenId.ClientId)
 	assert.Equal(t, "https://custom.example.com/auth", conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
 	assert.Equal(t, "https://custom.example.com/token", conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
-	assert.Equal(t, "https://custom.example.com/userinfo", conf.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint)
+	assert.Equal(t, "https://custom.example.com/userinfo", conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, "https://custom.example.com/jwks", conf.Auth.OpenId.DiscoveryOverride.JwksUri)
 }
 
@@ -1024,7 +1024,7 @@ func TestOpenIdDiscoveryOverrideMarshalUnmarshal(t *testing.T) {
 	conf.Auth.OpenId.DiscoveryOverride = DiscoveryOverrideConfig{
 		AuthorizationEndpoint: "https://custom.example.com/auth",
 		TokenEndpoint:         "https://custom.example.com/token",
-		UserInfoEndpoint:      "https://custom.example.com/userinfo",
+		UserinfoEndpoint:      "https://custom.example.com/userinfo",
 		JwksUri:               "https://custom.example.com/jwks",
 	}
 
@@ -1042,7 +1042,7 @@ func TestOpenIdDiscoveryOverrideMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, conf.Auth.OpenId.ClientId, conf2.Auth.OpenId.ClientId)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint, conf2.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint, conf2.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
-	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint, conf2.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint)
+	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint, conf2.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.JwksUri, conf2.Auth.OpenId.DiscoveryOverride.JwksUri)
 }
 
@@ -1066,7 +1066,7 @@ auth:
 	assert.Equal(t, "https://custom.example.com/auth", conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
 	assert.Equal(t, "https://custom.example.com/token", conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
 	// Unspecified endpoints should be empty
-	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint)
+	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.JwksUri)
 }
 

--- a/handlers/authentication/openid_auth_controller.go
+++ b/handlers/authentication/openid_auth_controller.go
@@ -1137,7 +1137,7 @@ func getOpenIdMetadata(conf *config.Config) (*openIdMetadata, error) {
 			authEndpoint = cfg.DiscoveryOverride.AuthorizationEndpoint
 			tokenEndpoint = cfg.DiscoveryOverride.TokenEndpoint
 			jwksUri = cfg.DiscoveryOverride.JwksUri
-			userInfoEndpoint = cfg.DiscoveryOverride.UserInfoEndpoint
+			userInfoEndpoint = cfg.DiscoveryOverride.UserinfoEndpoint
 		} else if cfg.AuthorizationEndpoint != "" { //nolint:staticcheck // SA1019: backward compatibility for deprecated auth.openid.authorization_endpoint (redirect-only)
 			// Backward compatibility: the deprecated authorization_endpoint is only used when starting the flow (redirect).
 			// Metadata (and the remaining endpoints: token/jwks/userinfo) still come from the issuer's discovery document.

--- a/handlers/authentication/openid_auth_controller_test.go
+++ b/handlers/authentication/openid_auth_controller_test.go
@@ -1766,7 +1766,7 @@ func TestOpenIdAuthControllerHandlesOptionalUserInfoEndpointWithDiscoveryOverrid
 	assert.Equal(t, "", metadata.UserInfoURL, "UserInfoURL should be empty when not provided in DiscoveryOverride")
 
 	// Test with UserInfoEndpoint provided in DiscoveryOverride
-	conf.Auth.OpenId.DiscoveryOverride.UserInfoEndpoint = "https://example.com/userinfo"
+	conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint = "https://example.com/userinfo"
 	config.Set(conf)
 	cachedOpenIdMetadata = nil // Reset cache
 


### PR DESCRIPTION
fixes #8777 

- Add TokenEndpoint, UserInfoEndpoint, and JwksUri fields to OpenIdConfig
- Enable explicit OIDC endpoint configuration to bypass auto-discovery
- Skip auto-discovery when explicit authorization_endpoint and token_endpoint are provided
- Use explicit endpoints for token exchange and validation when configured
- Fixes authentication issues when OIDC discovery endpoint is restricted

This allows Kiali to work with OIDC providers that restrict access to the /.well-known/openid-configuration endpoint by providing explicit endpoint URLs in the configuration instead of relying on auto-discovery.

(a copy of https://github.com/kiali/kiali/pull/8774 that is now rebased on master with conflicts resolved)