### PR TITLE
Istio 1.27+ enforces authentication on Istiod's debug/monitoring

### DIFF
--- a/business/controlplane_monitor.go
+++ b/business/controlplane_monitor.go
@@ -193,7 +193,9 @@ func (p *controlPlaneMonitor) getIstiodDebugStatus(client kubernetes.ClientInter
 			// The 15014 port on Istiod is open for control plane monitoring.
 			// Here's the Istio doc page about the port usage by istio:
 			// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
-			res, err := client.ForwardGetRequest(namespace, name, controlPlane.MonitoringPort, debugPath)
+			// Send Kiali's service account bearer token so requests succeed when
+			// Istiod debug endpoint auth is enforced (Istio 1.27+).
+			res, err := client.ForwardGetRequestWithBearerToken(namespace, name, controlPlane.MonitoringPort, debugPath, client.GetToken())
 			if err != nil {
 				errChan <- fmt.Errorf("%s: %s", name, err.Error())
 			} else {

--- a/business/controlplane_monitor_test.go
+++ b/business/controlplane_monitor_test.go
@@ -30,6 +30,10 @@ type fakeForwarder struct {
 }
 
 func (f *fakeForwarder) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
+	return f.ForwardGetRequestWithBearerToken(namespace, podName, destinationPort, path, "")
+}
+
+func (f *fakeForwarder) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, _ string) ([]byte, error) {
 	resp, err := http.Get(joinURL(f.testURL, path))
 	if err != nil {
 		return nil, err

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -1473,6 +1473,10 @@ type fakeForwarder struct {
 }
 
 func (f *fakeForwarder) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
+	return f.ForwardGetRequestWithBearerToken(namespace, podName, destinationPort, path, "")
+}
+
+func (f *fakeForwarder) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, _ string) ([]byte, error) {
 	url, _ := url.JoinPath(f.testURL, path)
 	resp, err := http.Get(url)
 	if err != nil {
@@ -1538,6 +1542,10 @@ type badForwarder struct {
 }
 
 func (f *badForwarder) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
+	return nil, fmt.Errorf("unable to forward request")
+}
+
+func (f *badForwarder) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, _ string) ([]byte, error) {
 	return nil, fmt.Errorf("unable to forward request")
 }
 

--- a/istio/version.go
+++ b/istio/version.go
@@ -198,6 +198,12 @@ func GetVersion(ctx context.Context, conf *config.Config, client kubernetes.Clie
 			return nil, err
 		}
 
+		// Send Kiali's service account bearer token so requests succeed when
+		// Istiod debug endpoint auth is enforced (Istio 1.27+).
+		if token := client.GetToken(); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return nil, err
@@ -205,10 +211,9 @@ func GetVersion(ctx context.Context, conf *config.Config, client kubernetes.Clie
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, err := io.ReadAll(resp.Body)
-			// Try and read the body here in case the error message is useful.
-			if err != nil {
-				return nil, fmt.Errorf("getting istio version returned error code: [%d]", resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+				return nil, fmt.Errorf("getting istio version returned [%d] - check that Kiali's service account/namespace has access to Istiod debug endpoints. body: %s", resp.StatusCode, body)
 			}
 			return nil, fmt.Errorf("getting istio version returned error code: [%d]. body: %s", resp.StatusCode, body)
 		}
@@ -238,7 +243,9 @@ func GetVersion(ctx context.Context, conf *config.Config, client kubernetes.Clie
 	})
 	istiod := GetLatestPod(istiods)
 
-	resp, err := client.ForwardGetRequest(istiod.Namespace, istiod.Name, controlPlane.MonitoringPort, "/version")
+	// Send Kiali's service account bearer token so requests succeed when
+	// Istiod debug endpoint auth is enforced (Istio 1.27+).
+	resp, err := client.ForwardGetRequestWithBearerToken(istiod.Namespace, istiod.Name, controlPlane.MonitoringPort, "/version", client.GetToken())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mesh version: %s", err)
 	}

--- a/istio/version_test.go
+++ b/istio/version_test.go
@@ -148,6 +148,10 @@ type fakeForwarder struct {
 }
 
 func (f *fakeForwarder) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
+	return f.ForwardGetRequestWithBearerToken(namespace, podName, destinationPort, path, "")
+}
+
+func (f *fakeForwarder) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, _ string) ([]byte, error) {
 	url, _ := url.JoinPath("http://"+f.hostname+":"+strconv.Itoa(destinationPort), path)
 	resp, err := http.Get(url)
 	if err != nil {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"reflect"
@@ -62,6 +63,7 @@ type K8SClientInterface interface {
 	GetSelfSubjectAccessReview(ctx context.Context, namespace, api, resourceType string, verbs []string) ([]*auth_v1.SelfSubjectAccessReview, error)
 	GetTokenSubject(authInfo *api.AuthInfo) (string, error)
 	ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error)
+	ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, bearerToken string) ([]byte, error)
 	StreamPodLogs(namespace, name string, opts *core_v1.PodLogOptions) (io.ReadCloser, error)
 }
 
@@ -86,6 +88,10 @@ type OSUserClientInterface interface {
 }
 
 func (in *K8SClient) ForwardGetRequest(namespace, podName string, destinationPort int, path string) ([]byte, error) {
+	return in.ForwardGetRequestWithBearerToken(namespace, podName, destinationPort, path, "")
+}
+
+func (in *K8SClient) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, bearerToken string) ([]byte, error) {
 	localPort := httputil.Pool.GetFreePort()
 	defer httputil.Pool.FreePort(localPort)
 
@@ -102,10 +108,18 @@ func (in *K8SClient) ForwardGetRequest(namespace, podName string, destinationPor
 	// Defering the finish of the port-forwarding
 	defer f.Stop()
 
+	var customHeaders map[string]string
+	if bearerToken != "" {
+		customHeaders = map[string]string{"Authorization": "Bearer " + bearerToken}
+	}
+
 	// Ready to create a request
-	resp, code, _, err := httputil.HttpGet(fmt.Sprintf("http://localhost:%d%s", localPort, path), nil, 10*time.Second, nil, nil, in.conf)
+	resp, code, _, err := httputil.HttpGet(fmt.Sprintf("http://localhost:%d%s", localPort, path), nil, 10*time.Second, customHeaders, nil, in.conf)
+	if code == http.StatusUnauthorized || code == http.StatusForbidden {
+		return resp, fmt.Errorf("error fetching [%s] from [%s/%s]: Istiod returned [%d] - check that Kiali's service account/namespace has access to Istiod debug endpoints", path, namespace, podName, code)
+	}
 	if code >= 400 {
-		return resp, fmt.Errorf("error fetching %s from %s/%s. Response code: %d", path, namespace, podName, code)
+		return resp, fmt.Errorf("error fetching [%s] from [%s/%s]: Response code: [%d]", path, namespace, podName, code)
 	}
 
 	return resp, err

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -227,6 +227,11 @@ func (o *K8SClientMock) ForwardGetRequest(namespace, podName string, destination
 	return args.Get(0).([]byte), args.Error(1)
 }
 
+func (o *K8SClientMock) ForwardGetRequestWithBearerToken(namespace, podName string, destinationPort int, path, bearerToken string) ([]byte, error) {
+	args := o.Called(namespace, podName, destinationPort, path, bearerToken)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (o *K8SClientMock) MockService(namespace, name string) {
 	s := FakeService(namespace, name)
 	o.On("GetService", namespace, name).Return(&s, nil)


### PR DESCRIPTION
port 15014. Kiali was making unauthenticated HTTP requests to `/debug/syncz` and `/version` on that port, which would start returning 401/403 errors.

fixes: https://github.com/kiali/kiali/issues/9296