### PR TITLE
Ambient checker: Include namespace to filter for the pod selection

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -928,15 +928,15 @@ func (in *WorkloadService) setPodsForDeployment(dep *apps_v1.Deployment, pods []
 			log.Errorf("Error converting deployment selector to map: %v", err)
 			// Fallback to template labels if selector conversion fails
 			selector := labels.Set(dep.Spec.Template.Labels).AsSelector()
-			w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+			w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, dep.Namespace, pods), in.businessLayer.Mesh.IsControlPlane)
 		} else {
 			selector := labels.Set(labelMap).AsSelector()
-			w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+			w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, dep.Namespace, pods), in.businessLayer.Mesh.IsControlPlane)
 		}
 	} else {
 		// For non-SPIRE workloads, use template labels
 		selector := labels.Set(dep.Spec.Template.Labels).AsSelector()
-		w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+		w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, dep.Namespace, pods), in.businessLayer.Mesh.IsControlPlane)
 	}
 }
 
@@ -1435,7 +1435,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(repset[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseReplicaSet(&repset[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as ReplicaSet", controllerName)
@@ -1453,7 +1453,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(repcon[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseReplicationController(&repcon[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as ReplicationController", controllerName)
@@ -1471,7 +1471,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(depcon[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseDeploymentConfig(&depcon[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as DeploymentConfig", controllerName)
@@ -1489,7 +1489,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(fulset[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseStatefulSet(&fulset[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as StatefulSet", controllerName)
@@ -1524,7 +1524,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(jbs[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseJob(&jbs[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as Job", controllerName)
@@ -1542,7 +1542,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(cronjbs[iFound].Spec.JobTemplate.Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseCronJob(&cronjbs[iFound], in.conf)
 			} else {
 				log.Warningf("Workload %s is not found as CronJob (CronJob could be deleted but children are still in the namespace)", controllerName)
@@ -1560,7 +1560,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			}
 			if found {
 				selector := labels.Set(daeset[iFound].Spec.Template.Labels).AsSelector()
-				w.SetPods(kubernetes.FilterPodsBySelector(selector, pods), in.businessLayer.Mesh.IsControlPlane)
+				w.SetPods(kubernetes.FilterPodsBySelectorAndNamespace(selector, controllerNamespace, pods), in.businessLayer.Mesh.IsControlPlane)
 				w.ParseDaemonSet(&daeset[iFound], in.conf)
 			} else {
 				log.Errorf("Workload %s is not found as DaemonSet", controllerName)

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -380,6 +380,10 @@ Then("the user doesn't see a L7 link", () => {
   cy.get('[data-test=workload-description-card]').should('not.contain', 'L7');
 });
 
+Then('the workload description card has no config issues', () => {
+  cy.get('[data-test=workload-description-card]').should('be.visible').and('not.contain', 'Config Issues');
+});
+
 Then('the user sees the L7 {string} link', (waypoint: string) => {
   cy.get('[data-test=workload-description-card]').should('contain', 'L7');
   cy.get(`[data-test=waypoint-list]`).contains('span', 'L7');

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -421,6 +421,12 @@ Feature: Kiali Waypoint related features
     Then 4 edges appear in the graph
     Then user "closes" traffic menu
 
+  Scenario: [Workload details] Sidecar and Ambient workloads with same name have no config issues
+    Given user is at the details page for the "workload" "test-sidecar/curl-client" located in the "" cluster
+    Then the workload description card has no config issues
+    And user is at the details page for the "workload" "test-ambient/curl-client" located in the "" cluster
+    Then the workload description card has no config issues
+
   # TODO: Remove skip-ossmc tag once the namespace page is created in OSSMC
   @skip-ossmc
   Scenario: [Namespaces] Add to Ambient in the test-sidecar namespace

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -298,6 +298,17 @@ func FilterPodsBySelector(selector labels.Selector, allPods []core_v1.Pod) []cor
 	return pods
 }
 
+// FilterPodsBySelectorAndNamespace returns pods matching selector in the given namespace.
+func FilterPodsBySelectorAndNamespace(selector labels.Selector, namespace string, allPods []core_v1.Pod) []core_v1.Pod {
+	var pods []core_v1.Pod
+	for _, pod := range allPods {
+		if pod.Namespace == namespace && selector.Matches(labels.Set(pod.Labels)) {
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
 func FilterWorkloadEntriesBySelector(selector labels.Selector, allEntries []*networking_v1.WorkloadEntry) []*networking_v1.WorkloadEntry {
 	var entries []*networking_v1.WorkloadEntry
 	// WorkloadGroup.Metadata.Labels is nullable

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -9,6 +9,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -147,6 +148,33 @@ func TestFilterPodsByController(t *testing.T) {
 			assert.Equal(tc.expectedLen, len(pods))
 		})
 	}
+}
+
+func TestFilterPodsBySelectorAndNamespace(t *testing.T) {
+	assert := assert.New(t)
+
+	selector := map[string]string{"app": "shared-app"}
+	pods := []core_v1.Pod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "pod-ns-a-1",
+				Namespace: "ns-a",
+				Labels:    selector,
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "pod-ns-b-1",
+				Namespace: "ns-b",
+				Labels:    selector,
+			},
+		},
+	}
+
+	filtered := FilterPodsBySelectorAndNamespace(labels.Set(selector).AsSelector(), "ns-a", pods)
+	assert.Len(filtered, 1)
+	assert.Equal("pod-ns-a-1", filtered[0].Name)
+	assert.Equal("ns-a", filtered[0].Namespace)
 }
 
 func TestFilterByNamespaces(t *testing.T) {


### PR DESCRIPTION
### Describe the change

 Include namespace to filter the pod in the Ambient 

### Steps to test the PR

- Run this example: 
`./istio/ambient/install-sidecars-ambient.sh -c kubectl -w true`

In the curl-client workload details page, from both test-sidecar and test-ambient, a validation check will appear: 
<img width="496" height="310" alt="image" src="https://github.com/user-attachments/assets/c64a3b6a-3180-4de3-bbe5-10932176abde" />

<img width="508" height="317" alt="Screenshot From 2026-04-14 12-42-30" src="https://github.com/user-attachments/assets/feb09fa4-b7ac-4397-813a-bb488169a571" />

It should not appear with this PR (But be visible on master). 

How to show a valid rule: 
`kubectl label ns test-sidecar istio.io/dataplane-mode=ambient`

### Automation testing

Added unit test and cypress test. 

### Issue reference

Fixes #9539 
