### PR TITLE
Reduce size of Metrics in SummaryPanel

### DIFF
--- a/frontend/src/components/SummaryPanel/RateChart.tsx
+++ b/frontend/src/components/SummaryPanel/RateChart.tsx
@@ -63,9 +63,7 @@ export class RateChart extends React.Component<Props, State> {
     const fontSizePx = cssVariables.kialiFontSizePx;
 
     const horizontalAxisStyle = { tickLabels: { fontSize: fontSize, padding: 3 } };
-    const verticalAxisStyle = singleBar
-      ? { tickLabels: { fontSize: fontSize, textAnchor: 'end' as const, padding: 5 } }
-      : { tickLabels: { fontSize: fontSize, textAnchor: 'end' as const, padding: 5 } };
+    const verticalAxisStyle = { tickLabels: { fontSize: fontSize, padding: 2 } };
 
     return (
       <Chart


### PR DESCRIPTION
### Describe the change

Reduced the size of Metrics. I also made it look symmetrical for when someone is switching between a Workload and a route, they wont be seeing a difference in the sizing. 

Before: 
<img width="366" height="534" alt="Screenshot From 2026-01-05 15-33-47" src="https://github.com/user-attachments/assets/d91a03a0-648d-463d-b191-8da029439cb6" />
<img width="415" height="581" alt="Screenshot From 2026-01-05 15-30-35" src="https://github.com/user-attachments/assets/5471f01c-b8ca-431d-9f75-66aa4e309ae7" />

After:
<img width="384" height="556" alt="Screenshot From 2026-01-09 11-19-54" src="https://github.com/user-attachments/assets/b9070252-0d6a-458e-89dc-900b327a7552" />
<img width="353" height="496" alt="Screenshot From 2026-01-06 09-28-49" src="https://github.com/user-attachments/assets/eca91c42-4b1b-4b1d-813e-9753014225e6" />


### Issue reference

Closes: https://github.com/kiali/kiali/issues/8860
