### PR TITLE
[AI][Tools] Added support of retrieving ArgoCD application resources

### DIFF
--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -232,10 +232,10 @@ Returns a human-readable summary of Pod CPU/memory usage (from Prometheus) compa
 
 ### 10. `list_or_get_resources`
 
-Unified tool to list or get details for services, workloads, apps, and namespaces. If `resourceName` is omitted, returns a compact list. If provided, returns detailed information for that specific resource.
+Unified tool to list or get details for services, workloads, apps, namespaces, and ArgoCD applications. If `resourceName` is omitted, returns a compact list. If provided, returns detailed information for that specific resource.
 
 **Parameters**:
-- `resourceType` (string, required): `"service"`, `"workload"`, `"app"`, or `"namespace"`.
+- `resourceType` (string, required): `"service"`, `"workload"`, `"app"`, `"namespace"`, or `"application"` (ArgoCD).
 - `namespaces` (string, optional): Comma-separated namespaces. If empty, queries all accessible namespaces.
 - `resourceName` (string, optional): If provided, returns detail view. If empty, returns list view.
 - `clusterName` (string, optional): Cluster name. Defaults to the Kiali configuration cluster.
@@ -336,7 +336,7 @@ Tool definitions are described in YAML files under `ai/mcp/tools/`. Each file de
       resourceType:
         type: "string"
         description: "The type of resource to query."
-        enum: ["service", "workload", "app", "namespace"]
+        enum: ["service", "workload", "app", "namespace", "application"]
       namespaces:
         type: "string"
         description: "Comma-separated list of namespaces to query."

--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -235,7 +235,7 @@ Returns a human-readable summary of Pod CPU/memory usage (from Prometheus) compa
 Unified tool to list or get details for services, workloads, apps, namespaces, and ArgoCD applications. If `resourceName` is omitted, returns a compact list. If provided, returns detailed information for that specific resource.
 
 **Parameters**:
-- `resourceType` (string, required): `"service"`, `"workload"`, `"app"`, `"namespace"`, or `"application"` (ArgoCD).
+- `resourceType` (string, required): `"service"`, `"workload"`, `"app"`, `"namespace"`, or `"argoapp"` (ArgoCD).
 - `namespaces` (string, optional): Comma-separated namespaces. If empty, queries all accessible namespaces.
 - `resourceName` (string, optional): If provided, returns detail view. If empty, returns list view.
 - `clusterName` (string, optional): Cluster name. Defaults to the Kiali configuration cluster.
@@ -244,12 +244,16 @@ Unified tool to list or get details for services, workloads, apps, namespaces, a
 - **Services/Workloads**: `map[cluster][]ResourceListItem` with `name`, `namespace`, `health`, `configuration`, `details`, `labels`, `type` (workloads only).
 - **Apps**: `AppListResponse` with `cluster` at root, `applications` array with `name`, `namespace`, `health`, `istio` status, `versions`, `istioReferences`.
 - **Namespaces**: `NamespaceListResponse` with `cluster` at root, `namespaces` array with `name`, `injection`, `health`, `counts`, `validations` (omitted when zero).
+- **ArgoCD Apps**: `ArgoCDAppListResponse` with `cluster` at root, `applications` array with `name`, `namespace`, `health`, `syncStatus`, `repoURL`.
 
 **Returns (detail mode)**:
 - **Services**: `ServiceDetailResponse` with service info, istio config, workloads, endpoints, health status, inbound success rate.
 - **Workloads**: `WorkloadDetailResponse` with workload info, replica status, traffic success rates, istio mode/proxy version/sync status, pods, associated services.
 - **Apps**: `AppDetailResponse` with app name, services, istio context, workloads with versions.
 - **Namespaces**: `NamespaceDetailResponse` with istio context (injection, discovery, revision) and resource counts.
+- **ArgoCD Apps**: `ArgoCDAppDetailResponse` with source, destination, sync status, health, managed resources, revision history, operation state.
+
+> **RBAC Requirement**: The `argoapp` resource type queries ArgoCD `Application` CRDs (`applications.argoproj.io`) using a Kubernetes dynamic client. The **Kiali Service Account must have `get` and `list` permissions** on `applications.argoproj.io` in the relevant namespaces (or cluster-wide). Without these permissions, queries will return a permission-denied error. See [ArgoCD RBAC Setup](#argocd-rbac-setup) below.
 
 **Examples**:
 ```json
@@ -258,6 +262,8 @@ Unified tool to list or get details for services, workloads, apps, namespaces, a
 {"resourceType": "namespace"}
 {"resourceType": "namespace", "resourceName": "bookinfo"}
 {"resourceType": "app", "namespaces": "bookinfo", "resourceName": "productpage"}
+{"resourceType": "argoapp", "namespaces": "argocd"}
+{"resourceType": "argoapp", "namespaces": "argocd", "resourceName": "guestbook"}
 ```
 
 ---
@@ -314,6 +320,38 @@ Create, patch, or delete Istio configuration. Always use `confirmed: false` firs
 
 ---
 
+## ArgoCD RBAC Setup
+
+To use the `argoapp` resource type in `list_or_get_resources`, the Kiali Service Account needs read access to ArgoCD Application CRDs. Create a `ClusterRole` and `ClusterRoleBinding` (or namespace-scoped `Role`/`RoleBinding` if ArgoCD applications are limited to specific namespaces):
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali-argocd-reader
+rules:
+- apiGroups: ["argoproj.io"]
+  resources: ["applications"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiali-argocd-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali-argocd-reader
+subjects:
+- kind: ServiceAccount
+  name: kiali
+  namespace: kiali  # adjust to your Kiali namespace
+```
+
+Without these permissions, the AI assistant will return a message indicating that ArgoCD Application resources could not be queried.
+
+---
+
 ## Tool Definitions (YAML)
 
 Tool definitions are described in YAML files under `ai/mcp/tools/`. Each file defines a single tool (or a list with exactly one tool). The loader reads all `*.yaml`/`*.yml` files and registers them by name.
@@ -336,7 +374,7 @@ Tool definitions are described in YAML files under `ai/mcp/tools/`. Each file de
       resourceType:
         type: "string"
         description: "The type of resource to query."
-        enum: ["service", "workload", "app", "namespace", "application"]
+        enum: ["service", "workload", "app", "namespace", "argoapp"]
       namespaces:
         type: "string"
         description: "Comma-separated list of namespaces to query."

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -8,18 +8,151 @@ import (
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util"
 )
 
 const DefaultRateInterval = "10m"
+
+var argoCDApplicationGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Resource: "applications",
+	Version:  "v1alpha1",
+}
+
+func newDynamicClient(clientFactory kubernetes.ClientFactory, clusterName string) (dynamic.Interface, error) {
+	saClient := clientFactory.GetSAClient(clusterName)
+	if saClient == nil {
+		return nil, fmt.Errorf("no SA client available for cluster %q", clusterName)
+	}
+	restConfig := saClient.ClusterInfo().ClientConfig
+	if restConfig == nil {
+		return nil, fmt.Errorf("no REST config available for cluster %q", clusterName)
+	}
+	return dynamic.NewForConfig(restConfig)
+}
+
+func getArgoCDAppDetail(ctx context.Context, dynClient dynamic.Interface, name, namespace, cluster string) (interface{}, int) {
+	result, err := dynClient.Resource(argoCDApplicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Sprintf("ArgoCD Application %q not found in namespace %q.", name, namespace), http.StatusOK
+		}
+		return classifyError(err, "application", name, namespace), http.StatusOK
+	}
+	return TransformArgoCDAppDetail(result.Object, cluster), http.StatusOK
+}
+
+func listArgoCDApps(ctx context.Context, dynClient dynamic.Interface, namespaces []string, cluster string) (interface{}, int) {
+	var allItems []interface{}
+	for _, ns := range namespaces {
+		result, err := dynClient.Resource(argoCDApplicationGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if k8serrors.IsForbidden(err) || k8serrors.IsNotFound(err) {
+				continue
+			}
+			log.Warningf("Error listing ArgoCD Applications in namespace %q: %v", ns, err)
+			continue
+		}
+		for i := range result.Items {
+			allItems = append(allItems, result.Items[i].Object)
+		}
+	}
+	return TransformArgoCDAppListFromItems(allItems, cluster), http.StatusOK
+}
+
+func executeArgoCDApplication(kialiInterface *mcputil.KialiInterface, namespaces, resourceName, clusterName string) (interface{}, int) {
+	nsSlice := parseNamespaceCSV(namespaces)
+
+	if len(nsSlice) > 0 {
+		saClient := kialiInterface.ClientFactory.GetSAClient(clusterName)
+		if saClient != nil {
+			valid, invalid := validateNamespacesViaK8s(saClient, nsSlice)
+			if len(invalid) > 0 && len(valid) == 0 {
+				return fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot retrieve application resources.", strings.Join(invalid, ", ")), http.StatusOK
+			}
+			nsSlice = valid
+		}
+	}
+
+	dynClient, dynErr := newDynamicClient(kialiInterface.ClientFactory, clusterName)
+	if dynErr != nil {
+		return "ArgoCD Application resources could not be queried. " +
+			"Please ensure ArgoCD is installed and the Kiali service account has permission to read Application CRDs.", http.StatusOK
+	}
+
+	ctx := kialiInterface.Request.Context()
+
+	if resourceName != "" {
+		if len(nsSlice) != 1 {
+			return "Exactly one namespace is required when getting a specific application by name.", http.StatusOK
+		}
+		resp, _ := getArgoCDAppDetail(ctx, dynClient, resourceName, nsSlice[0], clusterName)
+		return resp, http.StatusOK
+	}
+
+	if len(nsSlice) == 0 {
+		resp, _ := listArgoCDAppsAllNamespaces(ctx, dynClient, clusterName)
+		return resp, http.StatusOK
+	}
+	resp, _ := listArgoCDApps(ctx, dynClient, nsSlice, clusterName)
+	return resp, http.StatusOK
+}
+
+func validateNamespacesViaK8s(k8sClient kubernetes.ClientInterface, namespaces []string) (valid, invalid []string) {
+	for _, ns := range namespaces {
+		_, err := k8sClient.GetNamespace(ns)
+		if err != nil {
+			invalid = append(invalid, ns)
+		} else {
+			valid = append(valid, ns)
+		}
+	}
+	return
+}
+
+func parseNamespaceCSV(namespaces string) []string {
+	if namespaces == "" {
+		return nil
+	}
+	var result []string
+	for _, ns := range strings.Split(namespaces, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			result = append(result, ns)
+		}
+	}
+	return result
+}
+
+func listArgoCDAppsAllNamespaces(ctx context.Context, dynClient dynamic.Interface, cluster string) (interface{}, int) {
+	result, err := dynClient.Resource(argoCDApplicationGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "No ArgoCD Application CRD found on this cluster. ArgoCD may not be installed.", http.StatusOK
+		}
+		if k8serrors.IsForbidden(err) {
+			return "Access denied: the Kiali service account does not have permission to list ArgoCD Applications.", http.StatusOK
+		}
+		log.Warningf("Error listing ArgoCD Applications across all namespaces: %v", err)
+		return "Could not list ArgoCD Applications. Check Kiali server logs for details.", http.StatusOK
+	}
+	var allItems []interface{}
+	for i := range result.Items {
+		allItems = append(allItems, result.Items[i].Object)
+	}
+	return TransformArgoCDAppListFromItems(allItems, cluster), http.StatusOK
+}
 
 // classifyError returns a clear, human-readable message for the chatbot
 // describing why a Kubernetes/Istio API call failed.
@@ -94,6 +227,17 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	if queryTime.IsZero() {
 		queryTime = util.Clock.Now()
 	}
+	if clusterName == "" {
+		clusterName = kialiInterface.Conf.KubernetesConfig.ClusterName
+	}
+
+	// ArgoCD Application CRs often live outside the mesh (e.g. the "argocd"
+	// namespace) so we bypass Kiali's mesh-scoped namespace access check and
+	// let Kubernetes RBAC on the dynamic client handle authorization.
+	if resourceType == "application" {
+		return executeArgoCDApplication(kialiInterface, namespaces, resourceName, clusterName)
+	}
+
 	var namespacesSlice []string
 	if namespaces != "" {
 		invalidNamespaces := []string{}
@@ -134,6 +278,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 			namespacesSlice[i] = ns.Name
 		}
 	}
+
 	resourceArgs := ResourceDetailArgs{
 		ResourceType: resourceType,
 		Namespaces:   namespacesSlice,

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +31,13 @@ var argoCDApplicationGVR = schema.GroupVersionResource{
 	Version:  "v1alpha1",
 }
 
-func newDynamicClient(clientFactory kubernetes.ClientFactory, clusterName string) (dynamic.Interface, error) {
+var dynamicClientCache sync.Map // map[clusterName]dynamic.Interface
+
+func getOrCreateDynamicClient(clientFactory kubernetes.ClientFactory, clusterName string) (dynamic.Interface, error) {
+	if cached, ok := dynamicClientCache.Load(clusterName); ok {
+		return cached.(dynamic.Interface), nil
+	}
+
 	saClient := clientFactory.GetSAClient(clusterName)
 	if saClient == nil {
 		return nil, fmt.Errorf("no SA client available for cluster %q", clusterName)
@@ -39,7 +46,13 @@ func newDynamicClient(clientFactory kubernetes.ClientFactory, clusterName string
 	if restConfig == nil {
 		return nil, fmt.Errorf("no REST config available for cluster %q", clusterName)
 	}
-	return dynamic.NewForConfig(restConfig)
+	client, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	actual, _ := dynamicClientCache.LoadOrStore(clusterName, client)
+	return actual.(dynamic.Interface), nil
 }
 
 func getArgoCDAppDetail(ctx context.Context, dynClient dynamic.Interface, name, namespace, cluster string) (interface{}, int) {
@@ -48,7 +61,7 @@ func getArgoCDAppDetail(ctx context.Context, dynClient dynamic.Interface, name, 
 		if k8serrors.IsNotFound(err) {
 			return fmt.Sprintf("ArgoCD Application %q not found in namespace %q.", name, namespace), http.StatusOK
 		}
-		return classifyError(err, "application", name, namespace), http.StatusOK
+		return classifyError(err, "argoapp", name, namespace), http.StatusOK
 	}
 	return TransformArgoCDAppDetail(result.Object, cluster), http.StatusOK
 }
@@ -85,7 +98,7 @@ func executeArgoCDApplication(kialiInterface *mcputil.KialiInterface, namespaces
 		}
 	}
 
-	dynClient, dynErr := newDynamicClient(kialiInterface.ClientFactory, clusterName)
+	dynClient, dynErr := getOrCreateDynamicClient(kialiInterface.ClientFactory, clusterName)
 	if dynErr != nil {
 		return "ArgoCD Application resources could not be queried. " +
 			"Please ensure ArgoCD is installed and the Kiali service account has permission to read Application CRDs.", http.StatusOK
@@ -221,12 +234,6 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	if resourceType == "namespace" && resourceName != "" {
 		namespaces = resourceName
 	}
-	if resourceName != "" && namespaces == "" {
-		return "Namespaces are required when resource name is provided", http.StatusBadRequest
-	}
-	if queryTime.IsZero() {
-		queryTime = util.Clock.Now()
-	}
 	if clusterName == "" {
 		clusterName = kialiInterface.Conf.KubernetesConfig.ClusterName
 	}
@@ -234,8 +241,15 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	// ArgoCD Application CRs often live outside the mesh (e.g. the "argocd"
 	// namespace) so we bypass Kiali's mesh-scoped namespace access check and
 	// let Kubernetes RBAC on the dynamic client handle authorization.
-	if resourceType == "application" {
+	if resourceType == "argoapp" {
 		return executeArgoCDApplication(kialiInterface, namespaces, resourceName, clusterName)
+	}
+
+	if resourceName != "" && namespaces == "" {
+		return "Namespaces are required when resource name is provided", http.StatusBadRequest
+	}
+	if queryTime.IsZero() {
+		queryTime = util.Clock.Now()
 	}
 
 	var namespacesSlice []string

--- a/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	core_v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -93,7 +95,7 @@ func TestExecute_InvalidResourceType(t *testing.T) {
 func TestExecute_ValidResourceTypes(t *testing.T) {
 	util.Clock = util.RealClock{}
 
-	validTypes := []string{"service", "workload", "app"}
+	validTypes := []string{"service", "workload", "app", "application"}
 
 	for _, rt := range validTypes {
 		t.Run("ResourceType_"+rt, func(t *testing.T) {
@@ -384,4 +386,160 @@ func TestRecoverFromPanic_NoPanic(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, status)
 	assert.Equal(t, "success", res)
+}
+
+// ---------------------------------------------------------------------------
+// 6. ArgoCD Application tests
+// ---------------------------------------------------------------------------
+
+func TestExecute_ApplicationList(t *testing.T) {
+	util.Clock = util.RealClock{}
+	ki := setupMocks(t)
+
+	args := map[string]interface{}{
+		"resource_type": "application",
+	}
+
+	resp, code := Execute(ki, args)
+
+	assert.Equal(t, http.StatusOK, code)
+	// The fake K8s client has no real REST config, so the dynamic client
+	// creation fails gracefully with a friendly error message.
+	respStr, ok := resp.(string)
+	assert.True(t, ok, "Expected string error response from fake client, got %T", resp)
+	assert.Contains(t, respStr, "ArgoCD Application resources could not be queried")
+}
+
+func TestExecute_ApplicationListWithNonExistentNamespace(t *testing.T) {
+	util.Clock = util.RealClock{}
+	ki := setupMocks(t)
+
+	args := map[string]interface{}{
+		"resource_type": "application",
+		"namespaces":    "argocd-wrong",
+	}
+
+	resp, code := Execute(ki, args)
+
+	assert.Equal(t, http.StatusOK, code)
+	respStr, ok := resp.(string)
+	assert.True(t, ok, "Expected string response, got %T", resp)
+	assert.Contains(t, respStr, "argocd-wrong")
+	assert.Contains(t, respStr, "not found or not accessible")
+}
+
+func TestExecute_ApplicationDetailWithoutNamespace(t *testing.T) {
+	util.Clock = util.RealClock{}
+	ki := setupMocks(t)
+
+	args := map[string]interface{}{
+		"resource_type": "application",
+		"resource_name": "guestbook",
+	}
+
+	resp, code := Execute(ki, args)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "Namespaces are required when resource name is provided", resp)
+}
+
+func TestExecute_ApplicationDetailInNonExistentNamespace(t *testing.T) {
+	util.Clock = util.RealClock{}
+	ki := setupMocks(t)
+
+	args := map[string]interface{}{
+		"resource_type": "application",
+		"resource_name": "nonexistent-app",
+		"namespaces":    "argocd-wrong",
+	}
+
+	resp, code := Execute(ki, args)
+
+	assert.Equal(t, http.StatusOK, code)
+	respStr, ok := resp.(string)
+	assert.True(t, ok, "Expected string response, got %T", resp)
+	assert.Contains(t, respStr, "argocd-wrong")
+	assert.Contains(t, respStr, "not found or not accessible")
+}
+
+func TestValidateNamespacesViaK8s(t *testing.T) {
+	fakeClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "argocd"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "default"}},
+	)
+
+	t.Run("all valid", func(t *testing.T) {
+		valid, invalid := validateNamespacesViaK8s(fakeClient, []string{"argocd", "default"})
+		assert.Equal(t, []string{"argocd", "default"}, valid)
+		assert.Empty(t, invalid)
+	})
+
+	t.Run("all invalid", func(t *testing.T) {
+		valid, invalid := validateNamespacesViaK8s(fakeClient, []string{"no-such-ns"})
+		assert.Empty(t, valid)
+		assert.Equal(t, []string{"no-such-ns"}, invalid)
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		valid, invalid := validateNamespacesViaK8s(fakeClient, []string{"argocd", "bogus"})
+		assert.Equal(t, []string{"argocd"}, valid)
+		assert.Equal(t, []string{"bogus"}, invalid)
+	})
+}
+
+func TestParseNamespaceCSV(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"", nil},
+		{"argocd", []string{"argocd"}},
+		{"ns1,ns2", []string{"ns1", "ns2"}},
+		{"  ns1 , ns2 ", []string{"ns1", "ns2"}},
+		{"ns1,,ns2,", []string{"ns1", "ns2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseNamespaceCSV(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExecute_ApplicationAlwaysReturns200(t *testing.T) {
+	util.Clock = util.RealClock{}
+
+	scenarios := []struct {
+		name         string
+		args         map[string]interface{}
+		wantContains string
+	}{
+		{
+			name:         "list all namespaces",
+			args:         map[string]interface{}{"resource_type": "application"},
+			wantContains: "could not be queried",
+		},
+		{
+			name:         "list non-existent namespace",
+			args:         map[string]interface{}{"resource_type": "application", "namespaces": "argocd"},
+			wantContains: "not found or not accessible",
+		},
+		{
+			name:         "get from non-existent namespace",
+			args:         map[string]interface{}{"resource_type": "application", "resource_name": "myapp", "namespaces": "does-not-exist"},
+			wantContains: "not found or not accessible",
+		},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			ki := setupMocks(t)
+			resp, code := Execute(ki, sc.args)
+			assert.Equal(t, http.StatusOK, code, "Application queries must never return non-200 status")
+			if sc.wantContains != "" {
+				respStr, ok := resp.(string)
+				assert.True(t, ok, "Expected string response, got %T", resp)
+				assert.Contains(t, respStr, sc.wantContains)
+			}
+		})
+	}
 }

--- a/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
@@ -95,7 +95,7 @@ func TestExecute_InvalidResourceType(t *testing.T) {
 func TestExecute_ValidResourceTypes(t *testing.T) {
 	util.Clock = util.RealClock{}
 
-	validTypes := []string{"service", "workload", "app", "application"}
+	validTypes := []string{"service", "workload", "app", "argoapp"}
 
 	for _, rt := range validTypes {
 		t.Run("ResourceType_"+rt, func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestExecute_ApplicationList(t *testing.T) {
 	ki := setupMocks(t)
 
 	args := map[string]interface{}{
-		"resource_type": "application",
+		"resource_type": "argoapp",
 	}
 
 	resp, code := Execute(ki, args)
@@ -415,7 +415,7 @@ func TestExecute_ApplicationListWithNonExistentNamespace(t *testing.T) {
 	ki := setupMocks(t)
 
 	args := map[string]interface{}{
-		"resource_type": "application",
+		"resource_type": "argoapp",
 		"namespaces":    "argocd-wrong",
 	}
 
@@ -433,14 +433,18 @@ func TestExecute_ApplicationDetailWithoutNamespace(t *testing.T) {
 	ki := setupMocks(t)
 
 	args := map[string]interface{}{
-		"resource_type": "application",
+		"resource_type": "argoapp",
 		"resource_name": "guestbook",
 	}
 
 	resp, code := Execute(ki, args)
 
+	// argoapp routes early (before the generic namespace check) so with a fake
+	// client the dynamic client creation fails gracefully.
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "Namespaces are required when resource name is provided", resp)
+	respStr, ok := resp.(string)
+	assert.True(t, ok, "Expected string response, got %T", resp)
+	assert.Contains(t, respStr, "ArgoCD Application resources could not be queried")
 }
 
 func TestExecute_ApplicationDetailInNonExistentNamespace(t *testing.T) {
@@ -448,7 +452,7 @@ func TestExecute_ApplicationDetailInNonExistentNamespace(t *testing.T) {
 	ki := setupMocks(t)
 
 	args := map[string]interface{}{
-		"resource_type": "application",
+		"resource_type": "argoapp",
 		"resource_name": "nonexistent-app",
 		"namespaces":    "argocd-wrong",
 	}
@@ -516,17 +520,17 @@ func TestExecute_ApplicationAlwaysReturns200(t *testing.T) {
 	}{
 		{
 			name:         "list all namespaces",
-			args:         map[string]interface{}{"resource_type": "application"},
+			args:         map[string]interface{}{"resource_type": "argoapp"},
 			wantContains: "could not be queried",
 		},
 		{
 			name:         "list non-existent namespace",
-			args:         map[string]interface{}{"resource_type": "application", "namespaces": "argocd"},
+			args:         map[string]interface{}{"resource_type": "argoapp", "namespaces": "argocd"},
 			wantContains: "not found or not accessible",
 		},
 		{
 			name:         "get from non-existent namespace",
-			args:         map[string]interface{}{"resource_type": "application", "resource_name": "myapp", "namespaces": "does-not-exist"},
+			args:         map[string]interface{}{"resource_type": "argoapp", "resource_name": "myapp", "namespaces": "does-not-exist"},
 			wantContains: "not found or not accessible",
 		},
 	}

--- a/ai/mcp/list_or_get_resources/output_types.go
+++ b/ai/mcp/list_or_get_resources/output_types.go
@@ -188,3 +188,74 @@ type AppDetailResponse struct {
 	Services     []string          `json:"services"`
 	Workloads    []AppWorkloadInfo `json:"workloads"`
 }
+
+// --- ArgoCD Application types ---
+
+type ArgoCDAppSource struct {
+	Path           string `json:"path,omitempty"`
+	RepoURL        string `json:"repoURL"`
+	TargetRevision string `json:"targetRevision,omitempty"`
+}
+
+type ArgoCDAppDestination struct {
+	Namespace string `json:"namespace"`
+	Server    string `json:"server"`
+}
+
+type ArgoCDAppSyncStatus struct {
+	Revision string `json:"revision"`
+	Status   string `json:"status"`
+}
+
+type ArgoCDAppHealthStatus struct {
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status"`
+}
+
+type ArgoCDRevisionHistoryEntry struct {
+	DeployedAt string          `json:"deployedAt,omitempty"`
+	ID         int64           `json:"id"`
+	Revision   string          `json:"revision"`
+	Source     ArgoCDAppSource `json:"source"`
+}
+
+type ArgoCDManagedResource struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+type ArgoCDOperationState struct {
+	FinishedAt string `json:"finishedAt,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Phase      string `json:"phase"`
+}
+
+type ArgoCDAppDetailResponse struct {
+	Cluster         string                       `json:"cluster"`
+	Destination     ArgoCDAppDestination         `json:"destination"`
+	Health          ArgoCDAppHealthStatus        `json:"health"`
+	Name            string                       `json:"name"`
+	Namespace       string                       `json:"namespace"`
+	OperationState  *ArgoCDOperationState        `json:"operationState,omitempty"`
+	Project         string                       `json:"project"`
+	Resources       []ArgoCDManagedResource      `json:"resources"`
+	RevisionHistory []ArgoCDRevisionHistoryEntry `json:"revisionHistory"`
+	Source          ArgoCDAppSource              `json:"source"`
+	SourceType      string                       `json:"sourceType,omitempty"`
+	Sync            ArgoCDAppSyncStatus          `json:"sync"`
+}
+
+type ArgoCDAppListItem struct {
+	Health     string `json:"health"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	RepoURL    string `json:"repoURL,omitempty"`
+	SyncStatus string `json:"syncStatus"`
+}
+
+type ArgoCDAppListResponse struct {
+	Applications []ArgoCDAppListItem `json:"applications"`
+	Cluster      string              `json:"cluster"`
+}

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -551,6 +551,204 @@ func serviceWorkloadInfoFromListItem(wl *models.WorkloadListItem) ServiceWorkloa
 	}
 }
 
+// --- ArgoCD Application transforms ---
+func nestedString(obj map[string]interface{}, fields ...string) string {
+	current := obj
+	for i, field := range fields {
+		if i == len(fields)-1 {
+			if val, ok := current[field]; ok {
+				if s, ok := val.(string); ok {
+					return s
+				}
+			}
+			return ""
+		}
+		if next, ok := current[field]; ok {
+			if m, ok := next.(map[string]interface{}); ok {
+				current = m
+			} else {
+				return ""
+			}
+		} else {
+			return ""
+		}
+	}
+	return ""
+}
+
+func nestedMap(obj map[string]interface{}, field string) map[string]interface{} {
+	if val, ok := obj[field]; ok {
+		if m, ok := val.(map[string]interface{}); ok {
+			return m
+		}
+	}
+	return nil
+}
+
+func nestedSlice(obj map[string]interface{}, field string) []interface{} {
+	if val, ok := obj[field]; ok {
+		if s, ok := val.([]interface{}); ok {
+			return s
+		}
+	}
+	return nil
+}
+
+func nestedInt64(obj map[string]interface{}, fields ...string) int64 {
+	current := obj
+	for i, field := range fields {
+		if i == len(fields)-1 {
+			if val, ok := current[field]; ok {
+				switch v := val.(type) {
+				case int64:
+					return v
+				case float64:
+					return int64(v)
+				}
+			}
+			return 0
+		}
+		if next, ok := current[field]; ok {
+			if m, ok := next.(map[string]interface{}); ok {
+				current = m
+			} else {
+				return 0
+			}
+		} else {
+			return 0
+		}
+	}
+	return 0
+}
+
+func transformArgoCDSource(srcMap map[string]interface{}) ArgoCDAppSource {
+	if srcMap == nil {
+		return ArgoCDAppSource{}
+	}
+	return ArgoCDAppSource{
+		Path:           nestedString(srcMap, "path"),
+		RepoURL:        nestedString(srcMap, "repoURL"),
+		TargetRevision: nestedString(srcMap, "targetRevision"),
+	}
+}
+
+func TransformArgoCDAppDetail(obj map[string]interface{}, cluster string) ArgoCDAppDetailResponse {
+	metadata := nestedMap(obj, "metadata")
+	spec := nestedMap(obj, "spec")
+	status := nestedMap(obj, "status")
+
+	name := nestedString(metadata, "name")
+	namespace := nestedString(metadata, "namespace")
+
+	source := transformArgoCDSource(nestedMap(spec, "source"))
+	project := nestedString(spec, "project")
+
+	dest := nestedMap(spec, "destination")
+	destination := ArgoCDAppDestination{
+		Namespace: nestedString(dest, "namespace"),
+		Server:    nestedString(dest, "server"),
+	}
+
+	syncStatus := ArgoCDAppSyncStatus{
+		Revision: nestedString(status, "sync", "revision"),
+		Status:   nestedString(status, "sync", "status"),
+	}
+
+	healthMap := nestedMap(status, "health")
+	health := ArgoCDAppHealthStatus{
+		Message: nestedString(healthMap, "message"),
+		Status:  nestedString(healthMap, "status"),
+	}
+
+	sourceType := nestedString(status, "sourceType")
+
+	var revisionHistory []ArgoCDRevisionHistoryEntry
+	for _, item := range nestedSlice(status, "history") {
+		if entry, ok := item.(map[string]interface{}); ok {
+			revisionHistory = append(revisionHistory, ArgoCDRevisionHistoryEntry{
+				DeployedAt: nestedString(entry, "deployedAt"),
+				ID:         nestedInt64(entry, "id"),
+				Revision:   nestedString(entry, "revision"),
+				Source:     transformArgoCDSource(nestedMap(entry, "source")),
+			})
+		}
+	}
+	if revisionHistory == nil {
+		revisionHistory = []ArgoCDRevisionHistoryEntry{}
+	}
+
+	var resources []ArgoCDManagedResource
+	for _, item := range nestedSlice(status, "resources") {
+		if res, ok := item.(map[string]interface{}); ok {
+			resources = append(resources, ArgoCDManagedResource{
+				Kind:      nestedString(res, "kind"),
+				Name:      nestedString(res, "name"),
+				Namespace: nestedString(res, "namespace"),
+				Status:    nestedString(res, "status"),
+			})
+		}
+	}
+	if resources == nil {
+		resources = []ArgoCDManagedResource{}
+	}
+
+	var operationState *ArgoCDOperationState
+	if opState := nestedMap(status, "operationState"); opState != nil {
+		operationState = &ArgoCDOperationState{
+			FinishedAt: nestedString(opState, "finishedAt"),
+			Message:    nestedString(opState, "message"),
+			Phase:      nestedString(opState, "phase"),
+		}
+	}
+
+	return ArgoCDAppDetailResponse{
+		Cluster:         cluster,
+		Destination:     destination,
+		Health:          health,
+		Name:            name,
+		Namespace:       namespace,
+		OperationState:  operationState,
+		Project:         project,
+		Resources:       resources,
+		RevisionHistory: revisionHistory,
+		Source:          source,
+		SourceType:      sourceType,
+		Sync:            syncStatus,
+	}
+}
+
+func TransformArgoCDAppListFromItems(items []interface{}, cluster string) ArgoCDAppListResponse {
+	var apps []ArgoCDAppListItem
+	for _, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		metadata := nestedMap(obj, "metadata")
+		spec := nestedMap(obj, "spec")
+		status := nestedMap(obj, "status")
+
+		healthStatus := nestedString(status, "health", "status")
+		syncStatus := nestedString(status, "sync", "status")
+		repoURL := nestedString(spec, "source", "repoURL")
+
+		apps = append(apps, ArgoCDAppListItem{
+			Health:     healthStatus,
+			Name:       nestedString(metadata, "name"),
+			Namespace:  nestedString(metadata, "namespace"),
+			RepoURL:    repoURL,
+			SyncStatus: syncStatus,
+		})
+	}
+	if apps == nil {
+		apps = []ArgoCDAppListItem{}
+	}
+	return ArgoCDAppListResponse{
+		Applications: apps,
+		Cluster:      cluster,
+	}
+}
+
 func labelsToString(labels map[string]string) string {
 	if len(labels) == 0 {
 		return "None"

--- a/ai/mcp/list_or_get_resources/transforms_test.go
+++ b/ai/mcp/list_or_get_resources/transforms_test.go
@@ -525,3 +525,271 @@ func TestTransformWorkloadDetail_NoIstio(t *testing.T) {
 	assert.Equal(t, "", result.Istio.ProxyVersion)
 	assert.Nil(t, result.Istio.SyncStatus)
 }
+
+// ---------------------------------------------------------------------------
+// ArgoCD Application transform tests
+// ---------------------------------------------------------------------------
+
+func TestNestedString(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "guestbook",
+			"namespace": "argocd",
+		},
+		"status": map[string]interface{}{
+			"sync": map[string]interface{}{
+				"status":   "Synced",
+				"revision": "abc123",
+			},
+		},
+	}
+
+	assert.Equal(t, "guestbook", nestedString(obj, "metadata", "name"))
+	assert.Equal(t, "argocd", nestedString(obj, "metadata", "namespace"))
+	assert.Equal(t, "Synced", nestedString(obj, "status", "sync", "status"))
+	assert.Equal(t, "abc123", nestedString(obj, "status", "sync", "revision"))
+	assert.Equal(t, "", nestedString(obj, "nonexistent"))
+	assert.Equal(t, "", nestedString(obj, "metadata", "nonexistent"))
+	assert.Equal(t, "", nestedString(obj, "status", "sync", "nonexistent"))
+	assert.Equal(t, "", nestedString(nil))
+}
+
+func TestNestedMap(t *testing.T) {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"source": map[string]interface{}{
+				"repoURL": "https://github.com/example/repo",
+			},
+		},
+	}
+
+	result := nestedMap(obj, "spec")
+	assert.NotNil(t, result)
+	assert.Contains(t, result, "source")
+
+	assert.Nil(t, nestedMap(obj, "nonexistent"))
+	assert.Nil(t, nestedMap(nil, "spec"))
+}
+
+func TestNestedSlice(t *testing.T) {
+	obj := map[string]interface{}{
+		"items": []interface{}{"a", "b", "c"},
+	}
+
+	result := nestedSlice(obj, "items")
+	assert.Len(t, result, 3)
+	assert.Nil(t, nestedSlice(obj, "nonexistent"))
+	assert.Nil(t, nestedSlice(nil, "items"))
+}
+
+func TestNestedInt64(t *testing.T) {
+	obj := map[string]interface{}{
+		"status": map[string]interface{}{
+			"history": map[string]interface{}{
+				"id_int":   int64(42),
+				"id_float": float64(7),
+			},
+		},
+	}
+
+	assert.Equal(t, int64(42), nestedInt64(obj, "status", "history", "id_int"))
+	assert.Equal(t, int64(7), nestedInt64(obj, "status", "history", "id_float"))
+	assert.Equal(t, int64(0), nestedInt64(obj, "nonexistent"))
+	assert.Equal(t, int64(0), nestedInt64(obj, "status", "history", "nonexistent"))
+}
+
+func TestTransformArgoCDAppDetail_FullStatus(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "guestbook",
+			"namespace": "argocd",
+		},
+		"spec": map[string]interface{}{
+			"project": "default",
+			"source": map[string]interface{}{
+				"path":           "guestbook",
+				"repoURL":        "https://github.com/argoproj/argocd-example-apps.git",
+				"targetRevision": "HEAD",
+			},
+			"destination": map[string]interface{}{
+				"namespace": "default",
+				"server":    "https://kubernetes.default.svc",
+			},
+		},
+		"status": map[string]interface{}{
+			"sync": map[string]interface{}{
+				"revision": "abc123def",
+				"status":   "Synced",
+			},
+			"health": map[string]interface{}{
+				"status": "Healthy",
+			},
+			"sourceType": "Directory",
+			"history": []interface{}{
+				map[string]interface{}{
+					"deployedAt": "2026-03-01T10:00:00Z",
+					"id":         float64(0),
+					"revision":   "abc123def",
+					"source": map[string]interface{}{
+						"path":           "guestbook",
+						"repoURL":        "https://github.com/argoproj/argocd-example-apps.git",
+						"targetRevision": "HEAD",
+					},
+				},
+			},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"kind":      "Service",
+					"name":      "guestbook-ui",
+					"namespace": "default",
+					"status":    "Synced",
+				},
+				map[string]interface{}{
+					"kind":      "Deployment",
+					"name":      "guestbook-ui",
+					"namespace": "default",
+					"status":    "Synced",
+				},
+			},
+			"operationState": map[string]interface{}{
+				"finishedAt": "2026-03-01T10:00:05Z",
+				"message":    "successfully synced (all tasks run)",
+				"phase":      "Succeeded",
+			},
+		},
+	}
+
+	result := TransformArgoCDAppDetail(obj, "test-cluster")
+
+	assert.Equal(t, "guestbook", result.Name)
+	assert.Equal(t, "argocd", result.Namespace)
+	assert.Equal(t, "test-cluster", result.Cluster)
+	assert.Equal(t, "default", result.Project)
+
+	assert.Equal(t, "https://github.com/argoproj/argocd-example-apps.git", result.Source.RepoURL)
+	assert.Equal(t, "guestbook", result.Source.Path)
+	assert.Equal(t, "HEAD", result.Source.TargetRevision)
+
+	assert.Equal(t, "default", result.Destination.Namespace)
+	assert.Equal(t, "https://kubernetes.default.svc", result.Destination.Server)
+
+	assert.Equal(t, "Synced", result.Sync.Status)
+	assert.Equal(t, "abc123def", result.Sync.Revision)
+
+	assert.Equal(t, "Healthy", result.Health.Status)
+	assert.Equal(t, "", result.Health.Message)
+
+	assert.Equal(t, "Directory", result.SourceType)
+
+	assert.Len(t, result.RevisionHistory, 1)
+	assert.Equal(t, int64(0), result.RevisionHistory[0].ID)
+	assert.Equal(t, "abc123def", result.RevisionHistory[0].Revision)
+	assert.Equal(t, "2026-03-01T10:00:00Z", result.RevisionHistory[0].DeployedAt)
+
+	assert.Len(t, result.Resources, 2)
+	assert.Equal(t, "Service", result.Resources[0].Kind)
+	assert.Equal(t, "guestbook-ui", result.Resources[0].Name)
+	assert.Equal(t, "Deployment", result.Resources[1].Kind)
+
+	assert.NotNil(t, result.OperationState)
+	assert.Equal(t, "Succeeded", result.OperationState.Phase)
+	assert.Equal(t, "successfully synced (all tasks run)", result.OperationState.Message)
+}
+
+func TestTransformArgoCDAppDetail_MinimalStatus(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "myapp",
+			"namespace": "argocd",
+		},
+		"spec": map[string]interface{}{
+			"project": "default",
+			"source": map[string]interface{}{
+				"repoURL": "https://github.com/example/repo.git",
+			},
+			"destination": map[string]interface{}{
+				"server": "https://kubernetes.default.svc",
+			},
+		},
+		"status": map[string]interface{}{},
+	}
+
+	result := TransformArgoCDAppDetail(obj, "cluster1")
+
+	assert.Equal(t, "myapp", result.Name)
+	assert.Equal(t, "", result.Sync.Status)
+	assert.Equal(t, "", result.Health.Status)
+	assert.Empty(t, result.RevisionHistory)
+	assert.Empty(t, result.Resources)
+	assert.Nil(t, result.OperationState)
+}
+
+func TestTransformArgoCDAppDetail_NilFields(t *testing.T) {
+	obj := map[string]interface{}{}
+
+	result := TransformArgoCDAppDetail(obj, "cluster1")
+
+	assert.Equal(t, "", result.Name)
+	assert.Equal(t, "cluster1", result.Cluster)
+	assert.Empty(t, result.RevisionHistory)
+	assert.Empty(t, result.Resources)
+}
+
+func TestTransformArgoCDAppListFromItems(t *testing.T) {
+	items := []interface{}{
+		map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "guestbook",
+				"namespace": "argocd",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"repoURL": "https://github.com/argoproj/argocd-example-apps.git",
+				},
+			},
+			"status": map[string]interface{}{
+				"sync":   map[string]interface{}{"status": "Synced"},
+				"health": map[string]interface{}{"status": "Healthy"},
+			},
+		},
+		map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "helm-guestbook",
+				"namespace": "argocd",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"repoURL": "https://github.com/argoproj/argocd-example-apps.git",
+				},
+			},
+			"status": map[string]interface{}{
+				"sync":   map[string]interface{}{"status": "OutOfSync"},
+				"health": map[string]interface{}{"status": "Degraded"},
+			},
+		},
+	}
+
+	result := TransformArgoCDAppListFromItems(items, "test-cluster")
+
+	assert.Equal(t, "test-cluster", result.Cluster)
+	assert.Len(t, result.Applications, 2)
+
+	assert.Equal(t, "guestbook", result.Applications[0].Name)
+	assert.Equal(t, "argocd", result.Applications[0].Namespace)
+	assert.Equal(t, "Synced", result.Applications[0].SyncStatus)
+	assert.Equal(t, "Healthy", result.Applications[0].Health)
+	assert.Equal(t, "https://github.com/argoproj/argocd-example-apps.git", result.Applications[0].RepoURL)
+
+	assert.Equal(t, "helm-guestbook", result.Applications[1].Name)
+	assert.Equal(t, "OutOfSync", result.Applications[1].SyncStatus)
+	assert.Equal(t, "Degraded", result.Applications[1].Health)
+}
+
+func TestTransformArgoCDAppListFromItems_Empty(t *testing.T) {
+	result := TransformArgoCDAppListFromItems(nil, "test-cluster")
+	assert.Equal(t, "test-cluster", result.Cluster)
+	assert.Empty(t, result.Applications)
+
+	result = TransformArgoCDAppListFromItems([]interface{}{}, "test-cluster")
+	assert.Empty(t, result.Applications)
+}

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -8,7 +8,7 @@
       resourceType:
         type: "string"
         description: "The type of resource to query."
-        enum: ["service", "workload", "app", "namespace"]
+        enum: ["service", "workload", "app", "namespace", "application"]
       namespaces:
         type: "string"
         description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces."

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -7,8 +7,8 @@
     properties:
       resourceType:
         type: "string"
-        description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them."
-        enum: ["service", "workload", "app", "namespace", "application"]
+        description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them."
+        enum: ["service", "workload", "app", "namespace", "argoapp"]
       namespaces:
         type: "string"
         description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces."

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -7,7 +7,7 @@
     properties:
       resourceType:
         type: "string"
-        description: "The type of resource to query."
+        description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them."
         enum: ["service", "workload", "app", "namespace", "application"]
       namespaces:
         type: "string"

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -311,7 +311,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 			"resourceType": {
 				Type:        genai.TypeString,
 				Description: "The type of resource to query.",
-				Enum:        []string{"service", "workload", "app", "namespace"},
+				Enum:        []string{"service", "workload", "app", "namespace", "application"},
 			},
 			"namespaces": {
 				Type:        genai.TypeString,

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -310,7 +310,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 		Properties: map[string]*genai.Schema{
 			"resourceType": {
 				Type:        genai.TypeString,
-				Description: "The type of resource to query.",
+				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
 				Enum:        []string{"service", "workload", "app", "namespace", "application"},
 			},
 			"namespaces": {

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -310,8 +310,8 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 		Properties: map[string]*genai.Schema{
 			"resourceType": {
 				Type:        genai.TypeString,
-				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
-				Enum:        []string{"service", "workload", "app", "namespace", "application"},
+				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
+				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
 			},
 			"namespaces": {
 				Type:        genai.TypeString,

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -435,6 +435,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 								"workload",
 								"app",
 								"namespace",
+								"application",
 							},
 						},
 						"namespaces": map[string]interface{}{

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -429,13 +429,13 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 					"properties": map[string]interface{}{
 						"resourceType": map[string]interface{}{
 							"type":        "string",
-							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
+							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
 							"enum": []interface{}{
 								"service",
 								"workload",
 								"app",
 								"namespace",
-								"application",
+								"argoapp",
 							},
 						},
 						"namespaces": map[string]interface{}{

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -429,7 +429,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 					"properties": map[string]interface{}{
 						"resourceType": map[string]interface{}{
 							"type":        "string",
-							"description": "The type of resource to query.",
+							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'application' for ArgoCD Application CRDs (requires ArgoCD installed). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
 							"enum": []interface{}{
 								"service",
 								"workload",


### PR DESCRIPTION
### Describe the change

Modified `list_or_get_resources` tool to support a new resourceType "applications", which will regrieve applications generated by a ArgoCD.

### Steps to test the PR

Install ArgoCD on local machine.
In Kiali chatbot make requests like

"list application resources in namespace argocd"

"get application guestbook in namespace argocd"

It will return info about ArgoCD applications.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/9137
