### PR TITLE
Replaced calling costly GetRootNamespace per namespace in validations by computing in advance.

### DIFF
--- a/business/checkers/peer_authentication_checker.go
+++ b/business/checkers/peer_authentication_checker.go
@@ -1,14 +1,11 @@
 package checkers
 
 import (
-	"context"
-
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/business/checkers/peerauthentications"
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -16,17 +13,18 @@ import (
 type PeerAuthenticationChecker struct {
 	Cluster               string
 	Conf                  *config.Config
-	Discovery             istio.MeshDiscovery
 	MTLSDetails           kubernetes.MTLSDetails
 	PeerAuthentications   []*security_v1.PeerAuthentication
+	RootNamespaces        map[string]string
 	WorkloadsPerNamespace map[string]models.Workloads
 }
 
-// NewPeerAuthenticationChecker creates a new PeerAuthenticationChecker with all attributes
+// NewPeerAuthenticationChecker creates a new PeerAuthenticationChecker with all attributes.
+// rootNamespaces maps each namespace to its control plane's root namespace.
 func NewPeerAuthenticationChecker(
 	cluster string,
 	conf *config.Config,
-	discovery istio.MeshDiscovery,
+	rootNamespaces map[string]string,
 	mtlsDetails kubernetes.MTLSDetails,
 	peerAuthentications []*security_v1.PeerAuthentication,
 	workloadsPerNamespace map[string]models.Workloads,
@@ -34,9 +32,9 @@ func NewPeerAuthenticationChecker(
 	return PeerAuthenticationChecker{
 		Cluster:               cluster,
 		Conf:                  conf,
-		Discovery:             discovery,
 		MTLSDetails:           mtlsDetails,
 		PeerAuthentications:   peerAuthentications,
+		RootNamespaces:        rootNamespaces,
 		WorkloadsPerNamespace: workloadsPerNamespace,
 	}
 }
@@ -65,8 +63,7 @@ func (m PeerAuthenticationChecker) runChecks(peerAuthn *security_v1.PeerAuthenti
 		matchLabels = peerAuthn.Spec.Selector.MatchLabels
 	}
 	enabledCheckers = append(enabledCheckers, common.SelectorNoWorkloadFoundChecker(kubernetes.PeerAuthentications, matchLabels, m.WorkloadsPerNamespace))
-	rootNamespace := m.Discovery.GetRootNamespace(context.TODO(), m.Cluster, peerAuthn.Namespace)
-	isRootNamespace := rootNamespace == peerAuthn.Namespace
+	isRootNamespace := m.RootNamespaces[peerAuthn.Namespace] == peerAuthn.Namespace
 
 	if isRootNamespace {
 		enabledCheckers = append(enabledCheckers, peerauthentications.DisabledMeshWideChecker{PeerAuthn: peerAuthn, DestinationRules: m.MTLSDetails.DestinationRules})

--- a/business/checkers/peer_authentication_checker_test.go
+++ b/business/checkers/peer_authentication_checker_test.go
@@ -1,0 +1,104 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	api_security_v1 "istio.io/api/security/v1"
+	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestPeerAuthInRootNamespaceUsesMeshWideCheckers(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	pa := data.CreateEmptyPeerAuthentication("default", "istio-system",
+		data.CreateMTLS("STRICT"))
+
+	rootNamespaces := map[string]string{
+		"istio-system": "istio-system",
+		"bookinfo":     "istio-system",
+	}
+
+	checker := NewPeerAuthenticationChecker(
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		kubernetes.MTLSDetails{PeerAuthentications: []*security_v1.PeerAuthentication{pa}},
+		[]*security_v1.PeerAuthentication{pa},
+		map[string]models.Workloads{},
+	)
+
+	validations := checker.Check()
+	assert.NotNil(validations)
+}
+
+func TestPeerAuthMultiCPCorrectRootResolution(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// PA in istio-system-1 (root of CP1)
+	paCP1 := data.CreateEmptyPeerAuthentication("default", "istio-system-1",
+		data.CreateMTLS("STRICT"))
+	// PA in istio-system-2 (root of CP2)
+	paCP2 := data.CreateEmptyPeerAuthentication("default", "istio-system-2",
+		data.CreateMTLS("STRICT"))
+	// PA in app namespace (not a root namespace)
+	paApp := data.CreateEmptyPeerAuthentication("app-pa", "app-ns",
+		data.CreateMTLS("STRICT"))
+
+	rootNamespaces := map[string]string{
+		"istio-system-1": "istio-system-1",
+		"istio-system-2": "istio-system-2",
+		"app-ns":         "istio-system-1",
+	}
+
+	allPAs := []*security_v1.PeerAuthentication{paCP1, paCP2, paApp}
+
+	checker := NewPeerAuthenticationChecker(
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		kubernetes.MTLSDetails{PeerAuthentications: allPAs},
+		allPAs,
+		map[string]models.Workloads{},
+	)
+
+	validations := checker.Check()
+	assert.NotNil(validations)
+
+	// All three PAs should produce validation entries
+	assert.Len(validations, 3)
+}
+
+func TestPeerAuthUnknownNamespaceNotTreatedAsRoot(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// PA from a namespace not in the rootNamespaces map
+	pa := data.CreateEmptyPeerAuthentication("pa", "unknown-ns",
+		&api_security_v1.PeerAuthentication_MutualTLS{Mode: api_security_v1.PeerAuthentication_MutualTLS_DISABLE})
+
+	checker := NewPeerAuthenticationChecker(
+		config.DefaultClusterID,
+		conf,
+		map[string]string{"istio-system": "istio-system"},
+		kubernetes.MTLSDetails{PeerAuthentications: []*security_v1.PeerAuthentication{pa}},
+		[]*security_v1.PeerAuthentication{pa},
+		map[string]models.Workloads{},
+	)
+
+	validations := checker.Check()
+	assert.NotNil(validations)
+
+	// Should still produce a validation (namespace-wide path, not mesh-wide)
+	assert.Len(validations, 1)
+}

--- a/business/checkers/sidecars/global_checker.go
+++ b/business/checkers/sidecars/global_checker.go
@@ -1,34 +1,28 @@
 package sidecars
 
 import (
-	"context"
-
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/models"
 )
 
 type GlobalChecker struct {
-	Cluster   string
-	Discovery istio.MeshDiscovery
-	Sidecar   *networking_v1.Sidecar
+	RootNamespace string
+	Sidecar       *networking_v1.Sidecar
 }
 
 // NewGlobalChecker creates a new GlobalChecker with all required fields
-func NewGlobalChecker(cluster string, discovery istio.MeshDiscovery, sidecar *networking_v1.Sidecar) GlobalChecker {
+func NewGlobalChecker(rootNamespace string, sidecar *networking_v1.Sidecar) GlobalChecker {
 	return GlobalChecker{
-		Cluster:   cluster,
-		Discovery: discovery,
-		Sidecar:   sidecar,
+		RootNamespace: rootNamespace,
+		Sidecar:       sidecar,
 	}
 }
 
 func (gc GlobalChecker) Check() ([]*models.IstioCheck, bool) {
 	checks, valid := make([]*models.IstioCheck, 0), true
 
-	rootNamespace := gc.Discovery.GetRootNamespace(context.TODO(), gc.Cluster, gc.Sidecar.Namespace)
-	if rootNamespace != gc.Sidecar.Namespace {
+	if gc.RootNamespace != gc.Sidecar.Namespace {
 		return checks, valid
 	}
 

--- a/business/checkers/sidecars/global_checker_test.go
+++ b/business/checkers/sidecars/global_checker_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
@@ -17,8 +16,7 @@ func TestSidecarWithoutSelectorOutOfControlPlane(t *testing.T) {
 	config.Set(config.NewConfig())
 
 	vals, valid := NewGlobalChecker(
-		config.DefaultClusterID,
-		&istiotest.FakeDiscovery{},
+		config.IstioNamespaceDefault,
 		data.CreateSidecar("sidecar1", "bookinfo"),
 	).Check()
 
@@ -32,8 +30,7 @@ func TestSidecarWithoutSelectorInControlPlane(t *testing.T) {
 	config.Set(conf)
 
 	vals, valid := NewGlobalChecker(
-		config.DefaultClusterID,
-		&istiotest.FakeDiscovery{},
+		config.IstioNamespaceDefault,
 		data.CreateSidecar("sidecar1", config.IstioNamespaceDefault),
 	).Check()
 
@@ -46,8 +43,7 @@ func TestSidecarWithSelectorOutOfControlPlane(t *testing.T) {
 	config.Set(config.NewConfig())
 
 	vals, valid := NewGlobalChecker(
-		config.DefaultClusterID,
-		&istiotest.FakeDiscovery{},
+		config.IstioNamespaceDefault,
 		data.AddSelectorToSidecar(map[string]string{
 			"app": "reviews",
 		}, data.CreateSidecar("sidecar1", "bookinfo")),
@@ -63,8 +59,7 @@ func TestSidecarWithSelectorInControlPlane(t *testing.T) {
 	config.Set(conf)
 
 	vals, valid := NewGlobalChecker(
-		config.DefaultClusterID,
-		&istiotest.FakeDiscovery{},
+		config.IstioNamespaceDefault,
 		data.AddSelectorToSidecar(map[string]string{
 			"app": "reviews",
 		}, data.CreateSidecar("sidecar1", config.IstioNamespaceDefault)),

--- a/business/checkers/sidecars_checker.go
+++ b/business/checkers/sidecars_checker.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/business/checkers/sidecars"
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -14,19 +13,20 @@ import (
 type SidecarChecker struct {
 	Cluster               string
 	Conf                  *config.Config
-	Discovery             istio.MeshDiscovery
 	KubeServiceHosts      kubernetes.KubeServiceHosts
 	Namespaces            models.Namespaces
+	RootNamespaces        map[string]string
 	ServiceEntries        []*networking_v1.ServiceEntry
 	Sidecars              []*networking_v1.Sidecar
 	WorkloadsPerNamespace map[string]models.Workloads
 }
 
-// NewSidecarChecker creates a new SidecarChecker with all required fields
+// NewSidecarChecker creates a new SidecarChecker with all required fields.
+// rootNamespaces maps each namespace to its control plane's root namespace.
 func NewSidecarChecker(
 	cluster string,
 	conf *config.Config,
-	discovery istio.MeshDiscovery,
+	rootNamespaces map[string]string,
 	namespaces models.Namespaces,
 	kubeServiceHosts kubernetes.KubeServiceHosts,
 	serviceEntries []*networking_v1.ServiceEntry,
@@ -36,9 +36,9 @@ func NewSidecarChecker(
 	return SidecarChecker{
 		Cluster:               cluster,
 		Conf:                  conf,
-		Discovery:             discovery,
 		KubeServiceHosts:      kubeServiceHosts,
 		Namespaces:            namespaces,
+		RootNamespaces:        rootNamespaces,
 		ServiceEntries:        serviceEntries,
 		Sidecars:              sidecars,
 		WorkloadsPerNamespace: workloadsPerNamespace,
@@ -90,7 +90,7 @@ func (s SidecarChecker) runChecks(sidecar *networking_v1.Sidecar) models.IstioVa
 	enabledCheckers := []Checker{
 		common.WorkloadSelectorNoWorkloadFoundChecker(kubernetes.Sidecars, selectorLabels, s.WorkloadsPerNamespace),
 		sidecars.EgressHostChecker{Conf: s.Conf, Sidecar: sidecar, ServiceEntries: serviceHosts, KubeServiceHosts: s.KubeServiceHosts},
-		sidecars.NewGlobalChecker(s.Cluster, s.Discovery, sidecar),
+		sidecars.NewGlobalChecker(s.RootNamespaces[sidecar.Namespace], sidecar),
 		sidecars.OutboundTrafficPolicyModeChecker{Sidecar: sidecar},
 	}
 

--- a/business/checkers/sidecars_checker_test.go
+++ b/business/checkers/sidecars_checker_test.go
@@ -1,0 +1,135 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestSidecarWithSelectorInRootNamespaceMultiCP(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Sidecar with selector in root namespace of CP1 should trigger global.selector warning
+	sidecarCP1 := data.AddSelectorToSidecar(
+		map[string]string{"app": "reviews"},
+		data.CreateSidecar("sidecar1", "istio-system-1"),
+	)
+	// Sidecar with selector in root namespace of CP2 should also trigger global.selector warning
+	sidecarCP2 := data.AddSelectorToSidecar(
+		map[string]string{"app": "details"},
+		data.CreateSidecar("sidecar2", "istio-system-2"),
+	)
+
+	rootNamespaces := map[string]string{
+		"istio-system-1": "istio-system-1",
+		"istio-system-2": "istio-system-2",
+	}
+
+	checker := NewSidecarChecker(
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		models.Namespaces{},
+		kubernetes.KubeServiceFQDNs(nil, conf),
+		[]*networking_v1.ServiceEntry{},
+		[]*networking_v1.Sidecar{sidecarCP1, sidecarCP2},
+		map[string]models.Workloads{},
+	)
+
+	vals := checker.Check()
+
+	// Both sidecars are in their respective root namespaces and have selectors -> global.selector warning
+	sc1Key := models.BuildKey(kubernetes.Sidecars, "sidecar1", "istio-system-1", config.DefaultClusterID)
+	sc2Key := models.BuildKey(kubernetes.Sidecars, "sidecar2", "istio-system-2", config.DefaultClusterID)
+
+	assert.NotNil(vals[sc1Key])
+	assert.NotNil(vals[sc2Key])
+
+	for _, v := range []models.IstioValidationKey{sc1Key, sc2Key} {
+		found := false
+		for _, check := range vals[v].Checks {
+			if err := validations.ConfirmIstioCheckMessage("sidecar.global.selector", check); err == nil {
+				found = true
+			}
+		}
+		assert.True(found, "expected sidecar.global.selector for %s", v.Name)
+	}
+}
+
+func TestSidecarInAppNamespaceNotTreatedAsRoot(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Sidecar with selector in app namespace should NOT trigger global.selector warning
+	sidecar := data.AddSelectorToSidecar(
+		map[string]string{"app": "reviews"},
+		data.CreateSidecar("sidecar1", "bookinfo"),
+	)
+
+	rootNamespaces := map[string]string{
+		"istio-system": "istio-system",
+		"bookinfo":     "istio-system",
+	}
+
+	checker := NewSidecarChecker(
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		models.Namespaces{},
+		kubernetes.KubeServiceFQDNs(nil, conf),
+		[]*networking_v1.ServiceEntry{},
+		[]*networking_v1.Sidecar{sidecar},
+		map[string]models.Workloads{},
+	)
+
+	vals := checker.Check()
+	key := models.BuildKey(kubernetes.Sidecars, "sidecar1", "bookinfo", config.DefaultClusterID)
+	assert.NotNil(vals[key])
+
+	for _, check := range vals[key].Checks {
+		assert.Error(validations.ConfirmIstioCheckMessage("sidecar.global.selector", check),
+			"should NOT get sidecar.global.selector for app namespace")
+	}
+}
+
+func TestSidecarUnknownNamespaceNotTreatedAsRoot(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Sidecar with selector in unknown namespace (not in map) should not trigger global.selector
+	sidecar := data.AddSelectorToSidecar(
+		map[string]string{"app": "reviews"},
+		data.CreateSidecar("sidecar1", "unknown-ns"),
+	)
+
+	checker := NewSidecarChecker(
+		config.DefaultClusterID,
+		conf,
+		map[string]string{"istio-system": "istio-system"},
+		models.Namespaces{},
+		kubernetes.KubeServiceFQDNs(nil, conf),
+		[]*networking_v1.ServiceEntry{},
+		[]*networking_v1.Sidecar{sidecar},
+		map[string]models.Workloads{},
+	)
+
+	vals := checker.Check()
+	key := models.BuildKey(kubernetes.Sidecars, "sidecar1", "unknown-ns", config.DefaultClusterID)
+	assert.NotNil(vals[key])
+
+	for _, check := range vals[key].Checks {
+		assert.Error(validations.ConfirmIstioCheckMessage("sidecar.global.selector", check),
+			"should NOT get sidecar.global.selector for unknown namespace")
+	}
+}

--- a/business/checkers/workloads/uncovered_workload_checker.go
+++ b/business/checkers/workloads/uncovered_workload_checker.go
@@ -1,28 +1,26 @@
 package workloads
 
 import (
-	"context"
-
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/models"
 )
 
 type UncoveredWorkloadChecker struct {
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
-	Discovery             istio.MeshDiscovery
 	Namespace             string
+	RootNamespaces        map[string]string
 	Workload              *models.Workload
 }
 
-// NewUncoveredWorkloadChecker creates a new UncoveredWorkloadChecker with all required fields
-func NewUncoveredWorkloadChecker(authorizationPolicies []*security_v1.AuthorizationPolicy, discovery istio.MeshDiscovery, namespace string, workload *models.Workload) UncoveredWorkloadChecker {
+// NewUncoveredWorkloadChecker creates a new UncoveredWorkloadChecker with all required fields.
+// rootNamespaces maps each namespace to its control plane's root namespace.
+func NewUncoveredWorkloadChecker(authorizationPolicies []*security_v1.AuthorizationPolicy, rootNamespaces map[string]string, namespace string, workload *models.Workload) UncoveredWorkloadChecker {
 	return UncoveredWorkloadChecker{
 		AuthorizationPolicies: authorizationPolicies,
-		Discovery:             discovery,
 		Namespace:             namespace,
+		RootNamespaces:        rootNamespaces,
 		Workload:              workload,
 	}
 }
@@ -55,8 +53,7 @@ func (ucw UncoveredWorkloadChecker) hasCoveringAuthPolicy(wlSelector labels.Labe
 		if len(apLabels) > 0 {
 			apSelector = labels.SelectorFromSet(apLabels)
 		}
-		rootNamespace := ucw.Discovery.GetRootNamespace(context.TODO(), ucw.Workload.Cluster, apNamespace)
-		if rootNamespace == apNamespace || apNamespace == ucw.Namespace {
+		if ucw.RootNamespaces[ucw.Namespace] == apNamespace || apNamespace == ucw.Namespace {
 			if apSelector == nil || apSelector.Matches(wlSelector) {
 				return true
 			}

--- a/business/checkers/workloads/uncovered_workload_checker_test.go
+++ b/business/checkers/workloads/uncovered_workload_checker_test.go
@@ -7,7 +7,6 @@ import (
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
@@ -31,7 +30,7 @@ func TestCoveredworkloads(t *testing.T) {
 		// while other auths has diffrenet namespaces than current workload
 		vals, valid = UncoveredWorkloadChecker{
 			AuthorizationPolicies: variedAuthPolicies1(),
-			Discovery:             &istiotest.FakeDiscovery{},
+			RootNamespaces:        testRootNamespaces(),
 			Namespace:             ns2,
 			Workload:              wl,
 		}.Check()
@@ -43,7 +42,7 @@ func TestCoveredworkloads(t *testing.T) {
 		// while  other auths has diffrenet namespaces than current workload
 		vals, valid = UncoveredWorkloadChecker{
 			AuthorizationPolicies: variedAuthPolicies2(),
-			Discovery:             &istiotest.FakeDiscovery{},
+			RootNamespaces:        testRootNamespaces(),
 			Namespace:             ns2,
 			Workload:              wl,
 		}.Check()
@@ -57,7 +56,7 @@ func TestCoveredworkloads(t *testing.T) {
 	workloadsNS1 := workloadsNS1()
 	vals, valid = UncoveredWorkloadChecker{
 		AuthorizationPolicies: authorizationPoliciesNS1(),
-		Discovery:             &istiotest.FakeDiscovery{},
+		RootNamespaces:        testRootNamespaces(),
 		Namespace:             ns1,
 		Workload:              workloadsNS1[1],
 	}.Check()
@@ -94,7 +93,7 @@ func TestUnCoveredWorkloads(t *testing.T) {
 func testFailure(assert *assert.Assertions, ns string, authpolicies []*security_v1.AuthorizationPolicy, workload *models.Workload) {
 	vals, valid := UncoveredWorkloadChecker{
 		AuthorizationPolicies: authpolicies,
-		Discovery:             &istiotest.FakeDiscovery{},
+		RootNamespaces:        testRootNamespaces(),
 		Namespace:             ns,
 		Workload:              workload,
 	}.Check()
@@ -158,4 +157,12 @@ func variedAuthPolicies3() []*security_v1.AuthorizationPolicy {
 	auths = append(auths, authorizationPoliciesNS1()...)
 
 	return auths
+}
+
+func testRootNamespaces() map[string]string {
+	return map[string]string{
+		config.IstioNamespaceDefault: config.IstioNamespaceDefault,
+		ns1:                          config.IstioNamespaceDefault,
+		ns2:                          config.IstioNamespaceDefault,
+	}
 }

--- a/business/checkers/workloads_checker.go
+++ b/business/checkers/workloads_checker.go
@@ -7,7 +7,6 @@ import (
 	ambient "github.com/kiali/kiali/business/checkers/ambient"
 	"github.com/kiali/kiali/business/checkers/workloads"
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/models"
 )
 
@@ -17,17 +16,18 @@ type WorkloadChecker struct {
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
 	Cluster               string
 	Conf                  *config.Config
-	Discovery             istio.MeshDiscovery
 	Namespaces            models.Namespaces
+	RootNamespaces        map[string]string
 	WorkloadsPerNamespace map[string]models.Workloads
 }
 
-// NewWorkloadChecker creates a new WorkloadChecker with all attributes
+// NewWorkloadChecker creates a new WorkloadChecker with all attributes.
+// rootNamespaces maps each namespace to its control plane's root namespace.
 func NewWorkloadChecker(
 	authorizationPolicies []*security_v1.AuthorizationPolicy,
 	cluster string,
 	conf *config.Config,
-	discovery istio.MeshDiscovery,
+	rootNamespaces map[string]string,
 	namespaces models.Namespaces,
 	workloadsPerNamespace map[string]models.Workloads,
 ) WorkloadChecker {
@@ -35,8 +35,8 @@ func NewWorkloadChecker(
 		AuthorizationPolicies: authorizationPolicies,
 		Cluster:               cluster,
 		Conf:                  conf,
-		Discovery:             discovery,
 		Namespaces:            namespaces,
+		RootNamespaces:        rootNamespaces,
 		WorkloadsPerNamespace: workloadsPerNamespace,
 	}
 }
@@ -59,7 +59,7 @@ func (w WorkloadChecker) runChecks(workload *models.Workload, namespace string) 
 	key, rrValidation := EmptyValidValidation(wlName, namespace, schema.GroupVersionKind{Group: "", Version: "", Kind: WorkloadCheckerType}, w.Cluster)
 
 	enabledCheckers := []Checker{
-		workloads.NewUncoveredWorkloadChecker(w.AuthorizationPolicies, w.Discovery, namespace, workload),
+		workloads.NewUncoveredWorkloadChecker(w.AuthorizationPolicies, w.RootNamespaces, namespace, workload),
 		ambient.NewAmbientWorkloadChecker(w.Cluster, w.Conf, workload, namespace, w.Namespaces, w.AuthorizationPolicies),
 	}
 

--- a/business/checkers/workloads_checker_test.go
+++ b/business/checkers/workloads_checker_test.go
@@ -1,0 +1,175 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestWorkloadCoveredByMeshWideAuthPolicyMultiCP(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Mesh-wide auth policy in CP1's root namespace (no selector = covers all workloads)
+	meshAP := data.CreateEmptyAuthorizationPolicy("mesh-policy", "istio-system-1")
+
+	rootNamespaces := map[string]string{
+		"istio-system-1": "istio-system-1",
+		"istio-system-2": "istio-system-2",
+		"app-ns-1":       "istio-system-1",
+		"app-ns-2":       "istio-system-2",
+	}
+
+	workloadsPerNamespace := map[string]models.Workloads{
+		"app-ns-1": {
+			data.CreateWorkload("app-ns-1", "wl-1", map[string]string{"app": "reviews"}),
+		},
+		"app-ns-2": {
+			data.CreateWorkload("app-ns-2", "wl-2", map[string]string{"app": "ratings"}),
+		},
+	}
+
+	checker := NewWorkloadChecker(
+		[]*security_v1.AuthorizationPolicy{meshAP},
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		models.Namespaces{},
+		workloadsPerNamespace,
+	)
+
+	vals := checker.Check()
+
+	// wl-1 in app-ns-1 is managed by CP1 whose root is istio-system-1.
+	// The mesh-wide AP is in istio-system-1, so wl-1 should be covered.
+	wl1Key := models.IstioValidationKey{
+		ObjectGVK: workloadGVK(),
+		Name:      "wl-1",
+		Namespace: "app-ns-1",
+		Cluster:   config.DefaultClusterID,
+	}
+	assert.NotNil(vals[wl1Key])
+	for _, check := range vals[wl1Key].Checks {
+		assert.Error(validations.ConfirmIstioCheckMessage("workload.authorizationpolicy.needstobecovered", check),
+			"wl-1 should be covered by the mesh-wide AP from its own CP root")
+	}
+
+	// wl-2 in app-ns-2 is managed by CP2 whose root is istio-system-2.
+	// The mesh-wide AP is in istio-system-1, NOT istio-system-2, so wl-2 is NOT covered.
+	wl2Key := models.IstioValidationKey{
+		ObjectGVK: workloadGVK(),
+		Name:      "wl-2",
+		Namespace: "app-ns-2",
+		Cluster:   config.DefaultClusterID,
+	}
+	assert.NotNil(vals[wl2Key])
+	foundUncovered := false
+	for _, check := range vals[wl2Key].Checks {
+		if err := validations.ConfirmIstioCheckMessage("workload.authorizationpolicy.needstobecovered", check); err == nil {
+			foundUncovered = true
+		}
+	}
+	assert.True(foundUncovered, "wl-2 should NOT be covered by mesh-wide AP from a different CP root")
+}
+
+func TestWorkloadCoveredBySameNamespaceAuthPolicy(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Auth policy in app-ns-2 with no selector -> covers all workloads in app-ns-2
+	ap := data.CreateEmptyAuthorizationPolicy("ns-policy", "app-ns-2")
+
+	rootNamespaces := map[string]string{
+		"istio-system": "istio-system",
+		"app-ns-2":     "istio-system",
+	}
+
+	workloadsPerNamespace := map[string]models.Workloads{
+		"app-ns-2": {
+			data.CreateWorkload("app-ns-2", "wl-1", map[string]string{"app": "reviews"}),
+		},
+	}
+
+	checker := NewWorkloadChecker(
+		[]*security_v1.AuthorizationPolicy{ap},
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		models.Namespaces{},
+		workloadsPerNamespace,
+	)
+
+	vals := checker.Check()
+
+	wlKey := models.IstioValidationKey{
+		ObjectGVK: workloadGVK(),
+		Name:      "wl-1",
+		Namespace: "app-ns-2",
+		Cluster:   config.DefaultClusterID,
+	}
+	assert.NotNil(vals[wlKey])
+	for _, check := range vals[wlKey].Checks {
+		assert.Error(validations.ConfirmIstioCheckMessage("workload.authorizationpolicy.needstobecovered", check),
+			"workload should be covered by same-namespace auth policy")
+	}
+}
+
+func TestWorkloadUncoveredWhenNoMatchingAuthPolicy(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	// Auth policy in different namespace, not a root namespace for the workload
+	ap := data.CreateEmptyAuthorizationPolicy("other-policy", "other-ns")
+
+	rootNamespaces := map[string]string{
+		"istio-system": "istio-system",
+		"app-ns":       "istio-system",
+		"other-ns":     "istio-system",
+	}
+
+	workloadsPerNamespace := map[string]models.Workloads{
+		"app-ns": {
+			data.CreateWorkload("app-ns", "wl-1", map[string]string{"app": "reviews"}),
+		},
+	}
+
+	checker := NewWorkloadChecker(
+		[]*security_v1.AuthorizationPolicy{ap},
+		config.DefaultClusterID,
+		conf,
+		rootNamespaces,
+		models.Namespaces{},
+		workloadsPerNamespace,
+	)
+
+	vals := checker.Check()
+
+	wlKey := models.IstioValidationKey{
+		ObjectGVK: workloadGVK(),
+		Name:      "wl-1",
+		Namespace: "app-ns",
+		Cluster:   config.DefaultClusterID,
+	}
+	assert.NotNil(vals[wlKey])
+	foundUncovered := false
+	for _, check := range vals[wlKey].Checks {
+		if err := validations.ConfirmIstioCheckMessage("workload.authorizationpolicy.needstobecovered", check); err == nil {
+			foundUncovered = true
+		}
+	}
+	assert.True(foundUncovered, "workload should be uncovered when AP is in a different non-root namespace")
+}
+
+func workloadGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "", Version: "", Kind: WorkloadCheckerType}
+}

--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -79,11 +79,19 @@ func (m *healthMonitor) Start(ctx context.Context) {
 	}
 	m.logger.Info().Msgf("Starting health monitor with refresh interval: %s, timeout: %s", m.conf.HealthConfig.Compute.RefreshInterval, m.conf.HealthConfig.Compute.Timeout)
 
-	// Prime the cache with an initial refresh (with timeout)
+	// Prime the cache with an initial refresh (with timeout).
+	// Recover from panics so that a failure here does not crash the entire process.
 	refreshCtx, cancel := context.WithTimeout(ctx, timeout)
-	if err := m.RefreshHealth(refreshCtx); err != nil {
-		m.logger.Error().Err(err).Msg("Initial health refresh failed")
-	}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				m.logger.Error().Interface("panic", r).Msg("Panic during initial health refresh")
+			}
+		}()
+		if err := m.RefreshHealth(refreshCtx); err != nil {
+			m.logger.Error().Err(err).Msg("Initial health refresh failed")
+		}
+	}()
 	cancel()
 
 	go func() {
@@ -93,11 +101,18 @@ func (m *healthMonitor) Start(ctx context.Context) {
 				m.logger.Info().Msg("Stopping health monitor")
 				return
 			case <-time.After(interval):
-				refreshCtx, cancel := context.WithTimeout(ctx, timeout)
-				if err := m.RefreshHealth(refreshCtx); err != nil {
-					m.logger.Error().Err(err).Msg("Health refresh failed")
-				}
-				cancel()
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							m.logger.Error().Interface("panic", r).Msg("Panic during health refresh")
+						}
+					}()
+					refreshCtx, cancel := context.WithTimeout(ctx, timeout)
+					defer cancel()
+					if err := m.RefreshHealth(refreshCtx); err != nil {
+						m.logger.Error().Err(err).Msg("Health refresh failed")
+					}
+				}()
 			}
 		}
 	}()

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -128,6 +128,7 @@ type validationClusterInfo struct {
 	cluster          string                      // the cluster being validated
 	istioConfig      *models.IstioConfigList     // config for the cluster (all namespaces)
 	kubeServiceHosts kubernetes.KubeServiceHosts // pre-built host lookup from K8s services
+	rootNamespaces   map[string]string           // namespace => rootNamespace, pre-computed from ControlPlaneForNamespace
 	services         []core_v1.Service           // K8s services for the cluster (all namespaces)
 }
 
@@ -332,8 +333,23 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 	if err != nil {
 		return false, nil, err
 	}
-	filterIstioConfigByManagedNamespaces(istioConfigList, vInfo.mesh, cluster, getNsNames(vInfo.nsMap[cluster]))
+	nsNames := getNsNames(vInfo.nsMap[cluster])
+	filterIstioConfigByManagedNamespaces(istioConfigList, vInfo.mesh, cluster, nsNames)
 	vInfo.clusterInfo.istioConfig = istioConfigList
+
+	// Pre-compute namespace → rootNamespace so we can skip unmanaged namespaces and avoid
+	// repeated ControlPlaneForNamespace calls later in getAllObjectCheckers and filterPeerAuths.
+	// Uses ControlPlaneForNamespace directly (not BuildNamespaceToMeshConfig) because a namespace
+	// should be validated even if cp.MeshConfig is nil.
+	rootNamespaces := make(map[string]string, len(nsNames))
+	if vInfo.mesh != nil {
+		for _, ns := range nsNames {
+			if cp, err := vInfo.mesh.ControlPlaneForNamespace(cluster, ns); cp != nil && err == nil {
+				rootNamespaces[ns] = cp.RootNamespace
+			}
+		}
+	}
+	vInfo.clusterInfo.rootNamespaces = rootNamespaces
 
 	// if change detection is enabled then decide if we need to run the checkers
 	if vInfo.changeDetectionEnabled() {
@@ -344,6 +360,11 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 	}
 
 	for _, namespace := range vInfo.nsMap[cluster] {
+		// Skip validations for a particular namespace, mesh config was not found
+		if _, managed := rootNamespaces[namespace.Name]; !managed {
+			continue
+		}
+
 		vInfo.nsInfo = &validationNamespaceInfo{
 			namespace: &namespace,
 		}
@@ -518,14 +539,14 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) (
 		checkers.K8sHTTPRouteChecker{Conf: conf, K8sHTTPRoutes: istioConfigList.K8sHTTPRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Services: services, Cluster: cluster},
 		checkers.K8sReferenceGrantChecker{K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Cluster: cluster},
 		checkers.NoServiceChecker{Conf: conf, Namespaces: namespaces, IstioConfigList: istioConfigList, WorkloadsPerNamespace: workloadsPerNamespace, AuthorizationDetails: rbacDetails, KubeServiceHosts: kubeServiceHosts, Services: services, PolicyAllowAny: policyAllowAny, Cluster: cluster},
-		checkers.NewPeerAuthenticationChecker(cluster, conf, in.mesh.discovery, *mtlsDetails, mtlsDetails.PeerAuthentications, workloadsPerNamespace),
+		checkers.NewPeerAuthenticationChecker(cluster, conf, vInfo.clusterInfo.rootNamespaces, *mtlsDetails, mtlsDetails.PeerAuthentications, workloadsPerNamespace),
 		checkers.RequestAuthenticationChecker{RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadsPerNamespace: workloadsPerNamespace, Cluster: cluster},
 		checkers.ServiceEntryChecker{ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries, Cluster: cluster},
-		checkers.NewSidecarChecker(cluster, conf, in.mesh.discovery, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace),
+		checkers.NewSidecarChecker(cluster, conf, vInfo.clusterInfo.rootNamespaces, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace),
 		checkers.TelemetryChecker{Telemetries: istioConfigList.Telemetries, Namespaces: namespaces},
 		checkers.VirtualServiceChecker{Conf: conf, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices, DestinationRules: istioConfigList.DestinationRules, Cluster: cluster},
 		checkers.WasmPluginChecker{WasmPlugins: istioConfigList.WasmPlugins, Namespaces: namespaces},
-		checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, in.mesh.discovery, namespaces, workloadsPerNamespace),
+		checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, vInfo.clusterInfo.rootNamespaces, namespaces, workloadsPerNamespace),
 		checkers.WorkloadGroupsChecker{Cluster: cluster, WorkloadGroups: istioConfigList.WorkloadGroups, ServiceAccounts: vInfo.saMap},
 	}, nil
 }
@@ -636,6 +657,11 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 	var referenceChecker ReferenceChecker
 	conf := in.conf
 
+	rootNamespace := ""
+	if cp, err := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace); err == nil && cp != nil {
+		rootNamespace = cp.RootNamespace
+	}
+
 	policyAllowAny, err := in.isPolicyAllowAny(vInfo)
 	if err != nil {
 		log.Trace(err)
@@ -669,7 +695,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		objectCheckers = []checkers.ObjectChecker{serviceEntryChecker}
 		referenceChecker = references.ServiceEntryReferences{Conf: conf, AuthorizationPolicies: rbacDetails.AuthorizationPolicies, KubeServiceHosts: kubeServiceHosts, Namespace: namespace, Namespaces: nsNames, DestinationRules: istioConfigList.DestinationRules, ServiceEntries: istioConfigList.ServiceEntries, Sidecars: istioConfigList.Sidecars}
 	case kubernetes.Sidecars:
-		sidecarsChecker := checkers.NewSidecarChecker(cluster, conf, in.mesh.discovery, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace)
+		sidecarsChecker := checkers.NewSidecarChecker(cluster, conf, map[string]string{namespace: rootNamespace}, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace)
 		objectCheckers = []checkers.ObjectChecker{sidecarsChecker}
 		referenceChecker = references.SidecarReferences{Conf: conf, Sidecars: istioConfigList.Sidecars, Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, KubeServiceHosts: kubeServiceHosts, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.AuthorizationPolicies:
@@ -680,14 +706,15 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 			WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: *mtlsDetails, VirtualServices: istioConfigList.VirtualServices, KubeServiceHosts: kubeServiceHosts, Services: services, PolicyAllowAny: policyAllowAny,
 		}
 		objectCheckers = []checkers.ObjectChecker{authPoliciesChecker}
-		referenceChecker = references.NewAuthorizationPolicyReferences(rbacDetails.AuthorizationPolicies, conf, cluster, in.mesh.discovery, namespace, nsNames, istioConfigList.ServiceEntries, istioConfigList.VirtualServices, kubeServiceHosts, workloadsPerNamespace)
+		referenceChecker = references.NewAuthorizationPolicyReferences(rbacDetails.AuthorizationPolicies, conf, cluster, map[string]string{namespace: rootNamespace}, namespace, nsNames, istioConfigList.ServiceEntries, istioConfigList.VirtualServices, kubeServiceHosts, workloadsPerNamespace)
 	case kubernetes.PeerAuthentications:
 		// Validations on PeerAuthentications
-		peerAuthnChecker := checkers.NewPeerAuthenticationChecker(cluster, conf, in.mesh.discovery, *mtlsDetails, mtlsDetails.PeerAuthentications, workloadsPerNamespace)
+		rootNamespaces := map[string]string{namespace: rootNamespace}
+		peerAuthnChecker := checkers.NewPeerAuthenticationChecker(cluster, conf, rootNamespaces, *mtlsDetails, mtlsDetails.PeerAuthentications, workloadsPerNamespace)
 		objectCheckers = []checkers.ObjectChecker{peerAuthnChecker}
-		referenceChecker = references.NewPeerAuthReferences(cluster, conf, in.mesh.discovery, *mtlsDetails, workloadsPerNamespace)
+		referenceChecker = references.NewPeerAuthReferences(cluster, conf, rootNamespaces, *mtlsDetails, workloadsPerNamespace)
 	case schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"}:
-		workloadChecker := checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, in.mesh.discovery, namespaces, workloadsPerNamespace)
+		workloadChecker := checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, map[string]string{namespace: rootNamespace}, namespaces, workloadsPerNamespace)
 		objectCheckers = []checkers.ObjectChecker{workloadChecker}
 	case kubernetes.WorkloadEntries:
 		// Validation on WorkloadEntries are not yet in place
@@ -890,9 +917,9 @@ func (in *IstioValidationsService) setNamespaceIstioConfig(
 
 func (in *IstioValidationsService) filterPeerAuths(vInfo *validationInfo, mtlsDetails *kubernetes.MTLSDetails, peerAuths []*security_v1.PeerAuthentication) {
 	namespace := vInfo.nsInfo.namespace.Name
-	rootNs := in.mesh.discovery.GetRootNamespace(context.TODO(), vInfo.clusterInfo.cluster, namespace)
+	rootNs := vInfo.clusterInfo.rootNamespaces[namespace]
 	for _, pa := range peerAuths {
-		if pa.Namespace == rootNs {
+		if rootNs != "" && pa.Namespace == rootNs {
 			mtlsDetails.MeshPeerAuthentications = append(mtlsDetails.MeshPeerAuthentications, pa)
 		}
 		if pa.Namespace == namespace || namespace == "" {

--- a/business/references/auth_policy_references.go
+++ b/business/references/auth_policy_references.go
@@ -1,14 +1,11 @@
 package references
 
 import (
-	"context"
-
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -17,21 +14,22 @@ type AuthorizationPolicyReferences struct {
 	AuthorizationPolicies []*security_v1.AuthorizationPolicy
 	Cluster               string
 	Conf                  *config.Config
-	Discovery             istio.MeshDiscovery
 	KubeServiceHosts      kubernetes.KubeServiceHosts
 	Namespace             string
 	Namespaces            []string
+	RootNamespaces        map[string]string
 	ServiceEntries        []*networking_v1.ServiceEntry
 	VirtualServices       []*networking_v1.VirtualService
 	WorkloadsPerNamespace map[string]models.Workloads
 }
 
-// NewAuthorizationPolicyReferences creates a new AuthorizationPolicyReferences with all required fields
+// NewAuthorizationPolicyReferences creates a new AuthorizationPolicyReferences with all required fields.
+// rootNamespaces maps each namespace to its control plane's root namespace.
 func NewAuthorizationPolicyReferences(
 	authorizationPolicies []*security_v1.AuthorizationPolicy,
 	conf *config.Config,
 	cluster string,
-	discovery istio.MeshDiscovery,
+	rootNamespaces map[string]string,
 	namespace string,
 	namespaces []string,
 	serviceEntries []*networking_v1.ServiceEntry,
@@ -43,10 +41,10 @@ func NewAuthorizationPolicyReferences(
 		AuthorizationPolicies: authorizationPolicies,
 		Cluster:               cluster,
 		Conf:                  conf,
-		Discovery:             discovery,
 		KubeServiceHosts:      kubeServiceHosts,
 		Namespace:             namespace,
 		Namespaces:            namespaces,
+		RootNamespaces:        rootNamespaces,
 		ServiceEntries:        serviceEntries,
 		VirtualServices:       virtualServices,
 		WorkloadsPerNamespace: workloadsPerNamespace,
@@ -129,8 +127,7 @@ func (n AuthorizationPolicyReferences) getWorkloadReferences(ap *security_v1.Aut
 
 		// AuthPolicy searches Workloads from own namespace, or from all namespaces when AuthPolicy is in root namespace
 		for ns, workloads := range n.WorkloadsPerNamespace {
-			rootNamespace := n.Discovery.GetRootNamespace(context.TODO(), n.Cluster, ap.Namespace)
-			if rootNamespace != ap.Namespace && ns != ap.Namespace {
+			if n.RootNamespaces[ns] != ap.Namespace && ns != ap.Namespace {
 				continue
 			}
 			for _, wl := range workloads {

--- a/business/references/auth_policy_references_test.go
+++ b/business/references/auth_policy_references_test.go
@@ -8,7 +8,6 @@ import (
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -17,11 +16,17 @@ import (
 func prepareTestForAuthPolicy(ap *security_v1.AuthorizationPolicy, vs *networking_v1.VirtualService, se *networking_v1.ServiceEntry) models.IstioReferences {
 	conf := config.Get()
 	services := data.CreateFakeServicesWithSelector("foo-dev", "istio-system")
+	rootNamespaces := map[string]string{
+		config.IstioNamespaceDefault: config.IstioNamespaceDefault,
+		"bookinfo":                   config.IstioNamespaceDefault,
+		"bookinfo2":                  config.IstioNamespaceDefault,
+		"bookinfo3":                  config.IstioNamespaceDefault,
+	}
 	drReferences := NewAuthorizationPolicyReferences(
 		[]*security_v1.AuthorizationPolicy{ap},
 		conf,
 		config.DefaultClusterID,
-		&istiotest.FakeDiscovery{},
+		rootNamespaces,
 		"bookinfo",
 		[]string{"bookinfo", "bookinfo2", "bookinfo3"},
 		[]*networking_v1.ServiceEntry{se},

--- a/business/references/peer_auth_references.go
+++ b/business/references/peer_auth_references.go
@@ -1,13 +1,10 @@
 package references
 
 import (
-	"context"
-
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util"
@@ -16,24 +13,25 @@ import (
 type PeerAuthReferences struct {
 	Cluster               string
 	Conf                  *config.Config
-	Discovery             istio.MeshDiscovery
 	MTLSDetails           kubernetes.MTLSDetails
+	RootNamespaces        map[string]string
 	WorkloadsPerNamespace map[string]models.Workloads
 }
 
-// NewPeerAuthReferences creates a new PeerAuthReferences with all attributes
+// NewPeerAuthReferences creates a new PeerAuthReferences with all attributes.
+// rootNamespaces maps each namespace to its control plane's root namespace.
 func NewPeerAuthReferences(
 	cluster string,
 	conf *config.Config,
-	discovery istio.MeshDiscovery,
+	rootNamespaces map[string]string,
 	mtlsDetails kubernetes.MTLSDetails,
 	workloadsPerNamespace map[string]models.Workloads,
 ) PeerAuthReferences {
 	return PeerAuthReferences{
 		Cluster:               cluster,
 		Conf:                  conf,
-		Discovery:             discovery,
 		MTLSDetails:           mtlsDetails,
+		RootNamespaces:        rootNamespaces,
 		WorkloadsPerNamespace: workloadsPerNamespace,
 	}
 }
@@ -56,8 +54,7 @@ func (n PeerAuthReferences) getConfigReferences(peerAuthn *security_v1.PeerAuthe
 	keys := make(map[string]bool)
 	allDRs := make([]models.IstioReference, 0)
 	result := make([]models.IstioReference, 0)
-	rootNamespace := n.Discovery.GetRootNamespace(context.TODO(), n.Cluster, peerAuthn.Namespace)
-	if rootNamespace == peerAuthn.Namespace {
+	if n.RootNamespaces[peerAuthn.Namespace] == peerAuthn.Namespace {
 		if _, mode := kubernetes.PeerAuthnHasMTLSEnabled(peerAuthn); mode == "DISABLE" {
 			for _, dr := range n.MTLSDetails.DestinationRules {
 				if _, mode := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr); mode == "DISABLE" {
@@ -81,8 +78,7 @@ func (n PeerAuthReferences) getConfigReferences(peerAuthn *security_v1.PeerAuthe
 	// MeshWide and NamespaceWide references are only needed with autoMtls disabled
 	if !n.MTLSDetails.EnabledAutoMtls {
 		// PeerAuthentications into  the root namespace namespace are considered Mesh-wide objects
-		rootNamespace := n.Discovery.GetRootNamespace(context.TODO(), n.Cluster, peerAuthn.Namespace)
-		if rootNamespace == peerAuthn.Namespace {
+		if n.RootNamespaces[peerAuthn.Namespace] == peerAuthn.Namespace {
 			// if MeshPolicy have mtls in strict mode.
 			if strictMode := kubernetes.PeerAuthnHasStrictMTLS(peerAuthn); strictMode {
 				for _, dr := range n.MTLSDetails.DestinationRules {

--- a/business/references/peer_auth_references_test.go
+++ b/business/references/peer_auth_references_test.go
@@ -8,7 +8,6 @@ import (
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/kiali/kiali/config"
-	"github.com/kiali/kiali/istio/istiotest"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
@@ -28,7 +27,11 @@ func prepareTestForPeerAuth(pa *security_v1.PeerAuthentication, drs []*networkin
 			data.CreateWorkload("bookinfo", "details", map[string]string{"app": "details"}),
 		},
 	}
-	drReferences := NewPeerAuthReferences(config.DefaultClusterID, config.Get(), &istiotest.FakeDiscovery{}, mtlsDetails, workloadsPerNamespace)
+	rootNamespaces := map[string]string{
+		config.IstioNamespaceDefault: config.IstioNamespaceDefault,
+		"bookinfo":                   config.IstioNamespaceDefault,
+	}
+	drReferences := NewPeerAuthReferences(config.DefaultClusterID, config.Get(), rootNamespaces, mtlsDetails, workloadsPerNamespace)
 	return *drReferences.References()[models.IstioReferenceKey{ObjectGVK: kubernetes.PeerAuthentications, Namespace: pa.Namespace, Name: pa.Name}]
 }
 

--- a/business/tls.go
+++ b/business/tls.go
@@ -120,6 +120,11 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 	)
 	defer end()
 
+	mesh, err := in.discovery.Mesh(ctx)
+	if err != nil {
+		return models.MTLSStatus{}, err
+	}
+
 	allNamespaces, err := in.businessLayer.Namespace.GetClusterNamespaces(ctx, cluster)
 	if err != nil {
 		return models.MTLSStatus{}, err
@@ -136,7 +141,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 	}
 
 	pasAll := kubernetes.FilterByNamespaceNames(istioConfigList.PeerAuthentications, []string{namespace})
-	rootNamespace := in.discovery.GetRootNamespace(ctx, cluster, namespace)
+	rootNamespace := rootNamespaceFromMesh(mesh, cluster, namespace)
 	if rootNamespace == namespace {
 		pasAll = []*security_v1.PeerAuthentication{}
 	}
@@ -154,7 +159,7 @@ func (in *TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace, cl
 	mtlsStatus := mtls.MtlsStatus{
 		PeerAuthentications: pas,
 		DestinationRules:    drs,
-		AutoMtlsEnabled:     in.hasAutoMTLSEnabled(cluster, ns),
+		AutoMtlsEnabled:     autoMTLSFromMesh(mesh, cluster, namespace),
 		AllowPermissive:     false,
 	}
 
@@ -193,9 +198,11 @@ func (in *TLSService) ClusterWideNSmTLSStatus(ctx context.Context, namespaces []
 
 	meshStatusByRevision := in.meshStatusByRevisionForNamespaces(ctx, cluster, namespaces)
 
+	mesh, _ := in.discovery.Mesh(ctx)
+
 	for _, namespace := range namespaces {
 		pasAll := kubernetes.FilterByNamespaceNames(istioConfigList.PeerAuthentications, []string{namespace.Name})
-		rootNamespace := in.discovery.GetRootNamespace(ctx, namespace.Cluster, namespace.Name)
+		rootNamespace := rootNamespaceFromMesh(mesh, namespace.Cluster, namespace.Name)
 		if rootNamespace == namespace.Name {
 			pasAll = []*security_v1.PeerAuthentication{}
 		}
@@ -204,7 +211,7 @@ func (in *TLSService) ClusterWideNSmTLSStatus(ctx context.Context, namespaces []
 		mtlsStatus := mtls.MtlsStatus{
 			PeerAuthentications: pas,
 			DestinationRules:    istioConfigList.DestinationRules,
-			AutoMtlsEnabled:     in.hasAutoMTLSEnabled(cluster, &namespace),
+			AutoMtlsEnabled:     autoMTLSFromMesh(mesh, cluster, namespace.Name),
 			AllowPermissive:     false,
 		}
 
@@ -381,26 +388,26 @@ func (in *TLSService) peerAuthenticationHasValidationErrors(cluster string, peer
 	return false
 }
 
-func (in *TLSService) hasAutoMTLSEnabled(cluster string, namespace *models.Namespace) bool {
-	mesh, err := in.discovery.Mesh(context.TODO())
-	if err != nil {
+func rootNamespaceFromMesh(mesh *models.Mesh, cluster, namespace string) string {
+	if mesh == nil {
+		return ""
+	}
+	cp, err := mesh.ControlPlaneForNamespace(cluster, namespace)
+	if err != nil || cp == nil {
+		return ""
+	}
+	return cp.RootNamespace
+}
+
+// autoMTLSFromMesh returns whether auto mTLS is enabled for the control plane managing the given namespace.
+// Uses ControlPlaneForNamespace to find the correct CP without requiring revision labels.
+func autoMTLSFromMesh(mesh *models.Mesh, cluster, namespace string) bool {
+	if mesh == nil {
 		return true
 	}
-
-	// Find the controlplane that is controlling that namespace.
-	rev := namespace.Labels[config.IstioRevisionLabel]
-	if rev == "" {
-		// Assume that if there is no revision label, it is the default revision.
-		rev = models.DefaultRevisionLabel
-	}
-
-	// Find the controlplane that controls that namespace.
-	idx := slices.IndexFunc(mesh.ControlPlanes, func(controlPlane models.ControlPlane) bool {
-		return controlPlane.Revision == rev && controlPlane.Cluster.Name == cluster
-	})
-	if idx == -1 {
+	cp, err := mesh.ControlPlaneForNamespace(cluster, namespace)
+	if err != nil || cp == nil {
 		return true
 	}
-
-	return mesh.ControlPlanes[idx].MeshConfig.EnableAutoMtls.Value
+	return cp.MeshConfig.EnableAutoMtls.Value
 }

--- a/business/tls_perf_test.go
+++ b/business/tls_perf_test.go
@@ -76,9 +76,11 @@ func testPerfScenario(exStatus string, namespaces []core_v1.Namespace, drs []*ne
 	kubernetes.SetConfig(t, *conf)
 
 	var objs []runtime.Object
+	managedNs := make([]models.Namespace, 0, len(namespaces))
 	for _, obj := range namespaces {
 		o := obj
 		objs = append(objs, &o)
+		managedNs = append(managedNs, models.Namespace{Name: o.Name, Cluster: conf.KubernetesConfig.ClusterName})
 	}
 	objs = append(objs, kubernetes.ToRuntimeObjects(ps)...)
 	objs = append(objs, kubernetes.ToRuntimeObjects(drs)...)
@@ -87,9 +89,11 @@ func testPerfScenario(exStatus string, namespaces []core_v1.Namespace, drs []*ne
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
-				IstiodNamespace: config.IstioNamespaceDefault,
-				Revision:        "default",
-				Cluster:         &models.KubeCluster{Name: conf.KubernetesConfig.ClusterName},
+				Cluster:           &models.KubeCluster{Name: conf.KubernetesConfig.ClusterName},
+				IstiodNamespace:   config.IstioNamespaceDefault,
+				ManagedNamespaces: managedNs,
+				Revision:          "default",
+				RootNamespace:     config.IstioNamespaceDefault,
 				MeshConfig: &models.MeshConfig{
 					MeshConfig: &istiov1alpha1.MeshConfig{
 						EnableAutoMtls: wrapperspb.Bool(autoMtls),

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -414,10 +414,15 @@ func testNamespaceScenario(exStatus string, drs []*networking_v1.DestinationRule
 	discovery := &istiotest.FakeDiscovery{
 		MeshReturn: models.Mesh{
 			ControlPlanes: []models.ControlPlane{{
-				IstiodNamespace: config.IstioNamespaceDefault,
-				Revision:        "default",
 				Cluster:         &models.KubeCluster{Name: conf.KubernetesConfig.ClusterName},
-				MeshConfig:      meshConfig(autoMtls),
+				IstiodNamespace: config.IstioNamespaceDefault,
+				ManagedNamespaces: []models.Namespace{
+					{Name: "bookinfo", Cluster: conf.KubernetesConfig.ClusterName},
+					{Name: "foo", Cluster: conf.KubernetesConfig.ClusterName},
+				},
+				MeshConfig:    meshConfig(autoMtls),
+				Revision:      "default",
+				RootNamespace: config.IstioNamespaceDefault,
 			}},
 		},
 	}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -149,7 +149,7 @@ func (in *WorkloadService) isWorkloadIncluded(workload string) bool {
 }
 
 // @TODO do validations per cluster
-func (in *WorkloadService) getWorkloadValidations(authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads, cluster string) models.IstioValidations {
+func (in *WorkloadService) getWorkloadValidations(ctx context.Context, authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads, cluster string) models.IstioValidations {
 	userClient, ok := in.userClients[cluster]
 	if !ok {
 		return models.IstioValidations{}
@@ -158,7 +158,17 @@ func (in *WorkloadService) getWorkloadValidations(authpolicies []*security_v1.Au
 	if !found {
 		return models.IstioValidations{}
 	}
-	validations := checkers.NewWorkloadChecker(authpolicies, cluster, in.conf, in.businessLayer.Mesh.discovery, namespaces, workloadsPerNamespace).Check()
+
+	rootNamespaces := make(map[string]string, len(workloadsPerNamespace))
+	if mesh, err := in.businessLayer.Mesh.discovery.Mesh(ctx); err == nil && mesh != nil {
+		for ns := range workloadsPerNamespace {
+			if cp, err := mesh.ControlPlaneForNamespace(cluster, ns); err == nil && cp != nil {
+				rootNamespaces[ns] = cp.RootNamespace
+			}
+		}
+	}
+
+	validations := checkers.NewWorkloadChecker(authpolicies, cluster, in.conf, rootNamespaces, namespaces, workloadsPerNamespace).Check()
 
 	return validations
 }
@@ -397,7 +407,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		authpolicies := istioConfigList.AuthorizationPolicies
 		allWorkloads := map[string]models.Workloads{}
 		allWorkloads[namespace] = ws
-		validations := in.getWorkloadValidations(authpolicies, allWorkloads, cluster)
+		validations := in.getWorkloadValidations(ctx, authpolicies, allWorkloads, cluster)
 		validations.StripIgnoredChecks(in.conf)
 		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
 	}


### PR DESCRIPTION
### Describe the change

The initial issue was happening when Validations reconciliation + Health cache calculation were running in a background on a clusters with 1000+ namespaces overall.
The problem was that `GetRootNamespace` was called in a loops, which is coming with a mutex and is costly.

Now validations pre-compute the map between `namespace -> rootNamespace` by calling a read only `mesh.ControlPlaneForNamespace` and the result is reused in validations and references.

Also fixed the potential crash issue in health_cache, even though it should not happen with the above changes, but anyway.

### Steps to test the PR

Setup multicluster 
`./hack/run-integration-tests.sh --test-suite frontend-primary-remote --setup-only true`
Install second ControlPlane on the 'east' cluster. 
`
./hack/istio/install-istio-via-istioctl.sh \
  -iv 1.27.0 \
  -mid istio_27 \
  -n istio-system-27 \
  -ir "default-v1-27-0" \
  -cn east
 ` 
or
 `helm install istiod istio/istiod \
  --namespace istio-system-27 \
  --set revision=default-v1-27-0 \
  --set global.multiCluster.clusterName=east   # <-- this was missing
  `
  
Install another bookinfo and point to the second CP.
`
./hack/istio/install-bookinfo-demo.sh \
  -c kubectl \
  -tg \
  -n bookinfo27 \
  -in istio-system-27 \
  -ail "istio.io/rev=default-v1-27-0" \
  -kc kind-east
  `
Verify that Validations and references in data planes are pointing to correct objects from the same control-planes.
Verify the health status is correctly shown.

### Automation testing

Unit tests updated.

### Issue reference
https://github.com/kiali/kiali/issues/9476
