### PR TITLE
Ensure CI runs against the proper Istio versions for the supported OSSM releases

### DIFF
--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -58,7 +58,7 @@ jobs:
       run: hack/run-integration-tests.sh --test-suite backend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
 
     - name: Run backend controller integration tests
-      run: make $(if [ -n "${{ inputs.istio_version }}" ]; then echo "ISTIO_VERSION=${{ inputs.istio_version }}"; fi) test-integration-controller
+      run: make $(if [ -n "${ISTIO_VERSION:-${{ inputs.istio_version }}}" ]; then echo "ISTIO_VERSION=${ISTIO_VERSION:-${{ inputs.istio_version }}}"; fi) test-integration-controller
 
     - name: Get debug info when integration tests fail
       if: ${{ failure() && steps.intTests.conclusion == 'failure' }}

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -77,7 +77,7 @@ jobs:
   integration_tests_backend:
     name: Run backend integration tests
     uses: ./.github/workflows/integration-tests-backend.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -85,7 +85,7 @@ jobs:
   integration_tests_frontend_core_1:
     name: Run frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-core-1.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -93,7 +93,7 @@ jobs:
   integration_tests_frontend_core_2:
     name: Run frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-core-2.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -101,7 +101,7 @@ jobs:
   integration_tests_frontend_core_optional:
     name: Run frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-core-optional.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -109,7 +109,7 @@ jobs:
   integration_tests_frontend_ambient:
     name: Run Ambient frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-ambient.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -117,7 +117,7 @@ jobs:
   integration_tests_frontend_ambient_multi_primary:
     name: Run frontend Ambient Multi-Primary integration tests
     uses: ./.github/workflows/integration-tests-frontend-ambient-multi-primary.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -125,7 +125,7 @@ jobs:
   integration_tests_frontend_tempo:
     name: Run tracing frontend integration tests
     uses: ./.github/workflows/integration-tests-frontend-tempo.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -133,7 +133,7 @@ jobs:
   integration_tests_frontend_local_offline:
     name: Run frontend local and offline mode integration tests
     uses: ./.github/workflows/integration-tests-frontend-local-offline.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -141,7 +141,7 @@ jobs:
   integration_tests_backend_multicluster_external_controlplane:
     name: Run backend multicluster external-controlplane integration tests
     uses: ./.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -149,7 +149,7 @@ jobs:
   integration_tests_frontend_multicluster_primary_remote:
     name: Run frontend multicluster primary-remote integration tests
     uses: ./.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
@@ -157,7 +157,7 @@ jobs:
   integration_tests_frontend_multicluster_multi_primary:
     name: Run frontend multicluster multi-primary integration tests
     uses: ./.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
 
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
@@ -166,7 +166,7 @@ jobs:
   integration_tests_frontend_multicluster_external_kiali:
     name: Run frontend multicluster external-kiali integration tests
     uses: ./.github/workflows/integration-tests-frontend-multicluster-external-kiali.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
 
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
@@ -183,7 +183,7 @@ jobs:
   mcp_contract_tests:
     name: MCP Contract Tests (kubernetes-mcp-server)
     uses: ./.github/workflows/mcp-contract-tests.yml
-    needs: [build_backend]
+    needs: [initialize, build_backend]
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -184,7 +184,16 @@ if [ -z "${ISTIO_VERSION}" ]; then
     ISTIO_VERSION="1.23.6"
   elif [ "${TARGET_BRANCH}" == "v2.11" ]; then
     ISTIO_VERSION="1.26.8"
+  elif [ "${TARGET_BRANCH}" == "v2.17" ]; then
+    ISTIO_VERSION="1.27.5"
+  elif [ "${TARGET_BRANCH}" == "v2.22" ]; then
+    ISTIO_VERSION="1.28.3"
   fi
+fi
+
+# Persist the resolved ISTIO_VERSION for subsequent GitHub Actions steps
+if [ -n "${GITHUB_ENV:-}" ] && [ -n "${ISTIO_VERSION}" ]; then
+  echo "ISTIO_VERSION=${ISTIO_VERSION}" >> "${GITHUB_ENV}"
 fi
 
 KIND_NODE_IMAGE=""
@@ -194,6 +203,10 @@ elif [[ "${ISTIO_VERSION}" == 1.23.* ]]; then
   KIND_NODE_IMAGE="kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648"
 elif [[ "${ISTIO_VERSION}" == 1.26.* ]]; then
   KIND_NODE_IMAGE="kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040"
+elif [[ "${ISTIO_VERSION}" == 1.27.* ]]; then
+  KIND_NODE_IMAGE="kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040"
+elif [[ "${ISTIO_VERSION}" == 1.28.* ]]; then
+  KIND_NODE_IMAGE="kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48"
 fi
 
 if [ -z "${HELM_CHARTS_DIR}" ]; then


### PR DESCRIPTION
There are problems with the 2.17 and 2.22 branches not running Ci against the correct Istio version and not using the proper Kind image (with the correct Kube support).  This adds the proper version support for 2.17 and 2.22, as well as fixing some bugs that were causing the version, even if set, to be ignored.

This then needs to be backported to 2.22 and 2.17.