### PR TITLE
Unify getHeaders logic for standalone Kiali and OSSMC

### DIFF
--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -126,22 +126,20 @@ const loginHeaders = config.login.headers;
 /**  Helpers to Requests */
 
 const getHeaders = (method: HTTP_VERBS, urlEncoded: boolean): Partial<AxiosHeaders> => {
-  if (apiProxy) {
-    // apiProxy is used by OSSMC, which doesn't need Kiali login headers (and can cause CORS issues)
-    // Header name must match mcp.HeaderKialiUI (handlers/ChatMCP).
-    const headers = { 'Content-Type': 'application/x-www-form-urlencoded', 'Kiali-UI': 'true' };
+  const headers: Record<string, string | undefined> = {
+    'Content-Type': urlEncoded ? 'application/x-www-form-urlencoded' : 'application/json',
+    'Kiali-UI': 'true',
+    ...loginHeaders
+  };
 
-    // X-CSRFToken is used only for non-GET requests
-    if (method !== HTTP_VERBS.GET) {
-      headers['X-CSRFToken'] = getCSRFToken();
+  if (method !== HTTP_VERBS.GET) {
+    const csrf = getCSRFToken();
+    if (csrf) {
+      headers['X-CSRFToken'] = csrf;
     }
-
-    return headers;
-  } else if (urlEncoded) {
-    return { 'Content-Type': 'application/x-www-form-urlencoded', ...loginHeaders };
-  } else {
-    return { 'Content-Type': 'application/json', ...loginHeaders };
   }
+
+  return headers;
 };
 
 const basicAuth = (username: UserName, password: Password): BasicAuth => {

--- a/frontend/src/services/__tests__/ApiMethods.test.ts
+++ b/frontend/src/services/__tests__/ApiMethods.test.ts
@@ -1,6 +1,81 @@
+import axios from 'axios';
+import axiosMockAdapter from 'axios-mock-adapter';
+
 import * as API from '../Api';
+import * as Auth from '../../types/Auth';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { ServiceListQuery } from '../../types/ServiceList';
+
+describe('#getHeaders via public API calls', () => {
+  let mock: axiosMockAdapter;
+
+  beforeEach(() => {
+    mock = new axiosMockAdapter(axios);
+    mock.onAny().reply(200, {});
+  });
+
+  afterEach(() => {
+    mock.restore();
+    jest.restoreAllMocks();
+  });
+
+  it('should include Kiali-UI and Content-Type on GET requests', async () => {
+    await API.getStatus();
+
+    expect(mock.history.get).toHaveLength(1);
+    const headers = mock.history.get[0].headers!;
+    expect(headers['Kiali-UI']).toBe('true');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['X-Auth-Type-Kiali-UI']).toBe('1');
+  });
+
+  it('should not include X-CSRFToken on GET requests', async () => {
+    jest.spyOn(Auth, 'getCSRFToken').mockReturnValue('test-csrf-token');
+
+    await API.getStatus();
+
+    const headers = mock.history.get[0].headers!;
+    expect(headers['X-CSRFToken']).toBeUndefined();
+  });
+
+  it('should include X-CSRFToken on non-GET requests when token exists', async () => {
+    jest.spyOn(Auth, 'getCSRFToken').mockReturnValue('test-csrf-token');
+
+    await API.createIstioConfigDetail(
+      'test-ns',
+      { Group: 'networking.istio.io', Version: 'v1', Kind: 'VirtualService' },
+      '{}'
+    );
+
+    expect(mock.history.post).toHaveLength(1);
+    const headers = mock.history.post[0].headers!;
+    expect(headers['X-CSRFToken']).toBe('test-csrf-token');
+  });
+
+  it('should not include X-CSRFToken on non-GET requests when token is undefined', async () => {
+    jest.spyOn(Auth, 'getCSRFToken').mockReturnValue(undefined);
+
+    await API.createIstioConfigDetail(
+      'test-ns',
+      { Group: 'networking.istio.io', Version: 'v1', Kind: 'VirtualService' },
+      '{}'
+    );
+
+    const headers = mock.history.post[0].headers!;
+    expect(headers['X-CSRFToken']).toBeUndefined();
+  });
+
+  it('should use url-encoded Content-Type for login', async () => {
+    mock.onPost().reply(200, {});
+
+    await API.login({ username: 'admin', password: 'admin', token: '' });
+
+    expect(mock.history.post).toHaveLength(1);
+    const headers = mock.history.post[0].headers!;
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    expect(headers['Kiali-UI']).toBe('true');
+  });
+});
 
 describe('#GetErrorString', () => {
   it('should return an error message with status', () => {


### PR DESCRIPTION
## Summary

* The `getHeaders` function in `Api.ts` had separate code paths for OSSMC (`apiProxy`) and standalone Kiali, causing OSSMC to always use `application/x-www-form-urlencoded` Content-Type regardless of the request type and to omit login headers
* Unified into a single code path that sets `Content-Type` based on the `urlEncoded` parameter, always includes `loginHeaders` and `Kiali-UI`, and only adds `X-CSRFToken` for non-GET requests when a token is available
* Added a guard to prevent sending `X-CSRFToken: undefined` when no CSRF cookie exists
* Added unit tests verifying header behavior through public API functions using `axios-mock-adapter`

After this PR is merged, OSSMC will need some changes to avoid CORS issues - https://github.com/kiali/openshift-servicemesh-plugin/pull/639

## Test plan

- [x] Unit tests pass (`react-scripts test ApiMethods.test.ts`)
- [x] Tested in OSSMC multi-cluster environment
- [x] Verify standalone Kiali login still works
- [x] Verify OSSMC create/update/delete operations include CSRF token


Made with [Cursor](https://cursor.com)