### PR TITLE
Capture graph panic in defer refresh

### DIFF
--- a/graph/refresh_job.go
+++ b/graph/refresh_job.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -234,6 +235,15 @@ func (j *RefreshJob) cleanup() {
 // 4. Generates a fresh graph
 // 5. Updates the cache
 func (j *RefreshJob) refresh() {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Errorf("Panic while refreshing graph cache for session [%s]: %v\n%s", j.sessionID, recovered, string(debug.Stack()))
+			// A panic indicates a broken refresh cycle. Evict the stale graph and stop the job.
+			j.cache.Evict(j.sessionID)
+			j.Stop()
+		}
+	}()
+
 	// Check if session's graph still exists (use internal method to not update LastAccessed)
 	cached, found := j.cache.getSessionGraphInternal(j.sessionID)
 	if !found {

--- a/graph/refresh_job_test.go
+++ b/graph/refresh_job_test.go
@@ -270,6 +270,51 @@ func TestRefreshJob_GeneratorError(t *testing.T) {
 	assert.Equal(t, len(trafficMap), len(retrieved.TrafficMap))
 }
 
+func TestRefreshJob_GeneratorPanic(t *testing.T) {
+	ctx := context.Background()
+	config := &GraphCacheConfig{
+		Enabled:           true,
+		InactivityTimeout: 5 * time.Minute,
+		MaxCacheMemoryMB:  50,
+		RefreshInterval:   1 * time.Hour,
+	}
+	cache := NewGraphCache(ctx, config).(*GraphCacheImpl)
+
+	generator := func(ctx context.Context, options Options) (TrafficMap, error) {
+		panic("boom")
+	}
+	cache.SetGraphGenerator(generator)
+
+	options := Options{
+		TelemetryOptions: TelemetryOptions{
+			CommonOptions: CommonOptions{
+				Duration: 120 * time.Second,
+			},
+		},
+	}
+
+	// Set initial cached graph
+	trafficMap := createTestTrafficMap(5)
+	cached := &CachedGraph{
+		LastAccessed:    time.Now(),
+		Options:         options,
+		RefreshInterval: 30 * time.Second,
+		Timestamp:       time.Now(),
+		TrafficMap:      trafficMap,
+	}
+	err := cache.SetSessionGraph("test-session", cached)
+	require.NoError(t, err)
+
+	job := NewRefreshJob(ctx, "test-session", options, cache, generator, 30*time.Second)
+
+	// refresh should recover from panic and not crash the test
+	job.refresh()
+
+	assert.True(t, job.stopped)
+	_, found := cache.GetSessionGraph("test-session")
+	assert.False(t, found)
+}
+
 func TestRefreshJob_StartAndStop(t *testing.T) {
 	ctx := context.Background()
 	config := &GraphCacheConfig{


### PR DESCRIPTION
### Describe the change

Ref. https://github.com/kiali/kiali/pull/9537#discussion_r3076730428 
Different approach to handle panic: Try to recover in the refresh job, in case it is not possible, evict the graph and log the stack trace:
<img width="1456" height="747" alt="image" src="https://github.com/user-attachments/assets/c594f5ae-e182-426e-a2d1-0e5c5ed99d9e" />

```
2026-04-15T09:34:06+01:00 ERR Panic while refreshing graph cache for session [anonymous-shared]: namespaces "travel-agency" not found
goroutine 13036 [running]:
runtime/debug.Stack()
	/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/runtime/debug/stack.go:26 +0x8e
github.com/kiali/kiali/graph.(*RefreshJob).refresh.func1()
	kiali/graph/refresh_job.go:240 +0x4a
panic({0x46d0e80?, 0xc0024e5370?})
	pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/runtime/panic.go:783 +0x136
github.com/kiali/kiali/graph.CheckError({0x54b6760, 0xc001107c20})
	kiali/graph/util.go:52 +0x53
github.com/kiali/kiali/graph/telemetry/istio/appender.WorkloadEntryAppender.applyWorkloadEntries({0xc0019d7e00}, {0x54effb8, 0xc003ca9bc0}, 0xc003180630, 0xc002500240, 0xc001c0ea38)
	kiali/graph/telemetry/istio/appender/workload_entry.go:67 +0x54f
github.com/kiali/kiali/graph/telemetry/istio/appender.WorkloadEntryAppender.AppendGraph({0xc0019d7e00}, {0x54effb8, 0xc003ca9bc0}, 0xc003180630, 0xc002500240, 0xc001c0ea38)
	kiali/graph/telemetry/istio/appender/workload_entry.go:42 +0xae
github.com/kiali/kiali/graph/telemetry/istio.BuildNamespacesTrafficMap({_, _}, {0xc0019d7e00, {0x0, {0xc00114ec40, 0x7, 0x7}}, 0x0, 0x1, 0xc0019d7d40, ...}, ...)
	kiali/graph/telemetry/istio/istio.go:90 +0x115a
github.com/kiali/kiali/graph/api.graphNamespacesIstio({_, _}, _, {_, _}, {{0x506d83f, 0x6}, {0x506c319, 0x5}, {{0xc001626074, ...}, ...}, ...})
	kiali/graph/api/api.go:85 +0x149
github.com/kiali/kiali/graph/api.GraphNamespaces({_, _}, _, {_, _}, {{0x506d83f, 0x6}, {0x506c319, 0x5}, {{0xc001626074, ...}, ...}, ...})
	/kiali/graph/api/api.go:65 +0x77e
github.com/kiali/kiali/handlers.createGraphGenerator.func1({_, _}, {{0x506d83f, 0x6}, {0x506c319, 0x5}, {{0xc001626074, 0x15}, {0x45d964b800, {0xc001626032, ...}, ...}}, ...})
	kiali/handlers/graph.go:354 +0xde
github.com/kiali/kiali/graph.(*RefreshJob).refresh(0xc001664248)
	kiali/graph/refresh_job.go:284 +0x6df
created by github.com/kiali/kiali/graph.(*RefreshJob).Start in goroutine 2841
	kiali/graph/refresh_job.go:107 +0xbaf
```


### Steps to test the PR

This is not very easy to reproduce, but I tested it like this: 
- Install travels demo
- See travels demo graph (All 3 namespaces) 
- Delete travels demo
- Refresh the graph until it hits the error

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes: #9535
