### PR TITLE
Make redux-thunk import compatible with both v2 and v3

### DIFF
--- a/frontend/src/actions/__tests__/NamespaceAction.test.ts
+++ b/frontend/src/actions/__tests__/NamespaceAction.test.ts
@@ -1,12 +1,12 @@
 import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import configureMockStore from 'redux-mock-store';
-import * as reduxThunk from 'redux-thunk';
 import { NamespaceActions } from '../NamespaceAction';
 import { NamespaceThunkActions } from '../NamespaceThunkActions';
 
-// Compatible with both redux-thunk v2 (default export) and v3 (named export)
-const thunk = (reduxThunk as any).thunk ?? (reduxThunk as any).default;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/frontend/src/actions/__tests__/NotificationCenterAction.test.ts
+++ b/frontend/src/actions/__tests__/NotificationCenterAction.test.ts
@@ -1,11 +1,11 @@
 import { NotificationCenterActions } from '../NotificationCenterActions';
 import { NotificationCenterThunkActions } from '../NotificationCenterThunkActions';
 import { MessageType } from '../../types/NotificationCenter';
-import * as reduxThunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 
-// Compatible with both redux-thunk v2 (default export) and v3 (named export)
-const thunk = (reduxThunk as any).thunk ?? (reduxThunk as any).default;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/frontend/src/store/ConfigStore.ts
+++ b/frontend/src/store/ConfigStore.ts
@@ -4,9 +4,6 @@ import { persistStore, persistReducer, Transform } from 'redux-persist';
 import { persistFilter } from 'redux-persist-transform-filter';
 import { createTransform } from 'redux-persist';
 import { rootReducer } from '../reducers';
-import * as reduxThunk from 'redux-thunk';
-
-// defaults to localStorage for web and AsyncStorage for react-native
 import storage from 'redux-persist/lib/storage';
 import { INITIAL_GLOBAL_STATE } from '../reducers/GlobalState';
 import { INITIAL_LOGIN_STATE } from '../reducers/LoginState';
@@ -30,8 +27,9 @@ import { INITIAL_CHAT_AI_STATE } from 'reducers/ChatAIState';
 
 declare const window;
 
-// Compatible with both redux-thunk v2 (default export) and v3 (named export)
-const thunk = (reduxThunk as any).thunk ?? (reduxThunk as any).default;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 // `webRoot` can be undefined in some unit tests that mock `app/History`. Be defensive to avoid crashing at import-time.
 const safeWebRoot = typeof webRoot === 'string' && webRoot.length > 0 ? webRoot : '/';


### PR DESCRIPTION
### Describe the change

OCP 4.22 ships a Console that bundles redux-thunk v3, which removes the default export (import thunk from 'redux-thunk'). This breaks OSSMC at runtime when loaded as a dynamic plugin via Module Federation.

This PR replaces the default import with a runtime-compatible namespace import that detects the correct export shape, making Kiali work on both older OCP versions (redux-thunk v2) and OCP 4.22+ (redux-thunk v3).

### Steps to test the PR

Verify OSSMC works fine with OCP 4.22 and older OCP versions.

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/617
