### PR TITLE
[Flake] This may fix some flaky waypoint.feature tests

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -115,6 +115,8 @@ Then(`user sees empty graph`, () => {
 });
 
 Then(`user sees the {string} namespace`, ns => {
+  // Wait for graph (and thus summary panel) to be ready before asserting on the panel (avoids race)
+  assertGraphReady(() => { });
   cy.get('div#summary-panel-graph').find('div#summary-panel-graph-heading').find(`div#ns-${ns}`).should('be.visible');
 });
 
@@ -376,6 +378,8 @@ Given(
 Then(
   'the Istio objects for the {string} namespace for both clusters should be grouped together in the panel',
   (namespace: string) => {
+    // Wait for graph (and thus side panel) to be ready before asserting on the panel (avoids race)
+    assertGraphReady(() => { });
     cy.get('#graph-side-panel')
       .find(`#ns-${namespace}`)
       .within(() => {


### PR DESCRIPTION
This may fix some flaky waypoint.feature tests such as:
- `waypoint.feature: [Traffic] Waypoint for workload`
- `waypoint.feature: [Traffic] Waypoint for workload with waypoints`

The failure came from a race in steps like:
- `graph_display.ts: Then user sees the {string} namespace`

A previous step in the scenario, like `user graphs waypoint-forworkload namespaces` visits the graph page, waits for the graph API and `ensureKialiFinishedLoading()`. But `Then user sees the waypoint-forworkload namespace` immediately looks for `div#summary-panel-graph., and the summary panel may not have rendered. The step now waits for the graph to be ready using the same helper used elsewhere for graph assertions.

There are a couple of analogous cases.
