### PR TITLE
[tests] Wait for API to be ready

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -13,7 +13,7 @@ import {
   getColWithRowText,
   hasAtLeastOneClass
 } from './table';
-import { openTab } from './transition';
+import { openTab, waitForKialiApiReady } from './transition';
 import { enableKialiFeature, HEALTH_CACHE_CONFIG } from './kiali-config';
 
 // Type definition for health cache metrics API response
@@ -255,6 +255,7 @@ Then('user should see no duplicate namespaces', () => {
 // Health cache metrics test steps
 Given('health cache is enabled', () => {
   enableKialiFeature(HEALTH_CACHE_CONFIG);
+  waitForKialiApiReady();
 });
 
 Given('health cache metrics are recorded', () => {

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -1,5 +1,5 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { ensureKialiFinishedLoading } from './transition';
+import { ensureKialiFinishedLoading, waitForKialiApiReady } from './transition';
 import { assertGraphReady, select, selectAnd, selectOr } from './graph';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
 import { enableKialiFeature, GRAPH_CACHE_CONFIG } from './kiali-config';
@@ -473,6 +473,7 @@ type GraphCacheMetrics = {
 
 Given('graph cache is enabled', () => {
   enableKialiFeature(GRAPH_CACHE_CONFIG);
+  waitForKialiApiReady();
 });
 
 Given('graph cache metrics are recorded', () => {

--- a/frontend/cypress/integration/common/transition.ts
+++ b/frontend/cypress/integration/common/transition.ts
@@ -4,6 +4,35 @@ export const ensureKialiFinishedLoading = (): void => {
   cy.get('#loading_kiali_spinner').should('not.exist');
 };
 
+const KIALI_API_READY_TIMEOUT_MS = 120000;
+const KIALI_API_READY_POLL_MS = 5000;
+
+/**
+ * Waits for the Kiali API to be ready (e.g. after a restart from enableKialiFeature).
+ * Polls /api/status until it returns 200 or the timeout is reached.
+ */
+export const waitForKialiApiReady = (timeoutMs = KIALI_API_READY_TIMEOUT_MS): void => {
+  const start = Date.now();
+
+  cy.log(`Wait for Kiali API to be ready for ${timeoutMs}ms`);
+  function attempt(): void {
+    cy.request({ url: '/api/status', failOnStatusCode: false }).then(resp => {
+      if (resp.status === 200) {
+        return;
+      }
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(
+          `Timed out waiting for Kiali API to be ready (last status: ${resp.status}) after ${timeoutMs}ms`
+        );
+      }
+      cy.wait(KIALI_API_READY_POLL_MS);
+      attempt();
+    });
+  }
+
+  attempt();
+};
+
 export const openTab = (tab: string): void => {
   cy.get('#basic-tabs', { timeout: 60000 }).should('exist').contains(tab).click(); // Can be very slow for OpenShift, specially in the UI
 };


### PR DESCRIPTION
This backport https://github.com/kiali/kiali/pull/9405 introduced `waitForKialiApiReady` by [Wait for API to be ready](https://github.com/kiali/kiali/pull/9405/changes/4cbea802f741b7e75a2bd6ad592484b3de24261e)

Backported to master