### PR TITLE
[Overview] Add refresh button to the overview page

### DIFF
--- a/frontend/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/frontend/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { PFColors } from 'components/Pf/PfColors';
 import { kindToStringIncludeK8s } from '../../utils/IstioConfigUtils';
 
-const titles = ['applications', 'istio', 'istio/new', 'mesh', 'namespaces', 'services', 'workloads'];
+const titles = ['applications', 'istio', 'istio/new', 'mesh', 'namespaces', 'overview', 'services', 'workloads'];
 
 type ReduxProps = {
   istioAPIEnabled: boolean;
@@ -31,7 +31,9 @@ const flexStyle = kialiStyle({
 });
 
 const rightToolbarStyle = kialiStyle({
-  marginLeft: 'auto'
+  position: 'absolute',
+  right: '3rem',
+  zIndex: 1
 });
 
 const actionsToolbarStyle = kialiStyle({

--- a/frontend/src/components/Nav/Page/RenderHeader.tsx
+++ b/frontend/src/components/Nav/Page/RenderHeader.tsx
@@ -8,7 +8,7 @@ import { PFColors } from 'components/Pf/PfColors';
 
 const containerStyle = kialiStyle({
   backgroundColor: PFColors.BackgroundColor100,
-  paddingBottom: '1.5rem'
+  paddingBottom: '1rem'
 });
 
 const headerRowStyle = kialiStyle({

--- a/frontend/src/pages/Namespaces/NamespacesPage.tsx
+++ b/frontend/src/pages/Namespaces/NamespacesPage.tsx
@@ -31,7 +31,6 @@ import { availableFilters, nameFilter } from './Filters';
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { CubesIcon, SearchIcon } from '@patternfly/react-icons';
 import { isMultiCluster } from '../../config';
-import { kialiStyle } from 'styles/StyleUtils';
 import { addDanger } from '../../utils/AlertUtils';
 import { TLSStatus } from '../../types/TLSStatus';
 import { ValidationStatus } from '../../types/IstioObjects';
@@ -60,11 +59,6 @@ import { serverConfig } from '../../config';
 
 // Maximum number of namespaces to include in a single backend API call
 const MAX_NAMESPACES_PER_CALL = 100;
-
-const refreshStyle = kialiStyle({
-  marginLeft: '0.4rem',
-  marginRight: '0.4rem'
-});
 
 /**
  * Chunks an array into smaller arrays of a specified size
@@ -1117,9 +1111,7 @@ export class NamespacesPageComponent extends React.Component<NamespacesProps, St
       <>
         <DefaultSecondaryMasthead
           hideNamespaceSelector={true}
-          rightToolbar={
-            <Refresh className={refreshStyle} id="namespaces-list-refresh" disabled={false} manageURL={true} />
-          }
+          rightToolbar={<Refresh id="namespaces-list-refresh" disabled={false} manageURL={true} />}
         />
         <RenderContent>
           <VirtualList

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { Grid, GridItem, Title, TitleSizes } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
-import { PFColors } from 'components/Pf/PfColors';
-import { t } from 'utils/I18nUtils';
 import { ClusterStats } from './ClusterStats';
 import { IstioConfigStats } from './IstioConfigStats';
 import { ControlPlaneStats } from './ControlPlaneStats';
@@ -11,15 +9,8 @@ import { ApplicationStats } from './ApplicationStats';
 import { WorkloadInsights } from './WorkloadInsights';
 import { useKialiDispatch } from 'hooks/redux';
 import { setAIContext } from 'helpers/ChatAI';
-
-const titleContainerStyle = kialiStyle({
-  borderBottom: `1px solid ${PFColors.BorderColor100}`,
-  marginBottom: '0.25rem'
-});
-
-const titleStyle = kialiStyle({
-  marginBottom: '1rem'
-});
+import { DefaultSecondaryMasthead } from 'components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
+import { Refresh } from 'components/Refresh/Refresh';
 
 const overviewPageStyle = kialiStyle({
   display: 'flex',
@@ -36,13 +27,11 @@ export const OverviewPage: React.FC = () => {
 
   return (
     <div className={overviewPageStyle}>
-      <div className={titleContainerStyle}>
-        <Title headingLevel="h1" size={TitleSizes['2xl']} className={titleStyle}>
-          {t('Overview')}
-        </Title>
-      </div>
+      <DefaultSecondaryMasthead
+        hideNamespaceSelector={true}
+        rightToolbar={<Refresh id="namespaces-list-refresh" disabled={false} manageURL={true} />}
+      />
 
-      {/* Top row - Summary cards */}
       <Grid hasGutter>
         <GridItem span={7}>
           <Grid hasGutter>

--- a/frontend/src/pages/ServiceList/ServiceListPage.tsx
+++ b/frontend/src/pages/ServiceList/ServiceListPage.tsx
@@ -29,12 +29,6 @@ import { RefreshIntervalManual, RefreshIntervalPause } from 'config/Config';
 import { HistoryManager } from 'app/History';
 import { endPerfTimer, startPerfTimer } from '../../utils/PerformanceUtils';
 import { setAIContext } from 'helpers/ChatAI';
-import { kialiStyle } from 'styles/StyleUtils';
-
-const refreshStyle = kialiStyle({
-  marginLeft: '0.4rem',
-  marginRight: '0.4rem'
-});
 
 type ServiceListPageState = FilterComponent.State<ServiceListItem> & {
   loaded: boolean;

--- a/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/frontend/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -28,12 +28,6 @@ import { RefreshIntervalManual, RefreshIntervalPause } from 'config/Config';
 import { HistoryManager } from 'app/History';
 import { endPerfTimer, startPerfTimer } from '../../utils/PerformanceUtils';
 import { setAIContext } from 'helpers/ChatAI';
-import { kialiStyle } from 'styles/StyleUtils';
-
-const refreshStyle = kialiStyle({
-  marginLeft: '0.4rem',
-  marginRight: '0.4rem'
-});
 
 type WorkloadListPageState = FilterComponent.State<WorkloadListItem> & {
   loaded: boolean;


### PR DESCRIPTION
### Describe the change

Add refresh button to the overview page and reduce the padding of the namespace title. Additionally I have added @jshaughn's suggestion mentioned in https://github.com/kiali/kiali/pull/9102#pullrequestreview-3752633022.

<img width="2254" height="562" alt="image" src="https://github.com/user-attachments/assets/6f24a50c-48ae-4105-8931-a22839c3bdd6" />

<img width="2254" height="747" alt="image" src="https://github.com/user-attachments/assets/093934c9-d5a0-4ce8-ad05-6d2016bf1a0d" /> 

### Steps to test the PR

Review the refresh button in the overview page