### PR TITLE
[CI] Istio versions: Use sail repo to determine the Istio versions

### DIFF
--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -25,7 +25,7 @@ on:
         default: "master"
         type: string
       sail_operator_git_ref:
-        description: "sail_operator_git_ref: Optional Sail operator git ref (for example 'master'). If set, it overrides schedule defaults."
+        description: "sail_operator_git_ref: Optional Sail operator git ref (for example 'main'). If set, it overrides schedule defaults."
         required: false
         default: ""
         type: string
@@ -40,7 +40,22 @@ jobs:
       istio-version: ${{ steps.determine-istio-version-to-use.outputs.istio-version }}
       sail-operator-git-ref: ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}
     steps:
-    # The initialize job gathers variables for later use in jobs.
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.branch_to_test || github.ref_name }}
+    - name: Determine Sail Operator git ref to use
+      id: determine-sail-operator-git-ref-to-use
+      run: |
+        if [ -n "${{ github.event.inputs.sail_operator_git_ref }}" ]; then
+          SAIL_OPERATOR_GIT_REF="${{ github.event.inputs.sail_operator_git_ref }}"
+        else
+          case "${{ github.event.schedule }}" in
+            "0 6 * * *") SAIL_OPERATOR_GIT_REF="main" ;;
+            *) SAIL_OPERATOR_GIT_REF="" ;;
+          esac
+        fi
+        echo "sail-operator-git-ref=${SAIL_OPERATOR_GIT_REF}" | tee -a "$GITHUB_OUTPUT"
     - name: Determine Istio Version to use
       id: determine-istio-version-to-use
       run: |
@@ -57,73 +72,13 @@ jobs:
               *) echo "Invalid schedule or unknown trigger! Cannot determine Istio version." && exit 1 ;;
             esac
           fi
-          # Retry fetching Istio versions every 60 seconds for 2 hours (120 retries)
-          echo "Fetching Istio versions from GitHub API (with retry logic)..."
-          for retry in {1..120}; do
-            echo "Attempt $retry/120: Fetching Istio release data..."
-            CURL_RESULT=$(curl -s https://api.github.com/repos/istio/istio/releases)
-            if [ $? -eq 0 ] && [ -n "$CURL_RESULT" ] && echo "$CURL_RESULT" | jq -e '.[].tag_name' >/dev/null 2>&1; then
-              echo "Successfully fetched Istio release data."
-              LATEST_ISTIO_VERSIONS="$(echo "$CURL_RESULT" | jq -r '.[].tag_name' | sort -rV | awk -F'[-.]' '
-                {
-                  minor = $1"."$2
-                  is_rc = ($4 == "rc")
-                  z = is_rc ? $3 : $3
-                  rc_ver = is_rc ? $5 : ""
-
-                  if (!minor_ga[minor] && !minor_rc[minor]) {
-                    if (is_rc) { minor_rc[minor] = $0; minor_rc_z[minor] = z; minor_rc_rc[minor] = rc_ver }
-                    else { minor_ga[minor] = $0; minor_ga_z[minor] = z }
-                  } else if (!is_rc && minor_ga[minor]) {
-                    if (z > minor_ga_z[minor]) { minor_ga[minor] = $0; minor_ga_z[minor] = z }
-                  } else if (!is_rc && !minor_ga[minor]) {
-                    minor_ga[minor] = $0; minor_ga_z[minor] = z; delete minor_rc[minor]; delete minor_rc_z[minor]; delete minor_rc_rc[minor]
-                  } else if (is_rc && !minor_ga[minor]) {
-                    current_rc_stored = minor_rc[minor]
-                    split(current_rc_stored, current_rc_parts, "[-.]")
-                    current_rc_num_stored = current_rc_parts[5]
-
-                    if (!minor_rc[minor] || z > minor_rc_z[minor] || (z == minor_rc_z[minor] && rc_ver > current_rc_num_stored)) {
-                      minor_rc[minor] = $0; minor_rc_z[minor] = z; minor_rc_rc[minor] = rc_ver
-                    }
-                  }
-                }
-                END {
-                  # The latest patch version is not always available in Sail. Use -latest as patch version
-                  for (m in minor_ga) { split(minor_ga[m], version_parts, "."); minor_ga[m] = version_parts[1] "." version_parts[2] "-latest"; print minor_ga[m] }
-                  for (m in minor_rc) { split(minor_rc[m], version_parts, "."); minor_rc[m] = version_parts[1] "." version_parts[2] "-latest"; print minor_rc[m] }
-                }' | sort -Vr | grep -v '^$' | head -n $((OFFSET + 1)))"
-              break
-            else
-              if [ $retry -eq 120 ]; then
-                echo "ERROR: Failed to fetch Istio release data after 2 hours (120 retries). Giving up."
-                exit 1
-              fi
-              echo "Failed to fetch valid Istio release data. Retrying in 60 seconds..."
-              sleep 60
-            fi
-          done
-
-          ISTIO_VERSION=$(echo "${LATEST_ISTIO_VERSIONS}" | tail -n 1)
-          echo "The latest Istio versions are:"
-          echo "${LATEST_ISTIO_VERSIONS}"
-          echo "The Istio minor version offset is [${OFFSET}], thus the Istio version to be used in the tests will be: ${ISTIO_VERSION}"
+          VERSION_SOURCE="sail"
+          ISTIO_VERSION="$(bash ./hack/istio/determine-test-istio-version.sh --source "${VERSION_SOURCE}" --offset "${OFFSET}")"
+          echo "Resolved Istio version from source '${VERSION_SOURCE}' with offset [${OFFSET}]: ${ISTIO_VERSION}"
         else
           ISTIO_VERSION="${{ github.event.inputs.istio_version }}"
         fi
         echo "istio-version=${ISTIO_VERSION}" | tee -a "$GITHUB_OUTPUT"
-    - name: Determine Sail Operator git ref to use
-      id: determine-sail-operator-git-ref-to-use
-      run: |
-        if [ -n "${{ github.event.inputs.sail_operator_git_ref }}" ]; then
-          SAIL_OPERATOR_GIT_REF="${{ github.event.inputs.sail_operator_git_ref }}"
-        else
-          case "${{ github.event.schedule }}" in
-            "0 6 * * *") SAIL_OPERATOR_GIT_REF="master" ;;
-            *) SAIL_OPERATOR_GIT_REF="" ;;
-          esac
-        fi
-        echo "sail-operator-git-ref=${SAIL_OPERATOR_GIT_REF}" | tee -a "$GITHUB_OUTPUT"
     - run: echo "target-branch -> ${{ inputs.branch_to_test }}"
     - run: echo "build-branch -> ${{ inputs.branch_to_test }}"
     - run: echo "sail-operator-git-ref -> ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}"

--- a/hack/istio/determine-test-istio-version.sh
+++ b/hack/istio/determine-test-istio-version.sh
@@ -100,8 +100,8 @@ fetch_releases_with_retry() {
 
   for retry in $(seq 1 "${RETRIES}"); do
     echo "Attempt ${retry}/${RETRIES}: Fetching ${label} release data..." >&2
-    curl_result="$(curl -s "${url}")"
-    if [ $? -eq 0 ] && [ -n "${curl_result}" ] && echo "${curl_result}" | jq -e '.[].tag_name' >/dev/null 2>&1; then
+    curl_result="$(curl -s "${url}" || true)"
+    if [ -n "${curl_result}" ] && echo "${curl_result}" | jq -e '.[].tag_name' >/dev/null 2>&1; then
       echo "Successfully fetched ${label} release data." >&2
       printf "%s" "${curl_result}"
       return 0
@@ -147,7 +147,7 @@ determine_from_istio_releases() {
       # Historical behavior for Istio-based flow in this workflow.
       for (m in minor_ga) { split(minor_ga[m], version_parts, "."); print version_parts[1] "." version_parts[2] "-latest" }
       for (m in minor_rc) { split(minor_rc[m], version_parts, "."); print version_parts[1] "." version_parts[2] "-latest" }
-    }' | sort -Vr | grep -v '^$'
+    }' | sort -Vr | sed '/^$/d'
 }
 
 determine_from_sail_releases() {
@@ -165,7 +165,7 @@ determine_from_sail_releases() {
     }
     END {
       for (m in best) { print best[m] }
-    }' | sort -Vr | grep -v '^$'
+    }' | sort -Vr | sed '/^$/d'
 }
 
 if [ "${SOURCE}" = "sail" ]; then

--- a/hack/istio/determine-test-istio-version.sh
+++ b/hack/istio/determine-test-istio-version.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SOURCE="istio"
+OFFSET="0"
+RETRIES="120"
+RETRY_INTERVAL_SECONDS="60"
+
+helpmsg() {
+  cat <<'HELP'
+Determine test Istio version for CI/local runs.
+
+Usage:
+  determine-test-istio-version.sh [options]
+
+Options:
+  --source <istio|sail>
+    Version source. "istio" reads istio/istio releases.
+    "sail" reads istio-ecosystem/sail-operator releases and uses stable X.Y.Z only.
+    Default: istio
+
+  --offset <n>
+    Minor-version offset from newest candidate set.
+    0 = latest, 1 = previous minor, 2 = two minors back.
+    Negative values are converted to absolute value.
+    Default: 0
+
+  --retries <n>
+    Retry attempts when API fetch fails.
+    Default: 120
+
+  --retry-interval-seconds <n>
+    Seconds to sleep between retries.
+    Default: 60
+
+  -h|--help
+    Show this message.
+
+Output:
+  Prints the selected version to stdout.
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case "${key}" in
+    --source)
+      SOURCE="$2"
+      shift; shift
+      ;;
+    --offset)
+      OFFSET="$2"
+      shift; shift
+      ;;
+    --retries)
+      RETRIES="$2"
+      shift; shift
+      ;;
+    --retry-interval-seconds)
+      RETRY_INTERVAL_SECONDS="$2"
+      shift; shift
+      ;;
+    -h|--help)
+      helpmsg
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument [${key}]." >&2
+      helpmsg >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${SOURCE}" != "istio" && "${SOURCE}" != "sail" ]]; then
+  echo "ERROR: --source must be one of: istio, sail" >&2
+  exit 1
+fi
+
+if ! [[ "${OFFSET}" =~ ^-?[0-9]+$ ]]; then
+  echo "ERROR: --offset must be an integer." >&2
+  exit 1
+fi
+OFFSET=$(( OFFSET < 0 ? -OFFSET : OFFSET ))
+
+if ! [[ "${RETRIES}" =~ ^[0-9]+$ ]] || [ "${RETRIES}" -lt 1 ]; then
+  echo "ERROR: --retries must be a positive integer." >&2
+  exit 1
+fi
+
+if ! [[ "${RETRY_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || [ "${RETRY_INTERVAL_SECONDS}" -lt 1 ]; then
+  echo "ERROR: --retry-interval-seconds must be a positive integer." >&2
+  exit 1
+fi
+
+fetch_releases_with_retry() {
+  local url="$1"
+  local label="$2"
+
+  for retry in $(seq 1 "${RETRIES}"); do
+    echo "Attempt ${retry}/${RETRIES}: Fetching ${label} release data..." >&2
+    curl_result="$(curl -s "${url}")"
+    if [ $? -eq 0 ] && [ -n "${curl_result}" ] && echo "${curl_result}" | jq -e '.[].tag_name' >/dev/null 2>&1; then
+      echo "Successfully fetched ${label} release data." >&2
+      printf "%s" "${curl_result}"
+      return 0
+    fi
+
+    if [ "${retry}" -eq "${RETRIES}" ]; then
+      echo "ERROR: Failed to fetch ${label} release data after ${RETRIES} retries. Giving up." >&2
+      return 1
+    fi
+    echo "Failed to fetch valid ${label} release data. Retrying in ${RETRY_INTERVAL_SECONDS} seconds..." >&2
+    sleep "${RETRY_INTERVAL_SECONDS}"
+  done
+}
+
+determine_from_istio_releases() {
+  local curl_result="$1"
+
+  echo "${curl_result}" | jq -r '.[].tag_name' | sort -rV | awk -F'[-.]' '
+    {
+      minor = $1 "." $2
+      is_rc = ($4 == "rc")
+      z = $3
+      rc_ver = is_rc ? $5 : ""
+
+      if (!minor_ga[minor] && !minor_rc[minor]) {
+        if (is_rc) { minor_rc[minor] = $0; minor_rc_z[minor] = z; minor_rc_rc[minor] = rc_ver }
+        else { minor_ga[minor] = $0; minor_ga_z[minor] = z }
+      } else if (!is_rc && minor_ga[minor]) {
+        if (z > minor_ga_z[minor]) { minor_ga[minor] = $0; minor_ga_z[minor] = z }
+      } else if (!is_rc && !minor_ga[minor]) {
+        minor_ga[minor] = $0; minor_ga_z[minor] = z; delete minor_rc[minor]; delete minor_rc_z[minor]; delete minor_rc_rc[minor]
+      } else if (is_rc && !minor_ga[minor]) {
+        current_rc_stored = minor_rc[minor]
+        split(current_rc_stored, current_rc_parts, "[-.]")
+        current_rc_num_stored = current_rc_parts[5]
+
+        if (!minor_rc[minor] || z > minor_rc_z[minor] || (z == minor_rc_z[minor] && rc_ver > current_rc_num_stored)) {
+          minor_rc[minor] = $0; minor_rc_z[minor] = z; minor_rc_rc[minor] = rc_ver
+        }
+      }
+    }
+    END {
+      # Historical behavior for Istio-based flow in this workflow.
+      for (m in minor_ga) { split(minor_ga[m], version_parts, "."); print version_parts[1] "." version_parts[2] "-latest" }
+      for (m in minor_rc) { split(minor_rc[m], version_parts, "."); print version_parts[1] "." version_parts[2] "-latest" }
+    }' | sort -Vr | grep -v '^$'
+}
+
+determine_from_sail_releases() {
+  local curl_result="$1"
+
+  # Keep only stable X.Y.Z tags and select the highest patch for each minor.
+  echo "${curl_result}" | jq -r '.[].tag_name' | awk '
+    /^[0-9]+\.[0-9]+\.[0-9]+$/ {
+      split($0, parts, ".")
+      minor = parts[1] "." parts[2]
+      if (!(minor in best) || parts[3] > best_patch[minor]) {
+        best[minor] = $0
+        best_patch[minor] = parts[3]
+      }
+    }
+    END {
+      for (m in best) { print best[m] }
+    }' | sort -Vr | grep -v '^$'
+}
+
+if [ "${SOURCE}" = "sail" ]; then
+  releases_json="$(fetch_releases_with_retry "https://api.github.com/repos/istio-ecosystem/sail-operator/releases" "Sail Operator")"
+  candidates="$(determine_from_sail_releases "${releases_json}")"
+else
+  releases_json="$(fetch_releases_with_retry "https://api.github.com/repos/istio/istio/releases" "Istio")"
+  candidates="$(determine_from_istio_releases "${releases_json}")"
+fi
+
+if [ -z "${candidates}" ]; then
+  echo "ERROR: No candidate versions were found for source '${SOURCE}'." >&2
+  exit 1
+fi
+
+selected_version="$(echo "${candidates}" | head -n $((OFFSET + 1)) | tail -n 1)"
+if [ -z "${selected_version}" ]; then
+  echo "ERROR: Unable to determine a version for offset ${OFFSET} from source '${SOURCE}'." >&2
+  exit 1
+fi
+
+echo "Candidate versions for source '${SOURCE}':" >&2
+echo "${candidates}" >&2
+echo "Offset=${OFFSET}, selected version=${selected_version}" >&2
+printf "%s\n" "${selected_version}"

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -386,10 +386,12 @@ if [ -n "${CUSTOM_INSTALL_SETTINGS}" ]; then
   ISTIO_YAML=$(printf "%s" "$ISTIO_YAML" | yq "$CUSTOM_INSTALL_SETTINGS")
 fi
 
-# Sail operator CRDs only allow specific version strings per minor (e.g. v1.26.0-v1.26.3 and v1.26-latest).
-# Map any requested z-stream (vX.Y.Z) to the -latest variant for that minor so the CR validates on all branches.
 REQUESTED_VERSION=$(yq '.spec.version // ""' <<< "$ISTIO_YAML")
-if [[ -n "$REQUESTED_VERSION" && "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [ "${SAIL_OPERATOR_GIT_REF}" == "main" ]; then
+  # When testing Sail main, let Sail choose its default supported version.
+  ISTIO_YAML=$(echo "$ISTIO_YAML" | yq 'del(.spec.version)' -)
+  echo "Sail operator git ref is 'main'; ignoring requested Istio version (${REQUESTED_VERSION:-<unset>}) and letting Sail select the default version."
+elif [[ -n "$REQUESTED_VERSION" && "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   MINOR="${REQUESTED_VERSION#v}"
   MINOR="${MINOR%.*}"
   SAIL_VERSION="v${MINOR}-latest"
@@ -401,7 +403,7 @@ FINAL_VERSION="$(yq '.spec.version // ""' <<< "$ISTIO_YAML")"
 if [ -n "${FINAL_VERSION}" ]; then
   echo "Sail Istio CR version to apply: ${FINAL_VERSION} (requested: ${REQUESTED_VERSION:-<unset>})"
 else
-  echo "WARNING: Sail Istio CR spec.version is empty before apply."
+  echo "Sail Istio CR spec.version is not set; Sail operator default version will be used."
 fi
 
 ISTIO_NAME=$(yq '.metadata.name' <<< "$ISTIO_YAML")

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -397,6 +397,13 @@ if [[ -n "$REQUESTED_VERSION" && "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]
   echo "Mapping Istio version ${REQUESTED_VERSION} to ${SAIL_VERSION} (Sail CRD only allows specific versions per minor; using -latest)"
 fi
 
+FINAL_VERSION="$(yq '.spec.version // ""' <<< "$ISTIO_YAML")"
+if [ -n "${FINAL_VERSION}" ]; then
+  echo "Sail Istio CR version to apply: ${FINAL_VERSION} (requested: ${REQUESTED_VERSION:-<unset>})"
+else
+  echo "WARNING: Sail Istio CR spec.version is empty before apply."
+fi
+
 ISTIO_NAME=$(yq '.metadata.name' <<< "$ISTIO_YAML")
 ISTIO_NAMESPACE=$(yq '.spec.namespace' <<< "$ISTIO_YAML")
 


### PR DESCRIPTION
### Describe the change

Some changes related to this workflow:

- Fix branch ref from Sail (Use main)
- Use Sail repo to determine the Istio versions instead of Istio
- Extract `determine_istio_version` logic to an script, to be able to test it outside the workflow

### Steps to test the PR

Can run with:

```
gh workflow run "Test Istio Version" \
  --ref fix_istio_versions \
  -f branch_to_test=fix_istio_versions \
  -f istio_minor_version_offset=0 \
  -f sail_operator_git_ref=main
```

Run [here ](https://github.com/josunect/kiali/actions/runs/24662077928/job/72111229922) 

```
[2](https://github.com/josunect/kiali/actions/runs/24662077928/job/72111229922#step:7:233)
Sail operator git ref is 'main'; ignoring requested Istio version (v1.29.1) and letting Sail select the default version. 
```



### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/9568 
