### PR TITLE
Fix ReportPortal workflow checkout failure for fork PRs

### DIFF
--- a/.github/actions/report-to-reportportal/action.yml
+++ b/.github/actions/report-to-reportportal/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Test results file name'
     required: false
     default: 'junit.xml'
+  kiali_version:
+    description: 'Kiali version'
+    required: false
+    default: 'unknown'
   istio_version:
     description: 'Istio version'
     required: false
@@ -38,13 +42,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Extract Kiali version
-      shell: bash
-      run: |
-        # Extract VERSION from Makefile and get major.minor (e.g., v2.21.0-SNAPSHOT -> 2.21)
-        VERSION=$(grep -E '^VERSION \?=' Makefile | sed -E 's/^VERSION \?= v?([0-9]+\.[0-9]+).*/\1/')
-        echo "KIALI_VERSION=$VERSION" >> $GITHUB_ENV
-
     - name: Download ReportPortal script
       shell: bash
       run: |
@@ -55,7 +52,7 @@ runs:
     - name: Set EXTRA_ATTRIBUTES
       shell: bash
       run: |
-        echo "EXTRA_ATTRIBUTES=[{\"key\": \"build_type\", \"value\": \"pr_build\"}, {\"key\": \"kiali_version\", \"value\": \"${{ env.KIALI_VERSION }}\"}, {\"key\": \"istio_version\", \"value\": \"${{ inputs.istio_version }}\"}, {\"key\": \"data_plane_mode\", \"value\": \"${{ inputs.data_plane_mode }}\"}, {\"key\": \"pr_number\", \"value\": \"${{ inputs.pr_number }}\"}, {\"key\": \"target_branch\", \"value\": \"${{ inputs.target_branch }}\"}]" >> $GITHUB_ENV
+        echo "EXTRA_ATTRIBUTES=[{\"key\": \"build_type\", \"value\": \"pr_build\"}, {\"key\": \"kiali_version\", \"value\": \"${{ inputs.kiali_version }}\"}, {\"key\": \"istio_version\", \"value\": \"${{ inputs.istio_version }}\"}, {\"key\": \"data_plane_mode\", \"value\": \"${{ inputs.data_plane_mode }}\"}, {\"key\": \"pr_number\", \"value\": \"${{ inputs.pr_number }}\"}, {\"key\": \"target_branch\", \"value\": \"${{ inputs.target_branch }}\"}]" >> $GITHUB_ENV
 
     - name: Send results to ReportPortal
       shell: bash

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -194,15 +194,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [initialize]
     steps:
-    - name: Store PR number and target branch
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Store PR number, target branch, and Kiali version
       run: |
         mkdir -p pr-metadata
         echo "${{ github.event.number }}" > pr-metadata/pr_number.txt
         echo "${{ github.base_ref || github.ref_name }}" > pr-metadata/target_branch.txt
+        # Extract VERSION from Makefile and get major.minor (e.g., v2.21.0-SNAPSHOT -> 2.21)
+        VERSION=$(grep -E '^VERSION \?=' Makefile | sed -E 's/^VERSION \?= v?([0-9]+\.[0-9]+).*/\1/')
+        echo "${VERSION}" > pr-metadata/kiali_version.txt
         cat pr-metadata/pr_number.txt
         cat pr-metadata/target_branch.txt
+        cat pr-metadata/kiali_version.txt
 
-    # Upload PR number as artifact because workflow_run events triggered by PRs from forks
+    # Upload PR metadata as artifact because workflow_run events triggered by PRs from forks
     # don't have access to PR information in github.event.workflow_run.pull_requests
     # See: https://github.com/orgs/community/discussions/25220
     - name: Upload PR metadata

--- a/.github/workflows/report-to-reportportal.yml
+++ b/.github/workflows/report-to-reportportal.yml
@@ -14,12 +14,7 @@ jobs:
     container:
       image: quay.io/dno/droute:latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.workflow_run.head_branch }}
-
-    # Download PR metadata from artifact because workflow_run events triggered by PRs from forks
+    # Download test artifacts and PR metadata because workflow_run events triggered by PRs from forks
     # don't have access to PR information in github.event.workflow_run.pull_requests
     # See: https://github.com/orgs/community/discussions/25220
     - name: Download all test artifacts
@@ -67,6 +62,13 @@ jobs:
           echo "target_branch=unknown" >> $GITHUB_OUTPUT
         fi
 
+        if [ -f artifacts/pr-metadata/kiali_version.txt ]; then
+          KIALI_VERSION=$(cat artifacts/pr-metadata/kiali_version.txt)
+          echo "kiali_version=${KIALI_VERSION:-unknown}" >> $GITHUB_OUTPUT
+        else
+          echo "kiali_version=unknown" >> $GITHUB_OUTPUT
+        fi
+
     - name: Report backend tests to ReportPortal
       continue-on-error: true
       uses: ./.github/actions/report-to-reportportal
@@ -74,6 +76,7 @@ jobs:
         test_suite: 'backend'
         test_results_dir: 'artifacts/junit-rest-report'
         test_file_name: 'junit-rest-report.xml'
+        kiali_version: ${{ steps.metadata.outputs.kiali_version }}
         istio_version: ${{ steps.metadata.outputs.istio_version }}
         data_plane_mode: 'sidecar'
         pr_number: ${{ steps.metadata.outputs.pr_number }}
@@ -88,6 +91,7 @@ jobs:
         test_suite: 'cypress'
         test_results_dir: 'frontend-core/cypress/results'
         test_file_name: 'combined-report.xml'
+        kiali_version: ${{ steps.metadata.outputs.kiali_version }}
         istio_version: ${{ steps.metadata.outputs.istio_version }}
         data_plane_mode: 'sidecar'
         pr_number: ${{ steps.metadata.outputs.pr_number }}


### PR DESCRIPTION
The report-to-reportportal workflow was failing with 404 errors when checking out code for PRs from forks, because the head_branch doesn't exist in the base repository.

This fix:
- Extracts Kiali version in kiali-ci workflow where checkout works
- Saves version to pr-metadata artifact
- Removes checkout from report-to-reportportal workflow
- Updates report-to-reportportal action to accept version as input

