### PR TITLE
Make codecov informational until configuration is completed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,13 +12,13 @@ coverage:
       default:
         # 'auto' means it will use the current coverage of the base branch as the target
         target: auto
-        informational: false
+        informational: true
     patch:
       default:
         # Ensures that new code in a PR has at least 80% coverage
         target: 80%
         threshold: 0%
-        informational: false
+        informational: true
 
 ignore:
   # Exclude frontend UI code (since this is for the backend)


### PR DESCRIPTION
### Describe the change

Setting informational true in the codecov.yaml file to avoid getting issues while merging PR's until the configuration of the tool is completed
