### PR TITLE
Fix nil pointer dereference in SubsetPresenceChecker

### DIFF
--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -26,7 +26,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range httpRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host
@@ -50,7 +50,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range tcpRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host
@@ -75,7 +75,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range tlsRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host


### PR DESCRIPTION
## Summary

- Fix three nil guard conditions in `SubsetPresenceChecker.Check()` that used `&&` instead of `||`, causing a panic when a VirtualService contains nil entries in HTTP, TCP, or TLS route destination arrays
- Add `TestNilDestinationWeight` to cover all three route types with nil destination weights

Fixes: https://github.com/kiali/kiali/issues/9276

## Test plan

- [x] `TestNilDestinationWeight` verifies no panic occurs with nil destination weight entries in HTTP, TCP, and TLS routes
- [x] Full `./business/checkers/virtualservices/` test suite passes

Made with [Cursor](https://cursor.com)