### PR TITLE
Add ReportPortal integration for backend integration tests

### DIFF
--- a/.github/actions/report-to-reportportal/action.yml
+++ b/.github/actions/report-to-reportportal/action.yml
@@ -1,0 +1,68 @@
+name: 'Report to ReportPortal'
+description: 'Upload test results to ReportPortal'
+inputs:
+  test_suite:
+    description: 'Test suite name'
+    required: true
+  test_results_dir:
+    description: 'Directory containing test results'
+    required: false
+    default: '/tmp/artifacts'
+  test_file_name:
+    description: 'Test results file name'
+    required: false
+    default: 'junit.xml'
+  istio_version:
+    description: 'Istio version'
+    required: false
+    default: 'unknown'
+  data_plane_mode:
+    description: 'Data plane mode'
+    required: false
+    default: 'unknown'
+  data_router_username:
+    description: 'Data Router username (secret)'
+    required: true
+  data_router_password:
+    description: 'Data Router password (secret)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract Kiali version
+      shell: bash
+      run: |
+        # Extract VERSION from Makefile and get major.minor (e.g., v2.21.0-SNAPSHOT -> 2.21)
+        VERSION=$(grep -E '^VERSION \?=' Makefile | sed -E 's/^VERSION \?= v?([0-9]+\.[0-9]+).*/\1/')
+        echo "KIALI_VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Download ReportPortal script
+      shell: bash
+      run: |
+        curl -sSL -o /tmp/send_report_portal_results.sh \
+          https://raw.githubusercontent.com/openshift-service-mesh/ci-utils/main/report_portal/send_report_portal_results.sh
+        chmod +x /tmp/send_report_portal_results.sh
+
+    - name: Set EXTRA_ATTRIBUTES
+      shell: bash
+      run: |
+        echo "EXTRA_ATTRIBUTES=[{\"key\": \"build_type\", \"value\": \"pr_build\"}, {\"key\": \"kiali_version\", \"value\": \"${{ env.KIALI_VERSION }}\"}, {\"key\": \"istio_version\", \"value\": \"${{ inputs.istio_version }}\"}, {\"key\": \"data_plane_mode\", \"value\": \"${{ inputs.data_plane_mode }}\"}]" >> $GITHUB_ENV
+
+    - name: Send results to ReportPortal
+      shell: bash
+      env:
+        REPORT_PORTAL_HOSTNAME: reportportal-ossm.apps.dno.ocp-hub.prod.psi.redhat.com
+        REPORT_PORTAL_PROJECT: osssm_general
+        DATA_ROUTER_USERNAME: ${{ inputs.data_router_username }}
+        DATA_ROUTER_PASSWORD: ${{ inputs.data_router_password }}
+        TEST_RESULTS_DIR: ${{ inputs.test_results_dir }}
+        TEST_FILE_NAME: ${{ inputs.test_file_name }}
+        TEST_SUITE: ${{ inputs.test_suite }}
+        TESTRUN_NAME: Kiali ${{ inputs.test_suite }} test run
+        TESTRUN_DESCRIPTION: Kiali ${{ inputs.test_suite }} test run
+        INSTALLATION_METHOD: helm
+        PRODUCT_STAGE: upstream
+        TEST_REPO: ${{ github.repository }}
+        EXTRA_ATTRIBUTES: ${{ env.EXTRA_ATTRIBUTES }}
+      run: /tmp/send_report_portal_results.sh --verbose

--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -72,3 +72,42 @@ jobs:
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: junit-rest-report
+        path: tests/integration/junit-rest-report.xml
+        if-no-files-found: warn
+
+  report-to-reportportal:
+    name: Report to ReportPortal
+    needs: integration_tests_backend
+    if: always()
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/dno/droute:latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.build_branch }}
+
+    - name: Download test results
+      uses: actions/download-artifact@v7
+      with:
+        name: junit-rest-report
+        path: tests/integration/
+
+    - name: Report to ReportPortal
+      continue-on-error: true
+      uses: ./.github/actions/report-to-reportportal
+      with:
+        test_suite: 'backend'
+        test_results_dir: 'tests/integration'
+        test_file_name: 'junit-rest-report.xml'
+        istio_version: ${{ inputs.istio_version }}
+        data_plane_mode: 'sidecar'
+        data_router_username: ${{ secrets.DATA_ROUTER_USERNAME }}
+        data_router_password: ${{ secrets.DATA_ROUTER_PASSWORD }}

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -244,6 +244,11 @@ else
   HELM_CHARTS_DIR_ARG=""
 fi
 
+# Install go-junit-report if not already installed
+if ! command -v go-junit-report &> /dev/null; then
+  go install github.com/jstemmer/go-junit-report@latest
+fi
+
 # Determine where this script is and make it the cwd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
@@ -440,7 +445,7 @@ if [ "${TEST_SUITE}" == "${BACKEND}" ]; then
 
   # Run backend multicluster integration tests
   cd "${SCRIPT_DIR}"/../tests/integration/tests
-  go test -v -failfast
+  go test -v -failfast 2>&1 | tee >(go-junit-report > ../junit-rest-report.xml) ../int-test.log
   detectRaceConditions
 elif [ "${TEST_SUITE}" == "${BACKEND_EXTERNAL_CONTROLPLANE}" ]; then
   if [ "${TESTS_ONLY}" == "false" ]; then
@@ -475,7 +480,7 @@ elif [ "${TEST_SUITE}" == "${BACKEND_EXTERNAL_CONTROLPLANE}" ]; then
 
   # Run backend multicluster integration tests
   cd "${SCRIPT_DIR}"/../tests/integration/multicluster/
-  go test -v -failfast
+  go test -v -failfast 2>&1 | tee >(go-junit-report > ../junit-rest-report.xml) ../int-test.log
   detectRaceConditions "${CLUSTER1_CONTEXT}"
 elif [ "${TEST_SUITE}" == "${FRONTEND}" ]; then
   ensureCypressInstalled


### PR DESCRIPTION
Introduces automated test reporting to ReportPortal for backend integration tests. Changes include:
- New composite GitHub Action for uploading test results to ReportPortal
- Modified run-integration-tests.sh to generate JUnit XML output via go-junit-report

