### PR TITLE
[v2.22] Fix nil pointer dereference in SubsetPresenceChecker

### DIFF
--- a/business/checkers/virtualservices/subset_presence_checker.go
+++ b/business/checkers/virtualservices/subset_presence_checker.go
@@ -26,7 +26,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range httpRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host
@@ -50,7 +50,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range tcpRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host
@@ -75,7 +75,7 @@ func (checker SubsetPresenceChecker) Check() ([]*models.IstioCheck, bool) {
 			continue
 		}
 		for destWeightIdx, destinationWeight := range tlsRoute.Route {
-			if destinationWeight == nil && destinationWeight.Destination == nil {
+			if destinationWeight == nil || destinationWeight.Destination == nil {
 				continue
 			}
 			host := destinationWeight.Destination.Host


### PR DESCRIPTION
The nil guard conditions for destinationWeight used && instead of ||, causing a panic when a nil entry exists in HTTP, TCP, or TLS route destination arrays. Added a test to cover this case.

Made-with: Cursor

cherry pick of https://github.com/kiali/kiali/pull/9277