### PR TITLE
Graph Traffic menu: progressive help disclosure + shared help row

### DIFF
--- a/frontend/src/components/ToolbarDropdown/ToolbarDropdownHelpRow.tsx
+++ b/frontend/src/components/ToolbarDropdown/ToolbarDropdownHelpRow.tsx
@@ -1,0 +1,120 @@
+import { Popover, PopoverPosition } from '@patternfly/react-core';
+import * as React from 'react';
+import { KialiIcon } from 'config/KialiIcon';
+import {
+  displayMenuRowContentStyle,
+  displayMenuRowIconStyle,
+  displayMenuRowStyle,
+  displayMenuRowStyleNoHover
+} from 'styles/DropdownStyles';
+import { helpIconStyle } from 'styles/IconStyle';
+import { PFColors } from 'components/Pf/PfColors';
+import { useKialiTranslation } from 'utils/I18nUtils';
+
+export const TOOLBAR_DROPDOWN_HELP_HOVER_DELAY_MS = 200;
+
+export const TOOLBAR_DROPDOWN_HELP_POPOVER_WIDTH = '20rem';
+
+export type ToolbarDropdownHelpRowProps = {
+  /** When set, help icon stays visible and the row has no hover background (e.g. section titles). */
+  alwaysShowHelpIcon?: boolean;
+  /** Primary control(s); placed in the flexible left column. */
+  children: React.ReactNode;
+  /** Rich help body inside the popover; omit for a plain row with no help affordance. */
+  helpBody?: React.ReactNode;
+  /** Popover header; defaults to translated "Help". */
+  helpTitle?: React.ReactNode;
+  /** Fixed min/max width for the help popover. */
+  popoverWidth?: string;
+};
+
+/**
+ * Progressive help for PatternFly toolbar dropdown menus: defer the (?) icon until hover (with delay),
+ * then click for a Popover. Used by graph Display, graph Traffic, mesh Display, etc.
+ */
+export const ToolbarDropdownHelpRow: React.FC<ToolbarDropdownHelpRowProps> = ({
+  alwaysShowHelpIcon = false,
+  children,
+  helpBody,
+  helpTitle,
+  popoverWidth = TOOLBAR_DROPDOWN_HELP_POPOVER_WIDTH
+}) => {
+  const { t } = useKialiTranslation();
+  const [delayedHover, setDelayedHover] = React.useState(false);
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
+  const hoverTimerRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current !== null) {
+        window.clearTimeout(hoverTimerRef.current);
+      }
+    };
+  }, []);
+
+  const clearHoverTimer = (): void => {
+    if (hoverTimerRef.current !== null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  };
+
+  const handleMouseEnter = (): void => {
+    if (alwaysShowHelpIcon) {
+      return;
+    }
+    clearHoverTimer();
+    hoverTimerRef.current = window.setTimeout(() => {
+      setDelayedHover(true);
+      hoverTimerRef.current = null;
+    }, TOOLBAR_DROPDOWN_HELP_HOVER_DELAY_MS);
+  };
+
+  const handleMouseLeave = (): void => {
+    if (alwaysShowHelpIcon) {
+      return;
+    }
+    clearHoverTimer();
+    if (!popoverOpen) {
+      setDelayedHover(false);
+    }
+  };
+
+  if (!helpBody) {
+    return <div className={displayMenuRowStyle}>{children}</div>;
+  }
+
+  const showIcon = alwaysShowHelpIcon || delayedHover || popoverOpen;
+  const rowClass = alwaysShowHelpIcon ? displayMenuRowStyleNoHover : displayMenuRowStyle;
+  const header = helpTitle ?? t('Help');
+
+  return (
+    <div className={rowClass} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <div className={displayMenuRowContentStyle}>{children}</div>
+      <div
+        className={displayMenuRowIconStyle}
+        style={{
+          opacity: showIcon ? 1 : 0,
+          pointerEvents: showIcon ? 'auto' : 'none'
+        }}
+      >
+        <Popover
+          position={PopoverPosition.right}
+          triggerAction="click"
+          headerContent={header}
+          bodyContent={<div style={{ textAlign: 'left' }}>{helpBody}</div>}
+          minWidth={popoverWidth}
+          maxWidth={popoverWidth}
+          showClose={true}
+          onShown={() => setPopoverOpen(true)}
+          onHidden={() => setPopoverOpen(false)}
+          onHide={() => {
+            setDelayedHover(false);
+          }}
+        >
+          <KialiIcon.Help className={helpIconStyle} color={alwaysShowHelpIcon ? PFColors.Black500 : undefined} />
+        </Popover>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -1,13 +1,4 @@
-import {
-  Radio,
-  Checkbox,
-  Dropdown,
-  DropdownList,
-  MenuToggleElement,
-  MenuToggle,
-  Popover,
-  PopoverPosition
-} from '@patternfly/react-core';
+import { Radio, Checkbox, Dropdown, DropdownList, MenuToggleElement, MenuToggle } from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -21,25 +12,14 @@ import {
   BoundingClientAwareComponent,
   PropertyType
 } from 'components/BoundingClientAwareComponent/BoundingClientAwareComponent';
-import { KialiIcon } from 'config/KialiIcon';
-import {
-  containerStyle,
-  displayMenuRowIconStyle,
-  displayMenuRowContentStyle,
-  displayMenuRowStyle,
-  displayMenuRowStyleNoHover,
-  itemStyleWithoutInfo,
-  menuStyle,
-  titleStyle
-} from 'styles/DropdownStyles';
+import { ToolbarDropdownHelpRow } from 'components/ToolbarDropdown/ToolbarDropdownHelpRow';
+import { containerStyle, itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
 import { INITIAL_GRAPH_STATE } from 'reducers/GraphDataState';
 import { KialiDispatch } from 'types/Redux';
 import { KialiDisabledFeatures } from 'types/ServerConfig';
 import { getDisabledFeatures } from 'services/Api';
 import { serverConfig } from '../../../config';
-import { helpIconStyle } from 'styles/IconStyle';
 import { t } from 'utils/I18nUtils';
-import { PFColors } from 'components/Pf/PfColors';
 
 type ReduxStateProps = {
   boxByCluster: boolean;
@@ -83,9 +63,7 @@ type GraphSettingsProps = ReduxStateProps &
 
 type GraphSettingsState = {
   disabledFeatures?: KialiDisabledFeatures;
-  hoveredRowId: string | null;
   isOpen: boolean;
-  popoverOpenRowId: string | null;
 };
 
 interface DisplayOptionType {
@@ -101,21 +79,13 @@ interface DisplayOptionType {
 
 const marginBottom = 20;
 
-// Consistent width for all Display menu help popovers
-const DISPLAY_MENU_POPOVER_WIDTH = '20rem';
-
 class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, GraphSettingsState> {
-  private hoverDelayTimer: number | null = null;
-
   constructor(props: GraphSettingsProps) {
     super(props);
 
     this.state = {
-      hoveredRowId: null,
-      isOpen: false,
-      popoverOpenRowId: null
+      isOpen: false
     };
-    this.hoverDelayTimer = null;
 
     // Let URL override current redux state at construction time. Update URL as needed.
     this.handleURLBool(
@@ -363,35 +333,8 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
     );
   }
 
-  componentWillUnmount(): void {
-    if (this.hoverDelayTimer !== null) {
-      window.clearTimeout(this.hoverDelayTimer);
-    }
-  }
-
   private onToggle = (isOpen: boolean): void => {
     this.setState({ isOpen });
-  };
-
-  private readonly HOVER_DELAY_MS = 200;
-
-  private handleRowMouseEnter = (rowId: string): void => {
-    this.hoverDelayTimer = window.setTimeout(() => {
-      this.setState({ hoveredRowId: rowId });
-      this.hoverDelayTimer = null;
-    }, this.HOVER_DELAY_MS);
-  };
-
-  private handleRowMouseLeave = (): void => {
-    if (this.hoverDelayTimer !== null) {
-      window.clearTimeout(this.hoverDelayTimer);
-      this.hoverDelayTimer = null;
-    }
-
-    // Don't hide the icon if a popover is currently open
-    if (this.state.popoverOpenRowId === null) {
-      this.setState({ hoveredRowId: null });
-    }
   };
 
   private renderDisplayMenuRow = (
@@ -401,51 +344,15 @@ class GraphSettingsComponent extends React.PureComponent<GraphSettingsProps, Gra
     popoverTitle?: React.ReactNode,
     options?: { alwaysShowHelpIcon?: boolean }
   ): React.ReactNode => {
-    const { hoveredRowId, popoverOpenRowId } = this.state;
-    const alwaysShow = options?.alwaysShowHelpIcon === true;
-    const showIcon = popoverContent && (alwaysShow || hoveredRowId === rowId || popoverOpenRowId === rowId);
-
-    if (!popoverContent) {
-      return <div className={displayMenuRowStyle}>{content}</div>;
-    }
-
-    const rowStyle = alwaysShow ? displayMenuRowStyleNoHover : displayMenuRowStyle;
-
     return (
-      <div
-        className={rowStyle}
-        onMouseEnter={() => this.handleRowMouseEnter(rowId)}
-        onMouseLeave={this.handleRowMouseLeave}
+      <ToolbarDropdownHelpRow
+        key={rowId}
+        helpBody={popoverContent}
+        helpTitle={popoverTitle}
+        alwaysShowHelpIcon={options?.alwaysShowHelpIcon === true}
       >
-        <div className={displayMenuRowContentStyle}>{content}</div>
-        <div
-          className={displayMenuRowIconStyle}
-          style={{
-            opacity: showIcon ? 1 : 0,
-            pointerEvents: showIcon ? 'auto' : 'none'
-          }}
-        >
-          <Popover
-            position={PopoverPosition.right}
-            triggerAction="click"
-            headerContent={popoverTitle ?? t('Help')}
-            bodyContent={<div style={{ textAlign: 'left' }}>{popoverContent}</div>}
-            minWidth={DISPLAY_MENU_POPOVER_WIDTH}
-            maxWidth={DISPLAY_MENU_POPOVER_WIDTH}
-            showClose={true}
-            onShown={() => this.setState({ popoverOpenRowId: rowId })}
-            onHidden={() => this.setState({ popoverOpenRowId: null })}
-            onHide={() => {
-              // Only clear hoveredRowId if we're closing the popover for the same row
-              if (this.state.hoveredRowId === rowId) {
-                this.setState({ hoveredRowId: null });
-              }
-            }}
-          >
-            <KialiIcon.Help className={helpIconStyle} color={alwaysShow ? PFColors.Black500 : undefined} />
-          </Popover>
-        </div>
-      </div>
+        {content}
+      </ToolbarDropdownHelpRow>
     );
   };
 

--- a/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
@@ -1,13 +1,4 @@
-import {
-  Radio,
-  Checkbox,
-  Tooltip,
-  TooltipPosition,
-  Dropdown,
-  DropdownList,
-  MenuToggleElement,
-  MenuToggle
-} from '@patternfly/react-core';
+import { Radio, Checkbox, Dropdown, DropdownList, MenuToggleElement, MenuToggle } from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
@@ -21,16 +12,9 @@ import {
   BoundingClientAwareComponent,
   PropertyType
 } from 'components/BoundingClientAwareComponent/BoundingClientAwareComponent';
-import { KialiIcon } from 'config/KialiIcon';
-import {
-  containerStyle,
-  itemStyleWithInfo,
-  itemStyleWithoutInfo,
-  menuStyle,
-  menuEntryStyle
-} from 'styles/DropdownStyles';
+import { ToolbarDropdownHelpRow } from 'components/ToolbarDropdown/ToolbarDropdownHelpRow';
+import { containerStyle, itemStyleWithoutInfo, menuStyle } from 'styles/DropdownStyles';
 import { serverConfig } from 'config';
-import { infoStyle } from 'styles/IconStyle';
 
 type ReduxDispatchProps = {
   setTrafficRates: (trafficRates: TrafficRate[]) => void;
@@ -221,7 +205,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
         labelText: 'Total Bytes',
         isChecked: trafficRates.includes(TrafficRate.TCP_TOTAL),
         tooltip: (
-          <div style={{ textAlign: 'left' }}>Combined (Sent + Received) byte rate in bytes-per-second (mps).</div>
+          <div style={{ textAlign: 'left' }}>Combined (Sent + Received) byte rate in bytes-per-second (bps).</div>
         )
       }
     ];
@@ -235,41 +219,30 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
           {trafficRateOptions
             .filter((trafficRateOption: TrafficRateOptionType) => !trafficRateOption.isHidden)
             .map((trafficRateOption: TrafficRateOptionType) => (
-              <div key={trafficRateOption.id} className={menuEntryStyle}>
-                <label
-                  key={trafficRateOption.id}
-                  className={trafficRateOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                >
-                  <Checkbox
-                    id={trafficRateOption.id}
-                    name="trafficRateOptions"
-                    isChecked={trafficRateOption.isChecked}
-                    isDisabled={props.disabled}
-                    label={trafficRateOption.labelText}
-                    onChange={(event, _) => toggleTrafficRate(_, event)}
-                    value={trafficRateOption.id}
-                  />
-                </label>
-
-                {trafficRateOption.tooltip && (
-                  <Tooltip
-                    key={`tooltip_${trafficRateOption.id}`}
-                    position={TooltipPosition.right}
-                    content={trafficRateOption.tooltip}
-                  >
-                    <KialiIcon.Info className={infoStyle} />
-                  </Tooltip>
-                )}
+              <React.Fragment key={trafficRateOption.id}>
+                <ToolbarDropdownHelpRow helpBody={trafficRateOption.tooltip} helpTitle={trafficRateOption.labelText}>
+                  <label className={itemStyleWithoutInfo}>
+                    <Checkbox
+                      id={trafficRateOption.id}
+                      name="trafficRateOptions"
+                      isChecked={trafficRateOption.isChecked}
+                      isDisabled={props.disabled}
+                      label={trafficRateOption.labelText}
+                      onChange={(event, _) => toggleTrafficRate(_, event)}
+                      value={trafficRateOption.id}
+                    />
+                  </label>
+                </ToolbarDropdownHelpRow>
 
                 {trafficRateOption.id === TrafficRate.AMBIENT_GROUP && ambientOptions.some(o => o.isChecked) && (
                   <div>
                     {ambientOptions.map((ambientOption: TrafficRateOptionType) => (
-                      <div key={ambientOption.id} className={menuEntryStyle}>
-                        <label
-                          key={ambientOption.id}
-                          className={ambientOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                          style={{ paddingLeft: '2rem' }}
-                        >
+                      <ToolbarDropdownHelpRow
+                        key={ambientOption.id}
+                        helpBody={ambientOption.tooltip}
+                        helpTitle={ambientOption.labelText}
+                      >
+                        <label className={itemStyleWithoutInfo} style={{ paddingLeft: '2rem' }}>
                           <Radio
                             id={ambientOption.id}
                             style={{ paddingLeft: '0.25rem' }}
@@ -281,16 +254,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             value={ambientOption.id}
                           />
                         </label>
-                        {ambientOption.tooltip && (
-                          <Tooltip
-                            key={`tooltip_${ambientOption.id}`}
-                            position={TooltipPosition.right}
-                            content={ambientOption.tooltip}
-                          >
-                            <KialiIcon.Info className={infoStyle} />
-                          </Tooltip>
-                        )}
-                      </div>
+                      </ToolbarDropdownHelpRow>
                     ))}
                   </div>
                 )}
@@ -298,12 +262,12 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                 {trafficRateOption.id === TrafficRate.GRPC_GROUP && grpcOptions.some(o => o.isChecked) && (
                   <div>
                     {grpcOptions.map((grpcOption: TrafficRateOptionType) => (
-                      <div key={grpcOption.id} className={menuEntryStyle}>
-                        <label
-                          key={grpcOption.id}
-                          className={grpcOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                          style={{ paddingLeft: '2rem' }}
-                        >
+                      <ToolbarDropdownHelpRow
+                        key={grpcOption.id}
+                        helpBody={grpcOption.tooltip}
+                        helpTitle={grpcOption.labelText}
+                      >
+                        <label className={itemStyleWithoutInfo} style={{ paddingLeft: '2rem' }}>
                           <Radio
                             id={grpcOption.id}
                             style={{ paddingLeft: '0.25rem' }}
@@ -315,16 +279,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             value={grpcOption.id}
                           />
                         </label>
-                        {grpcOption.tooltip && (
-                          <Tooltip
-                            key={`tooltip_${grpcOption.id}`}
-                            position={TooltipPosition.right}
-                            content={grpcOption.tooltip}
-                          >
-                            <KialiIcon.Info className={infoStyle} />
-                          </Tooltip>
-                        )}
-                      </div>
+                      </ToolbarDropdownHelpRow>
                     ))}
                   </div>
                 )}
@@ -332,12 +287,12 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                 {trafficRateOption.id === TrafficRate.HTTP_GROUP && httpOptions.some(o => o.isChecked) && (
                   <div>
                     {httpOptions.map((httpOption: TrafficRateOptionType) => (
-                      <div key={httpOption.id} className={menuEntryStyle}>
-                        <label
-                          key={httpOption.id}
-                          className={httpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                          style={{ paddingLeft: '2rem' }}
-                        >
+                      <ToolbarDropdownHelpRow
+                        key={httpOption.id}
+                        helpBody={httpOption.tooltip}
+                        helpTitle={httpOption.labelText}
+                      >
+                        <label className={itemStyleWithoutInfo} style={{ paddingLeft: '2rem' }}>
                           <Radio
                             id={httpOption.id}
                             style={{ paddingLeft: '0.25rem' }}
@@ -349,17 +304,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             value={httpOption.id}
                           />
                         </label>
-
-                        {httpOption.tooltip && (
-                          <Tooltip
-                            key={`tooltip_${httpOption.id}`}
-                            position={TooltipPosition.right}
-                            content={httpOption.tooltip}
-                          >
-                            <KialiIcon.Info className={infoStyle} />
-                          </Tooltip>
-                        )}
-                      </div>
+                      </ToolbarDropdownHelpRow>
                     ))}
                   </div>
                 )}
@@ -367,12 +312,12 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                 {trafficRateOption.id === TrafficRate.TCP_GROUP && tcpOptions.some(o => o.isChecked) && (
                   <div>
                     {tcpOptions.map((tcpOption: TrafficRateOptionType) => (
-                      <div key={tcpOption.id} className={menuEntryStyle}>
-                        <label
-                          key={tcpOption.id}
-                          className={tcpOption.tooltip ? itemStyleWithInfo : itemStyleWithoutInfo}
-                          style={{ paddingLeft: '2rem' }}
-                        >
+                      <ToolbarDropdownHelpRow
+                        key={tcpOption.id}
+                        helpBody={tcpOption.tooltip}
+                        helpTitle={tcpOption.labelText}
+                      >
+                        <label className={itemStyleWithoutInfo} style={{ paddingLeft: '2rem' }}>
                           <Radio
                             id={tcpOption.id}
                             style={{ paddingLeft: '0.25rem' }}
@@ -384,20 +329,11 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
                             value={tcpOption.id}
                           />
                         </label>
-                        {tcpOption.tooltip && (
-                          <Tooltip
-                            key={`tooltip_${tcpOption.id}`}
-                            position={TooltipPosition.right}
-                            content={tcpOption.tooltip}
-                          >
-                            <KialiIcon.Info className={infoStyle} />
-                          </Tooltip>
-                        )}
-                      </div>
+                      </ToolbarDropdownHelpRow>
                     ))}
                   </div>
                 )}
-              </div>
+              </React.Fragment>
             ))}
         </div>
       </BoundingClientAwareComponent>

--- a/frontend/src/pages/Mesh/toolbar/MeshSettings.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshSettings.tsx
@@ -1,12 +1,4 @@
-import {
-  Checkbox,
-  Dropdown,
-  DropdownList,
-  MenuToggleElement,
-  MenuToggle,
-  Popover,
-  PopoverPosition
-} from '@patternfly/react-core';
+import { Checkbox, Dropdown, DropdownList, MenuToggleElement, MenuToggle } from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -16,19 +8,10 @@ import {
   BoundingClientAwareComponent,
   PropertyType
 } from 'components/BoundingClientAwareComponent/BoundingClientAwareComponent';
-import { KialiIcon } from 'config/KialiIcon';
-import {
-  containerStyle,
-  displayMenuRowContentStyle,
-  displayMenuRowIconStyle,
-  displayMenuRowStyle,
-  itemStyleWithoutInfo,
-  menuStyle,
-  titleStyle
-} from 'styles/DropdownStyles';
+import { ToolbarDropdownHelpRow } from 'components/ToolbarDropdown/ToolbarDropdownHelpRow';
+import { containerStyle, itemStyleWithoutInfo, menuStyle, titleStyle } from 'styles/DropdownStyles';
 import { KialiDispatch } from 'types/Redux';
 import { serverConfig } from '../../../config';
-import { helpIconStyle } from 'styles/IconStyle';
 import { INITIAL_MESH_STATE } from 'reducers/MeshDataState';
 import { MeshToolbarActions } from 'actions/MeshToolbarActions';
 import { useKialiTranslation } from 'utils/I18nUtils';
@@ -61,88 +44,21 @@ interface DisplayOptionType {
 }
 
 const marginBottom = 20;
-const HOVER_DELAY_MS = 200;
 
 const MeshSettingsComponent: React.FC<MeshSettingsProps> = (props: MeshSettingsProps) => {
-  const [hoveredRowId, setHoveredRowId] = React.useState<string | null>(null);
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
-  const [popoverOpenRowId, setPopoverOpenRowId] = React.useState<string | null>(null);
-  const hoverDelayTimer = React.useRef<number | null>(null);
   const { t } = useKialiTranslation();
-
-  // Cleanup timer on unmount
-  React.useEffect(() => {
-    return () => {
-      if (hoverDelayTimer.current !== null) {
-        window.clearTimeout(hoverDelayTimer.current);
-      }
-    };
-  }, []);
-
-  const handleRowMouseEnter = (rowId: string): void => {
-    hoverDelayTimer.current = window.setTimeout(() => {
-      setHoveredRowId(rowId);
-      hoverDelayTimer.current = null;
-    }, HOVER_DELAY_MS);
-  };
-
-  const handleRowMouseLeave = (): void => {
-    if (hoverDelayTimer.current !== null) {
-      window.clearTimeout(hoverDelayTimer.current);
-      hoverDelayTimer.current = null;
-    }
-
-    // Don't hide the icon if a popover is currently open
-    if (popoverOpenRowId === null) {
-      setHoveredRowId(null);
-    }
-  };
 
   const renderDisplayMenuRow = (
     rowId: string,
     content: React.ReactNode,
     tooltipContent?: React.ReactNode,
-    headerTitle?: string
+    headerTitle?: React.ReactNode
   ): React.ReactNode => {
-    // Show icon if hovering OR if the popover is open for this row
-    const showIcon = tooltipContent && (hoveredRowId === rowId || popoverOpenRowId === rowId);
-
-    if (!tooltipContent) {
-      return <div className={displayMenuRowStyle}>{content}</div>;
-    }
     return (
-      <div
-        className={displayMenuRowStyle}
-        onMouseEnter={() => handleRowMouseEnter(rowId)}
-        onMouseLeave={handleRowMouseLeave}
-      >
-        <div className={displayMenuRowContentStyle}>{content}</div>
-        <div
-          className={displayMenuRowIconStyle}
-          style={{
-            opacity: showIcon ? 1 : 0,
-            pointerEvents: showIcon ? 'auto' : 'none'
-          }}
-        >
-          <Popover
-            position={PopoverPosition.right}
-            triggerAction="click"
-            headerContent={headerTitle}
-            bodyContent={<div style={{ textAlign: 'left' }}>{tooltipContent}</div>}
-            showClose={true}
-            onShown={() => setPopoverOpenRowId(rowId)}
-            onHidden={() => setPopoverOpenRowId(null)}
-            onHide={() => {
-              // Only clear hoveredRowId if we're closing the popover for the same row
-              if (hoveredRowId === rowId) {
-                setHoveredRowId(null);
-              }
-            }}
-          >
-            <KialiIcon.Help className={helpIconStyle} />
-          </Popover>
-        </div>
-      </div>
+      <ToolbarDropdownHelpRow key={rowId} helpBody={tooltipContent} helpTitle={headerTitle}>
+        {content}
+      </ToolbarDropdownHelpRow>
     );
   };
 


### PR DESCRIPTION
This change applies the same progressive help pattern used in the graph Display menu (see #9355) to the graph **Traffic** dropdown: hover dwell reveals a (?) icon, click opens a Popover with the existing help text.

### Code sharing
- New `ToolbarDropdownHelpRow` (`frontend/src/components/ToolbarDropdown/ToolbarDropdownHelpRow.tsx`) centralizes hover delay, popover width, and click-to-open behavior.
- **GraphSettings** (Display) and **MeshSettings** (Display) now use this component instead of duplicated logic.

### Other
- TCP "Total" help text: fix unit typo (bps, not mps).

Closes #9588

Made with [Cursor](https://cursor.com)

**Testing**
- Ensure the refactored Graph and Mesh Display menus behave correctly.
- Ensure the graph Traffic menu now uses the same progressive help approach.