### PR TITLE
Add multi-arch CPU support to Yarn .yarnrc.yml configuration

### DIFF
--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -1,2 +1,9 @@
 enableTelemetry: false
 nodeLinker: node-modules
+supportedArchitectures:
+  cpu:
+  - current
+  - x64
+  - arm64
+  - ppc64
+  - s390x


### PR DESCRIPTION
### Describe the change

Adds supportedArchitectures.cpu to .yarnrc.yml so that Yarn Berry prefetches platform-specific dependencies for all build target architectures (x64, arm64, ppc64, s390x).

For downstream builds, the yarn install step fails on arm64 with getaddrinfo ENOTFOUND registry.yarnpkg.com because platform-specific conditional dependencies (e.g., @esbuild/linux-arm64) are not available in the prefetch cache. The prefetch task runs on x86_64 and Yarn only downloads packages for the current CPU by default.

### Steps to test the PR

This change only affects downstream, verify CI tests pass upstream.
