### PR TITLE
[CI] wait for waypoint tracing data

### DIFF
--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -10,6 +10,7 @@ Feature: Kiali Waypoint related features
   Background:
     Given user is at administrator perspective
     And all waypoints are healthy
+    And the waypoint tracing data is ready
 
   Scenario: [Setup] namespace is labeled with waypoint label
     Then "bookinfo" namespace is labeled with the waypoint label
@@ -112,7 +113,7 @@ Feature: Kiali Waypoint related features
     And user "enables" "ambient" traffic option
     And user "enables" "ambientWaypoint" traffic option
     And user "closes" traffic menu
-    Then 11 edges appear in the graph with retry
+    Then 11 edges appear in the graph
 
   @skip-ossmc
   Scenario: [Istio Config] Waypoint should not have validation errors


### PR DESCRIPTION
### Describe the change

Extended this PR to try to fix some issues: 

- Wait for tracing data to be generated. 
- The waypoint tests expect 11 edges, but sometime there is not enough traffic (Example of flake: https://github.com/kiali/kiali/actions/runs/21391251854/job/61585789627):
What is expected:
<img width="1239" height="749" alt="image" src="https://github.com/user-attachments/assets/dd7d69b6-e41e-4ff8-a6ac-49a3c20a5086" />

What is generated (Missing edge from V2):
<img width="786" height="456" alt="image" src="https://github.com/user-attachments/assets/1c013f72-77ae-4e07-a647-76bd2d4d4e03" />

- Waypoint multicluster: Added a setup condition to wait until the traffic graph returns the waypoint information. (Flake example: https://github.com/kiali/kiali/actions/runs/21372950781/job/61546204845) 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9050 
