### PR TITLE
Add AMBIENT_ENABLE_BAGGAGE

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -358,7 +358,8 @@ if [ "${CONFIG_PROFILE}" == "ambient" ]; then
   if [ -n "${CLUSTER_NAME}" ]; then
     ISTIO_YAML=$(echo "$ISTIO_YAML" | yq eval '
         .spec.values.global.multiCluster.clusterName = "'"${CLUSTER_NAME}"'" |
-        .spec.values.pilot.env.AMBIENT_ENABLE_MULTI_NETWORK = "true"
+        .spec.values.pilot.env.AMBIENT_ENABLE_MULTI_NETWORK = "true" |
+        .spec.values.pilot.env.AMBIENT_ENABLE_BAGGAGE = "true"
     ' -)
     ztunnelYAML=$(echo "$ztunnelYAML" | yq eval '
        .spec.values.ztunnel.multiCluster.clusterName = "'"${CLUSTER_NAME}"'" |

--- a/hack/istio/multicluster/install-ambient-multicluster.sh
+++ b/hack/istio/multicluster/install-ambient-multicluster.sh
@@ -69,7 +69,8 @@ install_ambient_on_cluster() {
       --cluster-name "${cluster_name}" \
       --network "${network}" \
       --addons "prometheus grafana jaeger" \
-      --set "values.pilot.env.AMBIENT_ENABLE_MULTI_NETWORK=true"
+      --set "values.pilot.env.AMBIENT_ENABLE_MULTI_NETWORK=true" \
+      --set "values.pilot.env.AMBIENT_ENABLE_BAGGAGE=true"
 
     if [ "$?" != "0" ]; then
       echo "Failed to install Istio with ambient profile using istioctl"


### PR DESCRIPTION
### Describe the change

Use AMBIENT_ENABLE_BAGGAGE in the Ambient multi cluster installation as indicated here: https://istio.io/latest/docs/ambient/install/multicluster/multi-primary_multi-network/ 

With this, it completes the inter cluster telemetry missing data: 

<img width="1149" height="809" alt="image" src="https://github.com/user-attachments/assets/7117562e-e40c-417b-bda4-5bc898cddb2d" />

<img width="1149" height="809" alt="image" src="https://github.com/user-attachments/assets/de4e3754-8db1-40be-aecf-28ab9e2fd5c6" />


### Steps to test the PR

The environment can be run with: 
`hack/run-integration-tests.sh --test-suite frontend-multi-primary --ambient true --waypoint true`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/issues/9507
TODO: OpenShift testing
