### PR TITLE
Fix custom dashboards Prometheus URL not used for metric queries

### DIFF
--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -17,6 +17,17 @@ import (
 
 const defaultNamespaceLabel = "namespace"
 
+var (
+	customDashboardsPromOnce   sync.Once
+	customDashboardsPromClient prometheus.ClientInterface
+)
+
+// newPromClient is the factory used to create a Prometheus client for the
+// custom dashboards endpoint. Tests can replace this to inject a mock.
+var newPromClient = func(conf config.Config, promCfg config.PrometheusConfig) (prometheus.ClientInterface, error) {
+	return prometheus.NewClientFromPrometheusConfig(conf, promCfg, "")
+}
+
 // DashboardsService deals with fetching dashboards from config
 type DashboardsService struct {
 	conf            *config.Config
@@ -36,6 +47,21 @@ func NewDashboardsService(conf *config.Config, grafana *grafana.Service, promCli
 	prom := conf.ExternalServices.Prometheus
 	if customEnabled && conf.ExternalServices.CustomDashboards.Prometheus.URL != "" {
 		prom = conf.ExternalServices.CustomDashboards.Prometheus
+
+		// Use a dedicated Prometheus client for custom dashboards when a
+		// separate URL is configured. The client is created once and cached
+		// for the lifetime of the process.
+		customDashboardsPromOnce.Do(func() {
+			client, err := newPromClient(*conf, prom)
+			if err != nil {
+				log.Errorf("Failed to create custom dashboards Prometheus client for [%s]: %v. Falling back to main Prometheus client.", prom.URL, err)
+			} else {
+				customDashboardsPromClient = client
+			}
+		})
+		if customDashboardsPromClient != nil {
+			promClient = customDashboardsPromClient
+		}
 	}
 	nsLabel := conf.ExternalServices.CustomDashboards.NamespaceLabel
 	if nsLabel == "" {

--- a/business/dashboards.go
+++ b/business/dashboards.go
@@ -18,14 +18,24 @@ import (
 const defaultNamespaceLabel = "namespace"
 
 var (
-	customDashboardsPromOnce   sync.Once
+	customDashboardsPromMu     sync.Mutex
 	customDashboardsPromClient prometheus.ClientInterface
+	// kialiSAToken is set once at startup via SetKialiSAToken so the
+	// custom dashboards Prometheus client can authenticate with the
+	// Kiali service-account token when auth.use_kiali_token is true.
+	kialiSAToken string
 )
+
+// SetKialiSAToken stores the Kiali service-account token for use when
+// creating the custom dashboards Prometheus client. Call once at startup.
+func SetKialiSAToken(token string) {
+	kialiSAToken = token
+}
 
 // newPromClient is the factory used to create a Prometheus client for the
 // custom dashboards endpoint. Tests can replace this to inject a mock.
-var newPromClient = func(conf config.Config, promCfg config.PrometheusConfig) (prometheus.ClientInterface, error) {
-	return prometheus.NewClientFromPrometheusConfig(conf, promCfg, "")
+var newPromClient = func(conf config.Config, promCfg config.PrometheusConfig, saToken string) (prometheus.ClientInterface, error) {
+	return prometheus.NewClientFromPrometheusConfig(conf, promCfg, saToken)
 }
 
 // DashboardsService deals with fetching dashboards from config
@@ -48,20 +58,24 @@ func NewDashboardsService(conf *config.Config, grafana *grafana.Service, promCli
 	if customEnabled && conf.ExternalServices.CustomDashboards.Prometheus.URL != "" {
 		prom = conf.ExternalServices.CustomDashboards.Prometheus
 
-		// Use a dedicated Prometheus client for custom dashboards when a
-		// separate URL is configured. The client is created once and cached
-		// for the lifetime of the process.
-		customDashboardsPromOnce.Do(func() {
-			client, err := newPromClient(*conf, prom)
-			if err != nil {
-				log.Errorf("Failed to create custom dashboards Prometheus client for [%s]: %v. Falling back to main Prometheus client.", prom.URL, err)
-			} else {
-				customDashboardsPromClient = client
+		// Lazily create a dedicated Prometheus client for custom dashboard
+		// queries. A mutex (rather than sync.Once) allows retry on transient
+		// errors such as TLS cert files not yet mounted at first request.
+		func() {
+			customDashboardsPromMu.Lock()
+			defer customDashboardsPromMu.Unlock()
+			if customDashboardsPromClient == nil {
+				client, err := newPromClient(*conf, prom, kialiSAToken)
+				if err != nil {
+					log.Errorf("Failed to create custom dashboards Prometheus client for [%s]: %v. Falling back to main Prometheus client.", prom.URL, err)
+				} else {
+					customDashboardsPromClient = client
+				}
 			}
-		})
-		if customDashboardsPromClient != nil {
-			promClient = customDashboardsPromClient
-		}
+			if customDashboardsPromClient != nil {
+				promClient = customDashboardsPromClient
+			}
+		}()
 	}
 	nsLabel := conf.ExternalServices.CustomDashboards.NamespaceLabel
 	if nsLabel == "" {

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/prometheus"
 	pmock "github.com/kiali/kiali/prometheus/prometheustest"
 )
 
@@ -331,4 +333,69 @@ func fakeMetrics() models.MetricsMap {
 		"tcp_opened":              fakeCounter(31),
 		"tcp_closed":              fakeCounter(32),
 	}
+}
+
+// resetCustomDashboardsPromClient resets the package-level cached custom
+// dashboards Prometheus client so that each test starts with a clean state.
+func resetCustomDashboardsPromClient() {
+	customDashboardsPromOnce = sync.Once{}
+	customDashboardsPromClient = nil
+}
+
+// TestGetDashboardUsesCustomDashboardsPromClient verifies that when
+// custom_dashboards.prometheus.url is configured, metric queries for custom
+// dashboards are sent to a separate Prometheus client rather than the main one.
+func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
+	assert := assert.New(t)
+
+	resetCustomDashboardsPromClient()
+	origFactory := newPromClient
+	t.Cleanup(func() {
+		newPromClient = origFactory
+		resetCustomDashboardsPromClient()
+	})
+
+	customProm := new(pmock.PromClientMock)
+	newPromClient = func(_ config.Config, _ config.PrometheusConfig) (prometheus.ClientInterface, error) {
+		return customProm, nil
+	}
+
+	conf := config.NewConfig()
+	conf.ExternalServices.CustomDashboards.Enabled = true
+	conf.ExternalServices.Prometheus.URL = "http://prometheus-main:9090"
+	conf.ExternalServices.CustomDashboards.Prometheus.URL = "http://prometheus-custom:9090"
+
+	conf.CustomDashboards = append(conf.CustomDashboards, *fakeDashboard("1"))
+
+	mainProm := new(pmock.PromClientMock)
+
+	ns := models.Namespace{Name: "my-namespace"}
+	grafanaSvc := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
+
+	expectedLabels := `{namespace="my-namespace",APP="my-app"}`
+	query := models.DashboardQuery{
+		Namespace: "my-namespace",
+		LabelsFilters: map[string]string{
+			"APP": "my-app",
+		},
+	}
+	query.FillDefaults()
+
+	customProm.MockMetric(context.Background(), "my_metric_1_1", expectedLabels, &query.RangeQuery, 10)
+	customProm.MockHistogram(context.Background(), "my_metric_1_2", expectedLabels, &query.RangeQuery, 11, 12)
+
+	dashboard, err := service.GetDashboard(context.Background(), query, "dashboard1")
+
+	assert.Nil(err)
+	assert.Equal("Dashboard 1", dashboard.Title)
+	assert.Len(dashboard.Charts, 2)
+
+	// The custom prom client should have been called for metric fetching.
+	customProm.AssertNumberOfCalls(t, "FetchRateRange", 1)
+	customProm.AssertNumberOfCalls(t, "FetchHistogramRange", 1)
+
+	// The main prom client should NOT have been called at all.
+	mainProm.AssertNumberOfCalls(t, "FetchRateRange", 0)
+	mainProm.AssertNumberOfCalls(t, "FetchHistogramRange", 0)
 }

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -2,10 +2,11 @@ package business
 
 import (
 	"context"
-	"sync"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/dashboards"
@@ -338,7 +339,6 @@ func fakeMetrics() models.MetricsMap {
 // resetCustomDashboardsPromClient resets the package-level cached custom
 // dashboards Prometheus client so that each test starts with a clean state.
 func resetCustomDashboardsPromClient() {
-	customDashboardsPromOnce = sync.Once{}
 	customDashboardsPromClient = nil
 }
 
@@ -356,7 +356,7 @@ func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
 	})
 
 	customProm := new(pmock.PromClientMock)
-	newPromClient = func(_ config.Config, _ config.PrometheusConfig) (prometheus.ClientInterface, error) {
+	newPromClient = func(_ config.Config, _ config.PrometheusConfig, _ string) (prometheus.ClientInterface, error) {
 		return customProm, nil
 	}
 
@@ -387,7 +387,7 @@ func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
 
 	dashboard, err := service.GetDashboard(context.Background(), query, "dashboard1")
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("Dashboard 1", dashboard.Title)
 	assert.Len(dashboard.Charts, 2)
 
@@ -398,4 +398,135 @@ func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
 	// The main prom client should NOT have been called at all.
 	mainProm.AssertNumberOfCalls(t, "FetchRateRange", 0)
 	mainProm.AssertNumberOfCalls(t, "FetchHistogramRange", 0)
+}
+
+// TestCustomDashboardsPromClientFallbackOnFactoryError verifies that when
+// the factory fails to create the custom Prometheus client, the service
+// falls back to the caller-supplied main client.
+func TestCustomDashboardsPromClientFallbackOnFactoryError(t *testing.T) {
+	assert := assert.New(t)
+
+	resetCustomDashboardsPromClient()
+	origFactory := newPromClient
+	t.Cleanup(func() {
+		newPromClient = origFactory
+		resetCustomDashboardsPromClient()
+	})
+
+	newPromClient = func(_ config.Config, _ config.PrometheusConfig, _ string) (prometheus.ClientInterface, error) {
+		return nil, fmt.Errorf("simulated TLS failure")
+	}
+
+	conf := config.NewConfig()
+	conf.ExternalServices.CustomDashboards.Enabled = true
+	conf.ExternalServices.CustomDashboards.Prometheus.URL = "http://prometheus-custom:9090"
+	conf.CustomDashboards = append(conf.CustomDashboards, *fakeDashboard("1"))
+
+	mainProm := new(pmock.PromClientMock)
+
+	ns := models.Namespace{Name: "my-namespace"}
+	grafanaSvc := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
+
+	expectedLabels := `{namespace="my-namespace",APP="my-app"}`
+	query := models.DashboardQuery{
+		Namespace: "my-namespace",
+		LabelsFilters: map[string]string{
+			"APP": "my-app",
+		},
+	}
+	query.FillDefaults()
+	mainProm.MockMetric(context.Background(), "my_metric_1_1", expectedLabels, &query.RangeQuery, 10)
+	mainProm.MockHistogram(context.Background(), "my_metric_1_2", expectedLabels, &query.RangeQuery, 11, 12)
+
+	dashboard, err := service.GetDashboard(context.Background(), query, "dashboard1")
+
+	require.NoError(t, err)
+	assert.Equal("Dashboard 1", dashboard.Title)
+
+	// Factory failed, so the main prom client should have been used.
+	mainProm.AssertNumberOfCalls(t, "FetchRateRange", 1)
+	mainProm.AssertNumberOfCalls(t, "FetchHistogramRange", 1)
+}
+
+// TestCustomDashboardsPromClientRetryAfterTransientError verifies that
+// after a transient factory failure, the next call retries (mutex-based
+// approach, unlike sync.Once which would lock in the failure permanently).
+func TestCustomDashboardsPromClientRetryAfterTransientError(t *testing.T) {
+	resetCustomDashboardsPromClient()
+	origFactory := newPromClient
+	t.Cleanup(func() {
+		newPromClient = origFactory
+		resetCustomDashboardsPromClient()
+	})
+
+	callCount := 0
+	customProm := new(pmock.PromClientMock)
+	newPromClient = func(_ config.Config, _ config.PrometheusConfig, _ string) (prometheus.ClientInterface, error) {
+		callCount++
+		if callCount == 1 {
+			return nil, fmt.Errorf("transient failure")
+		}
+		return customProm, nil
+	}
+
+	conf := config.NewConfig()
+	conf.ExternalServices.CustomDashboards.Enabled = true
+	conf.ExternalServices.CustomDashboards.Prometheus.URL = "http://prometheus-custom:9090"
+
+	ns := models.Namespace{Name: "ns"}
+
+	// First call: factory fails, falls back to main.
+	mainProm := new(pmock.PromClientMock)
+	svc1 := NewDashboardsService(conf, nil, mainProm, &ns, nil)
+	if svc1.promClient != mainProm {
+		t.Fatal("expected fallback to main prom after factory error")
+	}
+
+	// Second call: factory succeeds, custom client is used.
+	svc2 := NewDashboardsService(conf, nil, mainProm, &ns, nil)
+	if svc2.promClient != customProm {
+		t.Fatal("expected custom prom client after successful retry")
+	}
+
+	if callCount != 2 {
+		t.Fatalf("expected factory to be called twice (retry after failure), got %d", callCount)
+	}
+}
+
+// TestCustomDashboardsPromClientFactoryCalledOnce verifies that the factory
+// is called exactly once across multiple NewDashboardsService calls — the
+// successful result is cached and reused.
+func TestCustomDashboardsPromClientFactoryCalledOnce(t *testing.T) {
+	resetCustomDashboardsPromClient()
+	origFactory := newPromClient
+	t.Cleanup(func() {
+		newPromClient = origFactory
+		resetCustomDashboardsPromClient()
+	})
+
+	callCount := 0
+	customProm := new(pmock.PromClientMock)
+	newPromClient = func(_ config.Config, _ config.PrometheusConfig, _ string) (prometheus.ClientInterface, error) {
+		callCount++
+		return customProm, nil
+	}
+
+	conf := config.NewConfig()
+	conf.ExternalServices.CustomDashboards.Enabled = true
+	conf.ExternalServices.CustomDashboards.Prometheus.URL = "http://prometheus-custom:9090"
+
+	ns := models.Namespace{Name: "ns"}
+	mainProm := new(pmock.PromClientMock)
+
+	for i := 0; i < 5; i++ {
+		svc := NewDashboardsService(conf, nil, mainProm, &ns, nil)
+		if svc.promClient != customProm {
+			t.Fatalf("call %d: expected custom prom client", i)
+		}
+	}
+
+	if callCount != 1 {
+		t.Fatalf("expected factory to be called exactly once, got %d", callCount)
+	}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -89,6 +89,7 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 	// (e.g. projected service-account tokens rotated by the kubelet).
 	homeClient := clientFactory.GetSAHomeClusterClient()
 	kialiToken := kubernetes.GetServiceAccountTokenCredential(homeClient)
+	business.SetKialiSAToken(kialiToken)
 
 	// Create shared prometheus client shared by all prometheus requests in the business layer.
 	prom, err := prometheus.NewClient(*conf, kialiToken)

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -318,11 +318,16 @@ func initPromCache(ctx context.Context) {
 	}
 }
 
-// NewClient creates a new client to the Prometheus API.
-// It returns an error on any problem. kialiSAToken is only used if auth.UseKialiToken is true.
+// NewClient creates a new client to the Prometheus API using the main
+// Prometheus configuration (conf.ExternalServices.Prometheus).
 func NewClient(conf config.Config, kialiSAToken string) (*Client, error) {
-	cfg := conf.ExternalServices.Prometheus
-	clientConfig := api.Config{Address: cfg.URL}
+	return NewClientFromPrometheusConfig(conf, conf.ExternalServices.Prometheus, kialiSAToken)
+}
+
+// NewClientFromPrometheusConfig creates a new client to the Prometheus API
+// targeting the given PrometheusConfig rather than the main one in conf.
+func NewClientFromPrometheusConfig(conf config.Config, promCfg config.PrometheusConfig, kialiSAToken string) (*Client, error) {
+	clientConfig := api.Config{Address: promCfg.URL}
 
 	// Prom Cache will be initialized once at first use of Prometheus Client
 	once.Do(func() {
@@ -337,7 +342,7 @@ func NewClient(conf config.Config, kialiSAToken string) (*Client, error) {
 	ctx := log.ToContext(context.Background(), zl)
 
 	// Be sure to copy config.Auth and not modify the existing
-	auth := cfg.Auth
+	auth := promCfg.Auth
 	if auth.UseKialiToken {
 		// Note: if we are using the 'bearer' authentication method then we want to use the Kiali
 		// service account token and not the user's token. This is because Kiali does filtering based
@@ -356,7 +361,7 @@ func NewClient(conf config.Config, kialiSAToken string) (*Client, error) {
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
-	transportConfig, err := httputil.CreateTransport(&conf, &auth, roundTripper, httputil.DefaultTimeout, cfg.CustomHeaders)
+	transportConfig, err := httputil.CreateTransport(&conf, &auth, roundTripper, httputil.DefaultTimeout, promCfg.CustomHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -318,18 +318,25 @@ func initPromCache(ctx context.Context) {
 	}
 }
 
-// NewClient creates a new client to the Prometheus API using the main
-// Prometheus configuration (conf.ExternalServices.Prometheus).
+// NewClient creates a new client to the Prometheus API. It delegates to
+// NewClientFromPrometheusConfig with the main Prometheus configuration so
+// existing callers don't need to specify a PrometheusConfig explicitly.
 func NewClient(conf config.Config, kialiSAToken string) (*Client, error) {
 	return NewClientFromPrometheusConfig(conf, conf.ExternalServices.Prometheus, kialiSAToken)
 }
 
-// NewClientFromPrometheusConfig creates a new client to the Prometheus API
-// targeting the given PrometheusConfig rather than the main one in conf.
+// NewClientFromPrometheusConfig creates a new Prometheus API client from
+// an arbitrary PrometheusConfig. This was extracted from NewClient to allow
+// non-default Prometheus endpoints (e.g. custom dashboards) to reuse the
+// same transport-layer initialization (TLS, auth, round-trippers).
 func NewClientFromPrometheusConfig(conf config.Config, promCfg config.PrometheusConfig, kialiSAToken string) (*Client, error) {
 	clientConfig := api.Config{Address: promCfg.URL}
 
-	// Prom Cache will be initialized once at first use of Prometheus Client
+	// Prom Cache will be initialized once at first use of Prometheus Client.
+	// The cache configuration is read from config.Get() (the main Prometheus
+	// config), so callers should ensure the main client is created before any
+	// non-default client to avoid binding the cache to the wrong settings.
+	// In production cmd/server.go guarantees this ordering.
 	once.Do(func() {
 		// create the cache with its own context/logger
 		zl := log.WithGroup(log.PromCacheLogName)


### PR DESCRIPTION
When external_services.custom_dashboards.prometheus.url is configured, metric queries were still sent to the main Prometheus instance because NewDashboardsService always used the injected promClient. Create a dedicated client via sync.Once when a custom URL is configured, caching it for the lifetime of the process.

fixes #9531