### PR TITLE
Add checkout back to report-to-reportportal workflow

### DIFF
--- a/.github/workflows/report-to-reportportal.yml
+++ b/.github/workflows/report-to-reportportal.yml
@@ -14,6 +14,11 @@ jobs:
     container:
       image: quay.io/dno/droute:latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+
     # Download test artifacts and PR metadata because workflow_run events triggered by PRs from forks
     # don't have access to PR information in github.event.workflow_run.pull_requests
     # See: https://github.com/orgs/community/discussions/25220


### PR DESCRIPTION
The checkout is required to access the local custom action (./.github/actions/report-to-reportportal). Using head_sha instead of head_branch to avoid 404 errors for fork PRs.
