### PR TITLE
[CI] Stop post-merge CI runs

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -2,14 +2,6 @@ name: Kiali CI
 
 on:
   # Run on master and release branches
-  push:
-    branches:
-    - master
-    - v*.*
-    paths-ignore:
-    - "design/**"
-    - "**/*.md"
-    - "**/*.adoc"
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
Stop post-merge CI runs. This adds a lot of CI for little value. We already have nightly runs, and the CI runs from other PRs.
