### PR TITLE
[v1.73] Downgrade Go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiali/kiali
 
-go 1.25.8
+go 1.25.7
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
### Describe the change

Downgrade Go version to 1.25.7 since 1.25.8 is not available downstream yet