### PR TITLE
[AI][Tools] Added checks and tests for get_mesh_traffic_graph

### DIFF
--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -12,12 +12,20 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
 	graphApi "github.com/kiali/kiali/graph/api"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/mesh"
 	meshApi "github.com/kiali/kiali/mesh/api"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util"
 )
+
+var validGraphTypes = map[string]bool{
+	graph.GraphTypeApp:          true,
+	graph.GraphTypeService:      true,
+	graph.GraphTypeVersionedApp: true,
+	graph.GraphTypeWorkload:     true,
+}
 
 // MeshGraphArgs are the optional parameters accepted by the mesh graph tool.
 type MeshGraphArgs struct {
@@ -43,6 +51,10 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	toolArgs.RateInterval = mcputil.GetStringOrDefault(args, mcputil.DefaultRateInterval, "rateInterval")
 	toolArgs.GraphType = mcputil.GetStringOrDefault(args, mcputil.DefaultGraphType, "graphType")
 	toolArgs.ClusterName = mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
+
+	if !validGraphTypes[toolArgs.GraphType] {
+		return fmt.Sprintf("invalid graphType %q: must be one of app, service, versionedApp, workload", toolArgs.GraphType), http.StatusBadRequest
+	}
 
 	// Parse namespaces argument (comma-separated string)
 	namespaces := make([]string, 0)
@@ -72,24 +84,21 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 			namespaces = append(namespaces, ns_trimmed)
 		}
 
-		// If all requested namespaces are inaccessible, return 403
 		if len(namespaces) == 0 && len(invalidAccess) > 0 {
-			return fmt.Sprintf("requested namespace(s) not accessible or do not exist: %s", strings.Join(invalidAccess, ", ")), http.StatusForbidden
+			return fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot retrieve traffic graph.", strings.Join(invalidAccess, ", ")), http.StatusOK
 		}
+	}
+
+	if len(namespaces) == 0 {
+		return "No namespaces were specified. Please provide at least one namespace to generate the traffic graph.", http.StatusOK
 	}
 
 	resp := GetMeshGraphResponse{
 		Errors: make(map[string]string),
 	}
 
-	// Add warning if some namespaces were skipped
 	if len(invalidAccess) > 0 {
-		resp.Errors["namespaces"] = fmt.Sprintf("requested namespace(s) not accessible or do not exist (skipped): %s", strings.Join(invalidAccess, ", "))
-	}
-
-	// Validate that at least one namespace was provided
-	if len(namespaces) == 0 {
-		return "namespaces parameter is required", http.StatusBadRequest
+		resp.Errors["namespaces"] = fmt.Sprintf("namespace(s) not found or not accessible: %s", strings.Join(invalidAccess, ", "))
 	}
 
 	toolArgs.Namespaces = namespaces
@@ -127,6 +136,25 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	// Graph
 	go func() {
 		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				var msg string
+				switch v := r.(type) {
+				case graph.Response:
+					msg = v.Message
+				case error:
+					msg = v.Error()
+				case string:
+					msg = v
+				default:
+					msg = fmt.Sprintf("%v", v)
+				}
+				log.Errorf("get_mesh_traffic_graph: graph goroutine recovered from panic: %s", msg)
+				mu.Lock()
+				resp.Errors["graph"] = msg
+				mu.Unlock()
+			}
+		}()
 		graphReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ai/graph/namespaces", nil)
 		q := graphReq.URL.Query()
 		q.Set("namespaces", strings.Join(toolArgs.Namespaces, ","))
@@ -159,6 +187,25 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	// Mesh status (GraphMesh result)
 	go func() {
 		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				var msg string
+				switch v := r.(type) {
+				case graph.Response:
+					msg = v.Message
+				case error:
+					msg = v.Error()
+				case string:
+					msg = v
+				default:
+					msg = fmt.Sprintf("%v", v)
+				}
+				log.Errorf("get_mesh_traffic_graph: mesh status goroutine recovered from panic: %s", msg)
+				mu.Lock()
+				resp.Errors["mesh_status"] = msg
+				mu.Unlock()
+			}
+		}()
 		meshReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ai/mesh-graph", nil)
 		mq := meshReq.URL.Query()
 		if toolArgs.RateInterval != "" {

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
@@ -1,6 +1,7 @@
 package get_mesh_traffic_graph
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
+	graphCommon "github.com/kiali/kiali/graph/config/common"
 	"github.com/kiali/kiali/handlers/authentication"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
@@ -56,7 +58,7 @@ func mockPrometheusForHealth(prom *prometheustest.PromClientMock) {
 	prom.On("GetWorkloadRequestRates", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(emptyVec, emptyVec, nil)
 }
 
-func TestExecute_NonExistentNamespaces_ReturnsForbidden(t *testing.T) {
+func TestExecute_NonExistentNamespaces_ReturnsOKWithMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -81,14 +83,14 @@ func TestExecute_NonExistentNamespaces_ReturnsForbidden(t *testing.T) {
 	}
 
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: nil, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
-	require.Equal(t, http.StatusForbidden, code)
+	require.Equal(t, http.StatusOK, code)
 	msg, ok := res.(string)
 	require.True(t, ok)
-	// With CheckNamespaceAccess, error may be "cannot access namespace data: ..." or "not accessible or do not exist"
 	assert.Contains(t, msg, "nonexistent-ns")
+	assert.Contains(t, msg, "not found or not accessible")
 }
 
-func TestExecute_AllNonExistentFromList_ReturnsForbidden(t *testing.T) {
+func TestExecute_AllNonExistentFromList_ReturnsOKWithMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -112,11 +114,11 @@ func TestExecute_AllNonExistentFromList_ReturnsForbidden(t *testing.T) {
 	}
 
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: nil, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
-	require.Equal(t, http.StatusForbidden, code)
+	require.Equal(t, http.StatusOK, code)
 	msg, ok := res.(string)
 	require.True(t, ok)
-	// With CheckNamespaceAccess, error may be "cannot access namespace data: ..." or "not accessible or do not exist"
 	assert.True(t, strings.Contains(msg, "default2") || strings.Contains(msg, "missing-ns"))
+	assert.Contains(t, msg, "not found or not accessible")
 }
 
 func TestExecute_ValidSingleNamespace_ReturnsOKWithResponse(t *testing.T) {
@@ -235,11 +237,11 @@ func TestExecute_ValidAndInvalidNamespaces_ReturnsOKWithSkippedWarning(t *testin
 	require.NotNil(t, resp.Namespaces)
 	assert.NotEmpty(t, resp.Namespaces)
 	require.Contains(t, resp.Errors, "namespaces")
-	assert.Contains(t, resp.Errors["namespaces"], "skipped")
+	assert.Contains(t, resp.Errors["namespaces"], "not found or not accessible")
 	assert.Contains(t, resp.Errors["namespaces"], "default2")
 }
 
-func TestExecute_NoNamespacesProvided_ReturnsError(t *testing.T) {
+func TestExecute_NoNamespacesProvided_ReturnsOKWithMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -270,10 +272,10 @@ func TestExecute_NoNamespacesProvided_ReturnsError(t *testing.T) {
 	}
 
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: promClient, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
-	require.Equal(t, http.StatusBadRequest, code)
-	errMsg, ok := res.(string)
+	require.Equal(t, http.StatusOK, code)
+	msg, ok := res.(string)
 	require.True(t, ok)
-	assert.Contains(t, errMsg, "namespaces parameter is required")
+	assert.Contains(t, msg, "No namespaces were specified")
 }
 
 func TestExecute_WorkloadGraphType_FetchesWorkloadHealth(t *testing.T) {
@@ -506,4 +508,420 @@ func TestExecute_DefaultRateInterval_UsesDefault(t *testing.T) {
 	resp, ok := res.(CompactGraphResponse)
 	require.True(t, ok)
 	assert.NotNil(t, resp.Nodes)
+}
+
+// ========================================================================
+// Invalid GraphType Tests
+// ========================================================================
+
+func TestExecute_InvalidGraphType_ReturnsBadRequest(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+	)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	kialiCache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}), *conf)
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+	args := map[string]interface{}{
+		"namespaces":  "bookinfo",
+		"graphType":   "invalidType",
+		"clusterName": "Kubernetes",
+	}
+
+	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: nil, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
+	require.Equal(t, http.StatusBadRequest, code)
+	msg, ok := res.(string)
+	require.True(t, ok)
+	assert.Contains(t, msg, "invalid graphType")
+	assert.Contains(t, msg, "invalidType")
+}
+
+func TestExecute_EmptyGraphType_UsesDefault(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+	)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	kialiCache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}), *conf)
+
+	promAPI := new(prometheustest.PromAPIMock)
+	mockPrometheusForGraph(promAPI)
+	promClient, err := prometheus.NewClient(*conf, k8s.GetToken())
+	require.NoError(t, err)
+	promClient.Inject(promAPI)
+
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+	args := map[string]interface{}{
+		"namespaces":  "bookinfo",
+		"clusterName": "Kubernetes",
+	}
+
+	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: promClient, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
+	require.Equal(t, http.StatusOK, code)
+	resp, ok := res.(CompactGraphResponse)
+	require.True(t, ok)
+	assert.Equal(t, "versionedApp", resp.GraphType)
+}
+
+func TestExecute_AllValidGraphTypes_AcceptedWithoutError(t *testing.T) {
+	validTypes := []string{"app", "service", "versionedApp", "workload"}
+
+	for _, gt := range validTypes {
+		t.Run(gt, func(t *testing.T) {
+			conf := config.NewConfig()
+			conf.KubernetesConfig.ClusterName = "Kubernetes"
+			config.Set(conf)
+
+			k8s := kubetest.NewFakeK8sClient(
+				kubetest.FakeNamespace("bookinfo"),
+			)
+
+			promAPI := new(prometheustest.PromAPIMock)
+			mockPrometheusForGraph(promAPI)
+			promClient, err := prometheus.NewClient(*conf, k8s.GetToken())
+			require.NoError(t, err)
+			promClient.Inject(promAPI)
+
+			prom := new(prometheustest.PromClientMock)
+			mockPrometheusForHealth(prom)
+			businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build()
+			kialiCache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}), *conf)
+
+			clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+			saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+			discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+			req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
+			req = reqWithAuth(req, conf, k8s.GetToken())
+			args := map[string]interface{}{
+				"namespaces":  "bookinfo",
+				"graphType":   gt,
+				"clusterName": "Kubernetes",
+			}
+
+			res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: promClient, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
+			require.Equal(t, http.StatusOK, code)
+			resp, ok := res.(CompactGraphResponse)
+			require.True(t, ok)
+			assert.Equal(t, gt, resp.GraphType)
+		})
+	}
+}
+
+// ========================================================================
+// TransformGraph Unit Tests
+// ========================================================================
+
+func TestTransformGraph_NilGraphRaw_ReturnsEmptyNodesAndTraffic(t *testing.T) {
+	resp := TransformGraph(nil, "versionedApp", []string{"bookinfo"}, nil, nil)
+
+	assert.Equal(t, "versionedApp", resp.GraphType)
+	assert.Equal(t, []string{"bookinfo"}, resp.Namespaces)
+	assert.Empty(t, resp.Nodes)
+	assert.Empty(t, resp.Traffic)
+	assert.Nil(t, resp.Errors)
+	assert.Nil(t, resp.Health)
+}
+
+func TestTransformGraph_MalformedJSON_ReturnsGraphParseError(t *testing.T) {
+	malformed := json.RawMessage(`{not valid json}`)
+	resp := TransformGraph(malformed, "app", []string{"ns1"}, nil, nil)
+
+	require.NotNil(t, resp.Errors)
+	assert.Contains(t, resp.Errors, "graph_parse")
+	assert.Empty(t, resp.Nodes)
+	assert.Empty(t, resp.Traffic)
+}
+
+func TestTransformGraph_EmptyElements_ReturnsEmptyNodesAndTraffic(t *testing.T) {
+	cfg := graphCommon.Config{
+		Timestamp: 1000,
+		Duration:  600,
+		GraphType: "versionedApp",
+		Elements: graphCommon.Elements{
+			Nodes: []*graphCommon.NodeWrapper{},
+			Edges: []*graphCommon.EdgeWrapper{},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	resp := TransformGraph(raw, "versionedApp", []string{"bookinfo"}, nil, nil)
+
+	assert.Equal(t, "versionedApp", resp.GraphType)
+	assert.Empty(t, resp.Nodes)
+	assert.Empty(t, resp.Traffic)
+	assert.Nil(t, resp.Errors)
+}
+
+func TestTransformGraph_WithNodes_ExtractsCorrectly(t *testing.T) {
+	cfg := graphCommon.Config{
+		Timestamp: 1000,
+		Duration:  600,
+		GraphType: "versionedApp",
+		Elements: graphCommon.Elements{
+			Nodes: []*graphCommon.NodeWrapper{
+				{Data: &graphCommon.NodeData{ID: "n0", NodeType: "app", App: "productpage", Version: "v1", Namespace: "bookinfo"}},
+				{Data: &graphCommon.NodeData{ID: "n1", NodeType: "app", App: "reviews", Version: "v2", Namespace: "bookinfo"}},
+				{Data: &graphCommon.NodeData{ID: "box0", NodeType: "box", IsBox: "namespace", Namespace: "bookinfo"}},
+			},
+			Edges: []*graphCommon.EdgeWrapper{},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	resp := TransformGraph(raw, "versionedApp", []string{"bookinfo"}, nil, nil)
+
+	assert.Len(t, resp.Nodes, 2, "box nodes should be excluded")
+	assert.Equal(t, "productpage", resp.Nodes[0].Name)
+	assert.Equal(t, "v1", resp.Nodes[0].Version)
+	assert.Equal(t, "app", resp.Nodes[0].Type)
+	assert.Equal(t, "reviews", resp.Nodes[1].Name)
+	assert.Equal(t, "v2", resp.Nodes[1].Version)
+}
+
+func TestTransformGraph_WithEdges_ExtractsTraffic(t *testing.T) {
+	cfg := graphCommon.Config{
+		Timestamp: 1000,
+		Duration:  600,
+		GraphType: "versionedApp",
+		Elements: graphCommon.Elements{
+			Nodes: []*graphCommon.NodeWrapper{
+				{Data: &graphCommon.NodeData{ID: "n0", NodeType: "app", App: "productpage", Version: "v1"}},
+				{Data: &graphCommon.NodeData{ID: "n1", NodeType: "app", App: "reviews", Version: "v2"}},
+			},
+			Edges: []*graphCommon.EdgeWrapper{
+				{Data: &graphCommon.EdgeData{
+					ID:           "e0",
+					Source:       "n0",
+					Target:       "n1",
+					IsMTLS:       "100",
+					ResponseTime: "45",
+					Throughput:   "1024",
+					HealthStatus: "Healthy",
+					Traffic:      graphCommon.ProtocolTraffic{Protocol: "http"},
+				}},
+			},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	resp := TransformGraph(raw, "versionedApp", []string{"bookinfo"}, nil, nil)
+
+	require.Len(t, resp.Traffic, 1)
+	edge := resp.Traffic[0]
+	assert.Equal(t, "productpage (v1)", edge.Source)
+	assert.Equal(t, "reviews (v2)", edge.Target)
+	assert.True(t, edge.MTLS)
+	assert.Equal(t, 45, edge.ResponseTimeMs)
+	assert.Equal(t, "1024", edge.Throughput)
+	assert.Equal(t, "http", edge.Protocol)
+	assert.Equal(t, "Healthy", edge.Health)
+}
+
+func TestTransformGraph_PreservesExistingErrors(t *testing.T) {
+	existingErrors := map[string]string{
+		"mesh_status": "some mesh error",
+	}
+	resp := TransformGraph(nil, "app", []string{"ns1"}, nil, existingErrors)
+
+	require.NotNil(t, resp.Errors)
+	assert.Equal(t, "some mesh error", resp.Errors["mesh_status"])
+}
+
+func TestTransformGraph_WithHealthSummary(t *testing.T) {
+	health := &MeshHealthSummary{
+		OverallStatus: "HEALTHY",
+		Availability:  99.9,
+	}
+	resp := TransformGraph(nil, "app", []string{"ns1"}, health, nil)
+
+	require.NotNil(t, resp.Health)
+	assert.Equal(t, "HEALTHY", resp.Health.OverallStatus)
+	assert.InDelta(t, 99.9, resp.Health.Availability, 0.001)
+}
+
+func TestTransformGraph_NodeNameResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *graphCommon.NodeData
+		expected string
+	}{
+		{
+			name:     "app name",
+			node:     &graphCommon.NodeData{ID: "n0", NodeType: "app", App: "reviews"},
+			expected: "reviews",
+		},
+		{
+			name:     "workload name when no app",
+			node:     &graphCommon.NodeData{ID: "n0", NodeType: "workload", Workload: "reviews-v1"},
+			expected: "reviews-v1",
+		},
+		{
+			name:     "service name when no app or workload",
+			node:     &graphCommon.NodeData{ID: "n0", NodeType: "service", Service: "reviews-svc"},
+			expected: "reviews-svc",
+		},
+		{
+			name:     "falls back to ID",
+			node:     &graphCommon.NodeData{ID: "n0", NodeType: "unknown"},
+			expected: "n0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := graphCommon.Config{
+				Elements: graphCommon.Elements{
+					Nodes: []*graphCommon.NodeWrapper{{Data: tt.node}},
+					Edges: []*graphCommon.EdgeWrapper{},
+				},
+			}
+			raw, err := json.Marshal(cfg)
+			require.NoError(t, err)
+
+			resp := TransformGraph(raw, "app", []string{"ns1"}, nil, nil)
+			require.Len(t, resp.Nodes, 1)
+			assert.Equal(t, tt.expected, resp.Nodes[0].Name)
+		})
+	}
+}
+
+func TestTransformGraph_EdgeMTLS_NonHundredPercent(t *testing.T) {
+	cfg := graphCommon.Config{
+		Elements: graphCommon.Elements{
+			Nodes: []*graphCommon.NodeWrapper{
+				{Data: &graphCommon.NodeData{ID: "n0", App: "a"}},
+				{Data: &graphCommon.NodeData{ID: "n1", App: "b"}},
+			},
+			Edges: []*graphCommon.EdgeWrapper{
+				{Data: &graphCommon.EdgeData{
+					ID:      "e0",
+					Source:  "n0",
+					Target:  "n1",
+					IsMTLS:  "50",
+					Traffic: graphCommon.ProtocolTraffic{Protocol: "http"},
+				}},
+			},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	resp := TransformGraph(raw, "app", []string{"ns1"}, nil, nil)
+
+	require.Len(t, resp.Traffic, 1)
+	assert.False(t, resp.Traffic[0].MTLS, "mTLS should be false when not 100%%")
+}
+
+// ========================================================================
+// Empty Graph (No Traffic) Tests
+// ========================================================================
+
+func TestExecute_NamespaceWithNoTraffic_ReturnsEmptyGraph(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("empty-ns"),
+	)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	kialiCache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}), *conf)
+
+	promAPI := new(prometheustest.PromAPIMock)
+	mockPrometheusForGraph(promAPI)
+	promClient, err := prometheus.NewClient(*conf, k8s.GetToken())
+	require.NoError(t, err)
+	promClient.Inject(promAPI)
+
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+	args := map[string]interface{}{
+		"namespaces":  "empty-ns",
+		"graphType":   "versionedApp",
+		"clusterName": "Kubernetes",
+	}
+
+	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: promClient, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
+	require.Equal(t, http.StatusOK, code)
+	resp, ok := res.(CompactGraphResponse)
+	require.True(t, ok)
+	assert.Empty(t, resp.Nodes, "namespace with no traffic should return empty nodes")
+	assert.Empty(t, resp.Traffic, "namespace with no traffic should return empty traffic")
+	assert.Equal(t, "versionedApp", resp.GraphType)
+	assert.Contains(t, resp.Namespaces, "empty-ns")
+}
+
+// ========================================================================
+// Compact Graph Response Structure Tests
+// ========================================================================
+
+func TestExecute_ResponseStructure_HasExpectedFields(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+	)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	kialiCache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s}), *conf)
+
+	promAPI := new(prometheustest.PromAPIMock)
+	mockPrometheusForGraph(promAPI)
+	promClient, err := prometheus.NewClient(*conf, k8s.GetToken())
+	require.NoError(t, err)
+	promClient.Inject(promAPI)
+
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/get_mesh_graph", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+	args := map[string]interface{}{
+		"namespaces":  "bookinfo",
+		"graphType":   "versionedApp",
+		"clusterName": "Kubernetes",
+	}
+
+	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: promClient, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
+	require.Equal(t, http.StatusOK, code)
+
+	resp, ok := res.(CompactGraphResponse)
+	require.True(t, ok)
+
+	raw, marshalErr := json.Marshal(resp)
+	require.NoError(t, marshalErr)
+
+	var jsonMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &jsonMap))
+
+	assert.Contains(t, jsonMap, "graphType")
+	assert.Contains(t, jsonMap, "namespaces")
+	assert.Contains(t, jsonMap, "nodes")
+	assert.Contains(t, jsonMap, "traffic")
 }

--- a/ai/mcp/mcp_tools_test.go
+++ b/ai/mcp/mcp_tools_test.go
@@ -174,3 +174,81 @@ func TestPodPerformanceSchema_MCPToolsetRegistered(t *testing.T) {
 	_, inDefault := DefaultToolHandlers["get_pod_performance"]
 	assert.True(t, inDefault, "get_pod_performance should be in DefaultToolHandlers")
 }
+
+// ========================================================================
+// get_mesh_traffic_graph Schema Verification Tests
+// ========================================================================
+
+func TestMeshGraphSchema_ToolDefinitionLoads(t *testing.T) {
+	err := LoadTools()
+	require.NoError(t, err)
+
+	tool, ok := DefaultToolHandlers["get_mesh_traffic_graph"]
+	require.True(t, ok, "get_mesh_traffic_graph should be registered in DefaultToolHandlers")
+	assert.Equal(t, "get_mesh_traffic_graph", tool.GetName())
+	assert.NotEmpty(t, tool.GetDescription())
+}
+
+func TestMeshGraphSchema_RequiredFields(t *testing.T) {
+	err := LoadTools()
+	require.NoError(t, err)
+
+	tool := DefaultToolHandlers["get_mesh_traffic_graph"]
+	schema := tool.GetDefinition()
+
+	required, ok := schema["required"].([]interface{})
+	require.True(t, ok, "schema should have a 'required' field")
+	assert.Contains(t, required, "namespaces", "namespaces should be required")
+}
+
+func TestMeshGraphSchema_PropertiesIncludeExpectedFields(t *testing.T) {
+	err := LoadTools()
+	require.NoError(t, err)
+
+	tool := DefaultToolHandlers["get_mesh_traffic_graph"]
+	schema := tool.GetDefinition()
+
+	props, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "schema should have a 'properties' field")
+
+	expectedFields := []string{"namespaces", "graphType", "clusterName"}
+	for _, field := range expectedFields {
+		_, exists := props[field]
+		assert.True(t, exists, "schema should contain property %q", field)
+	}
+}
+
+func TestMeshGraphSchema_GraphTypeEnum(t *testing.T) {
+	err := LoadTools()
+	require.NoError(t, err)
+
+	tool := DefaultToolHandlers["get_mesh_traffic_graph"]
+	schema := tool.GetDefinition()
+
+	props := schema["properties"].(map[string]interface{})
+	graphTypeProp := props["graphType"].(map[string]interface{})
+	enumRaw, ok := graphTypeProp["enum"].([]interface{})
+	require.True(t, ok, "graphType should have an enum constraint")
+
+	enumValues := make([]string, len(enumRaw))
+	for i, v := range enumRaw {
+		enumValues[i] = v.(string)
+	}
+
+	assert.Contains(t, enumValues, "versionedApp")
+	assert.Contains(t, enumValues, "app")
+	assert.Contains(t, enumValues, "service")
+	assert.Contains(t, enumValues, "workload")
+	assert.Len(t, enumValues, 4, "graphType enum should have exactly 4 values")
+}
+
+func TestMeshGraphSchema_MCPToolsetRegistered(t *testing.T) {
+	err := LoadTools()
+	require.NoError(t, err)
+
+	_, inMCP := MCPToolHandlers["get_mesh_traffic_graph"]
+	assert.True(t, inMCP, "get_mesh_traffic_graph should be in MCPToolHandlers")
+
+	_, inDefault := DefaultToolHandlers["get_mesh_traffic_graph"]
+	assert.True(t, inDefault, "get_mesh_traffic_graph should be in DefaultToolHandlers")
+}


### PR DESCRIPTION
### Describe the change

Added more checks on input params of `get_mesh_traffic_graph`, added panic recovery and more tests.

### Steps to test the PR

```
# Against a locally running Kiali
curl -X POST http://localhost:20001/kiali/api/chat/mcp/get_mesh_traffic_graph \
  -H "Content-Type: application/json" \
  -d '{
    "namespaces": "bookinfo",
    "graphType": "versionedApp",
    "rateInterval": "10m"
  }'

# Non-existent namespace (should return friendly message, not error)
curl -X POST http://localhost:20001/kiali/api/chat/mcp/get_mesh_traffic_graph \
  -H "Content-Type: application/json" \
  -d '{"namespaces": "nonexistent-ns"}'

# Invalid graphType (should return 400)
curl -X POST http://localhost:20001/kiali/api/chat/mcp/get_mesh_traffic_graph \
  -H "Content-Type: application/json" \
  -d '{"namespaces": "bookinfo", "graphType": "invalidType"}'

# Empty namespace with no traffic
curl -X POST http://localhost:20001/kiali/api/chat/mcp/get_mesh_traffic_graph \
  -H "Content-Type: application/json" \
  -d '{"namespaces": "default"}'

# No namespaces provided (should return friendly message)
curl -X POST http://localhost:20001/kiali/api/chat/mcp/get_mesh_traffic_graph \
  -H "Content-Type: application/json" \
  -d '{"graphType": "app"}'

```

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/9365
