### PR TITLE
[CI] Fix to graph readiness checking

### DIFF
--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -129,7 +129,7 @@ const TopologyContent: React.FC<{
     peerAuths: PeerAuthentication[]
   ) => void;
   onNodeTap?: (node: Node<NodeModel>) => void;
-  onReady: (refs: GraphRefs) => void;
+  onReady: (refs: GraphRefs | undefined, isReady: boolean) => void;
   rankBy: RankMode[];
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (val: GraphLayout) => void;
@@ -315,7 +315,7 @@ const TopologyContent: React.FC<{
       }
 
       isReady = true;
-      onReady({ getController: () => controller, setSelectedIds: setSelectedIds });
+      onReady({ getController: () => controller, setSelectedIds: setSelectedIds }, true);
     }
 
     layoutInProgress = undefined;
@@ -342,6 +342,9 @@ const TopologyContent: React.FC<{
     //
     const resetGraph = (): void => {
       if (controller) {
+        // notify the parent that the graph is being updated and is not ready
+        onReady(undefined, false);
+
         const defaultModel: Model = {
           graph: {
             id: 'trafficgraph',
@@ -886,7 +889,7 @@ export const Graph: React.FC<{
     peerAuths: PeerAuthentication[]
   ) => void;
   onNodeTap?: (node: Node<NodeModel>) => void;
-  onReady: (refs: GraphRefs) => void;
+  onReady: (refs: GraphRefs | undefined, isReady: boolean) => void;
   rankBy: RankMode[];
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setLayout: (layout: GraphLayout) => void;

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -91,6 +91,7 @@ export type GraphURLPathProps = {
 };
 
 type ReduxDispatchProps = {
+  dispatch: KialiDispatch;
   endTour: () => void;
   onReady: (controller: any) => void;
   setActiveNamespaces: (namespaces: Namespace[]) => void;
@@ -105,7 +106,6 @@ type ReduxDispatchProps = {
   toggleIdleNodes: () => void;
   toggleLegend: () => void;
   updateSummary: (summaryData: SummaryData | null) => void;
-  dispatch: KialiDispatch;
 };
 type ReduxStateProps = {
   activeNamespaces: Namespace[];
@@ -594,8 +594,13 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
     console.debug(`onFocus(${focusNode})`);
   };
 
-  private handleReady = (refs: GraphRefs): void => {
-    this.setState({ graphRefs: refs, isReady: true });
+  private handleReady = (refs: GraphRefs | undefined, isReady: boolean): void => {
+    this.setState({ graphRefs: refs, isReady: isReady });
+
+    if (!isReady) {
+      this.initTime = Date.now();
+      return;
+    }
 
     const loadingTime = (Date.now() - this.initTime) / 1000;
     if (this.props.showTrafficAnimation && loadingTime > 10) {

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -264,8 +264,8 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     );
   }
 
-  private handleReady = (refs: GraphRefs): void => {
-    this.setState({ graphRefs: refs, isReady: true });
+  private handleReady = (refs: GraphRefs | undefined, isReady: boolean): void => {
+    this.setState({ graphRefs: refs, isReady: isReady });
   };
 
   private handleLaunchWizard = (key: WizardAction, mode: WizardMode): void => {


### PR DESCRIPTION
Make sure that if the graph is being reset that we notify that the graph is not ready. This will hopefully help some CI flakes that seem to be failing because they think the graph is ready when really it is not.
