### PR TITLE
Add v2.22 to the default values of Konflux release Github actions

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -6,14 +6,14 @@ on:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11
+        default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
   workflow_call:
     inputs:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11
+        default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 jobs:
   initialize:

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -6,7 +6,7 @@ on:
       tag_branches:
         description: Branches to tag (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17
+        default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 
 jobs:


### PR DESCRIPTION
### Describe the change

Add supported version v2.22 to the default values of Konflux release Github actions