### PR TITLE
improve MCP Chekcer be able to pass the repo to pass

### DIFF
--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -38,12 +38,16 @@ jobs:
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
+      kubernetes-mcp-server-repo: ${{ steps.check.outputs.kubernetes_mcp_server_repo }}
     steps:
     - name: Check trigger conditions
       id: check
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
       run: |
+        echo "kubernetes_mcp_server_repo=" >> $GITHUB_OUTPUT
+
         if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
           PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" --jq '.permission')
 
@@ -56,6 +60,13 @@ jobs:
             PR_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
             echo "pr-sha=$PR_SHA" >> $GITHUB_OUTPUT
             echo "Pinned to SHA: $PR_SHA"
+
+            K8S_MCP_SERVER_REPO=""
+            if [[ "$COMMENT_BODY" =~ (^|[[:space:]])KUBERNETES_MCP_SERVER_REPO=([^[:space:]]+) ]]; then
+              K8S_MCP_SERVER_REPO="${BASH_REMATCH[2]}"
+              echo "Using KUBERNETES_MCP_SERVER_REPO=${K8S_MCP_SERVER_REPO}"
+            fi
+            echo "kubernetes_mcp_server_repo=${K8S_MCP_SERVER_REPO}" >> $GITHUB_OUTPUT
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
             echo "User ${{ github.event.comment.user.login }} does not have permission to trigger evaluations"
@@ -74,6 +85,7 @@ jobs:
     env:
       TARGET_BRANCH: ${{ github.base_ref || 'master' }}
       BUILD_BRANCH: ${{ needs.check-trigger.outputs.pr-sha }}
+      KUBERNETES_MCP_SERVER_REPO: ${{ needs.check-trigger.outputs.kubernetes-mcp-server-repo }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -133,11 +133,12 @@ jobs:
         MCP_EVAL_ARGS="${{ github.event.inputs.verbose == 'true' && '-v' || '' }}"
         make mcp-run-eval MCP_EVAL_ARGS="${MCP_EVAL_ARGS}"
 
-        if [ -f mcpchecker-gemini-eval-out.json ]; then
-          TASKS_TOTAL=$(jq 'length' mcpchecker-gemini-eval-out.json)
-          TASKS_PASSED=$(jq '[.[] | select(.taskPassed == true)] | length' mcpchecker-gemini-eval-out.json)
-          ASSERTIONS_TOTAL=$(jq '[.[] | .assertionResults | to_entries | length] | add // 0' mcpchecker-gemini-eval-out.json)
-          ASSERTIONS_PASSED=$(jq '[.[] | .assertionResults | to_entries[] | select(.value.passed == true)] | length' mcpchecker-gemini-eval-out.json)
+        RESULTS_JSON="tests/evals/results/mcpchecker-gemini-eval-out.json"
+        if [ -f "${RESULTS_JSON}" ]; then
+          TASKS_TOTAL=$(jq 'length' "${RESULTS_JSON}")
+          TASKS_PASSED=$(jq '[.[] | select(.taskPassed == true)] | length' "${RESULTS_JSON}")
+          ASSERTIONS_TOTAL=$(jq '[.[] | .assertionResults | to_entries | length] | add // 0' "${RESULTS_JSON}")
+          ASSERTIONS_PASSED=$(jq '[.[] | .assertionResults | to_entries[] | select(.value.passed == true)] | length' "${RESULTS_JSON}")
 
           if [ "$TASKS_TOTAL" -gt 0 ]; then
             TASK_PASS_RATE=$(awk "BEGIN {printf \"%.2f\", $TASKS_PASSED / $TASKS_TOTAL}")
@@ -161,9 +162,9 @@ jobs:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
     - name: Generate token summary
-      if: always() && hashFiles('mcpchecker-gemini-eval-out.json') != ''
+      if: always() && hashFiles('tests/evals/results/mcpchecker-gemini-eval-out.json') != ''
       run: |
-        make mcp-eval-copy-results
+        make mcp-eval-summary-json >> $GITHUB_STEP_SUMMARY
         make mcp-eval-summary >> $GITHUB_STEP_SUMMARY
 
     - name: Post PR evaluation comment

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -5,7 +5,7 @@
 MCP_SERVER_PORT ?= 8080
 MCP_SERVER_CONFIG ?= /tmp/mcp-server-config.toml
 MCP_EVAL_CONFIG ?= tests/evals/gemini/eval.yaml
-MCP_EVAL_RESULTS ?= tests/evals/mcpchecker-results/mcpchecker-gemini-eval-out.json
+MCP_EVAL_RESULTS ?= tests/evals/results/mcpchecker-gemini-eval-out.json
 KIALI_URL ?= $(shell kubectl get svc kiali -n istio-system -o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali' 2>/dev/null)
 KUBERNETES_MCP_SERVER_REPO ?=
 
@@ -134,6 +134,7 @@ mcp-eval-diff:
 mcp-clean-eval-results:
 	@rm -rf mcpchecker-results
 	@rm -f mcpchecker-gemini-eval-out.json
+	@rm -f tests/evals/results/mcpchecker-gemini-eval-out.json
 
 ## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from mcpchecker summary of MCP_EVAL_RESULTS
 mcp-update-token-readme:

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -5,9 +5,9 @@
 MCP_SERVER_PORT ?= 8080
 MCP_SERVER_CONFIG ?= /tmp/mcp-server-config.toml
 MCP_EVAL_CONFIG ?= tests/evals/gemini/eval.yaml
-MCP_EVAL_RESULTS ?= mcpchecker-gemini-eval-out.json
-MCP_EVAL_RESULTS_COMMITTED ?= tests/evals/results/mcpchecker-gemini-eval-out.json
+MCP_EVAL_RESULTS ?= tests/evals/mcpchecker-results/mcpchecker-gemini-eval-out.json
 KIALI_URL ?= $(shell kubectl get svc kiali -n istio-system -o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali' 2>/dev/null)
+KUBERNETES_MCP_SERVER_REPO ?=
 
 ## mcp-install-mcpchecker: Download and install the latest mcpchecker binary
 mcp-install-mcpchecker:
@@ -23,16 +23,40 @@ mcp-install-mcpchecker:
 	rm -rf /tmp/mcpchecker.zip /tmp/mcpchecker; \
 	echo "mcpchecker installed to ${GOPATH}/bin/"
 
-## mcp-install-server: Download and install the latest kubernetes-mcp-server binary
-mcp-install-server:
+## mcp-install-kubernetes-mcp-server: Install kubernetes-mcp-server from release or repo#branch
+mcp-install-kubernetes-mcp-server:
 	@echo "Installing kubernetes-mcp-server..."
 	@mkdir -p "${GOPATH}/bin"
-	@RELEASE_URL=$$(curl -sL https://api.github.com/repos/containers/kubernetes-mcp-server/releases/latest \
-		| jq -r '.assets[] | select(.name | test("linux.*amd64")) | .browser_download_url'); \
-	echo "Downloading kubernetes-mcp-server from: $${RELEASE_URL}"; \
-	curl -sL "$${RELEASE_URL}" -o "${GOPATH}/bin/kubernetes-mcp-server"; \
-	chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
-	echo "kubernetes-mcp-server installed to ${GOPATH}/bin/"
+	@if [ -z "${KUBERNETES_MCP_SERVER_REPO}" ]; then \
+		RELEASE_URL=$$(curl -sL https://api.github.com/repos/containers/kubernetes-mcp-server/releases/latest \
+			| jq -r '.assets[] | select(.name | test("linux.*amd64")) | .browser_download_url'); \
+		echo "Downloading kubernetes-mcp-server from: $${RELEASE_URL}"; \
+		curl -sL "$${RELEASE_URL}" -o "${GOPATH}/bin/kubernetes-mcp-server"; \
+		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
+		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/"; \
+	else \
+		REPO_AND_BRANCH="${KUBERNETES_MCP_SERVER_REPO}"; \
+		REPO="$${REPO_AND_BRANCH%%#*}"; \
+		BRANCH="$${REPO_AND_BRANCH#*#}"; \
+		if [ "$${REPO}" = "$${REPO_AND_BRANCH}" ] || [ -z "$${REPO}" ] || [ -z "$${BRANCH}" ]; then \
+			echo "ERROR: KUBERNETES_MCP_SERVER_REPO must use format owner/repo#branch (example: aljesusg/kubernetes-mcp-server#kiali_refactor_reduction)"; \
+			exit 1; \
+		fi; \
+		WORKDIR=$$(mktemp -d /tmp/kubernetes-mcp-server-build.XXXXXX); \
+		echo "Building kubernetes-mcp-server from $${REPO} (branch: $${BRANCH})"; \
+		git clone "https://github.com/$${REPO}.git" "$${WORKDIR}"; \
+		cd "$${WORKDIR}"; \
+		git checkout "$${BRANCH}"; \
+		make build; \
+		if [ ! -f "$${WORKDIR}/kubernetes-mcp-server" ]; then \
+			echo "ERROR: build finished but binary '$${WORKDIR}/kubernetes-mcp-server' was not found"; \
+			exit 1; \
+		fi; \
+		mv -f "$${WORKDIR}/kubernetes-mcp-server" "${GOPATH}/bin/kubernetes-mcp-server"; \
+		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
+		rm -rf "$${WORKDIR}"; \
+		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/ from source"; \
+	fi
 
 ## mcp-install-gemini-cli: Install the Gemini CLI via npm
 mcp-install-gemini-cli:
@@ -40,7 +64,7 @@ mcp-install-gemini-cli:
 	npm install -g @google/gemini-cli@latest
 
 ## mcp-install-tools: Install all MCP evaluation dependencies
-mcp-install-tools: mcp-install-mcpchecker mcp-install-server mcp-install-gemini-cli
+mcp-install-tools: mcp-install-mcpchecker mcp-install-kubernetes-mcp-server mcp-install-gemini-cli
 
 ## mcp-resolve-kiali-url: Resolve the Kiali URL from the cluster ingress
 mcp-resolve-kiali-url:
@@ -80,25 +104,37 @@ mcp-stop-server:
 mcp-run-eval:
 	@echo "Running mcpchecker evaluation..."
 	${GOPATH}/bin/mcpchecker check ${MCP_EVAL_CONFIG} ${MCP_EVAL_ARGS}
+	@if [ -f mcpchecker-gemini-eval-out.json ]; then \
+		mkdir -p $(dir ${MCP_EVAL_RESULTS}); \
+		mv -f mcpchecker-gemini-eval-out.json ${MCP_EVAL_RESULTS}; \
+	fi
 
-## mcp-eval-summary: Show a pretty summary of the evaluation results
+## mcp-eval-summary: Text summary of the evaluation (for logs and GITHUB_STEP_SUMMARY)
 mcp-eval-summary:
 	@if [ ! -f ${MCP_EVAL_RESULTS} ]; then \
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker summary ${MCP_EVAL_RESULTS} --github-output
+	@${GOPATH}/bin/mcpchecker summary ${MCP_EVAL_RESULTS} --output text
 
-## mcp-eval-copy-results: Copy raw mcpchecker output to tests/evals/results/ (committed baseline path)
-mcp-eval-copy-results:
+## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker summary <eval.json> -o json)
+mcp-eval-summary-json:
 	@if [ ! -f ${MCP_EVAL_RESULTS} ]; then \
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@echo "Copying ${MCP_EVAL_RESULTS} to ${MCP_EVAL_RESULTS_COMMITTED}..."
-	@mkdir -p $(dir ${MCP_EVAL_RESULTS_COMMITTED})
-	@cp -f ${MCP_EVAL_RESULTS} ${MCP_EVAL_RESULTS_COMMITTED}
+	@${GOPATH}/bin/mcpchecker summary ${MCP_EVAL_RESULTS} --output json
 
-## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from tests/evals/results/mcpchecker-gemini-eval-out.json (via mcpchecker summary)
+## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
+mcp-eval-diff:
+	@test -n "$${MCP_DIFF_BASE}" && test -n "$${MCP_DIFF_CURRENT}" || (echo "Usage: make mcp-eval-diff MCP_DIFF_BASE=<path> MCP_DIFF_CURRENT=<path>" >&2; exit 1)
+	@${GOPATH}/bin/mcpchecker diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
+
+## mcp-clean-eval-results: Remove local mcpchecker evaluation outputs
+mcp-clean-eval-results:
+	@rm -rf mcpchecker-results
+	@rm -f mcpchecker-gemini-eval-out.json
+
+## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from mcpchecker summary of MCP_EVAL_RESULTS
 mcp-update-token-readme:
 	@${ROOTDIR}/hack/mcp/update-token-readme.sh


### PR DESCRIPTION
This PR lets to run mcpchecker with a mcp repo

You can run 
/run-mcpchecker KUBERNETES_MCP_SERVER_REPO=aljesusg/kubernetes-mcp-server#kiali_refactor_reduction

to install the mcp version from code of a repo and a branch or not set the variable and run the latest release