### PR TITLE
[v2.4] CVE-2026-4800: Upgrade lodash and lodash-es to 4.18.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
     "i18next": "^23.10.1",
     "i18next-http-backend": "^2.5.0",
     "js-yaml": "^4.1.0",
-    "lodash-es": "^4.17.23",
+    "lodash-es": "^4.18.0",
     "micro-memoize": "4.0.9",
     "moment": "^2.29.4",
     "react": "^17.0.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3122,7 +3122,7 @@ __metadata:
     jest-canvas-mock: "npm:2.2.0"
     js-yaml: "npm:^4.1.0"
     junit-report-merger: "npm:^3.0.5"
-    lodash-es: "npm:^4.17.23"
+    lodash-es: "npm:^4.18.0"
     micro-memoize: "npm:4.0.9"
     mocha-junit-reporter: "npm:^2.2.1"
     moment: "npm:^2.29.4"
@@ -12466,10 +12466,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:^4.18.0":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -12558,9 +12558,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Backport of #9479 to v2.4 (OSSM 3.0)
- Upgrades `lodash-es` (direct) from `^4.17.23` to `^4.18.0` in `frontend/package.json`
- Upgrades `lodash` (transitive) from `4.17.23` to `4.18.1` in `frontend/yarn.lock`
- Addresses CVE-2026-4800

## Test plan
- [x] `yarn install` succeeds
- [ ] CI passes