### PR TITLE
[AI] Fix panic in get_mesh_graph

### DIFF
--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -139,8 +139,7 @@ Retrieves service mesh topology, health status, and aggregated metrics for names
 **Purpose**: Get high-level mesh overview, health summaries, and topology data for analysis and troubleshooting.
 
 **Parameters**:
-- `namespace` (string, optional): Single namespace to include (alternative to `namespaces`).
-- `namespaces` (string, optional): Comma-separated list of namespaces (e.g., `"bookinfo,default"`).
+- `namespaces` (string, required): Comma-separated list of namespaces (e.g., `"bookinfo,default"`).
 - `rateInterval` (string, optional): Time interval for metrics (e.g., `"10m"`, `"5m"`, `"1h"`). Default is `"10m"`.
 - `graphType` (string, optional): Graph aggregation type - `"versionedApp"`, `"app"`, `"service"`, or `"workload"`. Default is `"versionedApp"`.
 - `clusterName` (string, optional): Cluster name. Defaults to the cluster in Kiali configuration.
@@ -159,7 +158,7 @@ Retrieves service mesh topology, health status, and aggregated metrics for names
 **Example 1**: Get mesh overview for bookinfo namespace
 ```json
 {
-  "namespace": "bookinfo",
+  "namespaces": "bookinfo",
   "rateInterval": "10m",
   "graphType": "versionedApp"
 }

--- a/ai/mcp/get_mesh_graph/get_mesh_graph.go
+++ b/ai/mcp/get_mesh_graph/get_mesh_graph.go
@@ -50,12 +50,11 @@ func Execute(r *http.Request, args map[string]interface{}, business *business.La
 	toolArgs.GraphType = mcputil.GetStringOrDefault(args, mcputil.DefaultGraphType, "graphType")
 	toolArgs.ClusterName = mcputil.GetStringOrDefault(args, conf.KubernetesConfig.ClusterName, "clusterName")
 
-	// Parse arguments: allow either `namespace` or `namespaces` (comma-separated string)
+	// Parse namespaces argument (comma-separated string)
 	namespaces := make([]string, 0)
 	var invalidAccess []string
 	seen := map[string]struct{}{}
 
-	// Collect namespace names from both possible parameters
 	namespacesArg := mcputil.GetStringArg(args, "namespaces")
 
 	if namespacesArg != "" {

--- a/ai/mcp/get_mesh_graph/get_mesh_graph_test.go
+++ b/ai/mcp/get_mesh_graph/get_mesh_graph_test.go
@@ -143,7 +143,7 @@ func TestExecute_ValidSingleNamespace_ReturnsOKWithResponse(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
 	req = reqWithAuth(req, conf, k8s.GetToken())
 	args := map[string]interface{}{
-		"namespace":    "bookinfo",
+		"namespaces":   "bookinfo",
 		"graphType":    "versionedApp",
 		"rateInterval": "10m",
 		"clusterName":  "Kubernetes",
@@ -302,7 +302,7 @@ func TestExecute_WorkloadGraphType_FetchesWorkloadHealth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
 	req = reqWithAuth(req, conf, k8s.GetToken())
 	args := map[string]interface{}{
-		"namespace":    "bookinfo",
+		"namespaces":   "bookinfo",
 		"graphType":    "workload",
 		"rateInterval": "5m",
 		"clusterName":  "Kubernetes",
@@ -342,7 +342,7 @@ func TestExecute_ServiceGraphType_FetchesServiceHealth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
 	req = reqWithAuth(req, conf, k8s.GetToken())
 	args := map[string]interface{}{
-		"namespace":    "bookinfo",
+		"namespaces":   "bookinfo",
 		"graphType":    "service",
 		"rateInterval": "15m",
 		"clusterName":  "Kubernetes",
@@ -457,7 +457,7 @@ func TestExecute_CustomRateInterval_UsesProvidedValue(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
 	req = reqWithAuth(req, conf, k8s.GetToken())
 	args := map[string]interface{}{
-		"namespace":    "bookinfo",
+		"namespaces":   "bookinfo",
 		"graphType":    "versionedApp",
 		"rateInterval": "30m",
 		"clusterName":  "Kubernetes",
@@ -494,7 +494,7 @@ func TestExecute_DefaultRateInterval_UsesDefault(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
 	req = reqWithAuth(req, conf, k8s.GetToken())
 	args := map[string]interface{}{
-		"namespace":   "bookinfo",
+		"namespaces":  "bookinfo",
 		"graphType":   "versionedApp",
 		"clusterName": "Kubernetes",
 		// No rateInterval provided


### PR DESCRIPTION
### Describe the change

- Fix panic in get_mesh_graph
- Add get_mesh_graph_tests

### Steps to test the PR

```bash
curl -X POST "$KIALI_URL/api/chat/mcp/get_mesh_graph" \
  -H "Content-Type: application/json" \
  -d '{
    "namespace": "bookinfo"
  }'
```

```bash
curl -X POST "$KIALI_URL/api/chat/mcp/get_mesh_graph" \
  -H "Content-Type: application/json" \
  -d '{
    "namespaces": "bookinfo,default",
    "graphType": "versionedApp",
    "rateInterval": "10m",
    "clusterName": "Kubernetes"
  }'
```

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9363 
