### PR TITLE
Fix namespace isolation in custom controller workload resolution

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1598,7 +1598,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			var cPods []core_v1.Pod
 			for _, rs := range repset {
 				rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
-				if rsOwnerRef != nil && rsOwnerRef.Name == controllerName && rsOwnerRef.Kind == controllerGVK.Kind {
+				if rsOwnerRef != nil && rs.Namespace == controllerNamespace && rsOwnerRef.Name == controllerName && rsOwnerRef.Kind == controllerGVK.Kind {
 					w.ParseReplicaSetParent(&rs, controllerName, controllerGVK, in.conf)
 					for _, pod := range pods {
 						if meta_v1.IsControlledBy(&pod, &rs) {
@@ -1609,9 +1609,9 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 				}
 			}
 			if len(cPods) == 0 {
-				// If no pods we're found for a ReplicaSet type, it's possible the controller
+				// If no pods were found for a ReplicaSet type, it's possible the controller
 				// is managing the pods itself i.e. the pod's have an owner ref directly to the controller type.
-				cPods = kubernetes.FilterPodsByController(controllerName, controllerGVK, pods)
+				cPods = kubernetes.FilterPodsByControllerAndNamespace(controllerName, controllerGVK, controllerNamespace, pods)
 				if len(cPods) > 0 {
 					w.ParsePods(controllerName, controllerGVK, cPods, in.conf)
 					log.Debugf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", controllerName, controllerGVK.Kind)
@@ -2289,7 +2289,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			var cPods []core_v1.Pod
 			for _, rs := range repset {
 				rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
-				if rsOwnerRef != nil && rsOwnerRef.Name == criteria.WorkloadName && rsOwnerRef.Kind == discoveredControllerGVK.Kind {
+				if rsOwnerRef != nil && rs.Namespace == criteria.Namespace && rsOwnerRef.Name == criteria.WorkloadName && rsOwnerRef.Kind == discoveredControllerGVK.Kind {
 					w.ParseReplicaSetParent(&rs, criteria.WorkloadName, discoveredControllerGVK, in.conf)
 					for _, pod := range pods {
 						if meta_v1.IsControlledBy(&pod, &rs) {
@@ -2301,7 +2301,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			}
 
 			if len(cPods) == 0 {
-				cPods = kubernetes.FilterPodsByController(criteria.WorkloadName, discoveredControllerGVK, pods)
+				cPods = kubernetes.FilterPodsByControllerAndNamespace(criteria.WorkloadName, discoveredControllerGVK, criteria.Namespace, pods)
 				if len(cPods) > 0 {
 					w.ParsePods(criteria.WorkloadName, discoveredControllerGVK, cPods, in.conf)
 					log.Debugf("Workload %s of type %s has not a ReplicaSet as a child controller, it may need a revisit", criteria.WorkloadName, discoveredControllerGVK.Kind)

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -250,9 +250,12 @@ func FilterK8sInferencePoolsBySelector(workloadSelector string, inferencePools [
 	return filtered
 }
 
-func FilterPodsByController(controllerName string, controllerGVK schema.GroupVersionKind, allPods []core_v1.Pod) []core_v1.Pod {
+func FilterPodsByControllerAndNamespace(controllerName string, controllerGVK schema.GroupVersionKind, namespace string, allPods []core_v1.Pod) []core_v1.Pod {
 	var pods []core_v1.Pod
 	for _, pod := range allPods {
+		if namespace != "" && pod.Namespace != namespace {
+			continue
+		}
 		for _, ref := range pod.OwnerReferences {
 			refGV, err := schema.ParseGroupVersion(ref.APIVersion)
 			if err != nil {

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -86,7 +86,7 @@ func ownerRefFrom(t *testing.T, owner runtime.Object) meta_v1.OwnerReference {
 	return *meta_v1.NewControllerRef(m, gvk)
 }
 
-func TestFilterPodsByController(t *testing.T) {
+func TestFilterPodsByControllerAndNamespaceEmptyNamespace(t *testing.T) {
 	rs := &apps_v1.ReplicaSet{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "Testing-RS",
@@ -144,10 +144,46 @@ func TestFilterPodsByController(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			pods := FilterPodsByController(tc.controllerName, tc.controllerGVK, tc.pods)
+			pods := FilterPodsByControllerAndNamespace(tc.controllerName, tc.controllerGVK, "", tc.pods)
 			assert.Equal(tc.expectedLen, len(pods))
 		})
 	}
+}
+
+func TestFilterPodsByControllerAndNamespace(t *testing.T) {
+	rs := &apps_v1.ReplicaSet{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "Testing-RS",
+			Namespace: "ns-a",
+			UID:       types.UID("e07b722f-c922-4046-8d98-7aa8487d41c1"),
+		},
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       ReplicaSets.Kind,
+			APIVersion: ReplicaSets.GroupVersion().String(),
+		},
+	}
+
+	pods := []core_v1.Pod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:            "rs-pod-ns-a",
+				Namespace:       "ns-a",
+				OwnerReferences: []meta_v1.OwnerReference{ownerRefFrom(t, rs)},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:            "rs-pod-ns-b",
+				Namespace:       "ns-b",
+				OwnerReferences: []meta_v1.OwnerReference{ownerRefFrom(t, rs)},
+			},
+		},
+	}
+
+	filtered := FilterPodsByControllerAndNamespace(rs.Name, ReplicaSets, "ns-a", pods)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "rs-pod-ns-a", filtered[0].Name)
+	assert.Equal(t, "ns-a", filtered[0].Namespace)
 }
 
 func TestFilterPodsBySelectorAndNamespace(t *testing.T) {


### PR DESCRIPTION
### Describe the change

Fix namespace isolation in custom controller workload resolution
Continuation from: https://github.com/kiali/kiali/pull/9554#issuecomment-4244929004 : 

`BUG-1 [Data integrity — pre-existing in same code path] business/workloads.go:1599-1601 — In the default branch for custom controllers, the loop over repset picks the first ReplicaSet whose owner ref matches name and kind only, not rs.Namespace == controllerNamespace. With the same controller name in two allowed namespaces, the wrong RS can be chosen and pods attached incorrectly. This PR does not introduce this; it fixes standard controller paths. Follow-up: add a namespace guard on rs (and audit similar loops) if custom controllers matter in multi-namespace list views.`

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Ref. #9539 