### PR TITLE
Fix an issue with health pre-compute

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -420,14 +420,16 @@ func fillAppRequestRates(allHealth models.NamespaceAppHealth, rates model.Vector
 	lblSrc := model.LabelName("source_canonical_service")
 
 	for _, sample := range rates {
-		name := string(sample.Metric[lblDest])
 		// include requests only to apps which have HTTP traffic capability
-		if _, ok := appHTTPTraffic[name]; ok {
-			if health, ok := allHealth[name]; ok {
+		destName := string(sample.Metric[lblDest])
+		if _, ok := appHTTPTraffic[destName]; ok {
+			if health, ok := allHealth[destName]; ok {
 				health.Requests.AggregateInbound(sample)
 			}
-			name = string(sample.Metric[lblSrc])
-			if health, ok := allHealth[name]; ok {
+		}
+		srcName := string(sample.Metric[lblSrc])
+		if _, ok := appHTTPTraffic[srcName]; ok {
+			if health, ok := allHealth[srcName]; ok {
 				health.Requests.AggregateOutbound(sample)
 			}
 		}
@@ -442,14 +444,16 @@ func fillWorkloadRequestRates(allHealth models.NamespaceWorkloadHealth, rates mo
 	lblDest := model.LabelName("destination_workload")
 	lblSrc := model.LabelName("source_workload")
 	for _, sample := range rates {
-		name := string(sample.Metric[lblDest])
-		// include requests only to workloads which have HTTP traffic capability
-		if _, ok := wlHTTPTraffic[name]; ok {
-			if health, ok := allHealth[name]; ok {
+		// include only workloads which have HTTP traffic capability
+		destName := string(sample.Metric[lblDest])
+		if _, ok := wlHTTPTraffic[destName]; ok {
+			if health, ok := allHealth[destName]; ok {
 				health.Requests.AggregateInbound(sample)
 			}
-			name = string(sample.Metric[lblSrc])
-			if health, ok := allHealth[name]; ok {
+		}
+		srcName := string(sample.Metric[lblSrc])
+		if _, ok := wlHTTPTraffic[srcName]; ok {
+			if health, ok := allHealth[srcName]; ok {
 				health.Requests.AggregateOutbound(sample)
 			}
 		}


### PR DESCRIPTION
Rate calculations for services and apps were missing some traffic when only the source workload was HTTP-enabled. A  practical example of this issue was with fault injection, where the destination workload is "unknown". The fix now considers source and dest workloads separately.

To test:
You can add 100% FI to, say the bookinfo reviews service. After it is established visit the Workloads list page. You will see the  reviews workload with failure health status. Visit the Apps or Services list page and everything is healthy.  With the fix, on Services you should see the productpage service show unhealthy, and also an unhealthy entry on the Apps list.

Part-of: #8900 