### PR TITLE
[v2.22] Capture graph panic in defer refresh (#9559)

### DIFF
--- a/graph/refresh_job.go
+++ b/graph/refresh_job.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -234,6 +235,15 @@ func (j *RefreshJob) cleanup() {
 // 4. Generates a fresh graph
 // 5. Updates the cache
 func (j *RefreshJob) refresh() {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Errorf("Panic while refreshing graph cache for session [%s]: %v\n%s", j.sessionID, recovered, string(debug.Stack()))
+			// A panic indicates a broken refresh cycle. Evict the stale graph and stop the job.
+			j.cache.Evict(j.sessionID)
+			j.Stop()
+		}
+	}()
+
 	// Check if session's graph still exists (use internal method to not update LastAccessed)
 	cached, found := j.cache.getSessionGraphInternal(j.sessionID)
 	if !found {

--- a/graph/refresh_job_test.go
+++ b/graph/refresh_job_test.go
@@ -270,6 +270,51 @@ func TestRefreshJob_GeneratorError(t *testing.T) {
 	assert.Equal(t, len(trafficMap), len(retrieved.TrafficMap))
 }
 
+func TestRefreshJob_GeneratorPanic(t *testing.T) {
+	ctx := context.Background()
+	config := &GraphCacheConfig{
+		Enabled:           true,
+		InactivityTimeout: 5 * time.Minute,
+		MaxCacheMemoryMB:  50,
+		RefreshInterval:   1 * time.Hour,
+	}
+	cache := NewGraphCache(ctx, config).(*GraphCacheImpl)
+
+	generator := func(ctx context.Context, options Options) (TrafficMap, error) {
+		panic("boom")
+	}
+	cache.SetGraphGenerator(generator)
+
+	options := Options{
+		TelemetryOptions: TelemetryOptions{
+			CommonOptions: CommonOptions{
+				Duration: 120 * time.Second,
+			},
+		},
+	}
+
+	// Set initial cached graph
+	trafficMap := createTestTrafficMap(5)
+	cached := &CachedGraph{
+		LastAccessed:    time.Now(),
+		Options:         options,
+		RefreshInterval: 30 * time.Second,
+		Timestamp:       time.Now(),
+		TrafficMap:      trafficMap,
+	}
+	err := cache.SetSessionGraph("test-session", cached)
+	require.NoError(t, err)
+
+	job := NewRefreshJob(ctx, "test-session", options, cache, generator, 30*time.Second)
+
+	// refresh should recover from panic and not crash the test
+	job.refresh()
+
+	assert.True(t, job.stopped)
+	_, found := cache.GetSessionGraph("test-session")
+	assert.False(t, found)
+}
+
 func TestRefreshJob_StartAndStop(t *testing.T) {
 	ctx := context.Background()
 	config := &GraphCacheConfig{


### PR DESCRIPTION
### Describe the change
Backport from: https://github.com/kiali/kiali/pull/9559 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/issues/9535 
