### PR TITLE
[CI] Update name for app lookup 

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -83,7 +83,18 @@ Then('user can filter spans by app {string} by {string}', (app: string, waypoint
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
   cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
-  cy.get(`li[label="${app}"]`).should('be.visible').find('button').click();
+  cy.get('body').then($body => {
+    const appOption = `li[label="${app}"]`;
+    const waypointOption = `li[label="${waypoint}"]`;
+
+    if ($body.find(appOption).length > 0) {
+      cy.get(appOption).should('be.visible').find('button').click();
+      return;
+    }
+
+    cy.get('input[placeholder="Filter by App"]').clear().type(`${waypoint}{enter}`);
+    cy.get(waypointOption).should('be.visible').find('button').click();
+  });
 
   getCellsForCol('App / Workload').each($cell => {
     cy.wrap($cell).contains(waypoint);


### PR DESCRIPTION
### Describe the change

How the tracing reporting is done in Ambient has changed in Istio 1.28. In previous versions, the app lookup is failing as the tracing app was reported as waypoint. 

https://github.com/kiali/kiali/actions/runs/22473805636/job/65096824413

This change supports the lookup by the app name OR the waypoint to support both trace reporting.

<img width="801" height="890" alt="image" src="https://github.com/user-attachments/assets/ef48be6c-52c6-44be-88f6-5011c48b541d" />
 

### Steps to test the PR
`hack/run-integration-tests.sh --test-suite frontend-ambient --istio-version 1.27-latest`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
