### PR TITLE
[v2.4] Add multi-arch CPU support to Yarn .yarnrc.yml configuration

### DIFF
--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -1,2 +1,9 @@
 enableTelemetry: false
 nodeLinker: node-modules
+supportedArchitectures:
+  cpu:
+  - current
+  - x64
+  - arm64
+  - ppc64
+  - s390x


### PR DESCRIPTION
## Summary

Backport of #9491 to v2.4.

- Adds `supportedArchitectures.cpu` to `.yarnrc.yml` so that Yarn Berry prefetches platform-specific dependencies for all build target architectures (x64, arm64, ppc64, s390x).
- Fixes downstream arm64 builds failing with `getaddrinfo ENOTFOUND registry.yarnpkg.com` because platform-specific conditional dependencies (e.g., `@esbuild/linux-arm64`) were not available in the prefetch cache.

## Test plan

- This change only affects downstream, verify CI tests pass upstream.

Made with [Cursor](https://cursor.com)