### PR TITLE
[Namespaces] Restore applications menu entry

### DIFF
--- a/frontend/src/mocks/handlers/status.ts
+++ b/frontend/src/mocks/handlers/status.ts
@@ -14,13 +14,18 @@ const mockStatus: StatusState = {
       version: '1.28.0'
     },
     {
-      name: 'Prometheus',
-      version: '2.45.0',
-      url: 'http://prometheus:9090'
+      name: 'jaeger',
+      url: 'http://jaeger-query:16686',
+      version: '1.62.0'
     },
     {
       name: 'Kubernetes',
       version: '1.33.0'
+    },
+    {
+      name: 'Prometheus',
+      url: 'http://prometheus:9090',
+      version: '2.45.0'
     }
   ],
   warningMessages: [],

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -49,6 +49,12 @@ const navMenuItems: MenuItem[] = [
     pathsActive: [new RegExp(`^/${Paths.NAMESPACES}(?:\\?.*)?$`)]
   },
   {
+    id: 'applications',
+    title: t('Applications'),
+    to: `/${Paths.APPLICATIONS}`,
+    pathsActive: [new RegExp(`^/namespaces/(.*)/${Paths.APPLICATIONS}/(.*)`)]
+  },
+  {
     id: 'services',
     title: t('Services'),
     to: `/${Paths.SERVICES}`,


### PR DESCRIPTION
### Describe the change

Restore applications menu entry removed by mistake in PR https://github.com/kiali/kiali/pull/9063. Additionaly, I  have added jaeger entry mock to show Distributed Tracing menu entry in mock mode.

<img width="278" height="500" alt="image" src="https://github.com/user-attachments/assets/5fbf98b4-50a9-4691-b981-62d6a756cb91" />

