### PR TITLE
[Ambient] Use waypoint data from spans for trace overlay

### DIFF
--- a/business/tracing.go
+++ b/business/tracing.go
@@ -132,6 +132,14 @@ func spanMatchesAmbientWorkload(span *jaegerModels.Span, workload, namespace str
 		spanTagMatches(span, "istio.source_workload", "istio.source_namespace", workload, namespace)
 }
 
+func spanHasAmbientWorkloadTags(span *jaegerModels.Span) bool {
+	_, hasDestWorkload := spanTagValue(span, "istio.destination_workload")
+	_, hasDestNamespace := spanTagValue(span, "istio.destination_namespace")
+	_, hasSourceWorkload := spanTagValue(span, "istio.source_workload")
+	_, hasSourceNamespace := spanTagValue(span, "istio.source_namespace")
+	return (hasDestWorkload && hasDestNamespace) || (hasSourceWorkload && hasSourceNamespace)
+}
+
 func (in *TracingService) GetWorkloadSpans(ctx context.Context, ns, workload string, query models.TracingQuery) ([]model.TracingSpan, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetWorkloadSpans",
@@ -310,8 +318,15 @@ func spanMatchesWorkload(ctx context.Context, span *jaegerModels.Span, namespace
 	// If the workload has a waypoint, the span won't match, but the operation name can
 	// When the workload has a waypoint, the operation name is filtered by the service
 	if tracingName.WaypointName != "" {
-		zl.Info().Msgf("spanMatchesWorkload workload: [%s] span: [%+v]", tracingName.Workload, span.Tags)
-		return spanMatchesAmbientWorkload(span, tracingName.Workload, namespace)
+		if spanHasAmbientWorkloadTags(span) {
+			matched := spanMatchesAmbientWorkload(span, tracingName.Workload, namespace)
+			zl.Trace().Msgf("spanMatchesWorkload ambient tags match=[%t] workload=[%s] tags=[%+v]", matched, tracingName.Workload, span.Tags)
+			return matched
+		}
+		// Fallback for older Istio traces that don't include ambient workload tags.
+		op := fmt.Sprintf("%s.%s", tracingName.App, namespace)
+		zl.Trace().Msgf("spanMatchesWorkload fallback operationName=[%s] prefix=[%s] (waypoint legacy)", span.OperationName, op)
+		return strings.HasPrefix(span.OperationName, op)
 	}
 	// For envoy traces, with a workload named "ai-locals", node_id is like:
 	// sidecar~172.17.0.20~ai-locals-6d8996bff-ztg6z.default~default.svc.cluster.local

--- a/business/tracing.go
+++ b/business/tracing.go
@@ -132,14 +132,6 @@ func spanMatchesAmbientWorkload(span *jaegerModels.Span, workload, namespace str
 		spanTagMatches(span, "istio.source_workload", "istio.source_namespace", workload, namespace)
 }
 
-func spanHasAmbientWorkloadTags(span *jaegerModels.Span) bool {
-	_, hasDestWorkload := spanTagValue(span, "istio.destination_workload")
-	_, hasDestNamespace := spanTagValue(span, "istio.destination_namespace")
-	_, hasSourceWorkload := spanTagValue(span, "istio.source_workload")
-	_, hasSourceNamespace := spanTagValue(span, "istio.source_namespace")
-	return (hasDestWorkload && hasDestNamespace) || (hasSourceWorkload && hasSourceNamespace)
-}
-
 func (in *TracingService) GetWorkloadSpans(ctx context.Context, ns, workload string, query models.TracingQuery) ([]model.TracingSpan, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetWorkloadSpans",

--- a/business/tracing.go
+++ b/business/tracing.go
@@ -96,9 +96,48 @@ func operationSpanFilter(ctx context.Context, ns, service string) SpanFilter {
 	// Filter out app spans based on operation name.
 	// For envoy traces, operation name is like "service-name.namespace.svc.cluster.local:8000/*"
 	return func(span *jaegerModels.Span) bool {
+		// For ambient traces, use canonical service tags when available.
+		if spanTagMatches(span, "istio.destination_canonical_service", "istio.destination_namespace", service, ns) ||
+			spanTagMatches(span, "istio.source_canonical_service", "istio.source_namespace", service, ns) {
+			return true
+		}
 		log.FromContext(ctx).Trace().Msgf("operationSpanFilter [%s] has prefix [%s]", span.OperationName, fqService)
 		return strings.HasPrefix(span.OperationName, fqService)
 	}
+}
+
+func spanTagValue(span *jaegerModels.Span, key string) (string, bool) {
+	for _, tag := range span.Tags {
+		if tag.Key != key {
+			continue
+		}
+		if v, ok := tag.Value.(string); ok && v != "" {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func spanTagMatches(span *jaegerModels.Span, nameTag, namespaceTag, expectedName, expectedNamespace string) bool {
+	name, nameFound := spanTagValue(span, nameTag)
+	namespace, nsFound := spanTagValue(span, namespaceTag)
+	if !nameFound || !nsFound {
+		return false
+	}
+	return name == expectedName && namespace == expectedNamespace
+}
+
+func spanMatchesAmbientWorkload(span *jaegerModels.Span, workload, namespace string) bool {
+	return spanTagMatches(span, "istio.destination_workload", "istio.destination_namespace", workload, namespace) ||
+		spanTagMatches(span, "istio.source_workload", "istio.source_namespace", workload, namespace)
+}
+
+func spanHasAmbientWorkloadTags(span *jaegerModels.Span) bool {
+	_, hasDestWorkload := spanTagValue(span, "istio.destination_workload")
+	_, hasDestNamespace := spanTagValue(span, "istio.destination_namespace")
+	_, hasSourceWorkload := spanTagValue(span, "istio.source_workload")
+	_, hasSourceNamespace := spanTagValue(span, "istio.source_namespace")
+	return (hasDestWorkload && hasDestNamespace) || (hasSourceWorkload && hasSourceNamespace)
 }
 
 func (in *TracingService) GetWorkloadSpans(ctx context.Context, ns, workload string, query models.TracingQuery) ([]model.TracingSpan, error) {
@@ -279,9 +318,8 @@ func spanMatchesWorkload(ctx context.Context, span *jaegerModels.Span, namespace
 	// If the workload has a waypoint, the span won't match, but the operation name can
 	// When the workload has a waypoint, the operation name is filtered by the service
 	if tracingName.WaypointName != "" {
-		op := fmt.Sprintf("%s.%s", tracingName.App, namespace)
-		zl.Trace().Msgf("spanMatchesWorkload [%s] has prefix [%s] (waypoint name)", span.OperationName, op)
-		return strings.HasPrefix(span.OperationName, op)
+		zl.Info().Msgf("spanMatchesWorkload workload: [%s] span: [%+v]", tracingName.Workload, span.Tags)
+		return spanMatchesAmbientWorkload(span, tracingName.Workload, namespace)
 	}
 	// For envoy traces, with a workload named "ai-locals", node_id is like:
 	// sidecar~172.17.0.20~ai-locals-6d8996bff-ztg6z.default~default.svc.cluster.local

--- a/business/tracing_test.go
+++ b/business/tracing_test.go
@@ -138,6 +138,35 @@ var waypointTrace = jaegerModels.Trace{
 	},
 }
 
+var ambientTagTrace = jaegerModels.Trace{
+	Spans: []jaegerModels.Span{{
+		ProcessID:     "at_process_1",
+		OperationName: "waypoint-proxy-operation",
+		Tags: []jaegerModels.KeyValue{{
+			Key:   "istio.destination_workload",
+			Value: "reviews-v1",
+		}, {
+			Key:   "istio.destination_namespace",
+			Value: "default",
+		}, {
+			Key:   "istio.destination_canonical_service",
+			Value: "reviews",
+		}, {
+			Key:   "istio.source_workload",
+			Value: "productpage-v1",
+		}, {
+			Key:   "istio.source_namespace",
+			Value: "default",
+		}},
+	}},
+	Processes: map[jaegerModels.ProcessID]jaegerModels.Process{
+		"at_process_1": {
+			ServiceName: "waypoint.default",
+			Tags:        []jaegerModels.KeyValue{},
+		},
+	},
+}
+
 func TestMatchingWorkload(t *testing.T) {
 	assert := assert.New(t)
 	tracingName := models.TracingName{App: "some-workload", Workload: "some-workload", Lookup: "some-workload"}
@@ -230,6 +259,61 @@ func TestTracesToSpanWaypointWithWorkloadFilter(t *testing.T) {
 	spans := tracesToSpans(context.Background(), tracingName, &r, wkdSpanFilter(context.Background(), "default", tracingName), config.NewConfig())
 	assert.Len(spans, 1)
 	// Process is empty here, because the span we are looking for is the service and the process is the waypoint
+}
+
+func TestTracesToSpanWaypointWithAmbientTagWorkloadFilter(t *testing.T) {
+	assert := assert.New(t)
+
+	r := model.TracingResponse{
+		Data:               []jaegerModels.Trace{ambientTagTrace},
+		TracingServiceName: "waypoint.default",
+	}
+	tracingName := models.TracingName{App: "reviews", Workload: "reviews-v1", Lookup: "waypoint", WaypointName: "waypoint"}
+	spans := tracesToSpans(context.Background(), tracingName, &r, wkdSpanFilter(context.Background(), "default", tracingName), config.NewConfig())
+	assert.Len(spans, 1)
+}
+
+func TestOperationSpanFilterMatchesAmbientCanonicalService(t *testing.T) {
+	assert := assert.New(t)
+
+	filter := operationSpanFilter(context.Background(), "default", "reviews")
+	span := jaegerModels.Span{
+		OperationName: "does-not-have-service-prefix",
+		Tags: []jaegerModels.KeyValue{
+			{Key: "istio.destination_canonical_service", Value: "reviews"},
+			{Key: "istio.destination_namespace", Value: "default"},
+		},
+	}
+	assert.True(filter(&span))
+}
+
+func TestTracesToSpanWaypointWithAmbientTagsDoNotFallbackToAppPrefix(t *testing.T) {
+	assert := assert.New(t)
+
+	trace := jaegerModels.Trace{
+		Spans: []jaegerModels.Span{{
+			ProcessID:     "at_process_1",
+			OperationName: "reviews.default.svc.cluster.local:9080/*",
+			Tags: []jaegerModels.KeyValue{
+				{Key: "istio.destination_workload", Value: "reviews-v1"},
+				{Key: "istio.destination_namespace", Value: "default"},
+			},
+		}},
+		Processes: map[jaegerModels.ProcessID]jaegerModels.Process{
+			"at_process_1": {
+				ServiceName: "waypoint.default",
+				Tags:        []jaegerModels.KeyValue{},
+			},
+		},
+	}
+
+	r := model.TracingResponse{
+		Data:               []jaegerModels.Trace{trace},
+		TracingServiceName: "waypoint.default",
+	}
+	tracingName := models.TracingName{App: "reviews", Workload: "reviews-v2", Lookup: "waypoint", WaypointName: "waypoint"}
+	spans := tracesToSpans(context.Background(), tracingName, &r, wkdSpanFilter(context.Background(), "default", tracingName), config.NewConfig())
+	assert.Len(spans, 0)
 }
 
 func TestValidateConfiguration(t *testing.T) {

--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -63,25 +63,14 @@ Then('user can filter spans by app {string}', (app: string) => {
   cy.get('ul[role="menu"]').should('be.visible');
 });
 
-Then('user can filter spans by app {string} by {string}', (app: string, waypoint: string) => {
+Then('user can filter spans by app {string} for waypoint traces', (app: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
   cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
-  cy.get('body').then($body => {
-    const appOption = `li[label="${app}"]`;
-    const waypointOption = `li[label="${waypoint}"]`;
-
-    if ($body.find(appOption).length > 0) {
-      cy.get(appOption).should('be.visible').find('button').click();
-      return;
-    }
-
-    cy.get('input[placeholder="Filter by App"]').clear().type(`${waypoint}{enter}`);
-    cy.get(waypointOption).should('be.visible').find('button').click();
-  });
+  cy.get(`li[label="${app}"]`).should('be.visible').find('button').click();
 
   getCellsForCol('App / Workload').each($cell => {
-    cy.wrap($cell).contains(waypoint);
+    cy.wrap($cell).contains(app);
   });
 
   getCellsForCol(4).first().click();

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -63,4 +63,4 @@ Feature: Kiali App Details page
     And user sees trace information
     When user selects a trace with at least 4 spans
     Then user sees span details
-    And user can filter spans by app "details" by "waypoint"
+    And user can filter spans by app "details" for waypoint traces

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -66,7 +66,7 @@ Feature: Kiali Workload Details page
     And user sees trace information
     When user selects a trace with at least 4 spans
     And user sees span details
-    And user can filter spans by workload "waypoint"
+    And user can filter spans by workload "details-v1"
 
   @bookinfo-app
   @tracing

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -141,7 +141,7 @@ class TraceDetailsComponent extends React.Component<Props, State> {
             <Button
               style={{ paddingLeft: 0, paddingRight: '0.25rem', fontSize: '0.75rem' }}
               variant={ButtonVariant.link}
-              onClick={() => this.props.setTraceId(t.traceID)}
+              onClick={() => this.props.setTraceId(this.props.cluster, t.traceID)}
             >
               {info.shortID()}
             </Button>

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -203,6 +203,8 @@ const TopologyContent: React.FC<{
   const suppressNextMiniGraphNodeTapRef = React.useRef(false);
   const prevGraphSelectionIdRef = React.useRef<string | undefined>(undefined);
   React.useEffect(() => {
+    // Clear trace overlay when switching between nodes. When a user selects a different node,
+    // the trace highlights from the previous node are no longer relevant and should be hidden.
     if (!isMiniGraph && controller.hasGraph()) {
       const newSelId = selectedIds.length > 0 ? selectedIds[0] : undefined;
       if (prevGraphSelectionIdRef.current !== undefined && prevGraphSelectionIdRef.current !== newSelId) {

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -201,7 +201,16 @@ const TopologyContent: React.FC<{
   const selectedRef = React.useRef<string>();
   // Mini graph pre-selects the focus node on load; skip one onNodeTap so that does not trigger client-side navigation.
   const suppressNextMiniGraphNodeTapRef = React.useRef(false);
+  const prevGraphSelectionIdRef = React.useRef<string | undefined>(undefined);
   React.useEffect(() => {
+    if (!isMiniGraph && controller.hasGraph()) {
+      const newSelId = selectedIds.length > 0 ? selectedIds[0] : undefined;
+      if (prevGraphSelectionIdRef.current !== undefined && prevGraphSelectionIdRef.current !== newSelId) {
+        hideTrace(controller);
+      }
+      prevGraphSelectionIdRef.current = newSelId;
+    }
+
     if (selectedIds.length > 0) {
       if (selectedRef.current === selectedIds[0]) {
         return;
@@ -274,14 +283,13 @@ const TopologyContent: React.FC<{
     }
 
     if (!!trace) {
-      const ambient = graphData.fetchParams.trafficRates.some(rate => rate === 'ambient');
-      showTrace(controller, graphData.fetchParams.graphType, ambient, trace);
+      showTrace(controller, graphData.fetchParams.graphType, trace);
     }
 
     return () => {
       hideTrace(controller);
     };
-  }, [controller, graphData.fetchParams.graphType, graphData.fetchParams.trafficRates, trace]);
+  }, [controller, graphData.fetchParams.graphType, trace]);
 
   //
   // Layout and resize handling

--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -867,7 +867,7 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => ({
   setLayout: bindActionCreators(GraphActions.setLayout, dispatch),
   setNode: bindActionCreators(GraphActions.setNode, dispatch),
   setRankResult: bindActionCreators(GraphActions.setRankResult, dispatch),
-  setTraceId: (traceId?: string) => dispatch(TracingThunkActions.setTraceId(traceId)),
+  setTraceId: (traceId?: string) => dispatch(TracingThunkActions.setTraceId(undefined, traceId)),
   setUpdateTime: (val: TimeInMilliseconds) => dispatch(GraphActions.setUpdateTime(val)),
   startTour: bindActionCreators(TourActions.startTour, dispatch),
   toggleIdleNodes: bindActionCreators(GraphToolbarActions.toggleIdleNodes, dispatch),

--- a/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -142,7 +142,12 @@ class SummaryPanelTraceDetailsComponent extends React.Component<Props, State> {
 
           <span className={closeBoxStyle}>
             <Tooltip content="Close and clear trace selection">
-              <Button icon={<KialiIcon.Close />} id="close-trace" variant={ButtonVariant.plain} onClick={this.props.close} />
+              <Button
+                icon={<KialiIcon.Close />}
+                id="close-trace"
+                variant={ButtonVariant.plain}
+                onClick={this.props.close}
+              />
             </Tooltip>
           </span>
         </div>
@@ -422,7 +427,7 @@ const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => ({
-  close: () => dispatch(TracingThunkActions.setTraceId('', undefined)),
+  close: () => dispatch(TracingThunkActions.setTraceId(undefined, undefined)),
   setNode: bindActionCreators(GraphActions.setNode, dispatch)
 });
 

--- a/frontend/src/pages/Graph/Trace.ts
+++ b/frontend/src/pages/Graph/Trace.ts
@@ -9,7 +9,7 @@ import {
   searchParentApp,
   searchParentWorkload
 } from 'utils/tracing/TracingHelper';
-import { edgesOut, elems, select, SelectAnd, selectAnd, setObserved } from 'helpers/GraphHelpers';
+import { edgesOut, elems, nodesIn, nodesOut, select, SelectAnd, selectAnd, setObserved } from 'helpers/GraphHelpers';
 
 /**
  * Extracts service name and namespace from span operationName or serviceName.
@@ -46,6 +46,66 @@ const extractServiceAndNsFromSpan = (span: Span): [string, string] => {
   // Fallback to process.serviceName
   const parts = span.process.serviceName.split('.');
   return [parts[0], parts.length > 1 ? parts[1] : ''];
+};
+
+const resolveDestinationWorkload = (
+  nodes: Node[],
+  span: Span,
+  app: string,
+  namespace: string,
+  lastSelection: Node[] | undefined
+): Node[] => {
+  const spanKind = String(span.tags.find(tag => tag.key === 'span.kind')?.value || '');
+  const canUseDirectWorkload = spanKind === 'server' || spanKind === 'consumer' || isWaypointProxySpan(span);
+
+  // Direct workload extraction is reliable for server/consumer spans (or waypoint spans).
+  // For envoy client/producer spans, node_id usually points to source proxy/workload.
+  if (canUseDirectWorkload) {
+    const destWlNs = getWorkloadFromSpan(span);
+    if (destWlNs?.workload) {
+      const selector: SelectAnd = [
+        { prop: NodeAttr.workload, val: destWlNs.workload },
+        { prop: NodeAttr.namespace, val: destWlNs.namespace }
+      ];
+      const selected = selectAnd(nodes, selector) as Node[];
+      const selectedByApp = selected.filter(n => {
+        const data = n.getData();
+        return data[NodeAttr.app] === app && (namespace === '' || data[NodeAttr.namespace] === namespace);
+      });
+      if (selectedByApp.length > 0) {
+        return selectedByApp;
+      }
+    }
+  }
+
+  // Gateway/waypoint spans may not include destination workload tags.
+  // In that case infer the destination workload from the selected service outgoing edges.
+  if (lastSelection && lastSelection.length > 0) {
+    const adjacentCandidates = [...nodesOut(lastSelection), ...nodesIn(lastSelection)];
+    const adjacentWorkloads = adjacentCandidates.filter(n => {
+      const data = n.getData();
+      return (
+        !!data[NodeAttr.workload] &&
+        data[NodeAttr.app] === app &&
+        (namespace === '' || data[NodeAttr.namespace] === namespace)
+      );
+    });
+    // Avoid false positives on sidecar/non-ambient traces where a service fan-outs to multiple versions.
+    // In that case the client span does not tell us the exact destination workload.
+    if (adjacentWorkloads.length === 1) {
+      return adjacentWorkloads;
+    }
+  }
+
+  const fallbackSelector: SelectAnd = [
+    { prop: NodeAttr.workload, op: 'truthy' },
+    { prop: NodeAttr.app, val: app }
+  ];
+  if (namespace) {
+    fallbackSelector.push({ prop: NodeAttr.namespace, val: namespace });
+  }
+  const fallback = selectAnd(nodes, fallbackSelector) as Node[];
+  return fallback.length === 1 ? fallback : [];
 };
 
 export const showTrace = (controller: Controller, graphType: GraphType, trace: JaegerTrace): void => {
@@ -120,7 +180,15 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Sp
     }
   } else {
     // Parent workload: for waypoint spans, source is in own tags; for others, search parent
-    const sourceWlNs = isWaypointProxySpan(span) ? getSourceWorkloadFromWaypointSpan(span) : searchParentWorkload(span);
+    let sourceWlNs = isWaypointProxySpan(span) ? getSourceWorkloadFromWaypointSpan(span) : searchParentWorkload(span);
+    if (!sourceWlNs) {
+      const spanKind = String(span.tags.find(tag => tag.key === 'span.kind')?.value || '');
+      if (spanKind === 'client' || spanKind === 'producer') {
+        // Root client spans (like ingress gateway -> service) have no parent span.
+        // In that case, node_id/process data points to the source workload itself.
+        sourceWlNs = getWorkloadFromSpan(span);
+      }
+    }
     if (sourceWlNs) {
       const parent = selectAnd(nodes, [
         { prop: NodeAttr.workload, val: sourceWlNs.workload },
@@ -159,13 +227,9 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Sp
     }
   } else {
     // Main workload (graph nodes store deployment name on `workload`, not `app`)
-    const destWlNs = getWorkloadFromSpan(span);
-    if (destWlNs && destWlNs.workload) {
-      const selector: SelectAnd = [
-        { prop: NodeAttr.workload, val: destWlNs.workload },
-        { prop: NodeAttr.namespace, val: destWlNs.namespace }
-      ];
-      lastSelection = nextHop(span, selectAnd(nodes, selector) as Node[], lastSelection);
+    const workloadSelection = resolveDestinationWorkload(nodes, span, app, namespace, lastSelection);
+    if (workloadSelection.length > 0) {
+      lastSelection = nextHop(span, workloadSelection, lastSelection);
     }
   }
 
@@ -179,6 +243,35 @@ const singleEdge = (edges: Edge[]): Edge | undefined => {
     console.debug(`Expected singleton, found [${edges.length}] edges. Using first.`);
   }
   return edges.length > 0 ? edges[0] : undefined;
+};
+
+const edgeProtocol = (edge: Edge): string | undefined => {
+  const protocol = edge.getData()?.traffic?.protocol;
+  return typeof protocol === 'string' ? protocol.toLowerCase() : undefined;
+};
+
+const spanProtocol = (span: Span): string | undefined => {
+  if (span.tags.some(tag => tag.key.startsWith('http.'))) {
+    return 'http';
+  }
+  if (span.tags.some(tag => tag.key.startsWith('peer.'))) {
+    return 'tcp';
+  }
+  return undefined;
+};
+
+const pickEdgeForSpan = (edges: Edge[], span: Span): Edge | undefined => {
+  if (edges.length === 0) {
+    return undefined;
+  }
+  const protocol = spanProtocol(span);
+  if (protocol) {
+    const matching = edges.filter(e => edgeProtocol(e) === protocol);
+    if (matching.length > 0) {
+      return singleEdge(matching);
+    }
+  }
+  return singleEdge(edges);
 };
 
 const singleNode = (nodes: Node[]): Node | undefined => {
@@ -267,7 +360,7 @@ const nextHop = (span: Span, next: Node[] | undefined, last: Node[] | undefined)
       if (!edge || edge.length === 0) {
         edge = edgesOut(next, last);
       }
-      addSpan(singleEdge(edge), span);
+      addSpan(pickEdgeForSpan(edge, span), span);
     }
     return next;
   }

--- a/frontend/src/pages/Graph/Trace.ts
+++ b/frontend/src/pages/Graph/Trace.ts
@@ -3,12 +3,50 @@ import { JaegerTrace, Span } from 'types/TracingInfo';
 import { NodeType, GraphType, SEInfo, NodeAttr } from 'types/Graph';
 import {
   getAppFromSpan,
+  getSourceWorkloadFromWaypointSpan,
   getWorkloadFromSpan,
   isWaypointProxySpan,
   searchParentApp,
   searchParentWorkload
 } from 'utils/tracing/TracingHelper';
 import { edgesOut, elems, select, SelectAnd, selectAnd, setObserved } from 'helpers/GraphHelpers';
+
+/**
+ * Extracts service name and namespace from span operationName or serviceName.
+ * Handles different formats:
+ * - "service.namespace.svc.cluster.local:port/path" (waypoint/gateway)
+ * - "router outbound|port||service.namespace.svc.cluster.local; egress" (envoy client)
+ * - "service.namespace" (standard)
+ * @returns [serviceName, namespace]
+ */
+const extractServiceAndNsFromSpan = (span: Span): [string, string] => {
+  const op = span.operationName;
+
+  // Handle envoy router format: "router outbound|9080||productpage.bookinfo.svc.cluster.local; egress"
+  if (op.includes('outbound|') && op.includes('||')) {
+    const parts = op.split('||');
+    if (parts.length >= 2) {
+      // Extract "productpage.bookinfo.svc.cluster.local" part
+      const serviceFqdn = parts[1].split(';')[0].trim();
+      const fqdnParts = serviceFqdn.split('.');
+      if (fqdnParts.length >= 2) {
+        return [fqdnParts[0], fqdnParts[1]];
+      }
+    }
+  }
+
+  // Handle standard service FQDN format: "service.namespace.svc.cluster.local:port/path"
+  if (op.includes('.svc.cluster.local') || (op.includes('.') && op.includes(':'))) {
+    const parts = op.split('.');
+    if (parts.length >= 2) {
+      return [parts[0], parts[1]];
+    }
+  }
+
+  // Fallback to process.serviceName
+  const parts = span.process.serviceName.split('.');
+  return [parts[0], parts.length > 1 ? parts[1] : ''];
+};
 
 export const showTrace = (controller: Controller, graphType: GraphType, trace: JaegerTrace): void => {
   if (!controller.hasGraph()) {
@@ -20,14 +58,23 @@ export const showTrace = (controller: Controller, graphType: GraphType, trace: J
 };
 
 const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Span): void => {
-  let split: string[];
-  if (isWaypointProxySpan(span)) {
-    // Waypoint proxy: logical service is in operationName (e.g. reviews.bookinfo), not process.serviceName
-    split = span.operationName.split('.');
+  // For proxy spans (waypoint, gateway, router), the operationName contains the destination service.
+  const operationHasServiceInfo =
+    span.operationName.includes('.svc.cluster.local') ||
+    span.operationName.includes('outbound|') ||
+    isWaypointProxySpan(span);
+
+  let app: string;
+  let namespace: string;
+
+  if (operationHasServiceInfo) {
+    // Extract service and namespace from operationName for proxies (waypoint, gateway, router)
+    [app, namespace] = extractServiceAndNsFromSpan(span);
   } else {
-    split = span.process.serviceName.split('.');
+    const split = span.process.serviceName.split('.');
+    app = split[0];
+    namespace = split.length > 1 ? split[1] : '';
   }
-  const app = split[0];
   // From upstream to downstream: Parent app or workload, Inbound Service Entry, Service, App or Workload, Outbound Service Entry
   let lastSelection: Node[] | undefined = undefined;
 
@@ -43,8 +90,10 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Sp
         { prop: NodeAttr.namespace, val: sourceAppNs.namespace }
       ]);
       if (parent.length === 0) {
-        // Try workload
-        const sourceWlNs = searchParentWorkload(span);
+        // Try workload: for waypoint spans, source is in own tags; for others, search parent
+        const sourceWlNs = isWaypointProxySpan(span)
+          ? getSourceWorkloadFromWaypointSpan(span)
+          : searchParentWorkload(span);
         if (sourceWlNs) {
           parent = selectAnd(nodes, [
             { prop: NodeAttr.workload, val: sourceWlNs.workload },
@@ -70,8 +119,8 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Sp
       }
     }
   } else {
-    // Parent workload
-    const sourceWlNs = searchParentWorkload(span);
+    // Parent workload: for waypoint spans, source is in own tags; for others, search parent
+    const sourceWlNs = isWaypointProxySpan(span) ? getSourceWorkloadFromWaypointSpan(span) : searchParentWorkload(span);
     if (sourceWlNs) {
       const parent = selectAnd(nodes, [
         { prop: NodeAttr.workload, val: sourceWlNs.workload },
@@ -92,8 +141,8 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Sp
     { prop: NodeAttr.nodeType, val: NodeType.SERVICE },
     { prop: NodeAttr.app, val: app }
   ];
-  if (split.length > 1) {
-    selector.push({ prop: NodeAttr.namespace, val: split[1] });
+  if (namespace) {
+    selector.push({ prop: NodeAttr.namespace, val: namespace });
   }
   lastSelection = nextHop(span, selectAnd(nodes, selector) as Node[], lastSelection);
 

--- a/frontend/src/pages/Graph/Trace.ts
+++ b/frontend/src/pages/Graph/Trace.ts
@@ -4,29 +4,25 @@ import { NodeType, GraphType, SEInfo, NodeAttr } from 'types/Graph';
 import {
   getAppFromSpan,
   getWorkloadFromSpan,
+  isWaypointProxySpan,
   searchParentApp,
   searchParentWorkload
 } from 'utils/tracing/TracingHelper';
 import { edgesOut, elems, select, SelectAnd, selectAnd, setObserved } from 'helpers/GraphHelpers';
 
-export const showTrace = (
-  controller: Controller,
-  graphType: GraphType,
-  isAmbient: boolean,
-  trace: JaegerTrace
-): void => {
+export const showTrace = (controller: Controller, graphType: GraphType, trace: JaegerTrace): void => {
   if (!controller.hasGraph()) {
     return;
   }
 
   hideTrace(controller);
-  trace.spans.forEach(span => showSpanSubtrace(controller, graphType, isAmbient, span));
+  trace.spans.forEach(span => showSpanSubtrace(controller, graphType, span));
 };
 
-const showSpanSubtrace = (controller: Controller, graphType: GraphType, isAmbient: boolean, span: Span): void => {
+const showSpanSubtrace = (controller: Controller, graphType: GraphType, span: Span): void => {
   let split: string[];
-  if (isAmbient) {
-    // For Ambient, the service Name will always be the waypoint or the gateway
+  if (isWaypointProxySpan(span)) {
+    // Waypoint proxy: logical service is in operationName (e.g. reviews.bookinfo), not process.serviceName
     split = span.operationName.split('.');
   } else {
     split = span.process.serviceName.split('.');
@@ -113,11 +109,11 @@ const showSpanSubtrace = (controller: Controller, graphType: GraphType, isAmbien
       lastSelection = nextHop(span, selectAnd(nodes, selector) as Node[], lastSelection);
     }
   } else {
-    // Main workload
+    // Main workload (graph nodes store deployment name on `workload`, not `app`)
     const destWlNs = getWorkloadFromSpan(span);
-    if (destWlNs) {
+    if (destWlNs && destWlNs.workload) {
       const selector: SelectAnd = [
-        { prop: NodeAttr.app, val: destWlNs.workload },
+        { prop: NodeAttr.workload, val: destWlNs.workload },
         { prop: NodeAttr.namespace, val: destWlNs.namespace }
       ];
       lastSelection = nextHop(span, selectAnd(nodes, selector) as Node[], lastSelection);

--- a/frontend/src/utils/tracing/TraceTransform.ts
+++ b/frontend/src/utils/tracing/TraceTransform.ts
@@ -1,50 +1,55 @@
 import _isEqual from 'lodash/isEqual';
 import { KeyValuePair, Span, SpanData, JaegerTrace, TraceData, RichSpanData } from 'types/TracingInfo';
-import { extractSpanInfo, getWorkloadFromSpan } from './TracingHelper';
+import { extractSpanInfo, getAppFromSpan, getWorkloadFromSpan, isWaypointProxySpan } from './TracingHelper';
+
+type TreeSearchFn = (value: string, node: TreeNode, depth: number) => boolean;
 
 class TreeNode {
   value: string;
-  children: any[];
+  children: TreeNode[];
 
-  static iterFunction(fn, depth = 0) {
-    return node => fn(node.value, node, depth);
+  static iterFunction(fn: TreeSearchFn, depth = 0): (node: TreeNode) => boolean {
+    return (node: TreeNode) => !!fn(node.value, node, depth);
   }
 
-  static searchFunction(search) {
+  static searchFunction(search: TreeNode | string | TreeSearchFn): TreeSearchFn {
     if (typeof search === 'function') {
       return search;
     }
 
-    return (value, node) => (search instanceof TreeNode ? node === search : value === search);
+    return (value: string, node: TreeNode, _depth: number) =>
+      search instanceof TreeNode ? node === search : value === search;
   }
 
-  constructor(value, children = []) {
+  constructor(value: string, children: TreeNode[] = []) {
     this.value = value;
     this.children = children;
   }
 
-  get depth() {
-    return this.children.reduce((depth, child) => Math.max(child.depth + 1, depth), 1);
+  get depth(): number {
+    return this.children.reduce((d, child) => Math.max(child.depth + 1, d), 1);
   }
 
-  get size() {
+  get size(): number {
     let i = 0;
-    this.walk(() => i++);
+    this.walk(() => {
+      i++;
+    });
     return i;
   }
 
-  addChild(child) {
+  addChild(child: string | TreeNode): this {
     this.children.push(child instanceof TreeNode ? child : new TreeNode(child));
     return this;
   }
 
-  find(search) {
+  find(search: TreeNode | string | TreeSearchFn): TreeNode | null {
     const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
     if (searchFn(this)) {
       return this;
     }
-    for (let i = 0; i < this.children.length; i++) {
-      const result = this.children[i].find(search);
+    for (let j = 0; j < this.children.length; j++) {
+      const result = this.children[j].find(search);
       if (result) {
         return result;
       }
@@ -52,18 +57,16 @@ class TreeNode {
     return null;
   }
 
-  getPath(search) {
+  getPath(search: TreeNode | string | TreeSearchFn): TreeNode[] | null {
     const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
 
-    const findPath = (currentNode, currentPath) => {
-      // skip if we already found the result
+    const findPath = (currentNode: TreeNode, currentPath: TreeNode[]): TreeNode[] | null => {
       const attempt = currentPath.concat([currentNode]);
-      // base case: return the array when there is a match
       if (searchFn(currentNode)) {
         return attempt;
       }
-      for (let i = 0; i < currentNode.children.length; i++) {
-        const child = currentNode.children[i];
+      for (let j = 0; j < currentNode.children.length; j++) {
+        const child = currentNode.children[j];
         const match = findPath(child, attempt);
         if (match) {
           return match;
@@ -75,24 +78,25 @@ class TreeNode {
     return findPath(this, []);
   }
 
-  walk(fn, depth = 0) {
-    const nodeStack: any[] = [];
+  walk(fn: (value: string, node: TreeNode, depth: number) => void, depth = 0): void {
+    const nodeStack: { depth: number; node: TreeNode }[] = [];
     let actualDepth = depth;
-    nodeStack.push({ node: this, depth: actualDepth });
+    nodeStack.push({ depth: actualDepth, node: this });
     while (nodeStack.length) {
-      const { node, depth: nodeDepth } = nodeStack.pop();
+      const popped = nodeStack.pop()!;
+      const { depth: nodeDepth, node } = popped;
       fn(node.value, node, nodeDepth);
       actualDepth = nodeDepth + 1;
       let i = node.children.length - 1;
       while (i >= 0) {
-        nodeStack.push({ node: node.children[i], depth: actualDepth });
+        nodeStack.push({ depth: actualDepth, node: node.children[i] });
         i--;
       }
     }
   }
 }
 
-function deduplicateTags(spanTags: Array<KeyValuePair>) {
+function deduplicateTags(spanTags: Array<KeyValuePair>): { tags: KeyValuePair[]; warnings: string[] } {
   const warningsHash: Map<string, string> = new Map<string, string>();
   const tags: Array<KeyValuePair> = spanTags.reduce<Array<KeyValuePair>>((uniqueTags, tag) => {
     if (!uniqueTags.some(t => t.key === tag.key && t.value === tag.value)) {
@@ -108,15 +112,18 @@ function deduplicateTags(spanTags: Array<KeyValuePair>) {
 
 export const TREE_ROOT_ID = '__root__';
 
-export const spansSort = (a: SpanData, b: SpanData) =>
+export const spansSort = (a: SpanData, b: SpanData): number =>
   +(a.startTime > b.startTime) || +(a.startTime === b.startTime) - 1;
 
-export function getTraceSpanIdsAsTree(trace: TraceData<SpanData>) {
+export function getTraceSpanIdsAsTree(trace: TraceData<SpanData>): TreeNode {
   const nodesById = new Map(trace.spans.map(span => [span.spanID, new TreeNode(span.spanID)]));
   const spansById = new Map(trace.spans.map(span => [span.spanID, span]));
   const root = new TreeNode(TREE_ROOT_ID);
   trace.spans.forEach(span => {
     const node = nodesById.get(span.spanID);
+    if (!node) {
+      return;
+    }
     if (Array.isArray(span.references) && span.references.length) {
       const { refType, spanID: parentID } = span.references[0];
       if (refType === 'CHILD_OF' || refType === 'FOLLOWS_FROM') {
@@ -129,12 +136,13 @@ export function getTraceSpanIdsAsTree(trace: TraceData<SpanData>) {
       root.children.push(node);
     }
   });
-  const comparator = (a, b) => spansSort(spansById.get(a.value)!, spansById.get(b.value)!);
+  const comparator = (a: TreeNode, b: TreeNode): number => spansSort(spansById.get(a.value)!, spansById.get(b.value)!);
   trace.spans.forEach(span => {
-    const node: any = nodesById.get(span.spanID);
-    if (node.children.length > 1) {
-      node.children.sort(comparator);
+    const node = nodesById.get(span.spanID);
+    if (!node || node.children.length <= 1) {
+      return;
     }
+    node.children.sort(comparator);
   });
   root.children.sort(comparator);
   return root;
@@ -201,7 +209,7 @@ export function transformTraceData(data: TraceData<SpanData>, cluster?: string):
   const svcCounts: Record<string, number> = {};
   let traceName = '';
 
-  tree.walk((spanID: string, node: TreeNode, depth: number = 0) => {
+  tree.walk((spanID: string, node: TreeNode, depth = 0) => {
     if (spanID === '__root__') {
       return;
     }
@@ -255,15 +263,24 @@ export const transformSpanData = (span: Span, cluster?: string): RichSpanData =>
   const workloadNs = getWorkloadFromSpan(span);
 
   const split = span.process.serviceName.split('.');
-  const app = split[0];
-  const namespace = workloadNs ? workloadNs.namespace : split.length > 1 ? split[1] : undefined;
+  const appFromProcess = split[0];
+  const appFromTags = getAppFromSpan(span)!;
+  const app =
+    isWaypointProxySpan(span) && appFromTags.app && String(appFromTags.app).trim() !== ''
+      ? appFromTags.app
+      : appFromProcess;
+
+  let namespace = workloadNs?.namespace ?? (split.length > 1 ? split[1] : undefined);
+  if (namespace === undefined && appFromTags.namespace) {
+    namespace = appFromTags.namespace;
+  }
   if (!namespace) {
     console.warn('Could not determine span namespace');
   }
 
-  const linkToApp = namespace ? '/namespaces/' + namespace + '/applications/' + app : undefined;
-  const linkToWorkload = workloadNs
-    ? '/namespaces/' + workloadNs.namespace + '/workloads/' + workloadNs.workload
+  const linkToApp = namespace ? `/namespaces/${namespace}/applications/${app}` : undefined;
+  const linkToWorkload = workloadNs?.workload
+    ? `/namespaces/${workloadNs.namespace}/workloads/${workloadNs.workload}`
     : undefined;
   return {
     ...span,

--- a/frontend/src/utils/tracing/TracingHelper.ts
+++ b/frontend/src/utils/tracing/TracingHelper.ts
@@ -15,9 +15,10 @@ import { spansSort } from './TraceTransform';
 
 export const defaultTracingDuration: DurationInSeconds = 600;
 
-export const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value === true || value === 'true');
+export const isErrorTag = ({ key, value }: KeyValuePair): boolean =>
+  key === 'error' && (value === true || value === 'true');
 
-export const getTimeRangeMicros = () => {
+export const getTimeRangeMicros = (): { from: number; to: number | undefined } => {
   const range = retrieveTimeRange();
   // Convert any time range (like duration) to bounded from/to
   const boundsMillis = guardTimeRange(range, durationToBounds, b => b);
@@ -31,16 +32,73 @@ export const getTimeRangeMicros = () => {
 };
 
 type WorkloadAndNamespace = {
+  namespace: string;
   pod: string;
   workload: string;
-  namespace: string;
 };
+
+const tagValue = (span: Span, key: string): string | undefined => {
+  const t = span.tags.find(tag => tag.key === key);
+  const v = t?.value;
+  if (v === undefined || v === null || String(v).trim() === '') {
+    return undefined;
+  }
+  return String(v);
+};
+
+/**
+ * Istio Ambient waypoint spans use node_id "waypoint~{ip}~{pod.namespace}~{domain}";
+ * the first segment is the proxy role, not the Kubernetes workload name (e.g. my-wp-…).
+ */
+export const isWaypointProxySpan = (span: Span): boolean => {
+  const nodeKV = span.tags.find(tag => tag.key === 'node_id');
+  const v = nodeKV?.value;
+  return typeof v === 'string' && v.startsWith('waypoint~');
+};
+
+/** Istio Ambient waypoint spans: source_* is the caller, destination_* is the workload handling the request. */
+const ambientWorkloadFromTags = (span: Span, end: 'source' | 'destination'): WorkloadAndNamespace | undefined => {
+  const prefix = end === 'source' ? 'istio.source' : 'istio.destination';
+  const pod = tagValue(span, `${prefix}_instance_name`);
+  const workload = tagValue(span, `${prefix}_workload`);
+  const ns = tagValue(span, `${prefix}_namespace`);
+  if (pod !== undefined || workload !== undefined || ns !== undefined) {
+    return {
+      namespace: ns || '',
+      pod: pod || '',
+      workload: workload || ''
+    };
+  }
+  return undefined;
+};
+
+const ambientWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefined => {
+  const kind = tagValue(span, 'span.kind');
+  if (kind === 'server' || kind === 'consumer') {
+    return ambientWorkloadFromTags(span, 'destination');
+  }
+  if (kind === 'client' || kind === 'producer') {
+    return ambientWorkloadFromTags(span, 'source');
+  }
+  if (tagValue(span, 'istio.destination_workload')) {
+    return ambientWorkloadFromTags(span, 'destination');
+  }
+  return ambientWorkloadFromTags(span, 'source');
+};
+
 export const getWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefined => {
+  if (isWaypointProxySpan(span)) {
+    const fromTags = ambientWorkloadFromSpan(span);
+    if (fromTags) {
+      return fromTags;
+    }
+    return undefined;
+  }
   const nodeKV = span.tags.find(tag => tag.key === 'node_id');
   if (nodeKV) {
     // Example of node value:
     // sidecar~172.17.0.20~ai-locals-6d8996bff-ztg6z.default~default.svc.cluster.local
-    const parts = nodeKV.value.split('~');
+    const parts = String(nodeKV.value).split('~');
     if (parts.length < 3) {
       return undefined;
     }
@@ -65,9 +123,9 @@ const extractWorkloadFromPod = (pod: string, ns: string): WorkloadAndNamespace |
   const result = replicasetFromPodRegex.exec(pod);
   if (result && result.length === 2) {
     return {
+      namespace: ns,
       pod: pod,
-      workload: adjustWorkloadNameFromReplicaset(result[1]),
-      namespace: ns
+      workload: adjustWorkloadNameFromReplicaset(result[1])
     };
   }
   return undefined;
@@ -117,7 +175,35 @@ export const searchParentWorkload = (span: Span): WorkloadAndNamespace | undefin
 };
 
 type AppAndNamespace = { app: string; namespace: string };
+
 export const getAppFromSpan = (span: Span): AppAndNamespace | undefined => {
+  if (isWaypointProxySpan(span)) {
+    const kind = tagValue(span, 'span.kind');
+    if (kind === 'server' || kind === 'consumer') {
+      const app = tagValue(span, 'istio.destination_canonical_service');
+      const ns = tagValue(span, 'istio.destination_namespace');
+      if (app !== undefined || ns !== undefined) {
+        return { app: app || '', namespace: ns || '' };
+      }
+    } else if (kind === 'client' || kind === 'producer') {
+      const app = tagValue(span, 'istio.source_canonical_service');
+      const ns = tagValue(span, 'istio.source_namespace');
+      if (app !== undefined || ns !== undefined) {
+        return { app: app || '', namespace: ns || '' };
+      }
+    } else {
+      const destApp = tagValue(span, 'istio.destination_canonical_service');
+      const destNs = tagValue(span, 'istio.destination_namespace');
+      if (destApp !== undefined || destNs !== undefined) {
+        return { app: destApp || '', namespace: destNs || '' };
+      }
+      const srcApp = tagValue(span, 'istio.source_canonical_service');
+      const srcNs = tagValue(span, 'istio.source_namespace');
+      if (srcApp !== undefined || srcNs !== undefined) {
+        return { app: srcApp || '', namespace: srcNs || '' };
+      }
+    }
+  }
   const split = span.process.serviceName.split('.');
   return { app: split[0], namespace: split.length > 1 ? split[1] : '' };
 };
@@ -236,7 +322,12 @@ export const extractEnvoySpanInfo = (span: Span): EnvoySpanInfo => {
   return info;
 };
 
-export const extractSpanInfo = (span: Span) => {
+export const extractSpanInfo = (
+  span: Span
+): {
+  info: OpenTracingBaseInfo | OpenTracingHTTPInfo | OpenTracingTCPInfo | EnvoySpanInfo;
+  type: ReturnType<typeof getSpanType>;
+} => {
   const type = getSpanType(span);
   const info =
     type === 'envoy'
@@ -246,7 +337,7 @@ export const extractSpanInfo = (span: Span) => {
       : type === 'tcp'
       ? extractOpenTracingTCPInfo(span)
       : extractOpenTracingBaseInfo(span);
-  return { type: type, info: info };
+  return { info, type };
 };
 
 export const sameSpans = (a: Span[], b: Span[]): boolean => {
@@ -266,7 +357,7 @@ export function formatDuration(micros: number): string {
 const TODAY = 'Today';
 const YESTERDAY = 'Yesterday';
 
-export function formatRelativeDate(value: any, fullMonthName: boolean = false) {
+export function formatRelativeDate(value: any, fullMonthName = false): string {
   const m = moment.isMoment(value) ? value : moment(value);
   const monthFormat = fullMonthName ? 'MMMM' : 'MMM';
   const dt = new Date();

--- a/frontend/src/utils/tracing/TracingHelper.ts
+++ b/frontend/src/utils/tracing/TracingHelper.ts
@@ -114,7 +114,8 @@ export const getWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefine
     if (fromTags) {
       return fromTags;
     }
-    return undefined;
+    // Older Istio waypoint traces may not include istio.source_/destination_ workload tags.
+    // Fall back to legacy node_id/hostname parsing to avoid returning "unknown".
   }
   const nodeKV = span.tags.find(tag => tag.key === 'node_id');
   if (nodeKV) {

--- a/frontend/src/utils/tracing/TracingHelper.ts
+++ b/frontend/src/utils/tracing/TracingHelper.ts
@@ -47,8 +47,13 @@ const tagValue = (span: Span, key: string): string | undefined => {
 };
 
 /**
- * Istio Ambient waypoint spans use node_id "waypoint~{ip}~{pod.namespace}~{domain}";
- * the first segment is the proxy role, not the Kubernetes workload name (e.g. my-wp-…).
+ * Checks if a span originates from an Istio Ambient waypoint proxy.
+ *
+ * Istio Ambient waypoint spans use node_id format: "waypoint~{ip}~{pod.namespace}~{domain}"
+ * where the first segment is the proxy role, not the Kubernetes workload name.
+ *
+ * @param span - The span to check
+ * @returns true if the span is from a waypoint proxy, false otherwise
  */
 export const isWaypointProxySpan = (span: Span): boolean => {
   const nodeKV = span.tags.find(tag => tag.key === 'node_id');
@@ -56,17 +61,28 @@ export const isWaypointProxySpan = (span: Span): boolean => {
   return typeof v === 'string' && v.startsWith('waypoint~');
 };
 
-/** Istio Ambient waypoint spans: source_* is the caller, destination_* is the workload handling the request. */
+/**
+ * Extracts workload information from Istio Ambient waypoint span tags.
+ *
+ * For waypoint spans:
+ * - source_* tags represent the caller workload
+ * - destination_* tags represent the workload handling the request
+ *
+ * @param span - The waypoint span
+ * @param end - Which end of the connection to extract ('source' or 'destination')
+ * @returns Workload info with namespace, workload name, and pod name, or undefined if insufficient data
+ */
 const ambientWorkloadFromTags = (span: Span, end: 'source' | 'destination'): WorkloadAndNamespace | undefined => {
   const prefix = end === 'source' ? 'istio.source' : 'istio.destination';
   const pod = tagValue(span, `${prefix}_instance_name`);
   const workload = tagValue(span, `${prefix}_workload`);
   const ns = tagValue(span, `${prefix}_namespace`);
-  if (pod !== undefined || workload !== undefined || ns !== undefined) {
+  // Only return if we have at least workload and namespace (minimum useful info)
+  if (workload && ns) {
     return {
-      namespace: ns || '',
+      namespace: ns,
       pod: pod || '',
-      workload: workload || ''
+      workload: workload
     };
   }
   return undefined;
@@ -80,10 +96,16 @@ const ambientWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefined =
   if (kind === 'client' || kind === 'producer') {
     return ambientWorkloadFromTags(span, 'source');
   }
+  // No span.kind or unrecognized kind: try destination first, then source
   if (tagValue(span, 'istio.destination_workload')) {
     return ambientWorkloadFromTags(span, 'destination');
   }
-  return ambientWorkloadFromTags(span, 'source');
+  const sourceResult = ambientWorkloadFromTags(span, 'source');
+  if (sourceResult) {
+    return sourceResult;
+  }
+  // Try destination as final fallback
+  return ambientWorkloadFromTags(span, 'destination');
 };
 
 export const getWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefined => {
@@ -116,6 +138,21 @@ export const getWorkloadFromSpan = (span: Span): WorkloadAndNamespace | undefine
     return extractWorkloadFromPod(hostnameKV.value, svcNs.length > 1 ? svcNs[1] : '');
   }
   return undefined;
+};
+
+/**
+ * Gets the SOURCE workload from a waypoint span.
+ * For waypoint server spans, this is the caller workload (from istio.source_* tags).
+ * This is different from getWorkloadFromSpan which returns destination for server spans.
+ *
+ * @param span - The waypoint span
+ * @returns Source workload info or undefined
+ */
+export const getSourceWorkloadFromWaypointSpan = (span: Span): WorkloadAndNamespace | undefined => {
+  if (!isWaypointProxySpan(span)) {
+    return undefined;
+  }
+  return ambientWorkloadFromTags(span, 'source');
 };
 
 const replicasetFromPodRegex = /^([a-z0-9-.]+)-[a-z0-9]+$/;

--- a/frontend/src/utils/tracing/__tests__/TracingHelper.test.ts
+++ b/frontend/src/utils/tracing/__tests__/TracingHelper.test.ts
@@ -1,4 +1,4 @@
-import { findChildren, findParent, getWorkloadFromSpan, searchParentWorkload } from '../TracingHelper';
+import { findChildren, findParent, getAppFromSpan, getWorkloadFromSpan, searchParentWorkload } from '../TracingHelper';
 import { Span, KeyValuePair, SpanData } from 'types/TracingInfo';
 import { transformTraceData } from '../TraceTransform';
 
@@ -76,7 +76,7 @@ describe('TracingHelper', () => {
   });
 
   it('tests more regex', () => {
-    const test = (podName: string, expectedWkd: string, expectedNs: string) => {
+    const test = (podName: string, expectedWkd: string, expectedNs: string): void => {
       const span = { tags: [{ key: 'node_id', value: `any~any~${podName}~any` }] } as Span;
       const wkdNs = getWorkloadFromSpan(span);
       expect(wkdNs).toBeDefined();
@@ -108,6 +108,69 @@ describe('TracingHelper', () => {
     expect(wkdNs).toBeDefined();
     expect(wkdNs!.namespace).toEqual('default');
     expect(wkdNs!.workload).toEqual('ai-locals');
+  });
+
+  it('ambient server span resolves destination workload', () => {
+    const span = ({
+      tags: [
+        {
+          key: 'node_id',
+          value: 'waypoint~10.244.0.23~my-wp-5b7cb7b55d-sdc4t.bookinfo~bookinfo.svc.cluster.local'
+        },
+        { key: 'span.kind', value: 'server' },
+        { key: 'istio.source_workload', value: 'productpage-v1' },
+        { key: 'istio.source_namespace', value: 'bookinfo' },
+        { key: 'istio.destination_workload', value: 'reviews-v1' },
+        { key: 'istio.destination_namespace', value: 'bookinfo' },
+        { key: 'istio.destination_instance_name', value: 'reviews-v1-598b896c9d-6nfcb' }
+      ],
+      process: { serviceName: 'waypoint.bookinfo', tags: [] }
+    } as unknown) as Span;
+    const wkdNs = getWorkloadFromSpan(span);
+    expect(wkdNs).toBeDefined();
+    expect(wkdNs!.workload).toEqual('reviews-v1');
+    expect(wkdNs!.namespace).toEqual('bookinfo');
+    expect(wkdNs!.pod).toEqual('reviews-v1-598b896c9d-6nfcb');
+  });
+
+  it('ambient client span resolves source workload', () => {
+    const span = ({
+      tags: [
+        {
+          key: 'node_id',
+          value: 'waypoint~10.244.0.23~my-wp-5b7cb7b55d-sdc4t.bookinfo~bookinfo.svc.cluster.local'
+        },
+        { key: 'span.kind', value: 'client' },
+        { key: 'istio.source_workload', value: 'productpage-v1' },
+        { key: 'istio.source_namespace', value: 'bookinfo' },
+        { key: 'istio.destination_workload', value: 'reviews-v1' },
+        { key: 'istio.destination_namespace', value: 'bookinfo' }
+      ],
+      process: { serviceName: 'waypoint.bookinfo', tags: [] }
+    } as unknown) as Span;
+    const wkdNs = getWorkloadFromSpan(span);
+    expect(wkdNs).toBeDefined();
+    expect(wkdNs!.workload).toEqual('productpage-v1');
+    expect(wkdNs!.namespace).toEqual('bookinfo');
+  });
+
+  it('getAppFromSpan uses istio tags for waypoint proxy spans', () => {
+    const span = ({
+      tags: [
+        {
+          key: 'node_id',
+          value: 'waypoint~10.244.0.23~my-wp-5b7cb7b55d-sdc4t.bookinfo~bookinfo.svc.cluster.local'
+        },
+        { key: 'span.kind', value: 'server' },
+        { key: 'istio.destination_canonical_service', value: 'reviews' },
+        { key: 'istio.destination_namespace', value: 'bookinfo' }
+      ],
+      process: { serviceName: 'waypoint.bookinfo', tags: [] }
+    } as unknown) as Span;
+    const appNs = getAppFromSpan(span);
+    expect(appNs).toBeDefined();
+    expect(appNs!.app).toEqual('reviews');
+    expect(appNs!.namespace).toEqual('bookinfo');
   });
 
   it('should not find parent workload', () => {

--- a/frontend/src/utils/tracing/__tests__/TracingHelper.test.ts
+++ b/frontend/src/utils/tracing/__tests__/TracingHelper.test.ts
@@ -154,6 +154,23 @@ describe('TracingHelper', () => {
     expect(wkdNs!.namespace).toEqual('bookinfo');
   });
 
+  it('ambient span without workload tags falls back to node_id parsing', () => {
+    const span = ({
+      tags: [
+        {
+          key: 'node_id',
+          value: 'waypoint~10.244.0.23~waypoint-5b7cb7b55d-sdc4t.bookinfo~bookinfo.svc.cluster.local'
+        },
+        { key: 'span.kind', value: 'server' }
+      ],
+      process: { serviceName: 'waypoint.bookinfo', tags: [] }
+    } as unknown) as Span;
+    const wkdNs = getWorkloadFromSpan(span);
+    expect(wkdNs).toBeDefined();
+    expect(wkdNs!.workload).toEqual('waypoint');
+    expect(wkdNs!.namespace).toEqual('bookinfo');
+  });
+
   it('getAppFromSpan uses istio tags for waypoint proxy spans', () => {
     const span = ({
       tags: [

--- a/tracing/tempo/grpc_client.go
+++ b/tracing/tempo/grpc_client.go
@@ -49,7 +49,25 @@ func (jc TempoGRPCClient) FindTraces(ctx context.Context, serviceName string, q 
 		}
 	}
 
-	selects := []string{"status", ".service_name", ".node_id", ".component", ".upstream_cluster", ".http.method", ".response_flags", "resource.hostname", "name"}
+	selects := []string{
+		"status",
+		".service_name",
+		".node_id",
+		".component",
+		".upstream_cluster",
+		".http.method",
+		".response_flags",
+		".istio.destination_workload",
+		".istio.destination_namespace",
+		".istio.destination_instance_name",
+		".istio.destination_canonical_service",
+		".istio.source_workload",
+		".istio.source_namespace",
+		".istio.source_instance_name",
+		".istio.source_canonical_service",
+		"resource.hostname",
+		"name",
+	}
 	trace := TraceQL{operator1: Subquery{queryPart}, operand: AND, operator2: Subquery{}}
 	queryQL := fmt.Sprintf("%s| %s", printOperator(trace), printSelect(selects))
 

--- a/tracing/tempo/http_client.go
+++ b/tracing/tempo/http_client.go
@@ -297,7 +297,25 @@ func (oc *OtelHTTPClient) prepareTraceQL(ctx context.Context, u *url.URL, tracin
 		}
 	}
 
-	selects := []string{"status", ".service_name", ".node_id", ".component", ".upstream_cluster", ".http.method", ".response_flags", "resource.hostname", "name"}
+	selects := []string{
+		"status",
+		".service_name",
+		".node_id",
+		".component",
+		".upstream_cluster",
+		".http.method",
+		".response_flags",
+		".istio.destination_workload",
+		".istio.destination_namespace",
+		".istio.destination_instance_name",
+		".istio.destination_canonical_service",
+		".istio.source_workload",
+		".istio.source_namespace",
+		".istio.source_instance_name",
+		".istio.source_canonical_service",
+		"resource.hostname",
+		"name",
+	}
 	trace := TraceQL{operator1: Subquery{queryPart}, operand: AND, operator2: Subquery{}}
 	queryQL := fmt.Sprintf("%s| %s", printOperator(trace), printSelect(selects))
 

--- a/tracing/tempo/http_client_test.go
+++ b/tracing/tempo/http_client_test.go
@@ -200,7 +200,7 @@ func TestQuery(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, rawQuery, fmt.Sprintf(".service.name = \"%s\"", serviceName))
 	// Verify it contains all the selects
-	assert.Contains(t, rawQuery, "select(status, .service_name, .node_id, .component, .upstream_cluster, .http.method, .response_flags, resource.hostname, name)")
+	assert.Contains(t, rawQuery, "select(status, .service_name, .node_id, .component, .upstream_cluster, .http.method, .response_flags, .istio.destination_workload, .istio.destination_namespace, .istio.destination_instance_name, .istio.destination_canonical_service, .istio.source_workload, .istio.source_namespace, .istio.source_instance_name, .istio.source_canonical_service, resource.hostname, name)")
 	// Verify it doesn't contain the cluster tag
 	assert.NotContains(t, rawQuery, models.IstioClusterTag)
 	// Verify it contains spans limit


### PR DESCRIPTION
### Describe the change

- Trace overlay in Ambient
- Update tracing matching workload as the information is now available as well

### Steps to test the PR

Before: 
<img width="1860" height="1002" alt="image" src="https://github.com/user-attachments/assets/661ffb76-3fe7-4d24-85f5-6f7094b49615" />

<img width="1860" height="1002" alt="image" src="https://github.com/user-attachments/assets/399d6074-737c-4148-9a6e-f61e591b44b2" />

With this PR: 
<img width="1868" height="958" alt="image" src="https://github.com/user-attachments/assets/36e60d25-5ce8-434d-a00e-fa8b8dfc35a7" />
<img width="1868" height="958" alt="image" src="https://github.com/user-attachments/assets/5ffaad3f-6d51-43c3-a78e-48f98847b245" />

Environment to test with older Istio versions (Trace overlay is not going to work, because this tags are included in Istio 1.29, but there should not be regressions): 

`./hack/istio/install-istio-via-istioctl.sh -c kubectl -iv 1.28.0 -cp ambient`
`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

The setting `external_services.tracing.use_waypoint_name: true`

With Tempo and latest Istio version: 

`./hack/istio/tempo/install-tempo-env.sh -c kubectl -a true -ii true -ib true -ik true`
The setting `external_services.tracing.use_waypoint_name: true`

With Istio 1.29 and oTEL: 

`hack/run-integration-tests.sh --test-suite frontend-ambient`
`istioctl waypoint apply -n bookinfo --enroll-namespace`

Here, it uses oTEL so the setting `external_services.tracing.use_waypoint_name: false` (By default)

With Istio 1.29 and zipkin: 

`./hack/istio/install-istio-via-istioctl.sh -c kubectl -cp ambient`
`istio/install-bookinfo-demo.sh -c kubectl -ai false -tg -w true`

The setting `external_services.tracing.use_waypoint_name: true`

To test with other examples, I've updated the travel-agency demo: https://github.com/kiali/demos/pull/55

To test it, download that PR and: 

```
istio/install-travel-agency-demo.sh -c kubectl -ai false -di travel-control,travel-agency,travel-portal -s "file:///path/to/demos" -w true
cd /path/to/demos/travels
./build-local.sh
CLUSTER_NAME=ci ./reload-travel-images.sh
```

Then, go to the traffic graph for the travels namespaces: 
<img width="1868" height="958" alt="image" src="https://github.com/user-attachments/assets/585821f2-9b3e-443c-b2e3-016911a97f6a" />

- The traces should include more than 1 span
- The trace overlay should be correct

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes: https://github.com/kiali/kiali/issues/9504 

