### PR TITLE
[v2.4] Add lpinterop tag (#8878)

### DIFF
--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -14,11 +14,13 @@ Feature: Kiali App Details page
     And user is at the details page for the "app" "bookinfo/details" located in the "" cluster
 
   @bookinfo-app
+  @lpinterop
   Scenario: See details for app.
     Then user sees details information for the "details" app
     But no cluster badge for the "app" should be visible
 
   @bookinfo-app
+  @lpinterop
   Scenario: See app Traffic information
     Then user sees inbound and outbound traffic information
     And the "Cluster" column "disappears"

--- a/frontend/cypress/integration/featureFiles/apps.feature
+++ b/frontend/cypress/integration/featureFiles/apps.feature
@@ -12,6 +12,7 @@ Feature: Kiali Apps List page
     And user selects the "bookinfo" namespace
 
   @bookinfo-app
+  @lpinterop
   Scenario: See all Apps objects in the bookinfo namespace.
     Then user sees all the Apps in the bookinfo namespace
     And user sees Health information for Apps
@@ -22,6 +23,7 @@ Feature: Kiali Apps List page
     And the "Cluster" column "disappears"
 
   @bookinfo-app
+  @lpinterop
   Scenario: See all Apps toggles
     Then user sees all the Apps toggles
 
@@ -94,7 +96,6 @@ Feature: Kiali Apps List page
 
   @bookinfo-app
   @error-rates-app
-  @skip-lpinterop
   Scenario: The degraded status of a logical mesh application is reported in the list of applications
     Given a degraded application in the mesh
     When I fetch the list of applications

--- a/frontend/cypress/integration/featureFiles/graph_display-pf.feature
+++ b/frontend/cypress/integration/featureFiles/graph_display-pf.feature
@@ -14,17 +14,20 @@ Feature: Kiali Graph page - Display menu
   # NOTE: Traffic animation, missing sidecars, virtual service, and idle edge options are nominally tested
 
   @error-rates-app
+  @lpinterop
   Scenario: Graph no namespaces
     When user graphs "" namespaces
     Then user sees no namespace selected
 
   # gamma will only show nodes when idle-nodes is enabled
   @error-rates-app
+  @lpinterop
   Scenario: Graph gamma namespaces
     When user graphs "gamma" namespaces
     Then user sees empty graph
 
   @error-rates-app
+  @lpinterop
   Scenario: User enables idle nodes
     When user opens display menu
     And user "enables" "idle nodes" option
@@ -32,11 +35,13 @@ Feature: Kiali Graph page - Display menu
     And idle nodes "appear" in the graph
 
   @error-rates-app
+  @lpinterop
   Scenario: User disables idle nodes
     When user "disables" "idle nodes" option
     Then user sees empty graph
 
   @error-rates-app
+  @lpinterop
   Scenario: Graph alpha and beta namespaces
     When user graphs "alpha,beta" namespaces
     Then user sees the "alpha" namespace

--- a/frontend/cypress/integration/featureFiles/graph_find_hide-pf.feature
+++ b/frontend/cypress/integration/featureFiles/graph_find_hide-pf.feature
@@ -15,12 +15,14 @@ Feature: Kiali Graph page - Find/Hide
     And user graphs "alpha,beta" namespaces
 
   @error-rates-app
+  @lpinterop
   Scenario: Find unhealthy workloads
     Then user sees nothing highlighted on the graph
     When user finds unhealthy workloads
     Then user sees unhealthy workloads highlighted on the graph
 
   @error-rates-app
+  @lpinterop
   Scenario: Hide unhealthy workloads
     When user hides unhealthy workloads
     Then user sees no unhealthy workloads on the graph

--- a/frontend/cypress/integration/featureFiles/graph_side_panel-pf.feature
+++ b/frontend/cypress/integration/featureFiles/graph_side_panel-pf.feature
@@ -10,6 +10,7 @@ Feature: Kiali Graph page - Side panel menu actions
     Given user is at administrator perspective
 
   @bookinfo-app
+  @lpinterop
   Scenario: Actions in kebab menu of the side panel for a service node with existing traffic routing
     Given user graphs "bookinfo" namespaces
     And user clicks the "productpage" "service" node

--- a/frontend/cypress/integration/featureFiles/graph_toolbar_legend-pf.feature
+++ b/frontend/cypress/integration/featureFiles/graph_toolbar_legend-pf.feature
@@ -12,6 +12,7 @@ Feature: Kiali Graph page - Graph toolbar and legend sidebar
     And user graphs "alpha,beta" namespaces
 
   @error-rates-app
+  @lpinterop
   Scenario Outline: Check if the <id> button is usable
     Then the toggle button "<id>" is enabled
     Examples:

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -13,6 +13,7 @@ Feature: Kiali Istio Config page
     And user selects the "bookinfo" namespace
 
   @bookinfo-app
+  @lpinterop
   Scenario: See all Istio Config objects in the bookinfo namespace.
     Then user sees all the Istio Config objects in the bookinfo namespace
     And the "Cluster" column "disappears"
@@ -22,10 +23,12 @@ Feature: Kiali Istio Config page
     And user sees Configuration information for Istio objects
 
   @bookinfo-app
+  @lpinterop
   Scenario: See all Istio Config toggles
     Then user sees all the Istio Config toggles
 
   @bookinfo-app
+  @lpinterop
   Scenario: Toggle Istio Config configuration toggle
     When user "unchecks" toggle "configuration"
     Then the "Configuration" column "disappears"
@@ -49,31 +52,38 @@ Feature: Kiali Istio Config page
     And user sees "bookinfo"
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create an AuthorizationPolicy object
     Then the user can create a "security.istio.io" "v1" "AuthorizationPolicy" Istio object
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a Gateway object
     Then the user can create a "networking.istio.io" "v1" "Gateway" Istio object
 
   @gateway-api
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "gateway.networking.k8s.io" "v1" "Gateway" K8s Istio object
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a PeerAuthentication object
     Then the user can create a "security.istio.io" "v1" "PeerAuthentication" Istio object
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a RequestAuthentication object
     Then the user can create a "security.istio.io" "v1" "RequestAuthentication" Istio object
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a ServiceEntry object
     Then the user can create a "networking.istio.io" "v1" "ServiceEntry" Istio object
 
   @bookinfo-app
+  @lpinterop
   Scenario: Ability to create a Sidecar object
     Then the user can create a "networking.istio.io" "v1" "Sidecar" Istio object
 

--- a/frontend/cypress/integration/featureFiles/kiali_about.feature
+++ b/frontend/cypress/integration/featureFiles/kiali_about.feature
@@ -9,6 +9,7 @@ Feature: Kiali help about verify
     Given user is at administrator perspective
     And user is at the "overview" page
 
+  @lpinterop
   Scenario: Open Kiali about page
 
     And user clicks on Help Button

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -21,14 +21,17 @@ Feature: Kiali Mesh page
     And user closes mesh tour
     Then user "does not see" mesh tour
 
+  @lpinterop
   Scenario: See mesh
     When user sees mesh side panel
     Then user sees expected mesh infra
 
+  @lpinterop
   Scenario: Test istiod
     When user selects mesh node with label "istiod"
     Then user sees control plane side panel
 
+  @lpinterop
   Scenario: Grafana Infra
     When user selects mesh node with label "Grafana"
     Then user sees "Grafana" node side panel
@@ -37,10 +40,12 @@ Feature: Kiali Mesh page
     When user selects tracing mesh node
     Then user sees tracing node side panel
 
+  @lpinterop
   Scenario: Prometheus Infra
     When user selects mesh node with label "Prometheus"
     Then user sees "Prometheus" node side panel
 
+  @lpinterop
   Scenario: Test DataPlane
     When user selects mesh node with label "Data Plane"
     Then user sees data plane side panel

--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -17,23 +17,28 @@ Feature: Kiali Overview page
     Given user is at administrator perspective
     And user is at the "overview" page
 
+  @lpinterop
   Scenario: See "alpha" and "beta" namespaces
     Then user sees the "alpha" namespace card
     And user does not see any cluster badge in the "alpha" namespace card
     And user sees the "beta" namespace card
     And user does not see any cluster badge in the "beta" namespace card
 
+  @lpinterop
   Scenario: Doesn't see a "bad" namespace
     Then user doesn't see the "bad" namespace card
 
+  @lpinterop
   Scenario: Select the COMPACT view
     When user clicks in the "COMPACT" view
     Then user sees a "COMPACT" "alpha" namespace
 
+  @lpinterop
   Scenario: Select the EXPAND view
     When user clicks in the "EXPAND" view
     Then user sees a "EXPAND" "beta" namespace
 
+  @lpinterop
   Scenario: Select the LIST view
     When user clicks in the "LIST" view
     Then user sees a "LIST" "beta" namespace
@@ -50,14 +55,17 @@ Feature: Kiali Overview page
     And user sorts by name desc
     Then user sees the "beta,alpha" namespace list
 
+  @lpinterop
   Scenario: Health for Apps
     When user selects Health for "Apps"
     Then user sees the "alpha" namespace with "Applications"
 
+  @lpinterop
   Scenario: Health for Workloads
     When user selects Health for "Workloads"
     Then user sees the "alpha" namespace with "Workloads"
 
+  @lpinterop
   Scenario: Health for Services
     When user selects Health for "Services"
     Then user sees the "alpha" namespace with "Services"
@@ -75,6 +83,7 @@ Feature: Kiali Overview page
 
   @error-rates-app
   @bookinfo-app
+  @lpinterop
   Scenario: The healthy status of a logical mesh application is reported in the overview of a namespace
     Given a healthy application in the cluster
     When I fetch the overview of the cluster
@@ -97,7 +106,6 @@ Feature: Kiali Overview page
     And the "failure" application indicator should list the application
 
   @error-rates-app
-  @skip-lpinterop
   Scenario: The degraded status of a logical mesh application is reported in the overview of a namespace
     Given a degraded application in the mesh
     When I fetch the overview of the cluster

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -12,6 +12,7 @@ Feature: Kiali Service Details page
     And user is at the details page for the "service" "bookinfo/productpage" located in the "" cluster
 
   @bookinfo-app
+  @lpinterop
   Scenario: See details for productpage
     Then sd::user sees a list with content "Overview"
     Then sd::user sees a list with content "Traffic"
@@ -20,6 +21,7 @@ Feature: Kiali Service Details page
     Then sd::user sees the service actions
 
   @bookinfo-app
+  @lpinterop
   Scenario: See details for service
     Then sd::user sees "productpage" details information for service "v1"
     Then sd::user sees Network card

--- a/frontend/cypress/integration/featureFiles/services.feature
+++ b/frontend/cypress/integration/featureFiles/services.feature
@@ -9,6 +9,7 @@ Feature: Kiali Services page
     Given user is at administrator perspective
 
   @bookinfo-app
+  @lpinterop
   Scenario: See services table with correct info
     And user is at the "services" page
     When user applies kiali api "rest" annotations
@@ -28,6 +29,7 @@ Feature: Kiali Services page
     And the "Cluster" column "disappears"
 
   @smoke
+  @lpinterop
   Scenario: See all Services toggles
     And user is at the "services" list page
     Then user sees all the Services toggles
@@ -132,7 +134,6 @@ Feature: Kiali Services page
     And the health status of the service should be "Failure"
 
   @error-rates-app
-  @skip-lpinterop
   Scenario: The degraded status of a service is reported in the list of services
     And user is at the "services" page
     Given a service in the mesh with a degraded amount of traffic

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -13,12 +13,14 @@ Feature: Kiali Istio Config wizard
     And user selects the "bookinfo" namespace
 
   @bookinfo-app
+  @lpinterop
   Scenario: Dropdown for cluster selection should not be visible in single cluster setup
     When user clicks in the "Gateway" Istio config actions
     Then user sees the "Create Gateway" config wizard
     And user does not see a dropdown for cluster selection
 
   @bookinfo-app
+  @lpinterop
   Scenario: Create an Sidecar with labels and annotations
     When user deletes sidecar named "mysidecarwithlabels" and the resource is no longer available
     And user clicks in the "Sidecar" Istio config actions
@@ -37,6 +39,7 @@ Feature: Kiali Istio Config wizard
 
   @gateway-api
   @bookinfo-app
+  @lpinterop
   Scenario: Create a K8s Gateway scenario
     When user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
     And user clicks in the "K8sGateway" Istio config actions

--- a/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_request_routing.feature
@@ -9,6 +9,7 @@ Feature: Service Details Wizard: Request Routing
     Given user is at administrator perspective
 
   @bookinfo-app
+  @lpinterop
   Scenario: Create a Request Routing scenario
     When user opens the namespace "bookinfo" and "reviews" service details page
     And user clicks in the "Request Routing" actions
@@ -32,6 +33,7 @@ Feature: Service Details Wizard: Request Routing
     Then user sees the "Istio Config" table with 2 rows
 
   @bookinfo-app
+  @lpinterop
   Scenario: See a DestinationRule generated
     When user clicks in the "Istio Config" table "DR" badge "reviews" name row link
     Then user sees the "kind: DestinationRule" regex in the editor
@@ -42,6 +44,7 @@ Feature: Service Details Wizard: Request Routing
     And user sees the "bookinfo" "reviews" "VirtualService" reference
 
   @bookinfo-app
+  @lpinterop
   Scenario: See a VirtualService generated
     When user clicks in the "bookinfo" "reviews" "VirtualService" reference
     Then user sees the "kind: VirtualService" regex in the editor

--- a/frontend/cypress/integration/featureFiles/workload_logs.feature
+++ b/frontend/cypress/integration/featureFiles/workload_logs.feature
@@ -12,6 +12,7 @@ Feature: Workload logs tab
     Given user is at administrator perspective
 
   @bookinfo-app
+  @lpinterop
   Scenario: The logs tab should show the logs of a pod
     Given I am on the "ratings-v1" workload detail page of the "bookinfo" namespace
     When I go to the Logs tab of the workload detail page

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -10,6 +10,7 @@ Feature: Kiali Workloads page
     And user is at the "workloads" list page
 
   @bookinfo-app
+  @lpinterop
   Scenario: See workloads table with correct info
     When user selects the "bookinfo" namespace
     Then user sees a table with headings
@@ -97,6 +98,7 @@ Feature: Kiali Workloads page
     And table length should be 1
 
   @bookinfo-app
+  @lpinterop
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
     When user selects the "bookinfo" namespace
@@ -118,7 +120,6 @@ Feature: Kiali Workloads page
     And the health status of the workload should be "Failure"
 
   @error-rates-app
-  @skip-lpinterop
   Scenario: The degraded status of a workload is reported in the list of workloads
     Given a degraded workload in the mesh
     When user selects the "alpha" namespace

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -13,16 +13,19 @@ Feature: Kiali Workload Details page
     And user is at the details page for the "workload" "bookinfo/details-v1" located in the "" cluster
 
   @bookinfo-app
+  @lpinterop
   Scenario: See details for workload
     Then user sees details information for workload
     But no cluster badge for the "workload" should be visible
 
   @bookinfo-app
+  @lpinterop
   Scenario: See workload traffic information
     Then user sees workload inbound and outbound traffic information
     And the "Cluster" column "disappears"
 
   @bookinfo-app
+  @lpinterop
   Scenario: See workload Inbound Metrics
     Then user sees workload inbound metrics information
 


### PR DESCRIPTION
I missed one more backport for smoke tests in downstream. 

Backport of https://github.com/kiali/kiali/pull/8878