### PR TITLE
Add StrictGet deployment config

### DIFF
--- a/business/health_cache_test.go
+++ b/business/health_cache_test.go
@@ -10,6 +10,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/log"
 )
@@ -136,9 +137,15 @@ func TestRefreshClusterHealth_GetAllWorkloadsError(t *testing.T) {
 
 	layer := NewLayerBuilder(t, conf).WithClient(k8s).Build()
 
-	// Remove the cluster's SA client from the WorkloadService so GetAllWorkloads
-	// fails with "Cluster [...] is not found", while the NamespaceService (which
-	// has its own copy of the SA clients) still succeeds for GetClusterNamespaces.
+	// Give WorkloadService its own copy of the SA clients map, then remove the
+	// cluster entry so GetAllWorkloads fails with "Cluster [...] is not found".
+	// The NamespaceService keeps the original map and still succeeds for
+	// GetClusterNamespaces.
+	wlSAClients := make(map[string]kubernetes.ClientInterface, len(layer.Workload.kialiSAClients))
+	for k, v := range layer.Workload.kialiSAClients {
+		wlSAClients[k] = v
+	}
+	layer.Workload.kialiSAClients = wlSAClients
 	delete(layer.Workload.kialiSAClients, cluster)
 
 	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -446,7 +446,7 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 	// When not in strict-get mode, try the user's own list; if it succeeds,
 	// intersect it with the SA list so we never return namespaces that Kiali
 	// itself cannot access.
-	if !in.conf.Deployment.StrictGet {
+	if !in.conf.KialiFeatureFlags.Authz.RequireNamespaceGet {
 		userNss, userErr := in.userClients[cluster].GetNamespaces(labelSelector)
 		if userErr == nil {
 			saSet := make(map[string]struct{}, len(nss))

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -168,25 +168,18 @@ func (in *NamespaceService) getNamespacesByCluster(ctx context.Context, cluster 
 
 	// Note that cluster-wide-access mode requires cluster role permission to list all namespaces.
 	if in.conf.Deployment.ClusterWideAccess {
-
-		nss, err := in.userClients[cluster].GetNamespaces("")
+		// get the intersection of KialiSA and user namespaces
+		nss, err := in.getNamespacesUsingKialiSA(cluster, "")
 		if err != nil {
-			// Fallback to using the Kiali service account, if needed
-			if errors.IsForbidden(err) {
-				if nss, err = in.getNamespacesUsingKialiSA(cluster, "", err); err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		namespaces = models.CastNamespaceCollection(nss, cluster)
 	} else {
-		// We do not have cluster wide access, so we do not have permission to list namespaces.
-		// Therefore, we assume we can extract the list of accessible namespaces from the discovery selectors configuration.
-		// That list of accessible namespaces will be used as our base list which we then filter with discovery selectors down below.
-		// Note if this is a remote cluster, that remote cluster must have the same namespaces as those in our own local
+		// We do not have cluster wide access, so we do not have permission to list namespaces. Therefore, we assume we can
+		// extract the list of accessible namespaces from the discovery selectors configuration. That list of accessible
+		// namespaces will be used as our base list which we then filter with discovery selectors down below.
+		// Note, if this is a remote cluster, that remote cluster must have the same namespaces as those in our own local
 		// cluster's accessible namespaces. This is one reason why we suggest enabling CWA for multi-cluster environments.
 		accessibleNamespaces := in.conf.Deployment.AccessibleNamespaces
 		k8sNamespaces := make([]core_v1.Namespace, 0)
@@ -434,33 +427,49 @@ func (in *NamespaceService) waitForCacheUpdate(ctx context.Context, cluster stri
 	}
 }
 
-func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelector string, forwardedError error) ([]core_v1.Namespace, error) {
-	// Check if we already are using the Kiali ServiceAccount token. If we are, no need to do further processing, since
-	// this would just circle back to the same results.
-	kialiToken := in.kialiSAClients[cluster].GetToken()
-	if in.userClients[cluster].GetToken() == kialiToken {
-		return nil, forwardedError
-	}
-
-	// Let's get the namespaces list using the Kiali Service Account
+// getNamespacesUsingKialiSA returns the intersection of namespaces Listed for KialiSA, narrowed by labelSelector, and those the
+// user can access (via List or Get, depending on the config)
+func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelector string) ([]core_v1.Namespace, error) {
 	nss, err := in.kialiSAClients[cluster].GetNamespaces(labelSelector)
 	if err != nil {
 		return nil, err
 	}
 
-	// Only take namespaces where the user has privileges
-	var namespaces []core_v1.Namespace
-	for _, item := range nss {
-		if _, getNsErr := in.userClients[cluster].GetNamespace(item.Name); getNsErr == nil {
-			// Namespace is accessible
-			namespaces = append(namespaces, item)
-		} else if !errors.IsForbidden(getNsErr) {
-			// Since the returned error is NOT "forbidden", something bad happened
-			return nil, getNsErr
+	// When not in strict-get mode, try the user's own list; if it succeeds,
+	// intersect it with the SA list so we never return namespaces that Kiali
+	// itself cannot access.
+	if !in.conf.Deployment.StrictGet {
+		userNss, userErr := in.userClients[cluster].GetNamespaces(labelSelector)
+		if userErr == nil {
+			saSet := make(map[string]struct{}, len(nss))
+			for _, ns := range nss {
+				saSet[ns.Name] = struct{}{}
+			}
+			var intersection []core_v1.Namespace
+			for i := range userNss {
+				if _, ok := saSet[userNss[i].Name]; ok {
+					intersection = append(intersection, userNss[i])
+				}
+			}
+			return intersection, nil
+		}
+		if !errors.IsForbidden(userErr) {
+			return nil, userErr
 		}
 	}
 
-	// Return the list of namespaces where the user has the 'get namespace' read privilege.
+	return in.filterToNamespacesUserCanGet(cluster, nss)
+}
+
+func (in *NamespaceService) filterToNamespacesUserCanGet(cluster string, candidates []core_v1.Namespace) ([]core_v1.Namespace, error) {
+	var namespaces []core_v1.Namespace
+	for _, item := range candidates {
+		if _, getNsErr := in.userClients[cluster].GetNamespace(item.Name); getNsErr == nil {
+			namespaces = append(namespaces, item)
+		} else if !errors.IsForbidden(getNsErr) {
+			return nil, getNsErr
+		}
+	}
 	return namespaces, nil
 }
 

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
@@ -435,6 +436,13 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 		return nil, err
 	}
 
+	// When the user token is the same as the SA token (e.g. anonymous auth)
+	// the SA list is already the correct answer — skip the redundant user
+	// LIST and intersection/filter.
+	if in.userClients[cluster].GetToken() == in.kialiSAClients[cluster].GetToken() {
+		return nss, nil
+	}
+
 	// When not in strict-get mode, try the user's own list; if it succeeds,
 	// intersect it with the SA list so we never return namespaces that Kiali
 	// itself cannot access.
@@ -462,6 +470,7 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 }
 
 func (in *NamespaceService) filterToNamespacesUserCanGet(cluster string, candidates []core_v1.Namespace) ([]core_v1.Namespace, error) {
+	start := time.Now()
 	var namespaces []core_v1.Namespace
 	for _, item := range candidates {
 		if _, getNsErr := in.userClients[cluster].GetNamespace(item.Name); getNsErr == nil {
@@ -470,6 +479,7 @@ func (in *NamespaceService) filterToNamespacesUserCanGet(cluster string, candida
 			return nil, getNsErr
 		}
 	}
+	log.Debugf("filterToNamespacesUserCanGet for cluster [%s]: checked %d candidates, kept %d namespaces in %s", cluster, len(candidates), len(namespaces), time.Since(start))
 	return namespaces, nil
 }
 

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -139,11 +139,20 @@ func TestGetNamespacesStrictGetFiltersToGetPermission(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Deployment.StrictGet = true
 
-	k8s := setupNamespaceServiceWithNs()
-	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	saClient := setupNamespaceServiceWithNs()
+	saClient.Token = "sa-token"
+
+	userClient := setupNamespaceServiceWithNs()
+	userClient.Token = "user-token"
+	cs := userClient.KubeClientset.(*clientsetfake.Clientset)
 	cs.PrependReactor("get", "namespaces", forbidGetNamespace("beta"))
 
-	nsservice := setupNamespaceService(t, k8s, conf)
+	saClients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: saClient}
+	userClients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: userClient}
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
 	ns, err := nsservice.GetNamespaces(context.TODO())
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"alpha", "bookinfo", "test", "test2"}, nsNames(ns))
@@ -154,11 +163,20 @@ func TestGetNamespacesStrictGetDisabledTrustsList(t *testing.T) {
 	conf := config.NewConfig()
 	require.False(t, conf.Deployment.StrictGet)
 
-	k8s := setupNamespaceServiceWithNs()
-	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	saClient := setupNamespaceServiceWithNs()
+	saClient.Token = "sa-token"
+
+	userClient := setupNamespaceServiceWithNs()
+	userClient.Token = "user-token"
+	cs := userClient.KubeClientset.(*clientsetfake.Clientset)
 	cs.PrependReactor("get", "namespaces", forbidGetNamespace("beta"))
 
-	nsservice := setupNamespaceService(t, k8s, conf)
+	saClients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: saClient}
+	userClients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: userClient}
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
 	ns, err := nsservice.GetNamespaces(context.TODO())
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"alpha", "beta", "bookinfo", "test", "test2"}, nsNames(ns))
@@ -239,20 +257,25 @@ func TestGetNamespacesGetInternalErrorPropagates(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Deployment.StrictGet = true
 
-	k8s := setupNamespaceServiceWithNs()
-	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	saClient := setupNamespaceServiceWithNs()
+	saClient.Token = "sa-token"
+
+	userClient := setupNamespaceServiceWithNs()
+	userClient.Token = "user-token"
+	cs := userClient.KubeClientset.(*clientsetfake.Clientset)
 	cs.PrependReactor("get", "namespaces", func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
-		getAction, ok := action.(kubeclienttesting.GetAction)
-		if !ok {
-			return false, nil, nil
-		}
-		if getAction.GetName() == "beta" {
+		if ga, ok := action.(kubeclienttesting.GetAction); ok && ga.GetName() == "beta" {
 			return true, nil, errors.NewInternalError(fmt.Errorf("apiserver down"))
 		}
 		return false, nil, nil
 	})
 
-	nsservice := setupNamespaceService(t, k8s, conf)
+	saClients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: saClient}
+	userClients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: userClient}
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
 	_, err := nsservice.GetNamespaces(context.TODO())
 	require.Error(t, err)
 	assert.True(t, errors.IsInternalError(err))

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -134,10 +134,10 @@ func nsNames(nss []models.Namespace) []string {
 	return names
 }
 
-// With deployment.strict_get and cluster-wide access, namespaces returned from list are kept only when the user may get each Namespace object.
-func TestGetNamespacesStrictGetFiltersToGetPermission(t *testing.T) {
+// With require_namespace_get and cluster-wide access, namespaces returned from list are kept only when the user may get each Namespace object.
+func TestGetNamespacesRequireNamespaceGetFiltersToGetPermission(t *testing.T) {
 	conf := config.NewConfig()
-	conf.Deployment.StrictGet = true
+	conf.KialiFeatureFlags.Authz.RequireNamespaceGet = true
 
 	saClient := setupNamespaceServiceWithNs()
 	saClient.Token = "sa-token"
@@ -158,10 +158,10 @@ func TestGetNamespacesStrictGetFiltersToGetPermission(t *testing.T) {
 	require.ElementsMatch(t, []string{"alpha", "bookinfo", "test", "test2"}, nsNames(ns))
 }
 
-// When strict_get is false, a successful namespace list is not filtered by per-namespace get (legacy behavior).
-func TestGetNamespacesStrictGetDisabledTrustsList(t *testing.T) {
+// When require_namespace_get is false, a successful namespace list is not filtered by per-namespace get (legacy behavior).
+func TestGetNamespacesRequireNamespaceGetDisabledTrustsList(t *testing.T) {
 	conf := config.NewConfig()
-	require.False(t, conf.Deployment.StrictGet)
+	require.False(t, conf.KialiFeatureFlags.Authz.RequireNamespaceGet)
 
 	saClient := setupNamespaceServiceWithNs()
 	saClient.Token = "sa-token"
@@ -182,11 +182,11 @@ func TestGetNamespacesStrictGetDisabledTrustsList(t *testing.T) {
 	require.ElementsMatch(t, []string{"alpha", "beta", "bookinfo", "test", "test2"}, nsNames(ns))
 }
 
-// When strict_get is false and user List succeeds, namespaces the user can
+// When require_namespace_get is false and user List succeeds, namespaces the user can
 // see but the Kiali SA cannot must be excluded (intersection with SA list).
 func TestGetNamespacesNonStrictIntersectsWithSAList(t *testing.T) {
 	conf := config.NewConfig()
-	require.False(t, conf.Deployment.StrictGet)
+	require.False(t, conf.KialiFeatureFlags.Authz.RequireNamespaceGet)
 
 	// SA can see bookinfo and alpha only.
 	saClient := kubetest.NewFakeK8sClient(
@@ -214,12 +214,12 @@ func TestGetNamespacesNonStrictIntersectsWithSAList(t *testing.T) {
 	require.ElementsMatch(t, []string{"alpha", "bookinfo"}, nsNames(ns))
 }
 
-// When strict_get is false and user List returns Forbidden, the code falls
+// When require_namespace_get is false and user List returns Forbidden, the code falls
 // through to filterToNamespacesUserCanGet which keeps only namespaces the
 // user can individually Get.
 func TestGetNamespacesNonStrictForbiddenListFallsBackToGet(t *testing.T) {
 	conf := config.NewConfig()
-	require.False(t, conf.Deployment.StrictGet)
+	require.False(t, conf.KialiFeatureFlags.Authz.RequireNamespaceGet)
 
 	// SA client can list all three namespaces.
 	saClient := kubetest.NewFakeK8sClient(
@@ -255,7 +255,7 @@ func TestGetNamespacesNonStrictForbiddenListFallsBackToGet(t *testing.T) {
 // must propagate up and fail the entire GetNamespaces call.
 func TestGetNamespacesGetInternalErrorPropagates(t *testing.T) {
 	conf := config.NewConfig()
-	conf.Deployment.StrictGet = true
+	conf.KialiFeatureFlags.Authz.RequireNamespaceGet = true
 
 	saClient := setupNamespaceServiceWithNs()
 	saClient.Token = "sa-token"

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	kubeclienttesting "k8s.io/client-go/testing"
 
 	"github.com/kiali/kiali/cache"
@@ -105,6 +106,156 @@ func TestGetNamespaces(t *testing.T) {
 	assert.NotNil(t, ns)
 	assert.Equal(t, len(ns), 5)
 	assert.Equal(t, ns[0].Name, "alpha")
+}
+
+// forbidGetNamespace returns a reactor that rejects Get for the named namespace with a Forbidden error.
+func forbidGetNamespace(name string) func(kubeclienttesting.Action) (bool, runtime.Object, error) {
+	return func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
+		if ga, ok := action.(kubeclienttesting.GetAction); ok && ga.GetName() == name {
+			return true, nil, errors.NewForbidden(core_v1.Resource("namespaces"), name, fmt.Errorf("forbidden"))
+		}
+		return false, nil, nil
+	}
+}
+
+// forbidListNamespaces returns a reactor that rejects List for namespaces with a Forbidden error.
+func forbidListNamespaces() func(kubeclienttesting.Action) (bool, runtime.Object, error) {
+	return func(_ kubeclienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewForbidden(core_v1.Resource("namespaces"), "", fmt.Errorf("forbidden"))
+	}
+}
+
+// nsNames extracts the sorted list of namespace names from a namespace slice.
+func nsNames(nss []models.Namespace) []string {
+	names := make([]string, len(nss))
+	for i, n := range nss {
+		names[i] = n.Name
+	}
+	return names
+}
+
+// With deployment.strict_get and cluster-wide access, namespaces returned from list are kept only when the user may get each Namespace object.
+func TestGetNamespacesStrictGetFiltersToGetPermission(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Deployment.StrictGet = true
+
+	k8s := setupNamespaceServiceWithNs()
+	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	cs.PrependReactor("get", "namespaces", forbidGetNamespace("beta"))
+
+	nsservice := setupNamespaceService(t, k8s, conf)
+	ns, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"alpha", "bookinfo", "test", "test2"}, nsNames(ns))
+}
+
+// When strict_get is false, a successful namespace list is not filtered by per-namespace get (legacy behavior).
+func TestGetNamespacesStrictGetDisabledTrustsList(t *testing.T) {
+	conf := config.NewConfig()
+	require.False(t, conf.Deployment.StrictGet)
+
+	k8s := setupNamespaceServiceWithNs()
+	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	cs.PrependReactor("get", "namespaces", forbidGetNamespace("beta"))
+
+	nsservice := setupNamespaceService(t, k8s, conf)
+	ns, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"alpha", "beta", "bookinfo", "test", "test2"}, nsNames(ns))
+}
+
+// When strict_get is false and user List succeeds, namespaces the user can
+// see but the Kiali SA cannot must be excluded (intersection with SA list).
+func TestGetNamespacesNonStrictIntersectsWithSAList(t *testing.T) {
+	conf := config.NewConfig()
+	require.False(t, conf.Deployment.StrictGet)
+
+	// SA can see bookinfo and alpha only.
+	saClient := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("alpha"),
+	)
+	saClient.Token = "sa-token"
+
+	// User can see bookinfo, alpha, and extra (SA does not have extra).
+	userClient := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("alpha"),
+		kubetest.FakeNamespace("extra"),
+	)
+	userClient.Token = "user-token"
+
+	saClients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: saClient}
+	userClients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: userClient}
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
+	ns, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"alpha", "bookinfo"}, nsNames(ns))
+}
+
+// When strict_get is false and user List returns Forbidden, the code falls
+// through to filterToNamespacesUserCanGet which keeps only namespaces the
+// user can individually Get.
+func TestGetNamespacesNonStrictForbiddenListFallsBackToGet(t *testing.T) {
+	conf := config.NewConfig()
+	require.False(t, conf.Deployment.StrictGet)
+
+	// SA client can list all three namespaces.
+	saClient := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("alpha"),
+		kubetest.FakeNamespace("beta"),
+	)
+	saClient.Token = "sa-token"
+
+	// User client: list is forbidden, individual get succeeds except for beta.
+	userClient := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("alpha"),
+		kubetest.FakeNamespace("beta"),
+	)
+	userClient.Token = "user-token"
+	userCS := userClient.KubeClientset.(*clientsetfake.Clientset)
+	userCS.PrependReactor("list", "namespaces", forbidListNamespaces())
+	userCS.PrependReactor("get", "namespaces", forbidGetNamespace("beta"))
+
+	saClients := map[string]kubernetes.ClientInterface{conf.KubernetesConfig.ClusterName: saClient}
+	userClients := map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: userClient}
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
+	ns, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"alpha", "bookinfo"}, nsNames(ns))
+}
+
+// A non-forbidden Get error (e.g. InternalError) in filterToNamespacesUserCanGet
+// must propagate up and fail the entire GetNamespaces call.
+func TestGetNamespacesGetInternalErrorPropagates(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Deployment.StrictGet = true
+
+	k8s := setupNamespaceServiceWithNs()
+	cs := k8s.KubeClientset.(*clientsetfake.Clientset)
+	cs.PrependReactor("get", "namespaces", func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(kubeclienttesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if getAction.GetName() == "beta" {
+			return true, nil, errors.NewInternalError(fmt.Errorf("apiserver down"))
+		}
+		return false, nil, nil
+	})
+
+	nsservice := setupNamespaceService(t, k8s, conf)
+	_, err := nsservice.GetNamespaces(context.TODO())
+	require.Error(t, err)
+	assert.True(t, errors.IsInternalError(err))
 }
 
 // Get namespace

--- a/config/config.go
+++ b/config/config.go
@@ -614,7 +614,8 @@ type DeploymentConfig struct {
 	ClusterNameOverrides map[string]string        `yaml:"cluster_name_overrides,omitempty"`
 	DiscoverySelectors   DiscoverySelectorsConfig `yaml:"discovery_selectors,omitempty"`
 	InstanceName         string                   `yaml:"instance_name"`
-	Namespace            string                   `yaml:"namespace,omitempty"` // Kiali deployment namespace
+	Namespace            string                   `yaml:"namespace,omitempty"`  // Kiali deployment namespace
+	StrictGet            bool                     `yaml:"strict_get,omitempty"` // Namespace access requires GET perm (LIST alone is insufficient).
 	TLSConfig            DeploymentTLSConfig      `yaml:"tls_config,omitempty" json:"tlsConfig,omitempty"`
 	ViewOnlyMode         bool                     `yaml:"view_only_mode,omitempty"`
 }
@@ -1028,6 +1029,7 @@ func NewConfig() (c *Config) {
 			DiscoverySelectors: DiscoverySelectorsConfig{Default: nil, Overrides: nil},
 			InstanceName:       "kiali",
 			Namespace:          IstioNamespaceDefault,
+			StrictGet:          false,
 			TLSConfig: DeploymentTLSConfig{
 				Source: TLSConfigSourceConfig,
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -614,8 +614,7 @@ type DeploymentConfig struct {
 	ClusterNameOverrides map[string]string        `yaml:"cluster_name_overrides,omitempty"`
 	DiscoverySelectors   DiscoverySelectorsConfig `yaml:"discovery_selectors,omitempty"`
 	InstanceName         string                   `yaml:"instance_name"`
-	Namespace            string                   `yaml:"namespace,omitempty"`  // Kiali deployment namespace
-	StrictGet            bool                     `yaml:"strict_get,omitempty"` // Namespace access requires GET perm (LIST alone is insufficient).
+	Namespace            string                   `yaml:"namespace,omitempty"` // Kiali deployment namespace
 	TLSConfig            DeploymentTLSConfig      `yaml:"tls_config,omitempty" json:"tlsConfig,omitempty"`
 	ViewOnlyMode         bool                     `yaml:"view_only_mode,omitempty"`
 }
@@ -868,8 +867,14 @@ type HealthCacheConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"` // Default: true
 }
 
+// FeatureFlagAuthz controls authorization-related feature flags.
+type FeatureFlagAuthz struct {
+	RequireNamespaceGet bool `yaml:"require_namespace_get,omitempty" json:"requireNamespaceGet,omitempty"`
+}
+
 // KialiFeatureFlags available from the CR
 type KialiFeatureFlags struct {
+	Authz                 FeatureFlagAuthz          `yaml:"authz,omitempty" json:"authz,omitempty"`
 	Clustering            FeatureFlagClustering     `yaml:"clustering,omitempty" json:"clustering,omitempty"`
 	CustomWorkloadTypes   []metav1.GroupVersionKind `yaml:"custom_workload_types,omitempty" json:"customWorkloadTypes,omitempty"`
 	DisabledFeatures      []string                  `yaml:"disabled_features,omitempty" json:"disabledFeatures,omitempty"`
@@ -1029,7 +1034,6 @@ func NewConfig() (c *Config) {
 			DiscoverySelectors: DiscoverySelectorsConfig{Default: nil, Overrides: nil},
 			InstanceName:       "kiali",
 			Namespace:          IstioNamespaceDefault,
-			StrictGet:          false,
 			TLSConfig: DeploymentTLSConfig{
 				Source: TLSConfigSourceConfig,
 			},
@@ -1144,6 +1148,9 @@ func NewConfig() (c *Config) {
 			VersionLabelName:            "",
 		},
 		KialiFeatureFlags: KialiFeatureFlags{
+			Authz: FeatureFlagAuthz{
+				RequireNamespaceGet: false,
+			},
 			Clustering: FeatureFlagClustering{
 				EnableExecProvider: false,
 			},


### PR DESCRIPTION
Closes #7125 

Add configuration that limits a user's accessible namespaces to only those for which the user has Get permission. List permission would not be enough. This provides more security for installs where users do not always have List+Get on the same set of namespaces.

Operator PR: https://github.com/kiali/kiali-operator/pull/1025
Helm-Charts PR: https://github.com/kiali/helm-charts/pull/394
Docs PR: https://github.com/kiali/kiali.io/pull/965
