### PR TITLE
[CI] Update route match in Envoy filter test

### DIFF
--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -123,7 +123,7 @@ Then('the user sees clusters expected information', () => {
 Then('the user sees listeners expected information', () => {
   cy.get('tbody').within(() => {
     cy.contains('td', 'PassthroughCluster').should('not.exist');
-    cy.contains('td', 'Route: 9090');
+    cy.contains('td', /Route:.*9090/);
   });
 });
 


### PR DESCRIPTION
### Describe the change

Update route match in Envoy filter test

### Steps to test the PR

- The failing test can be reproduced in Kiali 2.22 in OpenShift
- Run test "Workload Details page -- See Envoy listeners configuration for a workload" - Should pass

### Automation testing

cypress tests updated

### Issue reference

#9315 
