### PR TITLE
chore: bump Go to 1.25.9 to fix CVE-2026-32280

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiali/kiali
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
## Summary

- Bumps Go from 1.25.8 to 1.25.9 to fix CVE-2026-32280
- CVE-2026-32280 is a Denial of Service vulnerability in Go's `crypto/x509` certificate chain building where `x509.Certificate.Verify` becomes pathologically slow when the intermediates pool contains many similar certificates
- Fixed in Go 1.25.9 (1.25 branch) and Go 1.26.2 (1.26 branch)

## Test plan

- [x] `make build` passes with Go 1.25.9
- [x] `make test` passes (pre-existing `TestClientFactoryGetClients` failure unrelated to this change)
- [x] CI passes