### PR TITLE
Virtual list: Replace pixel-based height with flexbox layout

### DIFF
--- a/frontend/src/components/Filters/ListColumnManagementModal.tsx
+++ b/frontend/src/components/Filters/ListColumnManagementModal.tsx
@@ -1,4 +1,4 @@
-import type { FunctionComponent } from 'react';
+import * as React from 'react';
 import type { ModalProps } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import {
@@ -43,7 +43,7 @@ export interface ListColumnManagementModalProps extends Omit<ModalProps, 'childr
  * Reusable column management modal for list pages, based on PatternFly's ColumnManagementModal
  * with an optional {@link onResetToDefault} hook for URL/Redux-backed column state.
  */
-export const ListColumnManagementModal: FunctionComponent<ListColumnManagementModalProps> = ({
+export const ListColumnManagementModal: React.FC<ListColumnManagementModalProps> = ({
   title = 'Manage columns',
   description = 'Selected categories will be displayed in the table.',
   isOpen = false,

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -49,8 +49,8 @@ type NavigationProps = ReduxStateProps & ReduxDispatchProps;
 
 const flexBoxColumnStyle = kialiStyle({
   display: 'flex',
-  flexDirection: 'column',
   flex: 1,
+  flexDirection: 'column',
   minHeight: 0
 });
 
@@ -149,13 +149,13 @@ export const NavigationComponent: React.FC<NavigationProps> = (props: Navigation
 };
 
 const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
+  chatbotEnabled: state.chatAi.enabled,
   externalServices: state.statusState.externalServices,
   kiosk: state.globalState.kiosk,
   navCollapsed: state.userSettings.interface.navCollapse,
   showNotificationCenter: state.notificationCenter.expanded,
   theme: state.globalState.theme,
-  tracingUrl: state.tracingState.info && state.tracingState.info.url ? state.tracingState.info.url : undefined,
-  chatbotEnabled: state.chatAi.enabled
+  tracingUrl: state.tracingState.info && state.tracingState.info.url ? state.tracingState.info.url : undefined
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => ({

--- a/frontend/src/components/Nav/Page/RenderContent.tsx
+++ b/frontend/src/components/Nav/Page/RenderContent.tsx
@@ -3,13 +3,17 @@ import { PFColors } from 'components/Pf/PfColors';
 import { kialiStyle } from 'styles/StyleUtils';
 import { RenderComponentScroll } from './RenderComponentScroll';
 
-const divStyle = kialiStyle({
-  backgroundColor: PFColors.BackgroundColor100
+const contentStyle = kialiStyle({
+  backgroundColor: PFColors.BackgroundColor100,
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  minHeight: 0
 });
 
 export class RenderContent extends React.Component<{ needScroll?: boolean }> {
   render(): React.ReactNode {
-    const content = <div className={divStyle}>{this.props.children}</div>;
-    return this.props.needScroll ? <RenderComponentScroll>{content}</RenderComponentScroll> : <div>{content}</div>;
+    const content = <div className={contentStyle}>{this.props.children}</div>;
+    return this.props.needScroll ? <RenderComponentScroll>{content}</RenderComponentScroll> : content;
   }
 }

--- a/frontend/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/frontend/src/components/Nav/__tests__/Navigation.test.tsx
@@ -9,7 +9,7 @@ import { LoginActions } from 'actions/LoginActions';
 import { Theme } from 'types/Common';
 
 jest.mock('react-router-dom-v5-compat', () => ({
-  ...jest.requireActual('react-router-dom-v5-compat'),
+  ...(jest as any).requireActual('react-router-dom-v5-compat'),
   useLocation: () => ({ pathname: '/overview', search: '', hash: '', state: null })
 }));
 

--- a/frontend/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/frontend/src/components/Nav/__tests__/Navigation.test.tsx
@@ -8,6 +8,11 @@ import { Provider } from 'react-redux';
 import { LoginActions } from 'actions/LoginActions';
 import { Theme } from 'types/Common';
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useLocation: () => ({ pathname: '/overview', search: '', hash: '', state: null })
+}));
+
 const session = {
   expiresOn: '2018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761',
   username: 'admin'

--- a/frontend/src/components/VirtualList/Config.ts
+++ b/frontend/src/components/VirtualList/Config.ts
@@ -75,7 +75,6 @@ const istioConfiguration: ResourceType<NamespaceInfo> = {
   param: 'ic',
   title: 'Istio config',
   sortable: true,
-  width: 10,
   renderer: Renderers.istioConfig
 };
 
@@ -86,7 +85,7 @@ const item: ResourceType<TResource> = {
   param: 'wn',
   title: 'Name',
   sortable: true,
-  width: 30,
+  width: 25,
   renderer: Renderers.item
 };
 
@@ -96,7 +95,7 @@ const serviceItem: ResourceType<ServiceListItem> = {
   param: 'sn',
   title: 'Name',
   sortable: true,
-  width: 30,
+  width: 20,
   renderer: Renderers.item
 };
 
@@ -106,6 +105,7 @@ const istioItem: ResourceType<IstioConfigItem> = {
   param: 'in',
   title: 'Name',
   sortable: true,
+  width: 25,
   renderer: Renderers.item
 };
 
@@ -115,7 +115,6 @@ const cluster: ResourceType<TResource> = {
   param: 'cl',
   title: 'Cluster',
   sortable: true,
-  width: 15,
   renderer: Renderers.cluster
 };
 
@@ -125,7 +124,6 @@ const namespace: ResourceType<TResource> = {
   param: 'ns',
   title: 'Namespace',
   sortable: true,
-  width: 20,
   renderer: Renderers.namespace
 };
 
@@ -135,7 +133,7 @@ const labels: ResourceType<RenderResource> = {
   param: 'lb',
   title: 'Labels',
   sortable: false,
-  width: 20,
+  width: 10,
   renderer: Renderers.labels
 };
 
@@ -145,7 +143,7 @@ const health: ResourceType<TResource> = {
   param: 'he',
   title: 'Health',
   sortable: true,
-  width: 15,
+  width: 10,
   renderer: Renderers.health
 };
 
@@ -155,7 +153,6 @@ const details: ResourceType<AppListItem | WorkloadListItem | ServiceListItem> = 
   param: 'is',
   title: 'Details',
   sortable: true,
-  width: 15,
   renderer: Renderers.details
 };
 
@@ -165,7 +162,6 @@ const serviceConfiguration: ResourceType<ServiceListItem> = {
   param: 'cv',
   title: 'Configuration',
   sortable: true,
-  width: 20,
   renderer: Renderers.serviceConfiguration
 };
 
@@ -175,7 +171,6 @@ const istioObjectConfiguration: ResourceType<IstioConfigItem> = {
   param: 'cv',
   title: 'Configuration',
   sortable: true,
-  width: 20,
   renderer: Renderers.istioConfiguration
 };
 
@@ -224,7 +219,7 @@ const namespacesHealth: ResourceType<NamespaceInfo> = {
   renderer: Renderers.nsHealth,
   sortable: true,
   title: 'Health',
-  width: 20
+  width: 10
 };
 
 const typeNamespaces: ResourceType<NamespaceInfo> = {
@@ -240,8 +235,7 @@ const typeNamespaces: ResourceType<NamespaceInfo> = {
   param: 'type',
   renderer: Renderers.nsType,
   sortable: true,
-  title: 'Type',
-  width: 10
+  title: 'Type'
 };
 
 const modeNamespaces: ResourceType<NamespaceInfo> = {
@@ -250,8 +244,7 @@ const modeNamespaces: ResourceType<NamespaceInfo> = {
   param: 'mode',
   renderer: Renderers.nsMode,
   sortable: true,
-  title: 'Mode',
-  width: 10
+  title: 'Mode'
 };
 
 const revisionNamespaces: ResourceType<NamespaceInfo> = {
@@ -260,8 +253,7 @@ const revisionNamespaces: ResourceType<NamespaceInfo> = {
   param: 'rev',
   renderer: Renderers.nsRevision,
   sortable: true,
-  title: 'Revision',
-  width: 10
+  title: 'Revision'
 };
 
 const nsItemNamespaces: ResourceType<NamespaceInfo> = {
@@ -271,7 +263,7 @@ const nsItemNamespaces: ResourceType<NamespaceInfo> = {
   renderer: Renderers.nsItem,
   sortable: true,
   title: 'Namespace',
-  width: 20
+  width: 15
 };
 
 const tlsStatusNamespaces: ResourceType<NamespaceInfo> = {
@@ -280,8 +272,7 @@ const tlsStatusNamespaces: ResourceType<NamespaceInfo> = {
   param: 'm',
   renderer: Renderers.nsTls,
   sortable: true,
-  title: 'mTLS',
-  width: 10
+  title: 'mTLS'
 };
 
 const namespacesList: Resource = {

--- a/frontend/src/components/VirtualList/VirtualList.tsx
+++ b/frontend/src/components/VirtualList/VirtualList.tsx
@@ -31,8 +31,6 @@ import { sortFields } from '../../pages/Namespaces/Sorts';
 import { FilterSelected, StatefulFiltersRef } from '../Filters/StatefulFilters';
 import { kialiStyle } from 'styles/StyleUtils';
 import { SortableTh } from 'components/Table/SimpleTable';
-import { isKiosk } from 'components/Kiosk/KioskActions';
-import { store } from 'store/ConfigStore';
 import { classes } from 'typestyle';
 import { ManualRefreshEmptyState } from 'components/Refresh/ManualRefreshEmptyState';
 import { t } from 'utils/I18nUtils';
@@ -43,20 +41,13 @@ const emptyStyle = kialiStyle({
   borderBottom: 0
 });
 
-// TOP_PADDING constant is used to adjust the height of the main div to allow scrolling in the inner container layer.
-const TOP_PADDING = 269;
-
-// EMBEDDED_PADDING constant is a magic number used to adjust the height of the main div to allow scrolling in the inner container layer.
-// 42px is the height of the first tab menu
-const EMBEDDED_PADDING = 42 + 100;
-
-/**
- * By default, Kiali hides the global scrollbar and fixes the height for some pages to force the scrollbar to appear
- * Hiding global scrollbar is not possible when Kiali is embedded in other application (like Openshift Console)
- * In these cases height is not fixed to avoid multiple scrollbars (https://github.com/kiali/kiali/issues/6601)
- * GLOBAL_SCROLLBAR environment variable is not defined in standalone Kiali application (value is always false)
- */
-const globalScrollbar = process.env.GLOBAL_SCROLLBAR ?? 'false';
+const outerContainerStyle = kialiStyle({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  minHeight: 0,
+  width: '100%'
+});
 
 const innerScrollContainerStyle = kialiStyle({
   flex: 1,
@@ -98,7 +89,6 @@ type VirtualListProps<R> = ReduxProps & {
 type VirtualListState<R extends RenderResource> = {
   columns: ResourceType<R>[];
   conf: Resource;
-  scrollStyle: string;
   sortBy: {
     direction: Direction;
     index: number;
@@ -106,6 +96,8 @@ type VirtualListState<R extends RenderResource> = {
 };
 
 class VirtualListComponent<R extends RenderResource> extends React.Component<VirtualListProps<R>, VirtualListState<R>> {
+  private outerDivRef = React.createRef<HTMLDivElement>();
+  private resizeObserver: ResizeObserver | undefined;
   private statefulFilters: StatefulFiltersRef = React.createRef();
 
   constructor(props: VirtualListProps<R>) {
@@ -124,7 +116,6 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
         index,
         direction: HistoryManager.getParam(URLParam.DIRECTION) as Direction
       },
-      scrollStyle: kialiStyle({}),
       columns,
       conf
     };
@@ -147,12 +138,18 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
   };
 
   componentDidMount(): void {
-    this.updateWindowDimensions();
-    window.addEventListener('resize', this.updateWindowDimensions);
+    this.notifyResize();
+    if (this.outerDivRef.current && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.notifyResize());
+      this.resizeObserver.observe(this.outerDivRef.current);
+    } else {
+      window.addEventListener('resize', this.notifyResize);
+    }
   }
 
   componentWillUnmount(): void {
-    window.removeEventListener('resize', this.updateWindowDimensions);
+    this.resizeObserver?.disconnect();
+    window.removeEventListener('resize', this.notifyResize);
   }
 
   componentDidUpdate(): void {
@@ -166,33 +163,10 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
     }
   }
 
-  getScrollStyle = (height: number): string => {
-    if (globalScrollbar === 'false') {
-      return kialiStyle({
-        display: 'flex',
-        flexDirection: 'column',
-        height: height,
-        overflow: 'hidden',
-        width: '100%'
-      });
+  private notifyResize = (): void => {
+    if (this.props.onResize && this.outerDivRef.current) {
+      this.props.onResize(this.outerDivRef.current.clientHeight);
     }
-    return kialiStyle({});
-  };
-
-  updateWindowDimensions = (): void => {
-    const isStandalone = !isKiosk(store.getState().globalState.kiosk);
-    const topPadding = isStandalone ? TOP_PADDING : EMBEDDED_PADDING;
-
-    this.setState(
-      {
-        scrollStyle: this.getScrollStyle(window.innerHeight - topPadding)
-      },
-      () => {
-        if (this.props.onResize) {
-          this.props.onResize(window.innerHeight - topPadding);
-        }
-      }
-    );
   };
 
   private static getColumnId(column: { id?: string; name: string }): string {
@@ -294,7 +268,6 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
   };
 
   render(): React.ReactNode {
-    // If there is no global scrollbar, height is fixed to force the scrollbar to appear in the component
     const { rows } = this.props;
     const { sortBy, columns, conf } = this.state;
 
@@ -360,7 +333,7 @@ class VirtualListComponent<R extends RenderResource> extends React.Component<Vir
     const isManualRefresh = this.props.refreshInterval === RefreshIntervalManual && !this.props.loaded;
 
     return (
-      <div className={classes(this.state.scrollStyle, this.props.className)}>
+      <div ref={this.outerDivRef} className={classes(outerContainerStyle, this.props.className)}>
         {childrenWithProps}
         {isManualRefresh ? (
           <ManualRefreshEmptyState />

--- a/frontend/src/components/VirtualList/__tests__/VirtualList.test.tsx
+++ b/frontend/src/components/VirtualList/__tests__/VirtualList.test.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { store } from 'store/ConfigStore';
+
+jest.mock('components/DefaultSecondaryMasthead/DefaultSecondaryMasthead', () => ({
+  // eslint-disable-next-line react/display-name
+  DefaultSecondaryMasthead: () => <div data-test="DefaultSecondaryMasthead" />
+}));
+
+// VirtualList is a connected component; import after mocks
+// eslint-disable-next-line import/first
+import { VirtualList } from '../VirtualList';
+
+describe('VirtualList', () => {
+  let resizeCallback: (() => void) | undefined;
+  let observedElement: Element | undefined;
+
+  beforeEach(() => {
+    resizeCallback = undefined;
+    observedElement = undefined;
+
+    (window as any).ResizeObserver = class {
+      constructor(cb: () => void) {
+        resizeCallback = cb;
+      }
+      observe(el: Element): void {
+        observedElement = el;
+      }
+      disconnect(): void {
+        resizeCallback = undefined;
+        observedElement = undefined;
+      }
+    };
+  });
+
+  afterEach(() => {
+    delete (window as any).ResizeObserver;
+  });
+
+  it('calls onResize with the outer div clientHeight on mount', () => {
+    const onResize = jest.fn();
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} onResize={onResize} />
+      </Provider>
+    );
+
+    const outerDiv = wrapper.find('div').first().getDOMNode();
+
+    expect(onResize).toHaveBeenCalledWith(outerDiv.clientHeight);
+  });
+
+  it('attaches ResizeObserver to its own outer div', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} />
+      </Provider>
+    );
+
+    const outerDiv = wrapper.find('div').first().getDOMNode();
+
+    expect(observedElement).toBe(outerDiv);
+  });
+
+  it('calls onResize when ResizeObserver fires', () => {
+    const onResize = jest.fn();
+
+    mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} onResize={onResize} />
+      </Provider>
+    );
+
+    onResize.mockClear();
+    resizeCallback?.();
+
+    expect(onResize).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('disconnects ResizeObserver on unmount', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} />
+      </Provider>
+    );
+
+    expect(resizeCallback).toBeDefined();
+    wrapper.unmount();
+    expect(resizeCallback).toBeUndefined();
+  });
+
+  it('still calls onResize once on mount when ResizeObserver is unavailable', () => {
+    delete (window as any).ResizeObserver;
+    const onResize = jest.fn();
+
+    mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} onResize={onResize} />
+      </Provider>
+    );
+
+    expect(onResize).toHaveBeenCalledTimes(1);
+    expect(observedElement).toBeUndefined();
+  });
+
+  it('falls back to window resize listener when ResizeObserver is unavailable', () => {
+    delete (window as any).ResizeObserver;
+    const onResize = jest.fn();
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <VirtualList type="services" rows={[]} onResize={onResize} />
+      </Provider>
+    );
+
+    expect(addSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+    onResize.mockClear();
+    window.dispatchEvent(new Event('resize'));
+    expect(onResize).toHaveBeenCalled();
+
+    wrapper.unmount();
+    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/frontend/src/pages/Graph/components/__tests__/stylesComponentFactory.test.tsx
+++ b/frontend/src/pages/Graph/components/__tests__/stylesComponentFactory.test.tsx
@@ -1,0 +1,19 @@
+import { ModelKind } from '@patternfly/react-topology';
+import { stylesComponentFactory } from '../stylesComponentFactory';
+
+describe('stylesComponentFactory', () => {
+  it('returns a component for ModelKind.graph', () => {
+    const result = stylesComponentFactory(ModelKind.graph, '');
+    expect(result).toBeDefined();
+  });
+
+  it('returns a component for ModelKind.edge', () => {
+    const result = stylesComponentFactory(ModelKind.edge, '');
+    expect(result).toBeDefined();
+  });
+
+  it('returns undefined for unknown model kinds', () => {
+    const result = stylesComponentFactory('unknownKind' as ModelKind, '');
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/src/pages/Graph/components/stylesComponentFactory.tsx
+++ b/frontend/src/pages/Graph/components/stylesComponentFactory.tsx
@@ -11,8 +11,9 @@ import {
   withSelection
 } from '@patternfly/react-topology';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { clickHandler, ContextMenuOption, getOptions } from 'pages/Graph/ContextMenu/NodeContextMenu';
+import { DropdownGroup, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
+import { clickHandler, ContextMenuOption, getOptions } from 'pages/Graph/ContextMenu/NodeContextMenu';
 import { StyleEdge } from '../styles/styleEdge';
 import { StyleGroup } from '../styles/styleGroup';
 import { StyleNode } from '../styles/styleNode';
@@ -31,7 +32,6 @@ import { ServiceWizardActionsDropdownGroup } from 'components/IstioWizards/Servi
 import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
 import { ServiceDetailsInfo } from 'types/ServiceInfo';
 import { kialiStyle } from 'styles/StyleUtils';
-import { DropdownGroup, DropdownItem } from '@patternfly/react-core';
 import { getGVKTypeString } from '../../../utils/IstioConfigUtils';
 import { gvkType } from '../../../types/IstioConfigList';
 

--- a/frontend/src/pages/Mesh/components/__tests__/MeshComponentFactory.test.tsx
+++ b/frontend/src/pages/Mesh/components/__tests__/MeshComponentFactory.test.tsx
@@ -1,0 +1,19 @@
+import { ModelKind } from '@patternfly/react-topology';
+import { meshComponentFactory } from '../MeshComponentFactory';
+
+describe('meshComponentFactory', () => {
+  it('returns a component for ModelKind.graph', () => {
+    const result = meshComponentFactory(ModelKind.graph, '');
+    expect(result).toBeDefined();
+  });
+
+  it('returns a component for ModelKind.edge', () => {
+    const result = meshComponentFactory(ModelKind.edge, '');
+    expect(result).toBeDefined();
+  });
+
+  it('returns undefined for unknown model kinds', () => {
+    const result = meshComponentFactory('unknownKind' as ModelKind, '');
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/src/pages/Overview/ServiceInsights.tsx
+++ b/frontend/src/pages/Overview/ServiceInsights.tsx
@@ -126,7 +126,7 @@ const tableHeaderStyle = kialiStyle({
   borderBottom: 'none',
   color: 'var(--pf-t--global--text--color--primary--default)',
   fontSize: '0.875rem',
-  padding: '0.75rem 0.5rem',
+  padding: '0.5rem 0.5rem',
   textAlign: 'left'
 });
 


### PR DESCRIPTION
## Summary
- Replace VirtualList's brittle pixel-based height calculation (`window.innerHeight - TOP_PADDING`) with a proper flexbox layout chain (`flex: 1` + `minHeight: 0`) from `PageSection` through `RenderContent` down to `VirtualList`, eliminating the double scrollbar on list pages (Services, Workloads, Applications, Istio Config, Namespaces).
- Remove `GLOBAL_SCROLLBAR` env var handling and magic constants (`TOP_PADDING`, `EMBEDDED_PADDING`) from `VirtualList`; the flex layout naturally constrains the scroll region.
- Add `ResizeObserver`-based resize detection on VirtualList's own element with a `window.resize` fallback for browsers without `ResizeObserver` support.
- Minor cleanups: consistent `React.FC` import, alphabetical import ordering, table header padding fix, and new unit tests for component factories.

This PR is needed to include list pages within OSSMC.

## Changes
| File | What changed |
|------|-------------|
| `VirtualList.tsx` | Remove fixed-height calc, use flex container + `InnerScrollContainer` for scrolling, add `ResizeObserver` with `window.resize` fallback |
| `RenderContent.tsx` | Make content wrapper flex-aware; collapse redundant nested divs into a single styled div |
| `Navigation.tsx` | Sort `mapStateToProps` alphabetically; document PF6 `flex-shrink: 0` override on `PageSection` |
| `Navigation.test.tsx` | Add `useLocation` mock for router-dependent component |
| `VirtualList.test.tsx` | **New** — 6 tests covering `ResizeObserver` attachment, `clientHeight` reporting, `window.resize` fallback, and cleanup |
| `ListColumnManagementModal.tsx` | Use `React.FC` instead of `FunctionComponent` for consistent import style |
| `stylesComponentFactory.tsx` | Sort imports alphabetically |
| `stylesComponentFactory.test.tsx` | **New** — unit tests for graph styles component factory |
| `MeshComponentFactory.test.tsx` | **New** — unit tests for mesh component factory |
| `ServiceInsights.tsx` | Fix table header vertical padding (`0.75rem` → `0.5rem`) |

## Test plan
- [x] Verify no double scrollbar on Services, Workloads, Applications, Istio Config, and Namespaces list pages
- [x] Verify table scrolls correctly and the bottom row is fully visible
- [x] Verify kiosk mode still works (no extra scrollbar, content fills the viewport)
- [x] Resize the browser window and confirm the list area adjusts smoothly
- [x] Run `make build-ui-test` — all unit tests pass

## Issue reference

Part of https://github.com/kiali/openshift-servicemesh-plugin/issues/631