### PR TITLE
[v2.22] Make redux-thunk import compatible with both v2 and v3

### DIFF
--- a/frontend/src/actions/__tests__/NamespaceAction.test.ts
+++ b/frontend/src/actions/__tests__/NamespaceAction.test.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import { NamespaceActions } from '../NamespaceAction';
 import { NamespaceThunkActions } from '../NamespaceThunkActions';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -12,7 +14,7 @@ const mockStore = configureMockStore(middlewares);
 describe('NamespaceActions', () => {
   const RealDate = Date;
 
-  const mockDate = date => {
+  const mockDate = (date: Date): Date => {
     global.Date = jest.fn(() => date) as any;
     return date;
   };

--- a/frontend/src/actions/__tests__/NotificationCenterAction.test.ts
+++ b/frontend/src/actions/__tests__/NotificationCenterAction.test.ts
@@ -1,8 +1,11 @@
 import { NotificationCenterActions } from '../NotificationCenterActions';
 import { NotificationCenterThunkActions } from '../NotificationCenterThunkActions';
 import { MessageType } from '../../types/NotificationCenter';
-import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/frontend/src/store/ConfigStore.ts
+++ b/frontend/src/store/ConfigStore.ts
@@ -3,11 +3,7 @@ import { KialiAppState } from './Store';
 import { persistStore, persistReducer, Transform } from 'redux-persist';
 import { persistFilter } from 'redux-persist-transform-filter';
 import { createTransform } from 'redux-persist';
-
 import { rootReducer } from '../reducers';
-import thunk from 'redux-thunk';
-
-// defaults to localStorage for web and AsyncStorage for react-native
 import storage from 'redux-persist/lib/storage';
 import { INITIAL_GLOBAL_STATE } from '../reducers/GlobalState';
 import { INITIAL_LOGIN_STATE } from '../reducers/LoginState';
@@ -29,6 +25,10 @@ import { webRoot } from 'app/History';
 import { INITIAL_CHAT_AI_STATE } from 'reducers/ChatAIState';
 
 declare const window;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reduxThunkModule = require('redux-thunk');
+const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
 
 const persistKey = `kiali-${webRoot !== '/' ? webRoot.substring(1) : 'root'}`;
 


### PR DESCRIPTION
## Summary

Backport of #9492 to v2.22.

- OCP 4.22 ships a Console that bundles redux-thunk v3, which removes the default export (`import thunk from 'redux-thunk'`). This breaks OSSMC at runtime when loaded as a dynamic plugin via Module Federation.
- Replace the default import with a runtime-compatible `require()` that detects the correct export shape, making Kiali work on both older OCP versions (redux-thunk v2) and OCP 4.22+ (redux-thunk v3).

## Details

The middleware function lives on different properties depending on the version:

| redux-thunk version | OCP version | Module shape | Middleware location |
|---|---|---|---|
| v2 | < 4.22 | `{ default: fn, __esModule: true }` | `.default` |
| v3 | >= 4.22 | `{ thunk: fn, withExtraArgument: fn }` | `.thunk` |

The fix uses `require('redux-thunk')` and resolves the correct property at runtime via nullish coalescing:

```typescript
const thunk = reduxThunkModule.thunk ?? reduxThunkModule.default;
```

## Test plan

- [ ] `yarn build` succeeds (compile-time check with redux-thunk v2 types)
- [ ] `yarn test` passes (unit tests using the thunk middleware)
- [ ] Manual verification on OCP < 4.22 (redux-thunk v2 at runtime)
- [ ] Manual verification on OCP 4.22 (redux-thunk v3 at runtime)

Fixes kiali/openshift-servicemesh-plugin#617


Made with [Cursor](https://cursor.com)