### PR TITLE
[Perf] Added missing env variable.

### DIFF
--- a/frontend/cypress-perf.config.ts
+++ b/frontend/cypress-perf.config.ts
@@ -6,6 +6,7 @@ import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
 export default defineConfig({
   fixturesFolder: 'cypress/fixtures/perf',
   env: {
+    rootSelector: '#root',
     timeout: 10000,
     threshold: 100000
   },


### PR DESCRIPTION
Cypress perf tests were missing and env variable `rootSelector` which was causing graph tests to fail.