### PR TITLE
[v2.11] Bump react-router-dom-v5-compat to version 6.30.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "react-resize-detector": "9.1.1",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.11.2",
+    "react-router-dom-v5-compat": "^6.30.3",
     "react-virtualized": "9.x",
     "redux": "4.0.3",
     "redux-persist": "5.10.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2096,10 +2096,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@remix-run/router@1.17.1":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.17.1.tgz#bf93997beb81863fde042ebd05013a2618471362"
-  integrity sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==
+"@remix-run/router@1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
+  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -10488,14 +10488,14 @@ react-resize-detector@9.1.1:
   dependencies:
     lodash "^4.17.21"
 
-react-router-dom-v5-compat@^6.11.2:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.24.1.tgz#1b5f58c8a62389af11e30fbea6548eba944e12f5"
-  integrity sha512-RnK/NtweSP2NOjYGr8+HlaICOzPL/L2phmEyL3We8r589UZY+HuM706YR4eAHDQ3mWBc9Bg+JAkRzQghXA0caA==
+react-router-dom-v5-compat@^6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz#0bd5ccc0d9fc0e81ceabade75acc55240279aaaf"
+  integrity sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==
   dependencies:
-    "@remix-run/router" "1.17.1"
+    "@remix-run/router" "1.23.2"
     history "^5.3.0"
-    react-router "6.24.1"
+    react-router "6.30.3"
 
 react-router-dom@5.3.x:
   version "5.3.4"
@@ -10525,12 +10525,12 @@ react-router@5.3.4, react-router@5.3.x:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.24.1.tgz#5a3bbba0000afba68d42915456ca4c806f37a7de"
-  integrity sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==
+react-router@6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
+  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
   dependencies:
-    "@remix-run/router" "1.17.1"
+    "@remix-run/router" "1.23.2"
 
 react-scripts@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
### Describe the change

Backport of https://github.com/kiali/kiali/pull/9053 to branch v2.11
