### PR TITLE
[CI] Try fixing a flake that looks related to not waiting for data load

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -439,6 +439,8 @@ When('the user refreshes the page', () => {
 When('user filters for config {string}', (configName: string) => {
   cy.get('button#filter_select_value-toggle').click();
   cy.contains('div#filter_select_value button', configName).click();
+
+  ensureKialiFinishedLoading();
 });
 
 When(
@@ -571,6 +573,8 @@ Then('the user filters by {string} for {string}', (filter: string, filterValue: 
   } else if (filter === 'Label') {
     cy.get('input#filter_input_label').type(`${filterValue}{enter}`);
   }
+
+  ensureKialiFinishedLoading();
 });
 
 Then('user only sees {string}', (sees: string) => {

--- a/frontend/cypress/integration/common/istio_config_validation_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_validation_filters.ts
@@ -1,4 +1,5 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
 
 // Some of the steps from istio_config_validation_filters.feature are implemented in
 // the istio_config_type_filters.ts file. This is because some steps are identical.
@@ -45,6 +46,7 @@ When('a validation filter {string} is applied', (category: string) => {
   cy.get('button#filter_select_value-toggle').click();
   cy.contains('div#filter_select_value button', category).click();
 
+  ensureKialiFinishedLoading();
   cy.get('#filter-selection > :nth-child(2)').contains(category).parent().should('be.visible');
 });
 
@@ -63,6 +65,6 @@ When('user chooses {int} validation filters', (count: number) => {
     cy.get('button#filter_select_value-toggle').click();
     cy.get('div#filter_select_value').find('button').eq(i).click();
 
-    cy.get('#loading_kiali_spinner').should('not.exist');
+    ensureKialiFinishedLoading();
   }
 });

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -39,12 +39,9 @@ Given('a degraded application in the mesh', function () {
 });
 
 When('user clicks in the {string} view', (view: string) => {
-  cy.get(`button[data-test="overview-type-${view}"]`)
-    .click()
-    // Using the #loading_kiali_spinner selector we can control when the UI is still loading some data
-    // That may prevent that the test progress in cases where we need more control.
-    .get('#loading_kiali_spinner')
-    .should('not.exist');
+  cy.get(`button[data-test="overview-type-${view}"]`).click();
+
+  ensureKialiFinishedLoading();
 });
 
 When(`user filters {string} namespace`, (ns: string) => {
@@ -52,7 +49,8 @@ When(`user filters {string} namespace`, (ns: string) => {
   cy.contains('div#filter_select_type button', 'Namespace').click();
 
   cy.get('input#filter_input_value').type(ns).type('{enter}');
-  cy.get('#loading_kiali_spinner').should('not.exist');
+
+  ensureKialiFinishedLoading();
 });
 
 When(`user filters {string} health`, (health: string) => {
@@ -61,24 +59,28 @@ When(`user filters {string} health`, (health: string) => {
 
   cy.get('button#filter_select_value-toggle').click();
   cy.contains('div#filter_select_value button', health).click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+
+  ensureKialiFinishedLoading();
 });
 
 When(`user selects Health for {string}`, (type: string) => {
   cy.get('button#overview-type-toggle').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
+
   cy.contains('div#overview-type button', type).click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
 });
 
 When(`user sorts by name desc`, () => {
   cy.get('button[data-sort-asc="true"]').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+
+  ensureKialiFinishedLoading();
 });
 
 When(`user sorts by column {string} desc`, (column: string) => {
   cy.get(`th[data-label=${column}]`).click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+
+  ensureKialiFinishedLoading();
 });
 
 When(`the list is sorted by {string} desc`, (column: string) => {
@@ -99,16 +101,18 @@ When(`the list is sorted by {string} desc`, (column: string) => {
 
 When(`user selects {string} time range`, (interval: string) => {
   cy.get('button#time_range_duration-toggle').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
+
   cy.contains('div#time_range_duration button', interval).click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
 });
 
 When(`user selects {string} traffic direction`, (direction: string) => {
   cy.get('button#direction-type-toggle').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
+
   cy.contains('div#direction-type button', direction).click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
 });
 
 When('I fetch the overview of the cluster', () => {

--- a/frontend/cypress/integration/common/services.ts
+++ b/frontend/cypress/integration/common/services.ts
@@ -42,16 +42,22 @@ Then('the health column on the {string} row has a health icon', (row: string) =>
 When('user filters for service type {string}', (serviceType: string) => {
   cy.get('div#filter_select_value-toggle').find('button').click();
   cy.contains('div#filter_select_value button', serviceType).click();
+
+  ensureKialiFinishedLoading();
 });
 
 When('user filters for sidecar {string}', (sidecarState: string) => {
   cy.get('button#filter_select_value-toggle').click();
   cy.contains('div#filter_select_value button', sidecarState).click();
+
+  ensureKialiFinishedLoading();
 });
 
 When('user filters for health {string}', (health: string) => {
   cy.get('button#filter_select_value-toggle').click();
   cy.contains('div#filter_select_value button', health).click();
+
+  ensureKialiFinishedLoading();
 });
 
 Then('user should only see healthy services in the table', () => {
@@ -63,6 +69,8 @@ Then('user should only see healthy services in the table', () => {
 
 When('user filters for label {string}', (label: string) => {
   cy.get('input#filter_input_label').type(`${label}{enter}`);
+
+  ensureKialiFinishedLoading();
 });
 
 When('user applies kiali api {string} annotations', (type: string) => {

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -1,11 +1,12 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { checkHealthIndicatorInTable, checkHealthStatusInTable, colExists } from './table';
+import { ensureKialiFinishedLoading } from './transition';
 
 const activateFilter = (state: string): void => {
   //decided to pause the refresh, because I'm intercepting the very same request that is used for the timed refresh
   cy.get('button#workload-list-refresh-toggle').click();
   cy.get('button[id="0"]').click();
-  cy.get('#loading_kiali_spinner').should('not.exist');
+  ensureKialiFinishedLoading();
 
   cy.intercept({
     pathname: '**/api/clusters/workloads',
@@ -44,6 +45,8 @@ Given('a degraded workload in the mesh', function () {
 When('user filters for workload type {string}', (workloadType: string) => {
   cy.get('div#filter_select_value-toggle').find('button').click();
   cy.contains('div#filter_select_value button', workloadType).click();
+
+  ensureKialiFinishedLoading();
 });
 
 Then('user sees {string} in workloads table', (workload: string) => {


### PR DESCRIPTION
Try fixing a flake that looks related to not waiting for data load when filtering lists pages. From jenkins, a failure in:

`Filter services table by health`

<img width="1410" height="790" alt="image" src="https://github.com/user-attachments/assets/c17fc15a-d722-4284-996c-194d38a57316" />

It looks like maybe we are not waiting for a data load to complete before testing for results. The same applies to many places across list page tests. So, this PR adds `ensureKialiFinishedLoading()` in various places (or replaces the less robust spinner check).