### PR TITLE
[CI] Increase timeout. Update filter

### DIFF
--- a/frontend/cypress/integration/common/kiali-config.ts
+++ b/frontend/cypress/integration/common/kiali-config.ts
@@ -129,7 +129,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
  */
 export const restartKiali = (deploymentName: string, namespace: string): void => {
   cy.exec(
-    `kubectl rollout restart deployment/${deploymentName} -n ${namespace} && kubectl rollout status deployment/${deploymentName} -n ${namespace} --timeout=180s`,
+    `kubectl rollout restart deployment/${deploymentName} -n ${namespace} && kubectl rollout status deployment/${deploymentName} -n ${namespace} --timeout=240s`,
     { timeout: 300000 }
   );
 };
@@ -236,7 +236,7 @@ export const restoreKialiFeature = (featureConfig: KialiFeatureConfig): void => 
 
   const doRestart = (): void => {
     cy.exec(
-      `kubectl rollout restart deployment/${kialiDeploymentName} -n ${kialiDeploymentNamespace} && kubectl rollout status deployment/${kialiDeploymentName} -n ${kialiDeploymentNamespace} --timeout=180s`,
+      `kubectl rollout restart deployment/${kialiDeploymentName} -n ${kialiDeploymentNamespace} && kubectl rollout status deployment/${kialiDeploymentName} -n ${kialiDeploymentNamespace} --timeout=240s`,
       { timeout: 300000, failOnNonZeroExit: false }
     );
   };

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -92,7 +92,7 @@ Feature: Kiali Workload Details page
   @core-2
   @offline
   Scenario: See Envoy listeners configuration for a workload
-    When the user filters by "Destination" with value "Route: 9090" on the "Listeners" tab
+    When the user filters by "Destination" with value "9090" on the "Listeners" tab
     Then the user sees listeners expected information
 
   @bookinfo-app


### PR DESCRIPTION
### Describe the change
The following tests are failing in OpenShift: 

```
Envoy listeners configuration for a workload Kiali.Kiali Workload Details page

Timed out retrying after 40000ms: Expected to find content: '/Route:.*9090/' within the element: <tbody.pf-v6-c-table__tbody> and with the selector: 'td' but never did.
```
It needs the route the be updated in the filter as well.

There are a couple of other failures: 

- Graph cache metrics increase across repeated graph API requests Kiali.Kiali Graph page
- Health cache metrics increase when visiting apps list page Kiali.Kiali Apps List page 

With the same error: 

```
`cy.request()` failed on:  api/test/metrics/graph/cache  The response we received from your web server was:    > 503: Service Unavailable  This was considered a failure because the status code was not `2xx` or `3xx`.  If you do not want status codes to cause failures pass the option: `failOnStatusCode: false`  -----------------------------------------------------------
The application is currently not serving requests at this endpoint. It may not have been started or is still starting
```

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/9337 
