### PR TITLE
Add Cursor rule for OSSM CVE triage workflow

### DIFF
--- a/.cursor/rules/ossm-cve-triage.mdc
+++ b/.cursor/rules/ossm-cve-triage.mdc
@@ -1,0 +1,203 @@
+---
+description: Triage new OSSM Jira CVE issues for the Kiali component
+alwaysApply: false
+---
+
+# OSSM CVE Triage for Kiali
+
+IMPORTANT: Never modify Jira issues without explicit user approval. Present all
+proposed changes and wait for confirmation before executing any updates.
+
+## Step 1: Identify New CVE Issues
+
+Use the Jira MCP to find new CVE issues.
+
+### JQL Query
+
+The combined `status = New AND summary ~ CVE` JQL does not work reliably on this
+Jira instance. Use this two-step approach instead:
+
+1. Run a broad query:
+
+```
+project = OSSM AND component = Kiali AND status != Closed ORDER BY created DESC
+```
+
+2. Filter results client-side for issues where **status** is `New` and **summary** contains `CVE`.
+
+Use `jira_search` with fields `summary,status,components,priority,assignee,created`
+and `limit` of 50. Set `projects_filter` to `OSSM`.
+
+### Issue Naming Pattern
+
+```
+CVE-YYYY-NNNNN <registry>/<image>: <library>: <description> [ossm-X.Y]
+```
+
+- **Operator images**: `kiali-rhel9-operator`, `kiali-operator-bundle`
+- **Server images**: `kiali-rhel9`, `kiali-rhel8`
+- **OSSMC images**: `kiali-ossmc-rhel9`, `kiali-ossmc-rhel8`
+- **OSSM versions**: Typically span all active versions (e.g. 2.6, 3.0, 3.1, 3.2)
+- **Grouping**: A single CVE generates multiple issues — one per image per OSSM version
+
+### Presenting Results
+
+Summarize findings grouped by CVE, showing:
+- The CVE identifier and affected library/description
+- A table of issue keys organized by image and OSSM version
+- Total issue count
+- Whether any are already assigned
+
+### Multiple CVEs
+
+Step 1 may find issues for more than one CVE. Group the issues by CVE
+identifier (extracted from the beginning of the summary). Then perform
+Steps 2-6 independently for **each** CVE before moving to the next one.
+Present each CVE group separately so the user can make decisions per-CVE.
+
+## Step 2: Ask If This Is a JavaScript Vulnerability
+
+For the current CVE, ask the user:
+"Is this a JavaScript/NPM dependency vulnerability?"
+
+If the user confirms yes, proceed to Step 3. If not, skip to Step 4.
+
+## Step 3: Close Operator Issues (JavaScript CVEs only)
+
+When a CVE is a JavaScript/NPM dependency, issues filed against **operator
+images** can be closed because the operator does not contain or expose
+JavaScript code.
+
+Operator images are identified by these strings in the summary:
+- `kiali-rhel9-operator`
+- `kiali-operator-bundle`
+
+Present a summary table of proposed closures for user approval:
+- Issue key
+- Summary
+- Resolution: "Not a Bug"
+- VEX Justification: "Vulnerable Code not Present"
+- Comment text
+
+**Do not execute any changes until the user explicitly approves.**
+
+### How to Close (after approval)
+
+For each operator image issue, use `jira_transition_issue` with:
+- **transition_id**: `"61"` (Closed)
+- **fields**: `{"resolution": {"name": "Not a Bug"}, "customfield_10873": {"value": "Vulnerable_Code_Not_Present"}}`
+- **comment**: `"The Kiali operator does not contain javascript code nor expose the vulnerability. Any javascript is transitive due to ansible operator."`
+
+The VEX Justification field is `customfield_10873`. The exact value string is
+case-sensitive: `"Vulnerable Code not Present"` (lowercase "not"). Set it via
+`jira_update_issue` after the transition since it cannot be included in the
+transition call.
+
+Note: Comments cannot be included in the `jira_transition_issue` call (ADF
+format error). Add comments separately using `jira_add_comment` after the
+transition.
+
+### Full Closure Sequence (per issue)
+
+1. `jira_transition_issue` with transition_id `"61"` and fields
+   `{"resolution": {"name": "Not a Bug"}}`
+2. `jira_add_comment` with the comment text
+3. `jira_update_issue` with fields
+   `{"customfield_10873": {"value": "Vulnerable Code not Present"}}`
+
+## Step 4: Assign Remaining Open Issues for This CVE
+
+After operator issues are handled (closed or left open), assign all remaining
+open issues for this CVE. Ask the user: "Who should the remaining issues be
+assigned to? Default is jshaughn@redhat.com."
+
+If the user confirms the default or provides a different assignee, use
+`jira_update_issue` to set the assignee on each remaining open issue:
+- **fields**: `{"assignee": "<email>"}`
+
+Present the list of issues to be assigned and the proposed assignee for approval
+before executing.
+
+## Step 5: Move Issues to In Progress
+
+After assignment, transition this CVE's remaining open issues to "In Progress" using
+`jira_transition_issue` with:
+- **transition_id**: `"41"` (In Progress)
+
+Present the list of issues to be transitioned for approval before executing.
+
+## Step 6: Qualify the Vulnerability
+
+After initial triage is complete, extract details from the CVE and check the
+Kiali codebase to determine if a fix is straightforward.
+
+### 6a. Extract vulnerability details
+
+Use `jira_get_issue` on one of the open issues (with `fields` set to
+`"description"`) and extract from the description:
+- **Library name** (e.g. `lodash`, `immutable`)
+- **Fixed version** (often stated as "upgrade to version X.Y.Z")
+- **Vulnerability type** (e.g. prototype pollution, arbitrary code execution)
+
+### 6b. Check current dependency version
+
+**For NPM/JS dependencies:**
+1. Read `frontend/package.json` and search for the library name
+2. If not found as a direct dependency, search `frontend/yarn.lock` for the
+   package — it may be a transitive dependency
+
+**For Go dependencies:**
+1. Read `go.mod` and search for the module name
+2. If not a direct dependency, check `go.sum`
+
+### 6c. Present findings
+
+Summarize for the user:
+- Library name and current version in the codebase
+- Whether it is a direct or transitive dependency
+- The fixed version (if stated in the CVE description)
+- Whether the current version is already at or above the fix
+
+Then ask the user how to proceed (e.g. attempt the upgrade, investigate
+further, or handle manually).
+
+## Step 7: Fix the Vulnerability (NPM/JS dependencies)
+
+If the user approves an upgrade attempt, create a PR against master first.
+If it works well, backport PRs are created afterward (backporting is not
+covered by this rule).
+
+### Upgrade approach
+
+Do NOT add `resolutions` to `package.json` unless absolutely necessary.
+The approach differs based on whether the library is a direct or transitive
+dependency (Step 6c will have determined this).
+
+**Common first step:**
+1. Create a new branch from master (e.g. `CVE-YYYY-NNNNN-library-upgrade`)
+
+**For direct dependencies** (listed in `frontend/package.json`):
+2. Update the version range in `frontend/package.json` to require the fixed
+   version (e.g. change `"^4.17.23"` to `"^4.18.0"`)
+3. Run `yarn install --no-immutable` in the `frontend/` directory
+
+**For transitive/indirect dependencies** (only in `frontend/yarn.lock`):
+2. Remove the old entry for the package from `frontend/yarn.lock` entirely
+   (the entry block starts with `"package@npm:..."` and ends before the next
+   top-level entry). Use a script to do this reliably rather than manual
+   editing, since lockfile entries can be long and complex.
+3. Run `yarn install --no-immutable` in the `frontend/` directory to
+   regenerate the lockfile with the latest available version
+
+**Common verification steps:**
+4. Run `make build-ui` to verify the frontend builds
+5. Run `make build-ui-test` to verify frontend tests pass
+6. Present the diff and results to the user for review
+
+### After successful build
+
+Ask the user if they want to commit and create a PR. The PR should reference
+the CVE identifier and list the affected OSSM Jira issues.
+
+After completing Steps 2-7 for this CVE, if there are additional CVEs from
+Step 1, repeat Steps 2-7 for the next CVE.


### PR DESCRIPTION
## Summary
- Adds a manually-invoked Cursor rule (`.cursor/rules/ossm-cve-triage.mdc`) that automates the triage workflow for new OSSM Jira CVE issues affecting the Kiali component
- Covers: CVE identification, JavaScript classification, operator issue closure, assignment, status transitions, vulnerability qualification, and NPM/JS dependency fix procedures
- Work in progress

## Test plan
- [x] Tested the full workflow end-to-end against CVE-2026-4800 (lodash)