### PR TITLE
Upgrade Go to 1.25.8 (v2.17 backport)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiali/kiali
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Backport of Go 1.25.8 upgrade to the v2.17 release branch.

Fixes CVE-2026-25679: Incorrect parsing of IPv6 host literals in net/url.