### PR TITLE
[2.22] fix(cypress): import ensureKialiFinishedLoading in table helpers

### DIFF
--- a/frontend/cypress/integration/common/graph_context_menu.ts
+++ b/frontend/cypress/integration/common/graph_context_menu.ts
@@ -1,5 +1,4 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { ensureKialiFinishedLoading } from './transition';
 import { Visualization } from '@patternfly/react-topology';
 import { elems, selectAnd } from './graph';
 import { NodeAttr } from 'types/Graph';

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -1,4 +1,5 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
 import { TableDefinition } from 'cypress-cucumber-preprocessor';
 import { MeshCluster } from 'types/Mesh';
 


### PR DESCRIPTION
Fix for error:
```
{ensureKialiFinishedLoading is not defined ReferenceError ReferenceError: ensureKialiFinishedLoading is not defined
    at Context.eval (https://kiali-istio-system.apps.ci-op-wv6tbsm9-5de83.cspilp.interop.ccitredhat.com/__cypress/tests?p=cypress/integration/featureFiles/workloads.feature:16821:17)}
```

- checkHealthIndicatorInTable calls ensureKialiFinishedLoading on the refresh
retry path; the import was omitted after namespace selection moved to
namespace.ts, which caused an intermittent ReferenceError when retries ran.
- Removed unused ensureKialiFinishedLoading import from graph_context_menu.ts.

Assisted-by: Cursor Agent