### PR TITLE
Add ref property to fix OSSMC build

### DIFF
--- a/frontend/src/components/ChatBot/ChatMessage/ChatMessageMarkdown.tsx
+++ b/frontend/src/components/ChatBot/ChatMessage/ChatMessageMarkdown.tsx
@@ -60,7 +60,7 @@ const CodeBlockMessage: React.FC<
     'aria-label'?: string;
     inline?: boolean;
   }
-> = ({ children, className, 'aria-label': ariaLabel, inline: _inline, ...props }) => {
+> = ({ children, className, 'aria-label': ariaLabel, inline: _inline, ref: _ref, ...props }) => {
   const [copied, setCopied] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const tooltipIdRef = React.useRef(`chatbot-copy-${Math.random().toString(16).slice(2)}`);


### PR DESCRIPTION
### Describe the change

OSSMC build is failing with this error:

``` 
ERROR in ./src/kiali/components/ChatBot/ChatMessage/ChatMessageMarkdown.tsx:112:14
TS2769: No overload matches this call.
  Overload 1 of 2, '(props: SyntaxHighlighterProps | Readonly<SyntaxHighlighterProps>): SyntaxHighlighter', gave the following error.
    Type '{ children: string; language: string; style: Record<string, any>; PreTag: "div"; CodeTag: "div"; wrapLongLines: true; ref?: LegacyRef<HTMLElement> | undefined; ... 255 more ...; onTransitionEndCapture?: TransitionEventHandler<...> | undefined; }' is not assignable to type 'IntrinsicClassAttributes<SyntaxHighlighter>'.
      Types of property 'ref' are incompatible.
        Type 'LegacyRef<HTMLElement> | undefined' is not assignable to type 'LegacyRef<SyntaxHighlighter> | undefined'.
          Type '(instance: HTMLElement | null) => void' is not assignable to type 'LegacyRef<SyntaxHighlighter> | undefined'.
            Type '(instance: HTMLElement | null) => void' is not assignable to type '(instance: SyntaxHighlighter | null) => void'.
              Types of parameters 'instance' and 'instance' are incompatible.
                Type 'SyntaxHighlighter | null' is not assignable to type 'HTMLElement | null'.
                  Type 'Component<SyntaxHighlighterProps, {}, any>' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 314 more.
  Overload 2 of 2, '(props: SyntaxHighlighterProps, context: any): SyntaxHighlighter', gave the following error.
    Type '{ children: string; language: string; style: Record<string, any>; PreTag: "div"; CodeTag: "div"; wrapLongLines: true; ref?: LegacyRef<HTMLElement> | undefined; ... 255 more ...; onTransitionEndCapture?: TransitionEventHandler<...> | undefined; }' is not assignable to type 'IntrinsicClassAttributes<SyntaxHighlighter>'.
      Types of property 'ref' are incompatible.
        Type 'LegacyRef<HTMLElement> | undefined' is not assignable to type 'LegacyRef<SyntaxHighlighter> | undefined'.
          Type '(instance: HTMLElement | null) => void' is not assignable to type 'LegacyRef<SyntaxHighlighter> | undefined'.
            Type '(instance: HTMLElement | null) => void' is not assignable to type '(instance: SyntaxHighlighter | null) => void'.
              Types of parameters 'instance' and 'instance' are incompatible.
                Type 'SyntaxHighlighter | null' is not assignable to type 'HTMLElement | null'.
                  Type 'Component<SyntaxHighlighterProps, {}, any>' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, 
```  

The error is caused by spreading props into SyntaxHighlighter - the props includes a ref typed for HTMLElement, but SyntaxHighlighter is a class component that doesn't accept that ref type.
The fix is to destructure and exclude the ref from the props before spreading them into SyntaxHighlighter.

### Steps to test the PR

CI tests pass
