### PR TITLE
fix: speed up manage_istio_config tests from 45s to <1s

### DIFF
--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,8 +22,17 @@ import (
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
+
+func TestMain(m *testing.M) {
+	// The fake Istio clientset and the fake kubeCache are separate stores,
+	// so the cache-wait polls always time out (5s each, 9 tests = 45s).
+	// Shortcutting the timeout keeps the tests fast.
+	kubernetes.CacheWaitTimeout = 1 * time.Millisecond
+	os.Exit(m.Run())
+}
 
 // ---------------------------------------------------------------------------
 // helpers

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -626,6 +626,11 @@ func EnvVarIsTrue(key string, env core_v1.EnvVar) bool {
 	return env.Name == key && env.Value == "true"
 }
 
+// CacheWaitTimeout is how long the WaitForObject*InCache helpers poll before
+// giving up. Tests can lower this to avoid a 5-second per-call penalty when
+// the fake kubeCache never reflects writes from a separate fake clientset.
+var CacheWaitTimeout = 5 * time.Second
+
 // WaitForObjectUpdateInCache waits for the update to propagate to the cached object. Modifies obj passed
 // so don't use it afterward.
 func WaitForObjectUpdateInCache(ctx context.Context, kubeCache client.Reader, obj client.Object) error {
@@ -635,7 +640,7 @@ func WaitForObjectUpdateInCache(ctx context.Context, kubeCache client.Reader, ob
 		return fmt.Errorf("unable to convert currentResourceVersion for obj: %s/%s", obj.GetName(), obj.GetNamespace())
 	}
 
-	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, time.Second*5, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, CacheWaitTimeout, true, func(ctx context.Context) (bool, error) {
 		if err := kubeCache.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			return false, err
 		}
@@ -665,7 +670,7 @@ func WaitForObjectUpdateInCache(ctx context.Context, kubeCache client.Reader, ob
 // WaitForObjectDeleteInCache waits for the object to be deleted from the cache.
 func WaitForObjectDeleteInCache(ctx context.Context, kubeCache client.Reader, obj client.Object) error {
 	currentUID := obj.GetUID()
-	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, time.Second*5, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, CacheWaitTimeout, true, func(ctx context.Context) (bool, error) {
 		if err := kubeCache.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -684,7 +689,7 @@ func WaitForObjectDeleteInCache(ctx context.Context, kubeCache client.Reader, ob
 // This probably isn't 100% reliable since something could delete the object
 // after it is created and before we have a chance to see it.
 func WaitForObjectCreateInCache(ctx context.Context, kubeCache client.Reader, obj client.Object) error {
-	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, time.Second*5, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, CacheWaitTimeout, true, func(ctx context.Context) (bool, error) {
 		if err := kubeCache.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION
## Summary

- Extract the hardcoded 5-second cache-wait timeout in `WaitForObject{Create,Update,Delete}InCache` into an overrideable package-level variable `kubernetes.CacheWaitTimeout`
- Set it to 1ms in the MCP test's `TestMain`, dropping the `manage_istio_config` test suite from **~45s to ~0.3s**
- No production behavior change (default remains 5s)

## Root Cause

9 tests that perform confirmed write operations (create/delete/patch) each hit a 5s poll timeout because the fake Istio clientset and the fake `kubeCache` (controller-runtime client) are separate in-memory stores that never sync. The poll always exhausts the full timeout.

## Test plan

- [x] `go test ./ai/mcp/manage_istio_config/...` passes in ~0.3s (was ~45s)
- [x] `go test ./kubernetes/...` passes (WaitForObject* tests still use the 5s default)
- [x] `make test` passes — full suite clean

Fixes #9517

Made with [Cursor](https://cursor.com)