### PR TITLE
Re-order overview page top row cards to group infrastructure cards.

### DIFF
--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -72,24 +72,20 @@ export const OverviewPage: React.FC = () => {
           <ManualRefreshEmptyState />
         ) : (
           <Grid hasGutter>
-            <GridItem span={6}>
-              <Grid hasGutter>
-                <GridItem span={4}>
-                  <ClusterStats />
-                </GridItem>
-
-                <GridItem span={4}>
-                  <IstioConfigStats />
-                </GridItem>
-
-                <GridItem span={4}>
-                  <ControlPlaneStats />
-                </GridItem>
-              </Grid>
+            <GridItem span={2}>
+              <ClusterStats />
             </GridItem>
 
-            <GridItem span={6}>
+            <GridItem span={2}>
+              <ControlPlaneStats />
+            </GridItem>
+
+            <GridItem span={5}>
               <DataPlaneStats />
+            </GridItem>
+
+            <GridItem span={3}>
+              <IstioConfigStats />
             </GridItem>
 
             <GridItem span={4} className={secondRowItemStyle}>


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/9360

Moves Istio config to the right in order to group infrastructure. The Data Planes card may need extra space compared to the Clusters, Control Planes and Istio Config cards, so it is given extra room.  @Joeyyubo , just confirming that this is what you expect:

<img width="1916" height="927" alt="image" src="https://github.com/user-attachments/assets/1e384e65-ce84-4746-b58e-c169e5c61ffd" />

