### PR TITLE
[v2.22] Backport: revise kiali_health_status metric approach

### DIFF
--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -42,25 +42,27 @@ func NewHealthMonitor(
 	prom prometheus.ClientInterface,
 ) *healthMonitor {
 	return &healthMonitor{
-		cache:         cache,
-		clientFactory: clientFactory,
-		conf:          conf,
-		discovery:     discovery,
-		lastRun:       time.Time{},
-		logger:        log.Logger().With().Str("component", "health-monitor").Logger(),
-		prom:          prom,
+		cache:           cache,
+		clientFactory:   clientFactory,
+		conf:            conf,
+		discovery:       discovery,
+		healthStatusExp: NewHealthStatusExporter(conf),
+		lastRun:         time.Time{},
+		logger:          log.Logger().With().Str("component", "health-monitor").Logger(),
+		prom:            prom,
 	}
 }
 
 // healthMonitor pre-computes health for all namespaces and caches the results.
 type healthMonitor struct {
-	cache         cache.KialiCache
-	clientFactory kubernetes.ClientFactory
-	conf          *config.Config
-	discovery     istio.MeshDiscovery
-	lastRun       time.Time
-	logger        zerolog.Logger
-	prom          prometheus.ClientInterface
+	cache           cache.KialiCache
+	clientFactory   kubernetes.ClientFactory
+	conf            *config.Config
+	discovery       istio.MeshDiscovery
+	healthStatusExp *HealthStatusExporter
+	lastRun         time.Time
+	logger          zerolog.Logger
+	prom            prometheus.ClientInterface
 }
 
 // Start starts the background health refresh loop.
@@ -103,6 +105,18 @@ func (m *healthMonitor) RefreshHealth(ctx context.Context) error {
 
 	// Get clusters from cache
 	clusters := m.cache.GetClusters()
+
+	knownClusters := make(map[string]bool, len(clusters))
+	for _, c := range clusters {
+		knownClusters[c.Name] = true
+	}
+	// Run when RefreshHealth returns for any reason (success, createHealthLayer error, ctx
+	// cancellation, or empty cluster list). An empty knownClusters map reconciles all tracked
+	// clusters (same effect as a nil map when the cache lists no clusters).
+	if m.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		defer m.healthStatusExp.ReconcileDroppedClusters(knownClusters)
+	}
+
 	if len(clusters) == 0 {
 		m.logger.Warn().Msg("No clusters found, skipping health refresh")
 		return nil
@@ -177,6 +191,8 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 	// Verify we have access to this cluster
 	if m.clientFactory.GetSAClient(cluster) == nil {
 		log.Error().Msg("No SA client for cluster")
+		// No namespace list: ReconcileDroppedNamespacesForCluster is skipped, so series for
+		// namespaces no longer visible to Kiali may stay until the cluster can be refreshed again.
 		return 0, 1
 	}
 
@@ -185,19 +201,32 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 	namespaces, err := layer.Namespace.GetClusterNamespaces(ctx, cluster)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to get namespaces for cluster")
+		// Same as missing SA client: dropped-namespace reconciliation is deferred to a later success.
 		return 0, 1
 	}
 
+	visitedNamespaces := make(map[string]bool, len(namespaces))
 	errorCount := 0
 	for _, ns := range namespaces {
 		if ctx.Err() != nil {
+			// Skip ReconcileDroppedNamespacesForCluster: visitedNamespaces is incomplete and would
+			// incorrectly age metrics for namespaces not yet iterated in this loop.
 			return len(namespaces), errorCount
 		}
 
 		if err := m.refreshNamespaceHealth(ctx, layer, cluster, ns.Name, duration); err != nil {
 			log.Warn().Err(err).Str("namespace", ns.Name).Msg("Failed to refresh health for namespace")
 			errorCount++
+			continue
 		}
+		// Only namespaces that completed refresh (including partial health + export) count as
+		// visited. Total computation failure skips export/reconcile; leaving the name out lets
+		// ReconcileDroppedNamespacesForCluster age kiali_health_status series for that namespace.
+		visitedNamespaces[ns.Name] = true
+	}
+
+	if m.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		m.healthStatusExp.ReconcileDroppedNamespacesForCluster(cluster, visitedNamespaces)
 	}
 
 	return len(namespaces), errorCount
@@ -226,7 +255,8 @@ func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer
 	serviceHealth, svcErr := layer.Health.GetNamespaceServiceHealth(ctx, criteria)
 	workloadHealth, wkErr := layer.Health.GetNamespaceWorkloadHealth(ctx, criteria)
 
-	// If all failed, return error
+	// If all failed, return error (no cache write or metrics export; refreshClusterHealth will not
+	// mark this namespace visited so dropped-namespace reconciliation can age stale gauges).
 	if appErr != nil && svcErr != nil && wkErr != nil {
 		return fmt.Errorf("all health computations failed: app=%v, svc=%v, wk=%v", appErr, svcErr, wkErr)
 	}
@@ -255,43 +285,70 @@ func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer
 
 	m.cache.SetHealth(cluster, namespace, cachedData)
 
-	// Export health status metrics if enabled
-	if m.conf.Server.Observability.Metrics.Enabled {
+	// Export health status metrics if enabled (independent of general performance metrics)
+	if m.conf.Server.Observability.Metrics.HealthStatus.Enabled {
 		m.exportHealthStatusMetrics(cluster, namespace, appHealth, serviceHealth, workloadHealth)
 	}
 
 	return nil
 }
 
-// exportHealthStatusMetrics exports health status for each individual item as Prometheus metrics
-// using the state cardinality pattern (one metric per state, exactly one set to 1).
-// Uses the pre-calculated Status field from the health data.
+// exportHealthStatusMetrics exports health status for each individual item as Prometheus metrics.
+// Uses the pre-calculated Status field from the health data. Tracks seen entities for reconciliation.
 func (m *healthMonitor) exportHealthStatusMetrics(
 	cluster, namespace string,
 	appHealth models.NamespaceAppHealth,
 	serviceHealth models.NamespaceServiceHealth,
 	workloadHealth models.NamespaceWorkloadHealth,
 ) {
-	// Export app health metrics using pre-calculated status
+	if !m.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		return
+	}
+
+	// Track seen entities for reconciliation (to detect entities that disappeared)
+	seenKeys := make(map[entityKey]bool)
+
+	// Export app health severity
 	for appName, health := range appHealth {
+		status := "NA"
 		if health.Status != nil {
-			internalmetrics.SetHealthStatusForItem(cluster, namespace, internalmetrics.HealthTypeApp, appName, string(health.Status.Status))
+			status = string(health.Status.Status)
 		}
+		m.healthStatusExp.Observe(cluster, namespace, internalmetrics.HealthTypeApp, appName, status)
+		seenKeys[NewEntityKey(cluster, namespace, internalmetrics.HealthTypeApp, appName)] = true
 	}
 
-	// Export service health metrics using pre-calculated status
+	// Export service health severity
 	for svcName, health := range serviceHealth {
+		status := "NA"
 		if health.Status != nil {
-			internalmetrics.SetHealthStatusForItem(cluster, namespace, internalmetrics.HealthTypeService, svcName, string(health.Status.Status))
+			status = string(health.Status.Status)
 		}
+		m.healthStatusExp.Observe(cluster, namespace, internalmetrics.HealthTypeService, svcName, status)
+		seenKeys[NewEntityKey(cluster, namespace, internalmetrics.HealthTypeService, svcName)] = true
 	}
 
-	// Export workload health metrics using pre-calculated status
+	// Export workload health severity
 	for wkName, health := range workloadHealth {
+		status := "NA"
 		if health.Status != nil {
-			internalmetrics.SetHealthStatusForItem(cluster, namespace, internalmetrics.HealthTypeWorkload, wkName, string(health.Status.Status))
+			status = string(health.Status.Status)
 		}
+		m.healthStatusExp.Observe(cluster, namespace, internalmetrics.HealthTypeWorkload, wkName, status)
+		seenKeys[NewEntityKey(cluster, namespace, internalmetrics.HealthTypeWorkload, wkName)] = true
 	}
+
+	// Export namespace aggregate health (reuse existing aggregation function)
+	namespaceAggregate := models.AggregateNamespaceStatus(&appHealth, &serviceHealth, &workloadHealth)
+	namespaceStatus := "NA"
+	if namespaceAggregate != nil && namespaceAggregate.WorstStatus != "" {
+		namespaceStatus = namespaceAggregate.WorstStatus
+	}
+	m.healthStatusExp.Observe(cluster, namespace, internalmetrics.HealthTypeNamespace, namespace, namespaceStatus)
+	seenKeys[NewEntityKey(cluster, namespace, internalmetrics.HealthTypeNamespace, namespace)] = true
+
+	// Reconcile: handle entities that disappeared (treat as NA; same max_consecutive_na streak as Observe)
+	m.healthStatusExp.ReconcileNamespace(cluster, namespace, seenKeys)
 }
 
 // calculateDuration calculates the health duration based on configuration and elapsed time.

--- a/business/health_status_exporter.go
+++ b/business/health_status_exporter.go
@@ -1,0 +1,238 @@
+package business
+
+import (
+	"sync"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
+)
+
+// entityKey uniquely identifies a health entity for tracking grace state between refresh cycles.
+type entityKey struct {
+	cluster    string
+	healthType internalmetrics.HealthType
+	name       string
+	namespace  string
+}
+
+// NewEntityKey returns the canonical key for a health status metric entity.
+func NewEntityKey(cluster, namespace string, healthType internalmetrics.HealthType, name string) entityKey {
+	return entityKey{
+		cluster:    cluster,
+		healthType: healthType,
+		name:       name,
+		namespace:  namespace,
+	}
+}
+
+// entityState tracks consecutive NA or missing refresh cycles before deleting a metric series.
+type entityState struct {
+	naStreak int
+}
+
+// HealthStatusExporter manages health status metric export with NA grace handling.
+// It tracks per-entity state to avoid deleting metrics on transient NA status.
+// seriesPresent records label sets for which SetHealthStatusForItem has succeeded so
+// Delete is only invoked when a Prometheus child may exist (avoids redundant deletes
+// for entities that always report NA).
+type HealthStatusExporter struct {
+	conf          *config.Config
+	seriesPresent map[entityKey]struct{}
+	state         map[entityKey]*entityState
+	stateMutex    sync.RWMutex
+}
+
+// NewHealthStatusExporter creates a new HealthStatusExporter.
+func NewHealthStatusExporter(conf *config.Config) *HealthStatusExporter {
+	return &HealthStatusExporter{
+		conf:          conf,
+		seriesPresent: make(map[entityKey]struct{}),
+		state:         make(map[entityKey]*entityState),
+	}
+}
+
+// deleteHealthStatusSeriesIfPresent removes the Prometheus series only if this exporter
+// previously set a value for the key (GaugeVec.Delete is skipped otherwise).
+func (e *HealthStatusExporter) deleteHealthStatusSeriesIfPresent(key entityKey) {
+	if _, ok := e.seriesPresent[key]; !ok {
+		return
+	}
+	internalmetrics.DeleteHealthStatusForItem(key.cluster, key.namespace, key.healthType, key.name)
+	delete(e.seriesPresent, key)
+}
+
+// maxConsecutiveNA returns the configured streak length of NA or missing refresh cycles
+// before deleting a series. Values <= 0 use the default (3).
+func (e *HealthStatusExporter) maxConsecutiveNA() int {
+	n := e.conf.Server.Observability.Metrics.HealthStatus.MaxConsecutiveNA
+	if n <= 0 {
+		return 3
+	}
+	return n
+}
+
+// Observe processes a health status for an entity and updates the metric accordingly.
+// If status is NA, it increments a per-entity streak; after MaxConsecutiveNA consecutive
+// NA observations (from server config) the series is deleted only if a value was previously set for this key.
+// If status is non-NA, it sets the metric and clears streak state.
+func (e *HealthStatusExporter) Observe(cluster, namespace string, healthType internalmetrics.HealthType, name, status string) {
+	if !e.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		return
+	}
+
+	value, ok := internalmetrics.HealthStatusValue(status)
+	key := NewEntityKey(cluster, namespace, healthType, name)
+
+	limit := e.maxConsecutiveNA()
+
+	e.stateMutex.Lock()
+	defer e.stateMutex.Unlock()
+
+	if ok {
+		// Non-NA status: set metric and clear streak state
+		internalmetrics.SetHealthStatusForItem(cluster, namespace, healthType, name, value)
+		e.seriesPresent[key] = struct{}{}
+		delete(e.state, key)
+	} else {
+		// NA status: count consecutive refresh cycles with NA
+		state, exists := e.state[key]
+		if !exists {
+			if limit <= 1 {
+				e.deleteHealthStatusSeriesIfPresent(key)
+				return
+			}
+			e.state[key] = &entityState{naStreak: 1}
+		} else {
+			state.naStreak++
+			if state.naStreak >= limit {
+				e.deleteHealthStatusSeriesIfPresent(key)
+				delete(e.state, key)
+			}
+		}
+	}
+}
+
+// ReconcileNamespace processes entities that were seen in the current refresh cycle
+// and increments the streak for entities that are no longer present (treating them as NA).
+// Call this after processing all entities in a namespace.
+//
+// Keys must be reconciled for both NA streak state and seriesPresent: a non-NA Observe
+// clears state but leaves seriesPresent set, so an entity that drops out of app/service/workload
+// maps would otherwise never be advanced toward deletion.
+func (e *HealthStatusExporter) ReconcileNamespace(cluster, namespace string, seenKeys map[entityKey]bool) {
+	if !e.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		return
+	}
+
+	limit := e.maxConsecutiveNA()
+
+	e.stateMutex.Lock()
+	defer e.stateMutex.Unlock()
+
+	candidates := make(map[entityKey]struct{})
+	for key := range e.state {
+		if key.cluster == cluster && key.namespace == namespace {
+			candidates[key] = struct{}{}
+		}
+	}
+	for key := range e.seriesPresent {
+		if key.cluster == cluster && key.namespace == namespace {
+			candidates[key] = struct{}{}
+		}
+	}
+
+	for key := range candidates {
+		if seenKeys[key] {
+			continue
+		}
+		state, exists := e.state[key]
+		if !exists {
+			if limit <= 1 {
+				e.deleteHealthStatusSeriesIfPresent(key)
+				continue
+			}
+			e.state[key] = &entityState{naStreak: 1}
+			continue
+		}
+		state.naStreak++
+		if state.naStreak >= limit {
+			e.deleteHealthStatusSeriesIfPresent(key)
+			delete(e.state, key)
+		}
+	}
+}
+
+// distinctClusters returns every cluster value present in exporter state or seriesPresent.
+func (e *HealthStatusExporter) distinctClusters() []string {
+	e.stateMutex.RLock()
+	defer e.stateMutex.RUnlock()
+	set := make(map[string]struct{})
+	for key := range e.state {
+		set[key.cluster] = struct{}{}
+	}
+	for key := range e.seriesPresent {
+		set[key.cluster] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for cluster := range set {
+		out = append(out, cluster)
+	}
+	return out
+}
+
+// distinctNamespacesForCluster returns every namespace (for the given cluster) present in
+// exporter state or seriesPresent.
+func (e *HealthStatusExporter) distinctNamespacesForCluster(cluster string) []string {
+	e.stateMutex.RLock()
+	defer e.stateMutex.RUnlock()
+	set := make(map[string]struct{})
+	for key := range e.state {
+		if key.cluster == cluster {
+			set[key.namespace] = struct{}{}
+		}
+	}
+	for key := range e.seriesPresent {
+		if key.cluster == cluster {
+			set[key.namespace] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for ns := range set {
+		out = append(out, ns)
+	}
+	return out
+}
+
+// ReconcileDroppedClusters reconciles health status metrics for every (cluster, namespace)
+// still tracked by this exporter whose cluster is not in knownClusters (typically the set
+// from the current cache GetClusters() result). Call once at the end of a successful full
+// refresh when clusters may have been removed from the cache.
+func (e *HealthStatusExporter) ReconcileDroppedClusters(knownClusters map[string]bool) {
+	if !e.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		return
+	}
+	for _, cluster := range e.distinctClusters() {
+		if knownClusters[cluster] {
+			continue
+		}
+		for _, ns := range e.distinctNamespacesForCluster(cluster) {
+			e.ReconcileNamespace(cluster, ns, nil)
+		}
+	}
+}
+
+// ReconcileDroppedNamespacesForCluster reconciles namespaces that still have exporter state
+// for this cluster but were not returned in the current namespace list (cluster-scoped).
+// Call only after a successful GetClusterNamespaces for this cluster; visitedNamespaces
+// should contain every namespace name from that list.
+func (e *HealthStatusExporter) ReconcileDroppedNamespacesForCluster(cluster string, visitedNamespaces map[string]bool) {
+	if !e.conf.Server.Observability.Metrics.HealthStatus.Enabled {
+		return
+	}
+	for _, ns := range e.distinctNamespacesForCluster(cluster) {
+		if visitedNamespaces[ns] {
+			continue
+		}
+		e.ReconcileNamespace(cluster, ns, nil)
+	}
+}

--- a/business/health_status_exporter_test.go
+++ b/business/health_status_exporter_test.go
@@ -1,0 +1,335 @@
+package business
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/prometheus/internalmetrics"
+)
+
+func healthStatusMetricValue(t *testing.T, cluster, namespace string, healthType internalmetrics.HealthType, name string) (value float64, ok bool) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	internalmetrics.Metrics.HealthStatus.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var dm dto.Metric
+		if err := m.Write(&dm); err != nil {
+			t.Fatalf("metric Write: %v", err)
+		}
+		lbs := dtoLabelsToMap(dm.GetLabel())
+		if lbs["cluster"] == cluster && lbs["namespace"] == namespace &&
+			lbs["health_type"] == string(healthType) && lbs["name"] == name {
+			return dm.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+func dtoLabelsToMap(pairs []*dto.LabelPair) map[string]string {
+	out := make(map[string]string, len(pairs))
+	for _, lp := range pairs {
+		if lp != nil && lp.Name != nil && lp.Value != nil {
+			out[lp.GetName()] = lp.GetValue()
+		}
+	}
+	return out
+}
+
+func deleteTestHealthStatus(t *testing.T, cluster, namespace string, healthType internalmetrics.HealthType, name string) {
+	t.Helper()
+	internalmetrics.DeleteHealthStatusForItem(cluster, namespace, healthType, name)
+}
+
+func testExporterConfig(enabled bool, maxConsecutiveNA int) *config.Config {
+	c := config.NewConfig()
+	c.Server.Observability.Metrics.HealthStatus.Enabled = enabled
+	c.Server.Observability.Metrics.HealthStatus.MaxConsecutiveNA = maxConsecutiveNA
+	return c
+}
+
+func TestHealthStatusExporter_Disabled(t *testing.T) {
+	cluster := "TestHealthStatusExporter_Disabled"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(false, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_SetHealthy(t *testing.T) {
+	cluster := "TestHealthStatusExporter_SetHealthy"
+	ns := "ns"
+	name := "svc1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeService, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeService, name, "Healthy")
+	v, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeService, name)
+	require.True(t, found)
+	require.InDelta(t, 0.0, v, 1e-9)
+}
+
+func TestHealthStatusExporter_SetNotReady(t *testing.T) {
+	cluster := "TestHealthStatusExporter_SetNotReady"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Not Ready")
+	v, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+	require.InDelta(t, 1.0, v, 1e-9)
+}
+
+// Namespace aggregate metrics use health_type=namespace and name equal to the namespace string
+// (same as the namespace label), matching exportHealthStatusMetrics.
+func TestHealthStatusExporter_SetNamespaceAggregateHealth(t *testing.T) {
+	cluster := "TestHealthStatusExporter_SetNamespaceAggregateHealth"
+	ns := "bookinfo"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeNamespace, ns)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeNamespace, ns, "Degraded")
+	v, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeNamespace, ns)
+	require.True(t, found)
+	require.InDelta(t, 2.0, v, 1e-9)
+}
+
+func TestHealthStatusExporter_NAWithoutPriorSet_NoSeries(t *testing.T) {
+	cluster := "TestHealthStatusExporter_NAWithoutPriorSet_NoSeries"
+	ns := "ns"
+	name := "wk1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeWorkload, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 2))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeWorkload, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeWorkload, name, "NA")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeWorkload, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_SetThenNADeletesAfterMaxConsecutiveNA(t *testing.T) {
+	cluster := "TestHealthStatusExporter_SetThenNADeletesAfterMaxConsecutiveNA"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Degraded")
+	v, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+	require.InDelta(t, 2.0, v, 1e-9)
+
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_MaxConsecutiveNAOneDeletesOnFirstNA(t *testing.T) {
+	cluster := "TestHealthStatusExporter_MaxConsecutiveNAOneDeletesOnFirstNA"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 1))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_NAResetsAfterHealthy(t *testing.T) {
+	cluster := "TestHealthStatusExporter_NAResetsAfterHealthy"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 3))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+}
+
+func TestHealthStatusExporter_UnknownStatusTreatedAsNA(t *testing.T) {
+	cluster := "TestHealthStatusExporter_UnknownStatusTreatedAsNA"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 2))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "bogus")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "bogus")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_MaxConsecutiveNAZeroUsesDefaultThree(t *testing.T) {
+	cluster := "TestHealthStatusExporter_MaxConsecutiveNAZeroUsesDefaultThree"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 0))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Failure")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_ReconcileMissingIncrementsStreak(t *testing.T) {
+	cluster := "TestHealthStatusExporter_ReconcileMissingIncrementsStreak"
+	ns := "ns"
+	key := NewEntityKey(cluster, ns, internalmetrics.HealthTypeApp, "gone")
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, "gone")
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 2))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, "gone", "Healthy")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, "gone", "NA")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, "gone")
+	require.True(t, found)
+
+	e.ReconcileNamespace(cluster, ns, map[entityKey]bool{})
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, "gone")
+	require.False(t, found)
+
+	// Key should not linger in reconcile state
+	require.NotContains(t, e.state, key)
+}
+
+// Last status was non-NA so state was cleared; entity then disappears from refresh maps.
+// Reconcile must still use seriesPresent so the streak advances and the series is removed.
+func TestHealthStatusExporter_ReconcileDroppedEntityAfterLastHealthy(t *testing.T) {
+	cluster := "TestHealthStatusExporter_ReconcileDroppedEntityAfterLastHealthy"
+	ns := "ns"
+	name := "removed"
+	appKey := NewEntityKey(cluster, ns, internalmetrics.HealthTypeApp, name)
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 2))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+	require.NotContains(t, e.state, appKey)
+
+	nsKey := NewEntityKey(cluster, ns, internalmetrics.HealthTypeNamespace, ns)
+	seenKeys := map[entityKey]bool{nsKey: true}
+
+	e.ReconcileNamespace(cluster, ns, seenKeys)
+	require.Contains(t, e.state, appKey)
+	require.Equal(t, 1, e.state[appKey].naStreak)
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.ReconcileNamespace(cluster, ns, seenKeys)
+	require.NotContains(t, e.state, appKey)
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_ReconcileDroppedEntityLimitOneDeletesImmediately(t *testing.T) {
+	cluster := "TestHealthStatusExporter_ReconcileDroppedEntityLimitOneDeletesImmediately"
+	ns := "ns"
+	name := "removed"
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 1))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	nsKey := NewEntityKey(cluster, ns, internalmetrics.HealthTypeNamespace, ns)
+	e.ReconcileNamespace(cluster, ns, map[entityKey]bool{nsKey: true})
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.False(t, found)
+}
+
+func TestHealthStatusExporter_ReconcileSeenKeyDoesNotAdvanceStreak(t *testing.T) {
+	cluster := "TestHealthStatusExporter_ReconcileSeenKeyDoesNotAdvanceStreak"
+	ns := "ns"
+	name := "app1"
+	key := NewEntityKey(cluster, ns, internalmetrics.HealthTypeApp, name)
+	defer deleteTestHealthStatus(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 2))
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	e.Observe(cluster, ns, internalmetrics.HealthTypeApp, name, "NA")
+	_, found := healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+
+	e.ReconcileNamespace(cluster, ns, map[entityKey]bool{key: true})
+	_, found = healthStatusMetricValue(t, cluster, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, found)
+	require.Contains(t, e.state, key)
+	require.Equal(t, 1, e.state[key].naStreak)
+}
+
+// Namespace "gone" is no longer in the API list for this cluster; "kept" still is.
+func TestHealthStatusExporter_ReconcileDroppedNamespacesForCluster(t *testing.T) {
+	cluster := "TestHealthStatusExporter_ReconcileDroppedNamespacesForCluster"
+	nsGone := "gone"
+	nsKept := "kept"
+	name := "app1"
+	defer deleteTestHealthStatus(t, cluster, nsGone, internalmetrics.HealthTypeApp, name)
+	defer deleteTestHealthStatus(t, cluster, nsKept, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 1))
+	e.Observe(cluster, nsGone, internalmetrics.HealthTypeApp, name, "Healthy")
+	e.Observe(cluster, nsKept, internalmetrics.HealthTypeApp, name, "Healthy")
+	_, foundGone := healthStatusMetricValue(t, cluster, nsGone, internalmetrics.HealthTypeApp, name)
+	_, foundKept := healthStatusMetricValue(t, cluster, nsKept, internalmetrics.HealthTypeApp, name)
+	require.True(t, foundGone)
+	require.True(t, foundKept)
+
+	e.ReconcileDroppedNamespacesForCluster(cluster, map[string]bool{nsKept: true})
+	_, foundGone = healthStatusMetricValue(t, cluster, nsGone, internalmetrics.HealthTypeApp, name)
+	_, foundKept = healthStatusMetricValue(t, cluster, nsKept, internalmetrics.HealthTypeApp, name)
+	require.False(t, foundGone)
+	require.True(t, foundKept)
+}
+
+// Cluster c2 disappeared from cache; metrics should be reconciled toward removal.
+func TestHealthStatusExporter_ReconcileDroppedClusters(t *testing.T) {
+	c1 := "TestHealthStatusExporter_ReconcileDroppedClusters_c1"
+	c2 := "TestHealthStatusExporter_ReconcileDroppedClusters_c2"
+	ns := "ns"
+	name := "app1"
+	defer deleteTestHealthStatus(t, c1, ns, internalmetrics.HealthTypeApp, name)
+	defer deleteTestHealthStatus(t, c2, ns, internalmetrics.HealthTypeApp, name)
+
+	e := NewHealthStatusExporter(testExporterConfig(true, 1))
+	e.Observe(c1, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+	e.Observe(c2, ns, internalmetrics.HealthTypeApp, name, "Healthy")
+
+	e.ReconcileDroppedClusters(map[string]bool{c1: true})
+	_, foundC1 := healthStatusMetricValue(t, c1, ns, internalmetrics.HealthTypeApp, name)
+	_, foundC2 := healthStatusMetricValue(t, c2, ns, internalmetrics.HealthTypeApp, name)
+	require.True(t, foundC1)
+	require.False(t, foundC2)
+}

--- a/cmd/offline.go
+++ b/cmd/offline.go
@@ -114,6 +114,7 @@ This mode allows you to analyze pre-collected data without requiring a live clus
 			conf.RunConfig = &manifest
 			conf.Auth.Strategy = config.AuthStrategyAnonymous
 			conf.Server.Observability.Metrics.Enabled = false
+			conf.Server.Observability.Metrics.HealthStatus.Enabled = false
 			conf.KubernetesConfig.ClusterName = manifest.Cluster
 			conf.Deployment.ViewOnlyMode = true
 

--- a/config/config.go
+++ b/config/config.go
@@ -240,10 +240,17 @@ type Cluster struct {
 	SecretName string `yaml:"secret_name,omitempty"`
 }
 
+// HealthStatusConfig provides configuration for health status metrics.
+type HealthStatusConfig struct {
+	Enabled          bool `yaml:"enabled,omitempty"`
+	MaxConsecutiveNA int  `yaml:"max_consecutive_na,omitempty"`
+}
+
 // Metrics provides metrics configuration for the Kiali server.
 type Metrics struct {
-	Enabled bool `yaml:"enabled,omitempty"`
-	Port    int  `yaml:"port,omitempty"`
+	Enabled      bool               `yaml:"enabled,omitempty"`
+	HealthStatus HealthStatusConfig `yaml:"health_status,omitempty"`
+	Port         int                `yaml:"port,omitempty"`
 }
 
 // OtelCollector is OpenTelemetry collector configuration for tracing.
@@ -1243,7 +1250,11 @@ func NewConfig() (c *Config) {
 			Observability: Observability{
 				Metrics: Metrics{
 					Enabled: true,
-					Port:    9090,
+					HealthStatus: HealthStatusConfig{
+						Enabled:          false,
+						MaxConsecutiveNA: 3,
+					},
+					Port: 9090,
 				},
 				Tracing: Tracing{
 					CollectorType: OTELCollectorType,

--- a/design/KEPS/health-precompute/proposal.md
+++ b/design/KEPS/health-precompute/proposal.md
@@ -247,6 +247,7 @@ Each refresh cycle:
 2. For each cluster, iterates through all accessible namespaces
 3. Computes health for all apps, services, and workloads in each namespace
 4. Stores the results in the Kiali Cache
+5. Optionally updates **`kiali_health_status`** gauges for that namespace when **`server.observability.metrics.health_status.enabled`** is set (independent of general performance metrics; see [Prometheus Health Metrics](#prometheus-health-metrics))
 
 **Performance Optimization**: Health tolerance patterns (code, protocol, direction regexes) are pre-compiled when the `HealthRateMatcher` is created. The `HealthCalculator` uses these pre-compiled `CompiledTolerance` objects, avoiding repeated regex compilation during health calculations. This is especially important for the background health refresh job processing many namespaces.
 
@@ -311,39 +312,107 @@ If cache is missing (cold start, new entity, cache expiry), health is computed o
 
 ## Prometheus Health Metrics
 
-A key benefit of pre-computing health on the backend is the ability to export health status as Prometheus metrics. This enables external monitoring, alerting, and integration with existing observability infrastructure.
+A key benefit of pre-computing health on the backend is the ability to expose health-related data to Prometheus. This enables external monitoring, alerting, and integration with existing 
+observability infrastructure. **General performance metrics** (cache hit/miss counters and refresh-duration histogram) and **`kiali_health_status`** are controlled **separately**: you can export entity health status while leaving the rest of Kiali’s internal performance metrics disabled.
 
 ### Exported Metrics
 
-The following metrics are exported when health pre-computation is enabled:
+| Metric                                  | Type      | When emitted / purpose |
+| --------------------------------------- | --------- | ---------------------- |
+| `kiali_health_status`                   | Gauge     | When **`health_status.enabled`**: see [Health status gauge](#health-status-gauge-kiali_health_status). One time series per entity when the entity has a non-NA status (or had one before `max_consecutive_na` expires). |
+| `kiali_health_cache_hits_total`         | Counter   | When **`metrics.enabled`**: health cache hits by `health_type` (app / service / workload). |
+| `kiali_health_cache_misses_total`       | Counter   | When **`metrics.enabled`**: health cache misses by `health_type`. |
+| `kiali_health_refresh_duration_seconds` | Histogram | When **`metrics.enabled`**: health refresh duration per `cluster`. |
 
-| Metric                                  | Type      | Description                                                |
-| --------------------------------------- | --------- | ---------------------------------------------------------- |
-| `kiali_health_status`                   | Gauge     | Health status per entity using state cardinality pattern   |
-| `kiali_health_cache_hits_total`         | Counter   | Number of health cache hits by type (app/service/workload) |
-| `kiali_health_cache_misses_total`       | Counter   | Number of health cache misses by type                      |
-| `kiali_health_refresh_duration_seconds` | Histogram | Time required to refresh health data per cluster           |
+### Metrics HTTP endpoint
 
-### Health Status Metric
+The Prometheus scrape listener on **`server.observability.metrics.port`** starts when **either** `server.observability.metrics.enabled` **or** `server.observability.metrics.health_status.enabled` is true, so health-status-only deployments can still scrape `kiali_health_status`.
 
-The `kiali_health_status` metric uses the **state cardinality pattern** for efficient alerting. For each entity, exactly one status is set to 1 while all others are 0:
+### Health status gauge (`kiali_health_status`)
+
+**Enablement:** The gauge is updated only when:
+
+- `server.observability.metrics.health_status.enabled`
+
+This does **not** require `server.observability.metrics.enabled`.
+
+Example: health status only (no cache hit/miss or refresh histogram updates):
+
+```yaml
+server:
+  observability:
+    metrics:
+      enabled: false
+      health_status:
+        enabled: true
+        max_consecutive_na: 3
+```
+
+Example: all internal metrics including health status:
+
+```yaml
+server:
+  observability:
+    metrics:
+      enabled: true
+      health_status:
+        enabled: true
+        max_consecutive_na: 3
+```
+
+It is populated during the **Health Monitor** namespace refresh (the same path that updates the health cache). If the background refresh is not running, values will not update.
+
+**Semantics:** A **single gauge value** per entity (low cardinality labels—no per-status label). Numeric mapping:
+
+| Value | Status    |
+| ----- | --------- |
+| 0     | Healthy   |
+| 1     | Not Ready |
+| 2     | Degraded  |
+| 3     | Failure   |
+
+**Labels:**
+
+| Label          | Description |
+| -------------- | ----------- |
+| `cluster`      | Cluster name |
+| `namespace`    | Namespace   |
+| `health_type`  | `app`, `service`, `workload`, or `namespace` |
+| `name`         | App, service, or workload name; for `health_type="namespace"` this is the **namespace** name (aggregate across apps/services/workloads in that namespace). |
+
+**NA and series lifecycle:** `NA` is **not** written as a gauge value. For NA or unknown status, the exporter tracks a **per-entity streak** in **consecutive health refresh cycles**. After **`max_consecutive_na`** consecutive cycles where the entity is NA or **missing from the current refresh** (reconcile treats disappearance like NA), the time series is **removed** from the Prometheus client (`GaugeVec.Delete`), so scrapes stop reporting that label set. Reconciliation considers every key that still has an exported series **or** an active NA streak, so an app/service/workload that **drops out of the health maps** after a **non-NA** observation is still advanced toward deletion (a non-NA `Observe` clears streak state but the series remains until reconcile runs on the missing entity).
+
+- Default **`max_consecutive_na`** is `3` when unset or `<= 0`.
+- **`max_consecutive_na: 1`**: first NA (or missing) after a series existed deletes immediately.
+- Entities that **never** had a non-NA status **never** get a `Set` on the gauge; the exporter **does not** call `Delete` for those (avoids redundant client work for workloads that are always NA).
+
+**Operational note (HA):** Multiple Kiali replicas each maintain their own metric state; without a single writer or aggregation at query time, the same logical entity is reported by more than one scrape target (extra labels such as `instance` or `pod`). Dashboards and **raw** alert expressions can then show or fire **once per replica** for the same app or namespace.
+
+For **alerting**, aggregate across replicas so each entity appears at most once. A simple approach is to take the **maximum** value per entity label set (higher numeric value = worse health), which matches “fire if any replica sees Failure / Degraded”:
+
+```promql
+max by (cluster, namespace, health_type, name) (kiali_health_status)
+```
+
+Alternatives: scrape only one Kiali pod (dedicated Service / ServiceMonitor), or use recording rules that pre-aggregate the expression above.
+
+Example series (labels only; scrape targets add `job`, `instance`, etc.):
 
 ```promql
 kiali_health_status{
   cluster="cluster1",
   namespace="bookinfo",
-  health_type="app",      # app, service, or workload
-  name="reviews",
-  status="Degraded"       # Healthy, Degraded, Failure, Not Ready, or NA
-} 1
+  health_type="app",
+  name="reviews"
+} 2    # Degraded
 ```
 
-This pattern enables simple alerting rules:
+Example alerting (numeric thresholds; **HA-safe** via `max by`):
 
 ```yaml
 # Alert on any entity in Failure status
 - alert: KialiHealthFailure
-  expr: kiali_health_status{status="Failure"} == 1
+  expr: max by (cluster, namespace, health_type, name) (kiali_health_status) == 3
   for: 5m
   labels:
     severity: critical
@@ -352,7 +421,7 @@ This pattern enables simple alerting rules:
 
 # Alert on degraded entities
 - alert: KialiHealthDegraded
-  expr: kiali_health_status{status="Degraded"} == 1
+  expr: max by (cluster, namespace, health_type, name) (kiali_health_status) == 2
   for: 10m
   labels:
     severity: warning

--- a/models/health.go
+++ b/models/health.go
@@ -13,6 +13,23 @@ type ClustersNamespaceHealth struct {
 	WorkloadHealth map[string]*NamespaceWorkloadHealth `json:"namespaceWorkloadHealth,omitempty"`
 }
 
+// NamespaceHealthBucket buckets entity names by health status (matches frontend NamespaceStatus)
+type NamespaceHealthBucket struct {
+	InError      []string `json:"inError"`
+	InNotReady   []string `json:"inNotReady"`
+	InSuccess    []string `json:"inSuccess"`
+	InWarning    []string `json:"inWarning"`
+	NotAvailable []string `json:"notAvailable"`
+}
+
+// NamespaceHealthAggregate is the pre-aggregated namespace health returned with cluster health (matches frontend)
+type NamespaceHealthAggregate struct {
+	StatusApp      *NamespaceHealthBucket `json:"statusApp,omitempty"`
+	StatusService  *NamespaceHealthBucket `json:"statusService,omitempty"`
+	StatusWorkload *NamespaceHealthBucket `json:"statusWorkload,omitempty"`
+	WorstStatus    string                 `json:"worstStatus"`
+}
+
 // NamespaceAppsHealth is a list of app name x health for a given namespace
 type NamespaceAppHealth map[string]*AppHealth
 
@@ -235,4 +252,149 @@ func (ps ProxyStatus) IsSynced() bool {
 // isComponentStatusSynced returns true when componentStatus is Synced
 func isComponentStatusSynced(componentStatus string) bool {
 	return componentStatus == "Synced"
+}
+
+// newNamespaceHealthBucket returns a bucket with all slices initialized so JSON never marshals null.
+func newNamespaceHealthBucket() *NamespaceHealthBucket {
+	return &NamespaceHealthBucket{
+		InError:      []string{},
+		InNotReady:   []string{},
+		InSuccess:    []string{},
+		InWarning:    []string{},
+		NotAvailable: []string{},
+	}
+}
+
+// bucketFromAppHealth builds a NamespaceHealthBucket from app health map
+func bucketFromAppHealth(m NamespaceAppHealth) *NamespaceHealthBucket {
+	if m == nil {
+		return nil
+	}
+	b := newNamespaceHealthBucket()
+	for name, ah := range m {
+		if ah == nil || ah.Status == nil {
+			b.NotAvailable = append(b.NotAvailable, name)
+			continue
+		}
+		switch ah.Status.Status {
+		case HealthStatusFailure:
+			b.InError = append(b.InError, name)
+		case HealthStatusDegraded:
+			b.InWarning = append(b.InWarning, name)
+		case HealthStatusHealthy:
+			b.InSuccess = append(b.InSuccess, name)
+		case HealthStatusNotReady:
+			b.InNotReady = append(b.InNotReady, name)
+		default:
+			b.NotAvailable = append(b.NotAvailable, name)
+		}
+	}
+	return b
+}
+
+// bucketFromServiceHealth builds a NamespaceHealthBucket from service health map
+func bucketFromServiceHealth(m NamespaceServiceHealth) *NamespaceHealthBucket {
+	if m == nil {
+		return nil
+	}
+	b := newNamespaceHealthBucket()
+	for name, sh := range m {
+		if sh == nil || sh.Status == nil {
+			b.NotAvailable = append(b.NotAvailable, name)
+			continue
+		}
+		switch sh.Status.Status {
+		case HealthStatusFailure:
+			b.InError = append(b.InError, name)
+		case HealthStatusDegraded:
+			b.InWarning = append(b.InWarning, name)
+		case HealthStatusHealthy:
+			b.InSuccess = append(b.InSuccess, name)
+		case HealthStatusNotReady:
+			b.InNotReady = append(b.InNotReady, name)
+		default:
+			b.NotAvailable = append(b.NotAvailable, name)
+		}
+	}
+	return b
+}
+
+// bucketFromWorkloadHealth builds a NamespaceHealthBucket from workload health map
+func bucketFromWorkloadHealth(m NamespaceWorkloadHealth) *NamespaceHealthBucket {
+	if m == nil {
+		return nil
+	}
+	b := newNamespaceHealthBucket()
+	for name, wh := range m {
+		if wh == nil || wh.Status == nil {
+			b.NotAvailable = append(b.NotAvailable, name)
+			continue
+		}
+		switch wh.Status.Status {
+		case HealthStatusFailure:
+			b.InError = append(b.InError, name)
+		case HealthStatusDegraded:
+			b.InWarning = append(b.InWarning, name)
+		case HealthStatusHealthy:
+			b.InSuccess = append(b.InSuccess, name)
+		case HealthStatusNotReady:
+			b.InNotReady = append(b.InNotReady, name)
+		default:
+			b.NotAvailable = append(b.NotAvailable, name)
+		}
+	}
+	return b
+}
+
+// worstStatusFromBucket returns the worst HealthStatus represented in a bucket
+func worstStatusFromBucket(b *NamespaceHealthBucket) HealthStatus {
+	if b == nil {
+		return HealthStatusNA
+	}
+	if len(b.InError) > 0 {
+		return HealthStatusFailure
+	}
+	if len(b.InWarning) > 0 {
+		return HealthStatusDegraded
+	}
+	if len(b.InNotReady) > 0 {
+		return HealthStatusNotReady
+	}
+	if len(b.InSuccess) > 0 {
+		return HealthStatusHealthy
+	}
+	return HealthStatusNA
+}
+
+// AggregateNamespaceStatus derives NamespaceHealthAggregate from app, service, and workload health maps
+func AggregateNamespaceStatus(
+	appHealth *NamespaceAppHealth,
+	serviceHealth *NamespaceServiceHealth,
+	workloadHealth *NamespaceWorkloadHealth,
+) *NamespaceHealthAggregate {
+	var app NamespaceAppHealth
+	var svc NamespaceServiceHealth
+	var wl NamespaceWorkloadHealth
+	if appHealth != nil {
+		app = *appHealth
+	}
+	if serviceHealth != nil {
+		svc = *serviceHealth
+	}
+	if workloadHealth != nil {
+		wl = *workloadHealth
+	}
+	statusApp := bucketFromAppHealth(app)
+	statusService := bucketFromServiceHealth(svc)
+	statusWorkload := bucketFromWorkloadHealth(wl)
+	worst := MergeHealthStatus(
+		worstStatusFromBucket(statusApp),
+		MergeHealthStatus(worstStatusFromBucket(statusService), worstStatusFromBucket(statusWorkload)),
+	)
+	return &NamespaceHealthAggregate{
+		StatusApp:      statusApp,
+		StatusService:  statusService,
+		StatusWorkload: statusWorkload,
+		WorstStatus:    string(worst),
+	}
 }

--- a/prometheus/internalmetrics/internal_metrics.go
+++ b/prometheus/internalmetrics/internal_metrics.go
@@ -22,7 +22,6 @@ const (
 	labelCluster          = "cluster"
 	labelGraphKind        = "graph_kind"
 	labelGraphType        = "graph_type"
-	labelHealthStatus     = "status"
 	labelHealthType       = "health_type"
 	labelModel            = "ai_model"
 	labelName             = "name"
@@ -228,9 +227,9 @@ var Metrics = MetricsType{
 	HealthStatus: prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kiali_health_status",
-			Help: "Health status of individual apps, services, and workloads using state cardinality pattern. For each item, exactly one status is set to 1, others are 0. Labels: cluster, namespace, health_type (app/service/workload), name, status (Healthy/Degraded/Failure/Not Ready/NA).",
+			Help: "Health status of individual apps, services, workloads, and namespaces as a numeric value. 0=Healthy (best), 1=Not Ready, 2=Degraded, 3=Failure (worst). NA or missing entities: series removed after max_consecutive_na consecutive health refresh cycles (server config). Labels: cluster, namespace, health_type (app/service/workload/namespace), name.",
 		},
-		[]string{labelCluster, labelNamespace, labelHealthType, labelName, labelHealthStatus},
+		[]string{labelCluster, labelNamespace, labelHealthType, labelName},
 	),
 	TracingProcessingTime: prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -617,9 +616,10 @@ func GetTracingProcessingTimePrometheusTimer(queryGroup string) *prometheus.Time
 type HealthType string
 
 const (
-	HealthTypeApp      HealthType = "app"
-	HealthTypeService  HealthType = "service"
-	HealthTypeWorkload HealthType = "workload"
+	HealthTypeApp       HealthType = "app"
+	HealthTypeNamespace HealthType = "namespace" // all types (app + service + workload)
+	HealthTypeService   HealthType = "service"
+	HealthTypeWorkload  HealthType = "workload"
 )
 
 // GetHealthRefreshDurationTimer returns a timer for measuring health refresh duration.
@@ -644,23 +644,45 @@ func IncrementHealthCacheMisses(healthType HealthType) {
 	}).Inc()
 }
 
-// HealthStatuses is the list of all possible health status values
-var HealthStatuses = []string{"Healthy", "Degraded", "Failure", "Not Ready", "NA"}
-
-// SetHealthStatusForItem sets the health status for an individual item using the state cardinality pattern.
-// Exactly one status will be set to 1, all others will be set to 0.
-func SetHealthStatusForItem(cluster, namespace string, healthType HealthType, name, currentStatus string) {
-	for _, status := range HealthStatuses {
-		value := 0.0
-		if status == currentStatus {
-			value = 1.0
-		}
-		Metrics.HealthStatus.With(prometheus.Labels{
-			labelCluster:      cluster,
-			labelNamespace:    namespace,
-			labelHealthType:   string(healthType),
-			labelName:         name,
-			labelHealthStatus: status,
-		}).Set(value)
+// HealthStatusValue converts a health status string to a numeric value.
+// Returns (value, ok) where ok is false for "NA" status (should not be exported).
+// Value mapping: 0=Healthy (best), 1=Not Ready, 2=Degraded, 3=Failure (worst).
+func HealthStatusValue(status string) (float64, bool) {
+	switch status {
+	case "Healthy":
+		return 0.0, true
+	case "Not Ready":
+		return 1.0, true
+	case "Degraded":
+		return 2.0, true
+	case "Failure":
+		return 3.0, true
+	case "NA":
+		return 0.0, false
+	default:
+		// Unknown status treated as NA
+		return 0.0, false
 	}
+}
+
+// SetHealthStatusForItem sets the health status gauge for an individual item.
+// Only call this when status is not NA (check with HealthStatusValue first).
+func SetHealthStatusForItem(cluster, namespace string, healthType HealthType, name string, value float64) {
+	Metrics.HealthStatus.With(prometheus.Labels{
+		labelCluster:    cluster,
+		labelNamespace:  namespace,
+		labelHealthType: string(healthType),
+		labelName:       name,
+	}).Set(value)
+}
+
+// DeleteHealthStatusForItem deletes the health status gauge for an individual item.
+// Call this when an entity should no longer be tracked.
+func DeleteHealthStatusForItem(cluster, namespace string, healthType HealthType, name string) {
+	Metrics.HealthStatus.Delete(prometheus.Labels{
+		labelCluster:    cluster,
+		labelNamespace:  namespace,
+		labelHealthType: string(healthType),
+		labelName:       name,
+	})
 }

--- a/server/metrics_server_test.go
+++ b/server/metrics_server_test.go
@@ -12,9 +12,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/util/certtest"
 )
+
+func TestShouldStartMetricsServer(t *testing.T) {
+	c := config.NewConfig()
+	c.Server.Observability.Metrics.Enabled = false
+	c.Server.Observability.Metrics.HealthStatus.Enabled = false
+	require.False(t, shouldStartMetricsServer(c))
+
+	c.Server.Observability.Metrics.Enabled = true
+	require.True(t, shouldStartMetricsServer(c))
+
+	c.Server.Observability.Metrics.Enabled = false
+	c.Server.Observability.Metrics.HealthStatus.Enabled = true
+	require.True(t, shouldStartMetricsServer(c))
+
+	c.Server.Observability.Metrics.Enabled = true
+	require.True(t, shouldStartMetricsServer(c))
+}
 
 // TestMetricsServerHTTP verifies that the metrics server works with plain HTTP
 // when TLS is not configured.

--- a/server/server.go
+++ b/server/server.go
@@ -140,10 +140,14 @@ func (s *Server) Start() {
 		log.Warning(err)
 	}()
 
-	// Start the Metrics Server
-	if s.conf.Server.Observability.Metrics.Enabled {
+	// Start the Metrics Server when general metrics or health-status export is enabled
+	if shouldStartMetricsServer(s.conf) {
 		StartMetricsServer(s.conf)
 	}
+}
+
+func shouldStartMetricsServer(conf *config.Config) bool {
+	return conf.Server.Observability.Metrics.Enabled || conf.Server.Observability.Metrics.HealthStatus.Enabled
 }
 
 // Stop the HTTP server


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/commit/115b0ad515a1395a9e7ace1c92bd4b5fc37a17b6 (PR #9428).

**Summary**
- Reimplements `kiali_health_status` with much lower cardinality (single gauge series per entity with non-NA status).
- Health status metric can be enabled independently of legacy perf metrics; disabled by default (opt-in).
- Stops exporting NA health; entities that go NA are dropped after configurable consecutive NA evaluations.

**v2.22-specific**
- Includes model helpers and `HealthTypeNamespace` that exist on master from #9303 / #9312 but were not on v2.22, required for this backport to compile.

Refs #9428