### PR TITLE
[ci] for OLM molecule testing, just run the default test as a smoke test

### DIFF
--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -185,4 +185,4 @@ jobs:
         echo "Testing with Istio version [${ISTIO_VERSION}] using OLM install"
         echo "================================================================"
         echo
-        ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "${{ inputs.all_tests }}" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster false -ci true --operator-installer skip --olm-enabled true --olm-version "${{ inputs.olm_version }}"
+        ./hack/ci-kind-molecule-tests.sh --istio-version ${ISTIO_VERSION} --client-exe $(which kubectl) --kind-exe $(which kind) --all-tests "default" --git-clone-protocol https --irc-room "" --upload-logs false --rebuild-cluster false -ci true --operator-installer skip --olm-enabled true --olm-version "${{ inputs.olm_version }}"


### PR DESCRIPTION
This confirms the metadata is published correctly on OperatorHub.io and that Kiali Operator can be installed and runs successfully. This smoke test is all that is needed to confirm OLM functionality works.

The full test suite will still be run via the helm chart installer confirming the server and operator are fully functional.

fixes: https://github.com/kiali/kiali/issues/9021