### PR TITLE
[flake] try to resolve fails in kiali apps list page

### DIFF
--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -89,8 +89,6 @@ Feature: Kiali Apps List page
   @offline
   Scenario: The healthy status of a logical mesh application is reported in the list of applications
     Given a healthy application in the cluster
-    When I fetch the list of applications
-    And user selects the "bookinfo" namespace
     Then the application should be listed as "healthy"
 
   @bookinfo-app
@@ -99,7 +97,6 @@ Feature: Kiali Apps List page
   @core-1
   Scenario: The idle status of a logical mesh application is reported in the list of applications
     Given an idle sleep application in the cluster
-    When I fetch the list of applications
     And user selects the "sleep" namespace
     Then the application should be listed as "idle"
     And the health status of the application should be "Not Ready"
@@ -109,7 +106,6 @@ Feature: Kiali Apps List page
   @core-1
   Scenario: The failing status of a logical mesh application is reported in the list of applications
     Given a failing application in the mesh
-    When I fetch the list of applications
     And user selects the "alpha" namespace
     Then the application should be listed as "failure"
     And the health status of the application should be "Failure"
@@ -119,7 +115,6 @@ Feature: Kiali Apps List page
   @core-1
   Scenario: The degraded status of a logical mesh application is reported in the list of applications
     Given a degraded application in the mesh
-    When I fetch the list of applications
     And user selects the "alpha" namespace
     Then the application should be listed as "degraded"
     And the health status of the application should be "Degraded"


### PR DESCRIPTION
Specifically, this flake: "The healthy status of a logical mesh application is reported in the list of applications"

The test expects productpage to be healthy, but the screenshots show that it can be degraded. There are two things this PR tries to do to resolve things:

1. remove re-navigation or re-selection of what is already performed in the scenario Background
2. introduce retry when trying to validate a health status 
    - the original approach spent up to 60 seconds polling the DOM for span.icon-healthy against the same stale data
    -  it could never succeed if the initial fetch returned unhealthy status.
  - the new approach:
    - happy path: finds the health indicator immediately, no delay at all.
    - unhappy path: waits 10s, refreshes with fresh data, retries — up to 3 times.
      - Worst case is ~30 seconds, still faster than the old 60-second timeout, but each retry actually has a chance to succeed because it fetches new data from the server.
