### PR TITLE
[CI] Re-query from live DOM instead of using stale reference

### DIFF
--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -40,7 +40,7 @@ const waitForAppHealthStatus = (
   const checkHealth = (): Cypress.Chainable => {
     return cy
       .request({
-        url: `api/namespaces/${namespace}/apps/${app}/health`,
+        url: `api/namespaces/${namespace}/apps/${app}?health=true`,
         failOnStatusCode: false
       })
       .then(response => {
@@ -54,7 +54,7 @@ const waitForAppHealthStatus = (
           }
         }
 
-        const actualStatus = response.body?.status?.status;
+        const actualStatus = response.body?.health?.status?.status;
         cy.log(`App ${app} health status: ${actualStatus} (expecting ${expectedStatus})`);
 
         if (actualStatus === expectedStatus) {

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -27,6 +27,53 @@ const APP = 'details';
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
 
+// Helper function to wait for an app to reach a specific health status
+const waitForAppHealthStatus = (
+  namespace: string,
+  app: string,
+  expectedStatus: string,
+  timeoutMs = 90000
+): Cypress.Chainable => {
+  const startTime = Date.now();
+  const pollInterval = 5000; // Check every 5 seconds
+
+  const checkHealth = (): Cypress.Chainable => {
+    return cy
+      .request({
+        url: `api/namespaces/${namespace}/apps/${app}/health`,
+        failOnStatusCode: false
+      })
+      .then(response => {
+        if (response.status !== 200) {
+          cy.log(`Health API returned ${response.status}, retrying...`);
+          if (Date.now() - startTime < timeoutMs) {
+            cy.wait(pollInterval);
+            return checkHealth();
+          } else {
+            throw new Error(`Timeout waiting for app ${app} health API to be available`);
+          }
+        }
+
+        const actualStatus = response.body?.status?.status;
+        cy.log(`App ${app} health status: ${actualStatus} (expecting ${expectedStatus})`);
+
+        if (actualStatus === expectedStatus) {
+          cy.log(`✓ App ${app} reached ${expectedStatus} status`);
+          return cy.wrap(response.body);
+        } else if (Date.now() - startTime < timeoutMs) {
+          cy.wait(pollInterval);
+          return checkHealth();
+        } else {
+          throw new Error(
+            `Timeout after ${timeoutMs}ms: App ${app} in namespace ${namespace} never reached ${expectedStatus} status. Last status: ${actualStatus}`
+          );
+        }
+      });
+  };
+
+  return checkHealth();
+};
+
 Given('a healthy application in the cluster', function () {
   this.targetNamespace = 'bookinfo';
   this.targetApp = 'details';
@@ -43,11 +90,17 @@ Given('an idle sleep application in the cluster', function () {
 Given('a failing application in the mesh', function () {
   this.targetNamespace = 'alpha';
   this.targetApp = 'v-server';
+
+  // Wait for the app to actually be in Failure state before proceeding
+  waitForAppHealthStatus(this.targetNamespace, this.targetApp, 'Failure');
 });
 
 Given('a degraded application in the mesh', function () {
   this.targetNamespace = 'alpha';
   this.targetApp = 'b-client';
+
+  // Wait for the app to actually be in Degraded state before proceeding
+  waitForAppHealthStatus(this.targetNamespace, this.targetApp, 'Degraded');
 });
 
 Then('user sees trace information', () => {

--- a/frontend/cypress/integration/common/table.ts
+++ b/frontend/cypress/integration/common/table.ts
@@ -277,14 +277,16 @@ export const checkHealthIndicatorInTable = (
         const found = $row.find(`span.icon-${healthStatus}`).length > 0;
 
         if (found) {
-          cy.wrap($row).find(`span.icon-${healthStatus}`).should('exist');
+          // Re-query from the live DOM to avoid assertions on stale row snapshots.
+          cy.getBySel(rowSelector).find(`span.icon-${healthStatus}`).should('exist');
         } else if (retriesLeft > 0) {
           cy.getBySel('refresh-button').click();
           ensureKialiFinishedLoading();
           cy.wait(10000);
           checkHealth(retriesLeft - 1);
         } else {
-          cy.wrap($row).find(`span.icon-${healthStatus}`).should('exist');
+          // Give one final long retry window after the last refresh attempt.
+          cy.getBySel(rowSelector).find(`span.icon-${healthStatus}`, { timeout: 60000 }).should('exist');
         }
       });
     };

--- a/frontend/cypress/integration/common/workloads.ts
+++ b/frontend/cypress/integration/common/workloads.ts
@@ -2,6 +2,53 @@ import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { checkHealthIndicatorInTable, checkHealthStatusInTable, colExists } from './table';
 import { ensureKialiFinishedLoading } from './transition';
 
+// Helper function to wait for a workload to reach a specific health status
+const waitForWorkloadHealthStatus = (
+  namespace: string,
+  workload: string,
+  expectedStatus: string,
+  timeoutMs = 90000
+): Cypress.Chainable => {
+  const startTime = Date.now();
+  const pollInterval = 5000; // Check every 5 seconds
+
+  const checkHealth = (): Cypress.Chainable => {
+    return cy
+      .request({
+        url: `api/namespaces/${namespace}/workloads/${workload}?health=true`,
+        failOnStatusCode: false
+      })
+      .then(response => {
+        if (response.status !== 200) {
+          cy.log(`Health API returned ${response.status}, retrying...`);
+          if (Date.now() - startTime < timeoutMs) {
+            cy.wait(pollInterval);
+            return checkHealth();
+          } else {
+            throw new Error(`Timeout waiting for workload ${workload} health API to be available`);
+          }
+        }
+
+        const actualStatus = response.body?.health?.status?.status;
+        cy.log(`Workload ${workload} health status: ${actualStatus} (expecting ${expectedStatus})`);
+
+        if (actualStatus === expectedStatus) {
+          cy.log(`✓ Workload ${workload} reached ${expectedStatus} status`);
+          return cy.wrap(response.body);
+        } else if (Date.now() - startTime < timeoutMs) {
+          cy.wait(pollInterval);
+          return checkHealth();
+        } else {
+          throw new Error(
+            `Timeout after ${timeoutMs}ms: Workload ${workload} in namespace ${namespace} never reached ${expectedStatus} status. Last status: ${actualStatus}`
+          );
+        }
+      });
+  };
+
+  return checkHealth();
+};
+
 const activateFilter = (state: string): void => {
   //decided to pause the refresh, because I'm intercepting the very same request that is used for the timed refresh
   cy.get('button#workload-list-refresh-toggle').click();
@@ -35,11 +82,17 @@ Given('an idle sleep workload in the cluster', function () {
 Given('a failing workload in the mesh', function () {
   this.targetNamespace = 'alpha';
   this.targetWorkload = 'v-server';
+
+  // Wait for the workload to actually be in Failure state before proceeding
+  waitForWorkloadHealthStatus(this.targetNamespace, this.targetWorkload, 'Failure');
 });
 
 Given('a degraded workload in the mesh', function () {
   this.targetNamespace = 'alpha';
   this.targetWorkload = 'b-client';
+
+  // Wait for the workload to actually be in Degraded state before proceeding
+  waitForWorkloadHealthStatus(this.targetNamespace, this.targetWorkload, 'Degraded');
 });
 
 When('user filters for workload type {string}', (workloadType: string) => {


### PR DESCRIPTION
### Describe the change
Fix for https://github.com/kiali/kiali/actions/runs/24548007126/job/71768137211 

Working locally: 

<img width="953" height="312" alt="image" src="https://github.com/user-attachments/assets/67995bd8-b116-43b8-b332-8d1ebf0b5b79" />

With: hack/run-integration-tests.sh --test-suite frontend --stern false --istio-version 1.28-latest 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
