### PR TITLE
Update axios to 1.15.0 to fix CVE-2026-40175

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,7 +108,7 @@
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
     "@patternfly/react-topology": "^6.4.0",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "bootstrap-slider-without-jquery": "10.0.0",
     "deep-freeze": "0.0.1",
     "eventemitter3": "4.0.7",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2836,7 +2836,7 @@ __metadata:
     "@types/react-router-dom": "npm:^5.2.0"
     "@types/react-virtualized": "npm:9.x"
     "@wojtekmaj/enzyme-adapter-react-17": "npm:^0.6.7"
-    axios: "npm:^1.13.5"
+    axios: "npm:^1.15.0"
     axios-mock-adapter: "npm:^1.22.0"
     bootstrap-slider-without-jquery: "npm:10.0.0"
     cypress: "npm:^13.6.1"
@@ -5959,14 +5959,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/abf468c34f2d145f3dc7dbc0f1be67e520630624307bda69a41bbe8d386bd672d87b4405c4ee77f9ff54b235ab02f96a9968fb00e75b13ce64706e352a3068fd
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -16507,10 +16507,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Axios prior to 1.15.0 is vulnerable to a Prototype Pollution escalation that can lead to Remote Code Execution (RCE) or Full Cloud Compromise (via AWS IMDSv2 bypass).

This updates the direct `axios` dependency in `frontend/package.json` from `^1.13.5` to `^1.15.0` (resolved to 1.15.0).

All frontend unit tests pass.