### PR TITLE
Fix swagger definitions for chatAI endpoints

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -386,7 +386,6 @@ type ByLabelsParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"byLabels[]"`
 }
 
@@ -416,7 +415,6 @@ type FiltersParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"filters[]"`
 }
 
@@ -436,7 +434,6 @@ type QuantilesParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"quantiles[]"`
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1838,7 +1838,7 @@ func NewRoutes(
 			handlers.ChatAI(conf, kialiCache, aiStore, clientFactory, prom, cpm, traceClientLoader, grafana, perses, discovery),
 			true,
 		},
-		// swagger:route GET /chat/conversations chat aiChatAI
+		// swagger:route GET /chat/conversations chat aiChatConversations
 		// ---
 		// Endpoint to get the list of conversations for the user
 		//
@@ -1861,7 +1861,7 @@ func NewRoutes(
 			handlers.ChatConversations(conf, aiStore),
 			true,
 		},
-		// swagger:route DELETE /chat/conversations chat aiChatAI
+		// swagger:route DELETE /chat/conversations chat aiChatDeleteConversations
 		// ---
 		// Endpoint to delete conversations for the user
 		//
@@ -1869,13 +1869,6 @@ func NewRoutes(
 		//     - application/json
 		//
 		//     Schemes: http, https
-		//
-		//     Parameters:
-		//       - name: conversationIDs
-		//         in: query
-		//         description: Comma-separated list of conversation IDs to delete
-		//         required: true
-		//         type: string
 		//
 		// responses:
 		//      500: internalError


### PR DESCRIPTION
### Describe the change

To run some DAST scan tools, swagger documentation is needed. There are some invalid swagger annotations that avoid correct generation:

- Remove invalid `default: []` annotations from array query parameters (byLabels, filters, quantiles)
- Fix duplicate swagger operation IDs for chat conversation endpoints (aiChatConversations, aiChatDeleteConversations)
- Remove incorrect conversationIDs parameter documentation from DELETE /chat/conversations endpoint

### Steps to test the PR

Verify swagger documentation generates without errors running `swagger generate spec -o "swagger.json"`
