### PR TITLE
Populate cluster in IstioConfigDetails API response

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -593,7 +593,7 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, cluster
 	var err error
 
 	istioConfigDetail := models.IstioConfigDetails{}
-	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
+	istioConfigDetail.Namespace = models.Namespace{Cluster: cluster, Name: namespace}
 	istioConfigDetail.ObjectGVK = objectGVK
 
 	if _, ok := in.userClients[cluster]; !ok {
@@ -900,7 +900,7 @@ func (in *IstioConfigService) waitForCacheCreate(ctx context.Context, cluster st
 
 func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, cluster, namespace string, resourceType schema.GroupVersionKind, name, jsonPatch string) (models.IstioConfigDetails, error) {
 	istioConfigDetail := models.IstioConfigDetails{}
-	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
+	istioConfigDetail.Namespace = models.Namespace{Cluster: cluster, Name: namespace}
 	istioConfigDetail.ObjectGVK = resourceType
 
 	patchOpts := meta_v1.PatchOptions{}
@@ -1018,7 +1018,7 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 
 func (in *IstioConfigService) CreateIstioConfigDetail(ctx context.Context, cluster, namespace string, resourceType schema.GroupVersionKind, body []byte) (models.IstioConfigDetails, error) {
 	istioConfigDetail := models.IstioConfigDetails{}
-	istioConfigDetail.Namespace = models.Namespace{Name: namespace}
+	istioConfigDetail.Namespace = models.Namespace{Cluster: cluster, Name: namespace}
 	istioConfigDetail.ObjectGVK = resourceType
 
 	createOpts := meta_v1.CreateOptions{}

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -172,6 +172,7 @@ func TestGetIstioConfigDetails(t *testing.T) {
 	assert.Equal("gw-1", istioConfigDetails.Gateway.Name)
 	assert.True(istioConfigDetails.Permissions.Update)
 	assert.False(istioConfigDetails.Permissions.Delete)
+	assert.Equal(conf.KubernetesConfig.ClusterName, istioConfigDetails.Namespace.Cluster)
 	assert.Nil(err)
 
 	istioConfigDetails, err = configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", kubernetes.VirtualServices, "reviews")
@@ -202,12 +203,14 @@ func TestCheckMulticlusterPermissions(t *testing.T) {
 	assert.Equal("gw-1", istioConfigDetails.Gateway.Name)
 	assert.True(istioConfigDetails.Permissions.Update)
 	assert.False(istioConfigDetails.Permissions.Delete)
+	assert.Equal(config.Get().KubernetesConfig.ClusterName, istioConfigDetails.Namespace.Cluster)
 	assert.Nil(err)
 
 	istioConfigDetailsRemote, err := configService.GetIstioConfigDetails(context.TODO(), "east", "test", kubernetes.Gateways, "gw-1")
 	assert.Equal("gw-1", istioConfigDetailsRemote.Gateway.Name)
 	assert.True(istioConfigDetailsRemote.Permissions.Update)
 	assert.False(istioConfigDetailsRemote.Permissions.Delete)
+	assert.Equal("east", istioConfigDetailsRemote.Namespace.Cluster)
 	assert.Nil(err)
 }
 
@@ -523,6 +526,7 @@ func TestUpdateIstioConfigDetails(t *testing.T) {
 	updatedVirtualService, err := configService.UpdateIstioConfigDetail(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.VirtualServices, "reviews-to-update", "{}")
 	require.NoError(err)
 	assert.Equal("test", updatedVirtualService.Namespace.Name)
+	assert.Equal(conf.KubernetesConfig.ClusterName, updatedVirtualService.Namespace.Cluster)
 	assert.Equal(kubernetes.VirtualServices.String(), updatedVirtualService.ObjectGVK.String())
 	assert.Equal("reviews-to-update", updatedVirtualService.VirtualService.Name)
 }
@@ -538,6 +542,7 @@ func TestCreateIstioConfigDetails(t *testing.T) {
 
 	createVirtualService, err := configService.CreateIstioConfigDetail(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.VirtualServices, []byte("{}"))
 	assert.Equal("test", createVirtualService.Namespace.Name)
+	assert.Equal(conf.KubernetesConfig.ClusterName, createVirtualService.Namespace.Cluster)
 	assert.Equal(kubernetes.VirtualServices.String(), createVirtualService.ObjectGVK.String())
 	// Name is now encoded in the payload of the virtualservice so, it modifies this test
 	// assert.Equal("reviews-to-update", createVirtualService.VirtualService.Name)
@@ -603,7 +608,7 @@ func TestListWithAllNamespacesButNoAccessReturnsEmpty(t *testing.T) {
 	// in it so the list should return empty.
 	k8s.Token = "test"
 	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
-	configService.kialiCache.SetNamespaces("test", []models.Namespace{{Name: "nottest", Cluster: "Kubernetes"}})
+	configService.kialiCache.SetNamespaces("test", []models.Namespace{{Cluster: "Kubernetes", Name: "nottest"}})
 
 	criteria := IstioConfigCriteria{
 		IncludeGateways: true,

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -163,7 +163,8 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
       .then(resultConfigDetails => {
         this.setState(
           {
-            cluster: this.state.cluster,
+            cluster:
+              resultConfigDetails.data.cluster || resultConfigDetails.data.namespace.cluster || this.state.cluster,
             istioObjectDetails: resultConfigDetails.data,
             originalIstioObjectDetails: resultConfigDetails.data,
             istioValidations: resultConfigDetails.data.validation,
@@ -528,7 +529,6 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
                     istioObjectDetails={this.state.istioObjectDetails}
                     istioValidations={this.state.istioValidations}
                     namespace={this.state.istioObjectDetails.namespace.name}
-                    cluster={this.state.cluster}
                     statusMessages={istioStatusMsgs}
                     objectReferences={objectReferences}
                     serviceReferences={serviceReferences}

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -35,7 +35,6 @@ import { CLUSTER_DEFAULT } from 'types/Graph';
 import { infoStyle } from 'styles/IconStyle';
 
 interface IstioConfigOverviewProps {
-  cluster?: string;
   helpMessages?: HelpMessage[];
   istioObjectDetails: IstioConfigDetails;
   istioValidations?: ObjectValidation;
@@ -73,6 +72,8 @@ const linkStyle = kialiStyle({
 });
 
 export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: IstioConfigOverviewProps) => {
+  const cluster = props.istioObjectDetails.cluster || props.istioObjectDetails.namespace.cluster;
+
   const configurationHasWarnings = (): boolean | undefined => {
     return props.istioValidations?.checks.some(check => {
       return check.severity === ValidationTypes.Warning;
@@ -112,7 +113,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
   let urlInKiali = '';
 
   if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
-    const clusterInfo = serverConfig.clusters[props.cluster ?? homeCluster?.name ?? CLUSTER_DEFAULT];
+    const clusterInfo = serverConfig.clusters[cluster ?? homeCluster?.name ?? CLUSTER_DEFAULT];
     const kialiInstance = clusterInfo?.kialiInstances?.find(instance => instance.url.length !== 0);
 
     // Set the kiali url from kialiInstance info (here a "/console" is required as external link is used)
@@ -123,7 +124,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
         istioObject.metadata.name,
         istioObject.metadata.namespace,
         getIstioObjectGVK(istioObject.apiVersion, istioObject.kind),
-        props.cluster
+        cluster
       );
   }
 
@@ -138,7 +139,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
       <StackItem>
         {isMultiCluster && (
           <div key="cluster-icon">
-            <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {props.cluster}
+            <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {cluster}
           </div>
         )}
 
@@ -190,10 +191,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
 
       {props.istioValidations?.references && (
         <StackItem>
-          <IstioConfigValidationReferences
-            objectReferences={props.istioValidations.references}
-            cluster={props.cluster}
-          />
+          <IstioConfigValidationReferences objectReferences={props.istioValidations.references} cluster={cluster} />
         </StackItem>
       )}
 
@@ -205,7 +203,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
             serviceReferences={props.serviceReferences}
             workloadReferences={props.workloadReferences}
             isValid={!props.istioValidations || props.istioValidations?.valid}
-            cluster={props.cluster}
+            cluster={cluster}
           />
         </StackItem>
       )}

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -345,25 +345,27 @@ func (i IstioConfigDetails) MarshalJSON() ([]byte, error) {
 		resource = i.K8sTLSRoute
 	}
 
-	jsonMap["resource"] = resource
-	jsonMap["namespace"] = i.Namespace
+	jsonMap["cluster"] = i.Namespace.Cluster
 	jsonMap["gvk"] = i.ObjectGVK
-	jsonMap["permissions"] = i.Permissions
-	jsonMap["validation"] = i.IstioValidation
-	jsonMap["references"] = i.IstioReferences
 	jsonMap["help"] = i.IstioConfigHelpFields
+	jsonMap["namespace"] = i.Namespace
+	jsonMap["permissions"] = i.Permissions
+	jsonMap["references"] = i.IstioReferences
+	jsonMap["resource"] = resource
+	jsonMap["validation"] = i.IstioValidation
 
 	return json.Marshal(jsonMap)
 }
 
 func (icd *IstioConfigDetails) UnmarshalJSON(data []byte) error {
 	var temp struct {
+		Cluster               string                  `json:"cluster"`
+		IstioConfigHelpFields []IstioConfigHelp       `json:"help"`
+		IstioReferences       *IstioReferences        `json:"references"`
+		IstioValidation       *IstioValidation        `json:"validation"`
 		Namespace             Namespace               `json:"namespace"`
 		ObjectGVK             schema.GroupVersionKind `json:"gvk"`
 		Permissions           ResourcePermissions     `json:"permissions"`
-		IstioValidation       *IstioValidation        `json:"validation"`
-		IstioReferences       *IstioReferences        `json:"references"`
-		IstioConfigHelpFields []IstioConfigHelp       `json:"help"`
 		Resource              json.RawMessage         `json:"resource"`
 	}
 
@@ -372,6 +374,9 @@ func (icd *IstioConfigDetails) UnmarshalJSON(data []byte) error {
 	}
 
 	icd.Namespace = temp.Namespace
+	if icd.Namespace.Cluster == "" && temp.Cluster != "" {
+		icd.Namespace.Cluster = temp.Cluster
+	}
 	icd.ObjectGVK = temp.ObjectGVK
 	icd.Permissions = temp.Permissions
 	icd.IstioValidation = temp.IstioValidation

--- a/models/istio_config_test.go
+++ b/models/istio_config_test.go
@@ -1,0 +1,69 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kiali/kiali/models"
+)
+
+func TestMarshalJSON_IncludesTopLevelCluster(t *testing.T) {
+	details := models.IstioConfigDetails{}
+	details.Namespace = models.Namespace{Cluster: "east", Name: "bookinfo"}
+	details.ObjectGVK = schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "VirtualService"}
+	details.VirtualService = &networking_v1.VirtualService{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "reviews", Namespace: "bookinfo"},
+	}
+
+	data, err := json.Marshal(details)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	var cluster string
+	require.NoError(t, json.Unmarshal(raw["cluster"], &cluster))
+	assert.Equal(t, "east", cluster)
+
+	var ns models.Namespace
+	require.NoError(t, json.Unmarshal(raw["namespace"], &ns))
+	assert.Equal(t, "east", ns.Cluster)
+	assert.Equal(t, "bookinfo", ns.Name)
+}
+
+func TestUnmarshalJSON_ReadsTopLevelCluster(t *testing.T) {
+	jsonData := `{
+		"cluster": "west",
+		"namespace": {"name": "bookinfo"},
+		"gvk": {"Group": "networking.istio.io", "Version": "v1", "Kind": "VirtualService"},
+		"permissions": {},
+		"resource": {"metadata": {"name": "reviews", "namespace": "bookinfo"}, "kind": "VirtualService", "apiVersion": "networking.istio.io/v1"}
+	}`
+
+	var details models.IstioConfigDetails
+	require.NoError(t, json.Unmarshal([]byte(jsonData), &details))
+
+	assert.Equal(t, "west", details.Namespace.Cluster)
+	assert.Equal(t, "bookinfo", details.Namespace.Name)
+}
+
+func TestUnmarshalJSON_PrefersNamespaceCluster(t *testing.T) {
+	jsonData := `{
+		"cluster": "west",
+		"namespace": {"name": "bookinfo", "cluster": "east"},
+		"gvk": {"Group": "networking.istio.io", "Version": "v1", "Kind": "VirtualService"},
+		"permissions": {},
+		"resource": {"metadata": {"name": "reviews", "namespace": "bookinfo"}, "kind": "VirtualService", "apiVersion": "networking.istio.io/v1"}
+	}`
+
+	var details models.IstioConfigDetails
+	require.NoError(t, json.Unmarshal([]byte(jsonData), &details))
+
+	assert.Equal(t, "east", details.Namespace.Cluster)
+}


### PR DESCRIPTION
## Summary
- The IstioConfigDetails API response was missing the cluster field, causing the Istio Config details overview to not display the cluster badge in multi-cluster environments, including OSSMC
- Populates `Namespace.Cluster` in `GetIstioConfigDetails`, `UpdateIstioConfigDetail`, and `CreateIstioConfigDetail`
- Adds a top-level `cluster` field to `IstioConfigDetails.MarshalJSON`, matching the pattern used by Service and Workload detail endpoints
- Updates `UnmarshalJSON` to read the top-level `cluster` field as fallback when `namespace.cluster` is absent
- Frontend derives cluster from the API response object in `IstioConfigOverview` instead of relying on a URL-derived state prop, which does not work in OSSMC

## Test plan
- [x] Backend unit tests pass (`TestGetIstioConfigDetails`, `TestCheckMulticlusterPermissions`, `TestUpdateIstioConfigDetails`, `TestCreateIstioConfigDetails`)
- [x] New `Namespace.Cluster` assertions verify cluster is populated for home and remote clusters
- [x] New `MarshalJSON`/`UnmarshalJSON` serialization tests verify the wire format includes a top-level `cluster` field
- [x] Verify cluster badge shows in Istio Config details overview in multi-cluster Kiali
- [x] Verify cluster badge shows in Istio Config details overview in OSSMC

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/638

Made with [Cursor](https://cursor.com)