### PR TITLE
[CI] Add git ref and new schedule to run workflow "Istio test versions" with Sail main

### DIFF
--- a/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+++ b/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -52,7 +56,7 @@ jobs:
       run: chmod +x ~/go/bin/kiali
 
     - name: Run backend integration tests
-      run: hack/run-integration-tests.sh --test-suite backend-external-controlplane $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite backend-external-controlplane $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -55,7 +59,7 @@ jobs:
 
     - name: Run backend integration tests
       id: intTests
-      run: hack/run-integration-tests.sh --test-suite backend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite backend $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Run backend controller integration tests
       run: make $(if [ -n "${ISTIO_VERSION:-${{ inputs.istio_version }}}" ]; then echo "ISTIO_VERSION=${ISTIO_VERSION:-${{ inputs.istio_version }}}"; fi) test-integration-controller

--- a/.github/workflows/integration-tests-frontend-ambient.yml
+++ b/.github/workflows/integration-tests-frontend-ambient.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -68,7 +72,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Run frontend integration tests
-      run: hack/run-integration-tests.sh --test-suite frontend-ambient $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite frontend-ambient $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -68,7 +72,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Run frontend multi-cluster integration tests
-      run: hack/run-integration-tests.sh --test-suite frontend-multi-primary $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite frontend-multi-primary $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -68,7 +72,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Run frontend multi-cluster integration tests
-      run: hack/run-integration-tests.sh --test-suite frontend-primary-remote $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite frontend-primary-remote $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/integration-tests-frontend-tempo.yml
+++ b/.github/workflows/integration-tests-frontend-tempo.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -68,7 +72,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Run frontend integration tests
-      run: hack/run-integration-tests.sh --test-suite frontend-tempo $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite frontend-tempo $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: boolean
         default: false
+      sail_operator_git_ref:
+        required: false
+        type: string
+        default: ""
 
 env:
   TARGET_BRANCH: ${{ inputs.target_branch }}
@@ -72,7 +76,7 @@ jobs:
       run: yarn install --immutable
 
     - name: Run frontend integration tests
-      run: hack/run-integration-tests.sh --test-suite frontend --stern ${{ inputs.stern_logs }} $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite frontend --stern ${{ inputs.stern_logs }} $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi) $(if [ -n "${{ inputs.sail_operator_git_ref }}" ]; then echo "--sail-operator-git-ref ${{ inputs.sail_operator_git_ref }}"; fi)
 
     - name: Get debug info when integration tests fail
       if: failure()

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -3,9 +3,10 @@ name: Test Istio Version
 on:
   schedule:
   # These are in UTC time.
-  # If you change any of these, you must also change the case statment in the determine-istio-version-to-use task.
+  # If you change any of these, you must also change the case statement in the determine-* tasks below.
   - cron: "0 2 * * *"
   - cron: "0 4 * * *"
+  - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       istio_version:
@@ -23,6 +24,11 @@ on:
         required: true
         default: "master"
         type: string
+      sail_operator_git_ref:
+        description: "sail_operator_git_ref: Optional Sail operator git ref (for example 'master'). If set, it overrides schedule defaults."
+        required: false
+        default: ""
+        type: string
 
 jobs:
   initialize:
@@ -32,6 +38,7 @@ jobs:
       target-branch: ${{ inputs.branch_to_test }}
       build-branch: ${{ inputs.branch_to_test }}
       istio-version: ${{ steps.determine-istio-version-to-use.outputs.istio-version }}
+      sail-operator-git-ref: ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}
     steps:
     # The initialize job gathers variables for later use in jobs.
     - name: Determine Istio Version to use
@@ -44,6 +51,7 @@ jobs:
             OFFSET=$(( OFFSET < 0 ? -OFFSET : OFFSET ))
           else
             case "${{ github.event.schedule }}" in
+              "0 6 * * *") OFFSET=0 ;;
               "0 2 * * *") OFFSET=1 ;;
               "0 4 * * *") OFFSET=2 ;;
               *) echo "Invalid schedule or unknown trigger! Cannot determine Istio version." && exit 1 ;;
@@ -104,8 +112,21 @@ jobs:
           ISTIO_VERSION="${{ github.event.inputs.istio_version }}"
         fi
         echo "istio-version=${ISTIO_VERSION}" | tee -a "$GITHUB_OUTPUT"
+    - name: Determine Sail Operator git ref to use
+      id: determine-sail-operator-git-ref-to-use
+      run: |
+        if [ -n "${{ github.event.inputs.sail_operator_git_ref }}" ]; then
+          SAIL_OPERATOR_GIT_REF="${{ github.event.inputs.sail_operator_git_ref }}"
+        else
+          case "${{ github.event.schedule }}" in
+            "0 6 * * *") SAIL_OPERATOR_GIT_REF="master" ;;
+            *) SAIL_OPERATOR_GIT_REF="" ;;
+          esac
+        fi
+        echo "sail-operator-git-ref=${SAIL_OPERATOR_GIT_REF}" | tee -a "$GITHUB_OUTPUT"
     - run: echo "target-branch -> ${{ inputs.branch_to_test }}"
     - run: echo "build-branch -> ${{ inputs.branch_to_test }}"
+    - run: echo "sail-operator-git-ref -> ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}"
 
   test_backend:
     name: Run backend linters and unit tests
@@ -137,6 +158,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_backend_multicluster_external_controlplane:
     name: Run backend multicluster external-controlplane integration tests
@@ -146,6 +168,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_frontend:
     name: Run frontend integration tests
@@ -155,6 +178,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_frontend_multicluster_primary_remote:
     name: Run frontend multicluster primary-remote integration tests
@@ -164,6 +188,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_frontend_multicluster_multi_primary:
     name: Run frontend multicluster multi-primary integration tests
@@ -173,6 +198,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_frontend_ambient:
     name: Run Ambient frontend integration tests
@@ -183,6 +209,7 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}
 
   integration_tests_frontend_tempo:
     name: Run tracing frontend integration tests
@@ -192,3 +219,4 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
       istio_version: ${{ needs.initialize.outputs.istio-version }}
+      sail_operator_git_ref: ${{ needs.initialize.outputs.sail-operator-git-ref }}


### PR DESCRIPTION
### Describe the change

This PR adds support for testing Kiali against different Sail Operator versions by introducing a new optional sail_operator_git_ref input parameter across all 7 integration test workflows (backend, backend-multicluster-external-controlplane, frontend, frontend-ambient, frontend-multicluster-multi-primary, frontend-multicluster-primary-remote, and frontend-tempo). A new daily scheduled run at 6am UTC has been added to test-istio-version.yml that automatically tests against the Sail Operator's main branch (using OFFSET=0 for current Istio version), while the existing 2am and 4am schedules continue testing with stable Sail Operator versions. The parameter flows from the orchestrator workflow through the initialize job to all downstream integration test jobs, which conditionally pass --sail-operator-git-ref to the hack/run-integration-tests.sh script when provided.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8917 
