### PR TITLE
Align overview cards

### DIFF
--- a/frontend/src/pages/Overview/DataPlaneStats.tsx
+++ b/frontend/src/pages/Overview/DataPlaneStats.tsx
@@ -73,11 +73,6 @@ const labelNumberStyle = kialiStyle({
   fontSize: '1.5rem'
 });
 
-const labelStyle = kialiStyle({
-  marginTop: '0.5rem',
-  marginBottom: '0.5rem'
-});
-
 // Maximum number of items to show in the popover
 const MAX_POPOVER_ITEMS = 3;
 
@@ -260,18 +255,14 @@ export const DataPlaneStats: React.FC = () => {
               <div className={labelGroupStyle}>
                 {ambient > 0 && (
                   <div className={labelItemStyle}>
-                    <span className={labelNumberStyle}>{ambient}</span>{' '}
-                    <Label variant="outline" className={labelStyle}>
-                      {t('Ambient')}
-                    </Label>
+                    <span className={labelNumberStyle}>{ambient}</span>
+                    <Label variant="outline">{t('Ambient')}</Label>
                   </div>
                 )}
                 {sidecar > 0 && (
                   <div className={labelItemStyle}>
-                    <span className={labelNumberStyle}>{sidecar}</span>{' '}
-                    <Label variant="outline" className={labelStyle}>
-                      {t('Sidecar')}
-                    </Label>
+                    <span className={labelNumberStyle}>{sidecar}</span>
+                    <Label variant="outline">{t('Sidecar')}</Label>
                   </div>
                 )}
               </div>

--- a/frontend/src/pages/Overview/ServiceInsights.tsx
+++ b/frontend/src/pages/Overview/ServiceInsights.tsx
@@ -348,7 +348,6 @@ export const ServiceInsights: React.FC = () => {
               </>
             }
             position={PopoverPosition.top}
-            triggerAction="hover"
           >
             <KialiIcon.Help className={helpIconStyle} />
           </Popover>


### PR DESCRIPTION
### Describe the change

First row of overview cards has a little disalignment at the bottom. This PR fixes this issue.

Before: 

<img width="587" height="189" alt="image" src="https://github.com/user-attachments/assets/fe7a1a15-d69b-4bb5-90fb-bb04bd678878" />

After:

<img width="587" height="189" alt="image" src="https://github.com/user-attachments/assets/4a9d924e-ea05-4881-a0d5-fa8139275ca9" />

Additionally, I changed the "Service Insights" popover action from hover to click since the constant pop-ups are getting a bit distracting during normal navigation.

### Steps to test the PR

Verify the little disalignment has disappeared

### Issue reference

Part of https://github.com/kiali/kiali/issues/9162
