### PR TITLE
Populate namespace cache in GetKialiSAClusterNamespaces after fetching

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -323,6 +323,8 @@ func (in *NamespaceService) GetKialiSAClusterNamespaces(ctx context.Context, clu
 	// Apply discovery selector filtering
 	namespaces = istio.FilterNamespacesWithDiscoverySelectors(namespaces, istio.GetDiscoverySelectorsForCluster(ctx, in.discovery, cluster, in.conf))
 
+	in.kialiCache.SetNamespaces(saClient.GetToken(), namespaces)
+
 	return namespaces, nil
 }
 


### PR DESCRIPTION
This is a fix for a problem caught by @josunect in the review of the new overview page. That PR was merged so this is a follow-up. See [this comment in the PR](https://github.com/kiali/kiali/pull/9151#discussion_r2828626125).

GetKialiSAClusterNamespaces checks the cache on read but never writes back after fetching from the API, so the cache check always misses.
