### PR TITLE
[CI] Fix flake in apps.feature

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -29,7 +29,7 @@ const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
 
 Given('a healthy application in the cluster', function () {
   this.targetNamespace = 'bookinfo';
-  this.targetApp = 'productpage';
+  this.targetApp = 'details';
 });
 
 // When you use this, you need to annotate test by @sleep-app-scaleup-after to revert this change after the test


### PR DESCRIPTION
The productpage app is sometimes degraded in the CI env. It's not clear why, but it is the entry point from the gateway, and is also dependent on all of the upstream requests. Retry has not proven to make it a dependable app for testing for a healthy app, so let's just change the test to use the details app, which has less dependencies, is consistently healthy, and should be fine for what this test is trying to do.
