### PR TITLE
Added missing DataPlane Type for Ambient mesh

### DIFF
--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -13,6 +13,7 @@ import { NamespaceInfo } from '../../types/NamespaceInfo';
 import { StatefulFiltersRef } from '../Filters/StatefulFilters';
 import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
 import { getGVKTypeString, kindToStringIncludeK8s } from '../../utils/IstioConfigUtils';
+import { TypeHeader } from '../../pages/Namespaces/TypeHeader';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -237,7 +238,8 @@ const typeNamespaces: ResourceType<NamespaceInfo> = {
   title: 'Type',
   sortable: true,
   width: 10,
-  renderer: NamespacesRenderers.type
+  renderer: NamespacesRenderers.type,
+  headerContent: React.createElement(TypeHeader)
 };
 
 const nsItemNamespaces: ResourceType<NamespaceInfo> = {

--- a/frontend/src/pages/Namespaces/NamespacesRenderers.tsx
+++ b/frontend/src/pages/Namespaces/NamespacesRenderers.tsx
@@ -67,13 +67,14 @@ export const type: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
   // Determine if namespace is a data plane namespace
   // A namespace is a data plane namespace if:
   // - It's not a control plane namespace
-  // - AND it has the injection label enabled OR has the revision label set
+  // - AND (it has the injection label enabled OR has the revision label set OR is ambient)
   const isDataPlane =
     !ns.isControlPlane &&
-    ns.labels &&
-    (ns.labels[serverConfig.istioLabels.injectionLabelName] === 'enabled' ||
-      (ns.labels[serverConfig.istioLabels.injectionLabelRev] !== undefined &&
-        ns.labels[serverConfig.istioLabels.injectionLabelRev] !== ''));
+    (ns.isAmbient ||
+      (ns.labels &&
+        (ns.labels[serverConfig.istioLabels.injectionLabelName] === 'enabled' ||
+          (ns.labels[serverConfig.istioLabels.injectionLabelRev] !== undefined &&
+            ns.labels[serverConfig.istioLabels.injectionLabelRev] !== ''))));
 
   return (
     <Td role="gridcell" dataLabel="Type" key={`VirtuaItem_Type_${ns.name}`} style={{ verticalAlign: 'middle' }}>

--- a/frontend/src/pages/Namespaces/TypeHeader.tsx
+++ b/frontend/src/pages/Namespaces/TypeHeader.tsx
@@ -25,7 +25,7 @@ export const TypeHeader: React.FC = () => {
           <strong>{t('DP')}</strong> - {t('Data plane')}: {t('Namespace is part of the mesh')}
         </div>
         <div>
-          <strong>-</strong> - {t('Not part of the mesh')}: {t('Namespace is not part of the mesh')}
+          <strong>Empty</strong> - {t('Namespace is not part of the mesh')}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Describe the change

Ambient mesh DataPlanes are now marked as 'DP' in Type.
Added help icon and tooltip on Type header.

<img width="1588" height="663" alt="Screenshot From 2026-01-23 11-14-02" src="https://github.com/user-attachments/assets/34c954bd-4fb1-4142-a9ad-b65eefd0cc7e" />


### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/9104

