### PR TITLE
Fix comment due mcpchecker new version

### DIFF
--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -280,14 +280,14 @@ jobs:
         cp "${ARTIFACT_JSON}" tests/evals/results/mcpchecker-gemini-eval-out.json
 
         if [[ "${PREVIOUS_EXISTS}" -eq 1 ]]; then
-          "${MCPCHECKER}" diff --base "${PREVIOUS}" --current tests/evals/results/mcpchecker-gemini-eval-out.json --output markdown > baseline-pr-diff.md
+          "${MCPCHECKER}" result diff --base "${PREVIOUS}" --current tests/evals/results/mcpchecker-gemini-eval-out.json --output markdown > baseline-pr-diff.md
         else
           echo "_No previous committed baseline on \`master\` at this path — first update or new file._" > baseline-pr-diff.md
         fi
 
         make mcp-update-token-readme
         echo "Updated baseline summary:"
-        "${MCPCHECKER}" summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json | head -c 2000
+        "${MCPCHECKER}" result summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json | head -c 2000
         echo
 
     - name: Create PR with updated baseline

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -7,34 +7,35 @@ MCP_SERVER_CONFIG ?= /tmp/mcp-server-config.toml
 MCP_EVAL_CONFIG ?= tests/evals/gemini/eval.yaml
 MCP_EVAL_RESULTS ?= tests/evals/results/mcpchecker-gemini-eval-out.json
 KIALI_URL ?= $(shell kubectl get svc kiali -n istio-system -o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali' 2>/dev/null)
+
+KUBERNETES_MCP_SERVER_VERSION ?= latest
 KUBERNETES_MCP_SERVER_REPO ?=
+KUBERNETES_MCP_SERVER ?= $(shell pwd)/_output/tools/bin/kubernetes-mcp-server
+
+
+MCPCHECKER = $(shell pwd)/_output/tools/bin/mcpchecker
+MCPCHECKER_VERSION ?= latest
+
+EVAL_CONFIG ?= evals/openai-agent/eval.yaml
+EVAL_LABEL_SELECTOR ?= suite=kubernetes
+EVAL_TASK_FILTER ?=
+EVAL_VERBOSE ?= false
 
 ## mcp-install-mcpchecker: Download and install the latest mcpchecker binary
 mcp-install-mcpchecker:
-	@echo "Installing mcpchecker..."
-	@mkdir -p "${GOPATH}/bin"
-	@MCPCHECKER_URL=$$(curl -sL https://api.github.com/repos/mcpchecker/mcpchecker/releases/latest \
-		| jq -r '.assets[] | select(.name == "mcpchecker-linux-amd64.zip") | .browser_download_url'); \
-	echo "Downloading mcpchecker from: $${MCPCHECKER_URL}"; \
-	curl -sL "$${MCPCHECKER_URL}" -o /tmp/mcpchecker.zip; \
-	unzip -o /tmp/mcpchecker.zip -d /tmp/mcpchecker; \
-	chmod +x /tmp/mcpchecker/mcpchecker; \
-	mv /tmp/mcpchecker/mcpchecker "${GOPATH}/bin/"; \
-	rm -rf /tmp/mcpchecker.zip /tmp/mcpchecker; \
-	echo "mcpchecker installed to ${GOPATH}/bin/"
+	@[ -f $(MCPCHECKER) ] || { \
+		set -e ;\
+		echo "Installing mcpchecker $(MCPCHECKER_VERSION) to $(MCPCHECKER)..." ;\
+		mkdir -p $(shell dirname $(MCPCHECKER)) ;\
+		GOBIN=$(shell dirname $(MCPCHECKER)) go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@$(MCPCHECKER_VERSION) ;\
+	}
 
 ## mcp-install-kubernetes-mcp-server: Install kubernetes-mcp-server from release or repo#branch
 mcp-install-kubernetes-mcp-server:
-	@echo "Installing kubernetes-mcp-server..."
-	@mkdir -p "${GOPATH}/bin"
-	@if [ -z "${KUBERNETES_MCP_SERVER_REPO}" ]; then \
-		RELEASE_URL=$$(curl -sL https://api.github.com/repos/containers/kubernetes-mcp-server/releases/latest \
-			| jq -r '.assets[] | select(.name | test("linux.*amd64")) | .browser_download_url'); \
-		echo "Downloading kubernetes-mcp-server from: $${RELEASE_URL}"; \
-		curl -sL "$${RELEASE_URL}" -o "${GOPATH}/bin/kubernetes-mcp-server"; \
-		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
-		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/"; \
-	else \
+	@if [ -f "$(KUBERNETES_MCP_SERVER)" ]; then \
+		echo "kubernetes-mcp-server already exists at $(KUBERNETES_MCP_SERVER), skipping install"; \
+	elif [ -n "${KUBERNETES_MCP_SERVER_REPO}" ]; then \
+		set -e; \
 		REPO_AND_BRANCH="${KUBERNETES_MCP_SERVER_REPO}"; \
 		REPO="$${REPO_AND_BRANCH%%#*}"; \
 		BRANCH="$${REPO_AND_BRANCH#*#}"; \
@@ -52,10 +53,16 @@ mcp-install-kubernetes-mcp-server:
 			echo "ERROR: build finished but binary '$${WORKDIR}/kubernetes-mcp-server' was not found"; \
 			exit 1; \
 		fi; \
-		mv -f "$${WORKDIR}/kubernetes-mcp-server" "${GOPATH}/bin/kubernetes-mcp-server"; \
-		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
+		mkdir -p "$(shell dirname $(KUBERNETES_MCP_SERVER))"; \
+		mv -f "$${WORKDIR}/kubernetes-mcp-server" "$(KUBERNETES_MCP_SERVER)"; \
+		chmod +x "$(KUBERNETES_MCP_SERVER)"; \
 		rm -rf "$${WORKDIR}"; \
-		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/ from source"; \
+		echo "kubernetes-mcp-server installed to $(KUBERNETES_MCP_SERVER) from source"; \
+	else \
+		set -e; \
+		echo "Installing kubernetes-mcp-server $(KUBERNETES_MCP_SERVER_VERSION) to $(KUBERNETES_MCP_SERVER)..."; \
+		mkdir -p "$(shell dirname $(KUBERNETES_MCP_SERVER))"; \
+		GOBIN="$(shell dirname $(KUBERNETES_MCP_SERVER))" go install github.com/containers/kubernetes-mcp-server/cmd/kubernetes-mcp-server@$(KUBERNETES_MCP_SERVER_VERSION); \
 	fi
 
 ## mcp-install-gemini-cli: Install the Gemini CLI via npm
@@ -73,11 +80,11 @@ mcp-resolve-kiali-url:
 	@echo "Resolved Kiali URL: ${KIALI_URL}"
 
 ## mcp-start-server: Start the kubernetes-mcp-server in the background
-mcp-start-server: mcp-resolve-kiali-url
+mcp-start-server: mcp-resolve-kiali-url mcp-install-kubernetes-mcp-server
 	@echo "Starting kubernetes-mcp-server on port ${MCP_SERVER_PORT}..."
 	@cat > ${MCP_SERVER_CONFIG} <<< $$'toolsets = ["kiali"]\nlog_level = 0\nport = "${MCP_SERVER_PORT}"\n[toolset_configs.kiali]\nurl = "${KIALI_URL}"\ninsecure = true'
 	@echo "MCP server config:"; cat ${MCP_SERVER_CONFIG}
-	@${GOPATH}/bin/kubernetes-mcp-server --config ${MCP_SERVER_CONFIG} & \
+	@$(KUBERNETES_MCP_SERVER) --config ${MCP_SERVER_CONFIG} & \
 	MCP_PID=$$!; \
 	echo "$$MCP_PID" > /tmp/mcp-server.pid; \
 	echo "Waiting for kubernetes-mcp-server (pid $$MCP_PID) to be ready..."; \
@@ -103,7 +110,7 @@ mcp-stop-server:
 ## mcp-run-eval: Run the mcpchecker evaluation
 mcp-run-eval:
 	@echo "Running mcpchecker evaluation..."
-	${GOPATH}/bin/mcpchecker check ${MCP_EVAL_CONFIG} ${MCP_EVAL_ARGS}
+	$(MCPCHECKER) check ${MCP_EVAL_CONFIG} ${MCP_EVAL_ARGS}
 	@if [ -f mcpchecker-gemini-eval-out.json ]; then \
 		mkdir -p $(dir ${MCP_EVAL_RESULTS}); \
 		mv -f mcpchecker-gemini-eval-out.json ${MCP_EVAL_RESULTS}; \
@@ -115,7 +122,7 @@ mcp-eval-summary:
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker result summary ${MCP_EVAL_RESULTS} --output text
+	@$(MCPCHECKER) result summary ${MCP_EVAL_RESULTS} --output text
 
 ## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker summary <eval.json> -o json)
 mcp-eval-summary-json:
@@ -123,12 +130,12 @@ mcp-eval-summary-json:
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker summary ${MCP_EVAL_RESULTS} --output json
+	@$(MCPCHECKER) result summary ${MCP_EVAL_RESULTS} --output json
 
 ## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
 mcp-eval-diff:
 	@test -n "$${MCP_DIFF_BASE}" && test -n "$${MCP_DIFF_CURRENT}" || (echo "Usage: make mcp-eval-diff MCP_DIFF_BASE=<path> MCP_DIFF_CURRENT=<path>" >&2; exit 1)
-	@${GOPATH}/bin/mcpchecker diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
+	@$(MCPCHECKER) result diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
 
 ## mcp-clean-eval-results: Remove local mcpchecker evaluation outputs
 mcp-clean-eval-results:
@@ -138,4 +145,4 @@ mcp-clean-eval-results:
 
 ## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from mcpchecker summary of MCP_EVAL_RESULTS
 mcp-update-token-readme:
-	@${ROOTDIR}/hack/mcp/update-token-readme.sh
+	@$(shell pwd)/hack/mcp/update-token-readme.sh

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -27,7 +27,7 @@ mcp-install-mcpchecker:
 		set -e ;\
 		echo "Installing mcpchecker $(MCPCHECKER_VERSION) to $(MCPCHECKER)..." ;\
 		mkdir -p $(shell dirname $(MCPCHECKER)) ;\
-		GOBIN=$(shell dirname $(MCPCHECKER)) go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@$(MCPCHECKER_VERSION) ;\
+		GOBIN=$(shell dirname $(MCPCHECKER)) GOTOOLCHAIN=auto go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@$(MCPCHECKER_VERSION) ;\
 	}
 
 ## mcp-install-kubernetes-mcp-server: Install kubernetes-mcp-server from release or repo#branch
@@ -62,7 +62,7 @@ mcp-install-kubernetes-mcp-server:
 		set -e; \
 		echo "Installing kubernetes-mcp-server $(KUBERNETES_MCP_SERVER_VERSION) to $(KUBERNETES_MCP_SERVER)..."; \
 		mkdir -p "$(shell dirname $(KUBERNETES_MCP_SERVER))"; \
-		GOBIN="$(shell dirname $(KUBERNETES_MCP_SERVER))" go install github.com/containers/kubernetes-mcp-server/cmd/kubernetes-mcp-server@$(KUBERNETES_MCP_SERVER_VERSION); \
+		GOBIN="$(shell dirname $(KUBERNETES_MCP_SERVER))" GOTOOLCHAIN=auto go install github.com/containers/kubernetes-mcp-server/cmd/kubernetes-mcp-server@$(KUBERNETES_MCP_SERVER_VERSION); \
 	fi
 
 ## mcp-install-gemini-cli: Install the Gemini CLI via npm


### PR DESCRIPTION
Commands diff and summary are now under resutls command from mcpchecker 0.0.16 

```bash
agutierr@agutierr-thinkpadp1gen7:~/Projects/kiali/kiali (improve_ci_and_tests)$ _output/tools/bin/mcpchecker -h
mcpchecker is a framework for evaluating MCP agents against tasks.
It runs agents through defined tasks and validates their behavior using assertions.

Usage:
  mcpchecker [command]

Available Commands:
  check       Run an evaluation
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  result      Commands for inspecting and analyzing evaluation result files
  version     Print version information

Flags:
  -h, --help      help for mcpchecker
  -v, --version   version for mcpchecker

Use "mcpchecker [command] --help" for more information about a command.
agutierr@agutierr-thinkpadp1gen7:~/Projects/kiali/kiali (improve_ci_and_tests)$ _output/tools/bin/mcpchecker result -h
Commands for inspecting and analyzing evaluation result files.

These commands operate on the JSON result files produced by 'mcpchecker check'.

Usage:
  mcpchecker result [command]

Available Commands:
  diff        Compare two evaluation results
  summary     Show a compact summary of evaluation results
  verify      Verify evaluation results meet thresholds
  view        Pretty-print evaluation results from a JSON file

Flags:
  -h, --help   help for result

Use "mcpchecker result [command] --help" for more information about a command.

``