### PR TITLE
[flake] fix race condition involving state.dashboard

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -30,18 +30,10 @@ Then('user sees inbound metrics information', () => {
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact();
 
-  cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'inbound-metrics-component' } })
-    // HOCs can match the component name. This filters the HOCs for just the bare component.
-    .then(
-      (metricsComponents: any) =>
-        metricsComponents.filter((component: any) => component.name === 'IstioMetricsComponent')[0]
-    )
-    .getCurrentState()
-    .then(state => {
-      cy.wrap(state.dashboard).should('not.be.empty');
-    });
+  // Charts render only when dashboard data is loaded. The metrics component does not forward
+  // data-test to the DOM; with unmountOnExit only this tab's content is mounted.
+  cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
 Then('user sees outbound metrics information', () => {
@@ -49,18 +41,10 @@ Then('user sees outbound metrics information', () => {
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact();
 
-  cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'outbound-metrics-component' } })
-    // HOCs can match the component name. This filters the HOCs for just the bare component.
-    .then(
-      (metricsComponents: any) =>
-        metricsComponents.filter((component: any) => component.name === 'IstioMetricsComponent')[0]
-    )
-    .getCurrentState()
-    .then(state => {
-      cy.wrap(state.dashboard).should('not.be.empty');
-    });
+  // Charts render only when dashboard data is loaded. The metrics component does not forward
+  // data-test to the DOM; with unmountOnExit only this tab's content is mounted.
+  cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
 Then('user can filter spans by app {string}', (app: string) => {

--- a/frontend/cypress/integration/common/app_details_multicluster.ts
+++ b/frontend/cypress/integration/common/app_details_multicluster.ts
@@ -6,7 +6,6 @@ import { Visualization } from '@patternfly/react-topology';
 import { NodeType } from 'types/Graph';
 import { elems } from 'helpers/GraphHelpers';
 import { nodeInfo } from './graph';
-import { GraphDataSource } from 'services/GraphDataSource';
 
 Then('user sees details information for the remote {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
@@ -25,18 +24,11 @@ Then(
 
     openTab(`${metrics} Metrics`);
     cy.wait('@fetchMetrics');
-    cy.waitForReact();
 
-    cy.getReact('IstioMetricsComponent', { props: { 'data-test': `${metrics.toLowerCase()}-metrics-component` } })
-      // HOCs can match the component name. This filters the HOCs for just the bare component.
-      .then(
-        (metricsComponents: any) =>
-          metricsComponents.filter((component: any) => component.name === 'IstioMetricsComponent')[0]
-      )
-      .getCurrentState()
-      .then(state => {
-        cy.wrap(state.dashboard).should('not.be.empty');
-      });
+    // Charts render only when dashboard data is loaded. The metrics component does not forward
+    // data-test to the DOM; with unmountOnExit only this tab's content is mounted, so we assert
+    // on chart presence directly.
+    cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
   }
 );
 

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -30,18 +30,10 @@ Then('user sees workload inbound metrics information', () => {
 
   openTab('Inbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact();
 
-  cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'inbound-metrics-component' } })
-    // HOCs can match the component name. This filters the HOCs for just the bare component.
-    .then(
-      (metricsComponents: any) =>
-        metricsComponents.filter((component: any) => component.name === 'IstioMetricsComponent')[0]
-    )
-    .getCurrentState()
-    .then(state => {
-      cy.wrap(state.dashboard).should('not.be.empty');
-    });
+  // Charts render only when dashboard data is loaded. The metrics component does not forward
+  // data-test to the DOM; with unmountOnExit only this tab's content is mounted.
+  cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
 Then('user sees workload outbound metrics information', () => {
@@ -49,18 +41,10 @@ Then('user sees workload outbound metrics information', () => {
 
   openTab('Outbound Metrics');
   cy.wait('@fetchMetrics');
-  cy.waitForReact();
 
-  cy.getReact('IstioMetricsComponent', { props: { 'data-test': 'outbound-metrics-component' } })
-    // HOCs can match the component name. This filters the HOCs for just the bare component.
-    .then(
-      (metricsComponents: any) =>
-        metricsComponents.filter((component: any) => component.name === 'IstioMetricsComponent')[0]
-    )
-    .getCurrentState()
-    .then(state => {
-      cy.wrap(state.dashboard).should('not.be.empty');
-    });
+  // Charts render only when dashboard data is loaded. The metrics component does not forward
+  // data-test to the DOM; with unmountOnExit only this tab's content is mounted.
+  cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
 Then('user sees Perses link in the Inbound Metrics tab', () => {
@@ -159,18 +143,12 @@ Then('the user sees the metrics tab', () => {
   openEnvoyTab('Metrics');
 
   cy.wait('@fetchEnvoyMetrics');
-  cy.waitForReact();
 
   cy.contains('Loading metrics').should('not.exist');
 
-  cy.getReact('CustomMetricsComponent', { props: { 'data-test': 'envoy-metrics-component' } })
-    .then(
-      (metricsComponents: any) => metricsComponents.filter(component => component.name === 'CustomMetricsComponent')[0]
-    )
-    .getCurrentState()
-    .then(state => {
-      cy.wrap(state.dashboard).should('not.be.empty');
-    });
+  // Charts render only when dashboard data is loaded. CustomMetrics does not forward data-test
+  // to the DOM; with unmountOnExit only this tab's content is mounted.
+  cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
 Then('the user can see the {string} link', (link: string) => {


### PR DESCRIPTION
Attempt to fix Fix flaky Cypress metrics steps suffering from a possible race condition. Try asserting on DOM instead of React state

Metrics steps were intermittently failing with ".empty was passed non-string primitive undefined" because they asserted on "state.dashboard" after the API returned. But setState runs asynchronously, so getCurrentState() could run before the component had applied the response and state.dashboard was still undefined.

Replace getReact/getCurrentState and the state.dashboard assertion with a wait for at least one [data-test="metrics-chart"] inside the metrics component. Charts only render when dashboard data is loaded, so this achieves the same intent (dashboard loaded and visible) without the race, and tests the visible outcome instead of React internals.

Fixes #9339 