### PR TITLE
[AI] Check accessible namespace

### DIFF
--- a/ai/mcp/get_action_ui/get_action_ui.go
+++ b/ai/mcp/get_action_ui/get_action_ui.go
@@ -29,6 +29,28 @@ type GetActionUIResponse struct {
 
 var validResourceTypes = []string{"service", "workload", "app", "istio", "graph", "overview", "namespaces"}
 
+func invalidNamespaces(ctx context.Context, businessLayer *business.Layer, clusterName, rawNamespaces string) []string {
+	if rawNamespaces == "" || rawNamespaces == "all" {
+		return nil
+	}
+	invalid := make([]string, 0)
+	seen := map[string]struct{}{}
+	for _, ns := range strings.Split(rawNamespaces, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			continue
+		}
+		if _, ok := seen[ns]; ok {
+			continue
+		}
+		seen[ns] = struct{}{}
+		if _, err := businessLayer.Namespace.GetClusterNamespace(ctx, ns, clusterName); err != nil {
+			invalid = append(invalid, ns)
+		}
+	}
+	return invalid
+}
+
 // validateResourceExists checks that the given resource exists in the namespace
 // before generating a navigation link. Returns a non-empty error message when
 // either the namespace is inaccessible or the named resource cannot be found.
@@ -112,6 +134,15 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}
 	if !slices.Contains(validResourceTypes, resourceType) {
 		return "invalid resourceType '" + resourceType + "'. Must be one of: service, workload, app, istio, graph, overview, namespaces", http.StatusBadRequest
+	}
+	// Validate explicitly provided namespaces before building any action.
+	// Keep single-namespace + resource validation behavior unchanged below.
+	if resourceName == "" || strings.Contains(namespaces, ",") {
+		if invalid := invalidNamespaces(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, clusterName, namespaces); len(invalid) > 0 {
+			return GetActionUIResponse{
+				Errors: fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot generate UI actions.", strings.Join(invalid, ", ")),
+			}, http.StatusOK
+		}
 	}
 
 	namespacesValue := namespaces

--- a/ai/mcp/get_action_ui/get_action_ui_test.go
+++ b/ai/mcp/get_action_ui/get_action_ui_test.go
@@ -28,6 +28,7 @@ func TestExecute(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "details-v1",
@@ -261,6 +262,7 @@ func TestActionRoutesMatchFrontend(t *testing.T) {
 
 	k8s := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("bookinfo"),
+		kubetest.FakeNamespace("istio-system"),
 		&apps_v1.Deployment{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "details-v1",

--- a/ai/mcp/get_logs/get_logs.go
+++ b/ai/mcp/get_logs/get_logs.go
@@ -50,6 +50,9 @@ func Execute(
 	if code != http.StatusOK {
 		return errMsg, code
 	}
+	if errMsg := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); errMsg != "" {
+		return errMsg + " Cannot retrieve logs.", http.StatusOK
+	}
 
 	log.Debugf("[Chat AI][get_logs] ns=%s requested=%s workload=%s pod=%s container=%s tail=%d severity=%v previous=%t cluster=%s",
 		parsed.Namespace, parsed.Requested, parsed.Workload, parsed.Pod, parsed.Container, parsed.TailLines, parsed.Severities, parsed.Previous, parsed.ClusterName)

--- a/ai/mcp/get_logs/get_logs.go
+++ b/ai/mcp/get_logs/get_logs.go
@@ -50,8 +50,8 @@ func Execute(
 	if code != http.StatusOK {
 		return errMsg, code
 	}
-	if errMsg := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); errMsg != "" {
-		return errMsg + " Cannot retrieve logs.", http.StatusOK
+	if nsErrMsg, nsCode := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); nsErrMsg != "" {
+		return nsErrMsg + " Cannot retrieve logs.", nsCode
 	}
 
 	log.Debugf("[Chat AI][get_logs] ns=%s requested=%s workload=%s pod=%s container=%s tail=%d severity=%v previous=%t cluster=%s",

--- a/ai/mcp/get_mesh_status/get_mesh_status.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status.go
@@ -25,12 +25,12 @@ func Execute(ki *mcputil.KialiInterface, args map[string]interface{}) (interface
 	namespaces, nsErr := ki.BusinessLayer.Namespace.GetNamespaces(ctx)
 	if nsErr != nil {
 		if business.IsAccessibleError(nsErr) || k8serrors.IsForbidden(nsErr) || k8serrors.IsUnauthorized(nsErr) {
-			return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusOK
+			return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusForbidden
 		}
-		return fmt.Sprintf("failed to validate token access for mesh status: %v", nsErr), http.StatusOK
+		return fmt.Sprintf("failed to validate token access for mesh status: %v", nsErr), http.StatusInternalServerError
 	}
 	if len(namespaces) == 0 {
-		return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusOK
+		return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusForbidden
 	}
 
 	meshReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ai/mesh-status", nil)
@@ -51,7 +51,7 @@ func Execute(ki *mcputil.KialiInterface, args map[string]interface{}) (interface
 
 	summary := transformToSummary(meshConfig)
 	if !hasAccessibleControlPlane(summary) {
-		return "No accessible control plane data found for this token. Cannot retrieve mesh status.", http.StatusOK
+		return "No accessible control plane data found for this token. Cannot retrieve mesh status.", http.StatusForbidden
 	}
 	enrichNamespaceHealth(ctx, ki.BusinessLayer, summary.Components.DataPlane.MonitoredNamespaces)
 

--- a/ai/mcp/get_mesh_status/get_mesh_status.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/kubernetes"
@@ -19,6 +21,17 @@ import (
 
 func Execute(ki *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
 	ctx := ki.Request.Context()
+
+	namespaces, nsErr := ki.BusinessLayer.Namespace.GetNamespaces(ctx)
+	if nsErr != nil {
+		if business.IsAccessibleError(nsErr) || k8serrors.IsForbidden(nsErr) || k8serrors.IsUnauthorized(nsErr) {
+			return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusOK
+		}
+		return fmt.Sprintf("failed to validate token access for mesh status: %v", nsErr), http.StatusOK
+	}
+	if len(namespaces) == 0 {
+		return "Token does not have access to any namespace. Cannot retrieve mesh status.", http.StatusOK
+	}
 
 	meshReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ai/mesh-status", nil)
 	meshOpts := mesh.NewOptions(meshReq, &ki.BusinessLayer.Namespace)
@@ -37,9 +50,16 @@ func Execute(ki *mcputil.KialiInterface, args map[string]interface{}) (interface
 	}
 
 	summary := transformToSummary(meshConfig)
+	if !hasAccessibleControlPlane(summary) {
+		return "No accessible control plane data found for this token. Cannot retrieve mesh status.", http.StatusOK
+	}
 	enrichNamespaceHealth(ctx, ki.BusinessLayer, summary.Components.DataPlane.MonitoredNamespaces)
 
 	return summary, http.StatusOK
+}
+
+func hasAccessibleControlPlane(summary MeshSummaryFormatted) bool {
+	return len(summary.Components.ControlPlane.Nodes) > 0
 }
 
 func transformToSummary(cfg meshCommon.Config) MeshSummaryFormatted {

--- a/ai/mcp/get_mesh_status/get_mesh_status_test.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status_test.go
@@ -88,6 +88,26 @@ func TestTransformToSummary_ControlPlane(t *testing.T) {
 	assert.Equal(t, kubernetes.ComponentHealthy, node.Status)
 }
 
+func TestHasAccessibleControlPlane_TrueWithIstiodNode(t *testing.T) {
+	summary := transformToSummary(sampleMeshConfig())
+	assert.True(t, hasAccessibleControlPlane(summary))
+}
+
+func TestHasAccessibleControlPlane_FalseWithoutControlPlaneNodes(t *testing.T) {
+	cfg := meshCommon.Config{
+		Elements: meshCommon.Elements{
+			Nodes: []*meshCommon.NodeWrapper{
+				makeNode("n-kiali", mesh.InfraTypeKiali, "kiali", "cluster-1", "istio-system", "v2.22.0", kubernetes.ComponentHealthy, nil),
+				makeNode("n-prom", mesh.InfraTypeMetricStore, "Prometheus", "_external_", "", "3.5.0", kubernetes.ComponentHealthy, nil),
+			},
+		},
+		Timestamp: time.Now().Unix(),
+	}
+	summary := transformToSummary(cfg)
+	assert.False(t, hasAccessibleControlPlane(summary))
+	assert.Equal(t, "UNKNOWN", summary.Components.ControlPlane.Status)
+}
+
 func TestTransformToSummary_ObservabilityStack(t *testing.T) {
 	summary := transformToSummary(sampleMeshConfig())
 

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -59,6 +59,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	// Parse namespaces argument (comma-separated string)
 	namespaces := make([]string, 0)
 	var invalidAccess []string
+	invalidStatusCode := http.StatusNotFound
 	seen := map[string]struct{}{}
 
 	namespacesArg := mcputil.GetStringArg(args, "namespaces")
@@ -76,16 +77,21 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 			seen[ns_trimmed] = struct{}{}
 
 			// Validate access to this namespace
-			_, err := mcputil.CheckNamespaceAccess(kialiInterface.Request, kialiInterface.Conf, kialiInterface.KialiCache, kialiInterface.Discovery, kialiInterface.ClientFactory, ns_trimmed, toolArgs.ClusterName)
-			if err != nil {
+			if _, statusCode := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, ns_trimmed, toolArgs.ClusterName); statusCode != http.StatusOK {
 				invalidAccess = append(invalidAccess, ns_trimmed)
+				// Prefer the most severe status among invalid namespaces.
+				// 500 > 403 > 404.
+				if statusCode == http.StatusInternalServerError ||
+					(statusCode == http.StatusForbidden && invalidStatusCode != http.StatusInternalServerError) {
+					invalidStatusCode = statusCode
+				}
 				continue
 			}
 			namespaces = append(namespaces, ns_trimmed)
 		}
 
 		if len(namespaces) == 0 && len(invalidAccess) > 0 {
-			return fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot retrieve traffic graph.", strings.Join(invalidAccess, ", ")), http.StatusOK
+			return fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot retrieve traffic graph.", strings.Join(invalidAccess, ", ")), invalidStatusCode
 		}
 	}
 

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
@@ -42,7 +42,7 @@ func mockPrometheusForGraph(promAPI *prometheustest.PromAPIMock) {
 	promAPI.On("Buildinfo", mock.Anything).Return(prom_v1.BuildinfoResult{}, nil)
 }
 
-// reqWithAuth sets auth info on the request context so CheckNamespaceAccess can resolve user clients.
+// reqWithAuth sets auth info on the request context so ValidateNamespaceAccess can resolve user clients.
 func reqWithAuth(req *http.Request, conf *config.Config, token string) *http.Request {
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: token}}
 	ctx := authentication.SetAuthInfoContext(req.Context(), authInfo)

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph_test.go
@@ -58,7 +58,7 @@ func mockPrometheusForHealth(prom *prometheustest.PromClientMock) {
 	prom.On("GetWorkloadRequestRates", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(emptyVec, emptyVec, nil)
 }
 
-func TestExecute_NonExistentNamespaces_ReturnsOKWithMessage(t *testing.T) {
+func TestExecute_NonExistentNamespaces_ReturnsNotFoundWithMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -83,14 +83,14 @@ func TestExecute_NonExistentNamespaces_ReturnsOKWithMessage(t *testing.T) {
 	}
 
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: nil, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
-	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, http.StatusNotFound, code)
 	msg, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, msg, "nonexistent-ns")
 	assert.Contains(t, msg, "not found or not accessible")
 }
 
-func TestExecute_AllNonExistentFromList_ReturnsOKWithMessage(t *testing.T) {
+func TestExecute_AllNonExistentFromList_ReturnsNotFoundWithMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -114,7 +114,7 @@ func TestExecute_AllNonExistentFromList_ReturnsOKWithMessage(t *testing.T) {
 	}
 
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Prom: nil, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf, Graphana: nil, Perses: nil, Discovery: discovery}, args)
-	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, http.StatusNotFound, code)
 	msg, ok := res.(string)
 	require.True(t, ok)
 	assert.True(t, strings.Contains(msg, "default2") || strings.Contains(msg, "missing-ns"))

--- a/ai/mcp/get_metrics/get_metrics.go
+++ b/ai/mcp/get_metrics/get_metrics.go
@@ -17,9 +17,13 @@ func Execute(
 	namespace := mcputil.GetStringArg(args, "namespace")
 	resourceName := mcputil.GetStringArg(args, "resourceName")
 
-	namespaceInfo, err := mcputil.CheckNamespaceAccess(kialiInterface.Request, kialiInterface.Conf, kialiInterface.KialiCache, kialiInterface.Discovery, kialiInterface.ClientFactory, namespace, clusterName)
+	if nsErrMsg, nsCode := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); nsErrMsg != "" {
+		return nsErrMsg, nsCode
+	}
+
+	namespaceInfo, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespace(kialiInterface.Request.Context(), namespace, clusterName)
 	if err != nil {
-		return err.Error(), http.StatusForbidden
+		return err.Error(), http.StatusInternalServerError
 	}
 	params := models.IstioMetricsQuery{Cluster: clusterName, Namespace: namespace}
 

--- a/ai/mcp/get_pod_performance/get_pod_performance.go
+++ b/ai/mcp/get_pod_performance/get_pod_performance.go
@@ -61,10 +61,8 @@ func Execute(
 
 	// Validate namespace existence early so the user gets a clear message.
 	if kialiInterface.BusinessLayer != nil {
-		if _, nsErr := kialiInterface.BusinessLayer.Namespace.GetClusterNamespace(
-			kialiInterface.Request.Context(), namespace, clusterName,
-		); nsErr != nil {
-			return fmt.Sprintf("Namespace %q does not exist in cluster %q. Please verify the namespace name and try again.", namespace, clusterName), http.StatusOK
+		if errMsg := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
+			return errMsg + " Please verify the namespace name and your permissions, then try again.", http.StatusOK
 		}
 	}
 

--- a/ai/mcp/get_pod_performance/get_pod_performance.go
+++ b/ai/mcp/get_pod_performance/get_pod_performance.go
@@ -61,8 +61,8 @@ func Execute(
 
 	// Validate namespace existence early so the user gets a clear message.
 	if kialiInterface.BusinessLayer != nil {
-		if errMsg := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
-			return errMsg + " Please verify the namespace name and your permissions, then try again.", http.StatusOK
+		if nsErrMsg, nsCode := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); nsErrMsg != "" {
+			return nsErrMsg + " Please verify the namespace name and your permissions, then try again.", nsCode
 		}
 	}
 

--- a/ai/mcp/get_pod_performance/get_pod_performance_test.go
+++ b/ai/mcp/get_pod_performance/get_pod_performance_test.go
@@ -649,7 +649,7 @@ func TestExecute_NamespaceDoesNotExist_ReturnsOKWithFriendlyMessage(t *testing.T
 	require.Equal(t, http.StatusOK, code, "chatbot tools should return 200 with friendly messages, not 404")
 	msg := res.(string)
 	assert.Contains(t, msg, "nonexistent-namespace")
-	assert.Contains(t, msg, "does not exist")
+	assert.Contains(t, msg, "does not exist or is not accessible")
 }
 
 func TestExecute_NamespaceDoesNotExist_WithWorkloadName_ReturnsOKWithFriendlyMessage(t *testing.T) {
@@ -670,7 +670,7 @@ func TestExecute_NamespaceDoesNotExist_WithWorkloadName_ReturnsOKWithFriendlyMes
 	require.Equal(t, http.StatusOK, code, "chatbot tools should return 200 with friendly messages, not 404")
 	msg := res.(string)
 	assert.Contains(t, msg, "nonexistent-namespace")
-	assert.Contains(t, msg, "does not exist")
+	assert.Contains(t, msg, "does not exist or is not accessible")
 }
 
 func TestExecute_NamespaceExists_DoesNotBlockExecution(t *testing.T) {

--- a/ai/mcp/get_pod_performance/get_pod_performance_test.go
+++ b/ai/mcp/get_pod_performance/get_pod_performance_test.go
@@ -631,7 +631,7 @@ func TestExecute_PodNotFound_ReturnsOKWithFriendlyMessage(t *testing.T) {
 	assert.Contains(t, msg, "not found")
 }
 
-func TestExecute_NamespaceDoesNotExist_ReturnsOKWithFriendlyMessage(t *testing.T) {
+func TestExecute_NamespaceDoesNotExist_ReturnsNotFoundWithFriendlyMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -646,13 +646,13 @@ func TestExecute_NamespaceDoesNotExist_ReturnsOKWithFriendlyMessage(t *testing.T
 	}
 
 	res, code := Execute(newKialiInterface(conf, clientFactory, nil, businessLayer), args)
-	require.Equal(t, http.StatusOK, code, "chatbot tools should return 200 with friendly messages, not 404")
+	require.Equal(t, http.StatusNotFound, code, "missing namespace should return 404")
 	msg := res.(string)
 	assert.Contains(t, msg, "nonexistent-namespace")
-	assert.Contains(t, msg, "does not exist or is not accessible")
+	assert.Contains(t, msg, "does not exist in cluster")
 }
 
-func TestExecute_NamespaceDoesNotExist_WithWorkloadName_ReturnsOKWithFriendlyMessage(t *testing.T) {
+func TestExecute_NamespaceDoesNotExist_WithWorkloadName_ReturnsNotFoundWithFriendlyMessage(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "Kubernetes"
 	config.Set(conf)
@@ -667,10 +667,10 @@ func TestExecute_NamespaceDoesNotExist_WithWorkloadName_ReturnsOKWithFriendlyMes
 	}
 
 	res, code := Execute(newKialiInterface(conf, clientFactory, nil, businessLayer), args)
-	require.Equal(t, http.StatusOK, code, "chatbot tools should return 200 with friendly messages, not 404")
+	require.Equal(t, http.StatusNotFound, code, "missing namespace should return 404")
 	msg := res.(string)
 	assert.Contains(t, msg, "nonexistent-namespace")
-	assert.Contains(t, msg, "does not exist or is not accessible")
+	assert.Contains(t, msg, "does not exist in cluster")
 }
 
 func TestExecute_NamespaceExists_DoesNotBlockExecution(t *testing.T) {

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -38,13 +38,26 @@ func classifyError(err error, resourceType, name, namespace string) string {
 	}
 }
 
+func classifyErrorStatus(err error) int {
+	switch {
+	case business.IsAccessibleError(err), k8serrors.IsForbidden(err), k8serrors.IsUnauthorized(err):
+		return http.StatusForbidden
+	case k8serrors.IsNotFound(err):
+		return http.StatusNotFound
+	case k8serrors.IsBadRequest(err):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 // recoverFromPanic catches panics from the business layer (e.g. nil pointer
 // dereferences when a K8s API call returns nil + error) and converts them into
 // a clean error message returned as HTTP 200 so the LLM can relay it to the user.
 func recoverFromPanic(res *interface{}, status *int, resourceType, name, namespace string) {
 	if r := recover(); r != nil {
 		*res = fmt.Sprintf("Internal error while processing %s %q in namespace %q: %v", resourceType, name, namespace, r)
-		*status = http.StatusOK
+		*status = http.StatusInternalServerError
 	}
 }
 
@@ -69,14 +82,14 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	errors := map[string]string{}
 	// Validate parameters
 	if resourceType == "" {
-		return "Resource type is required", http.StatusOK
+		return "Resource type is required", http.StatusBadRequest
 	}
 
 	if resourceType == "namespace" && resourceName != "" {
 		namespaces = resourceName
 	}
 	if resourceName != "" && namespaces == "" {
-		return "Namespaces are required when resource name is provided", http.StatusOK
+		return "Namespaces are required when resource name is provided", http.StatusBadRequest
 	}
 	if queryTime.IsZero() {
 		queryTime = util.Clock.Now()
@@ -84,14 +97,19 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	var namespacesSlice []string
 	if namespaces != "" {
 		invalidNamespaces := []string{}
+		invalidStatusCode := http.StatusNotFound
 		for _, ns := range strings.Split(namespaces, ",") {
 			ns = strings.TrimSpace(ns)
 			if ns == "" {
 				continue
 			}
-			_, err := mcputil.CheckNamespaceAccess(kialiInterface.Request, kialiInterface.Conf, kialiInterface.KialiCache, kialiInterface.Discovery, kialiInterface.ClientFactory, ns, clusterName)
-			if err != nil {
+			_, statusCode := mcputil.ValidateNamespaceAccess(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, ns, clusterName)
+			if statusCode != http.StatusOK {
 				invalidNamespaces = append(invalidNamespaces, ns)
+				if statusCode == http.StatusInternalServerError ||
+					(statusCode == http.StatusForbidden && invalidStatusCode != http.StatusInternalServerError) {
+					invalidStatusCode = statusCode
+				}
 				continue
 			}
 			namespacesSlice = append(namespacesSlice, ns)
@@ -104,12 +122,12 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 			if resourceName != "" {
 				msg = fmt.Sprintf("Namespace(s) %s not found or not accessible. Cannot retrieve %s %q.", strings.Join(invalidNamespaces, ", "), resourceType, resourceName)
 			}
-			return msg, http.StatusOK
+			return msg, invalidStatusCode
 		}
 	} else {
 		allNamespaces, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespaces(kialiInterface.Request.Context(), clusterName)
 		if err != nil {
-			return fmt.Sprintf("error fetching namespace list: %s", err.Error()), http.StatusOK
+			return fmt.Sprintf("error fetching namespace list: %s", err.Error()), classifyErrorStatus(err)
 		}
 		namespacesSlice = make([]string, len(allNamespaces))
 		for i, ns := range allNamespaces {
@@ -128,7 +146,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	var status int
 	var err error
 	if resourceName != "" && len(namespacesSlice) > 1 {
-		return "Exactly one namespace is required when resource name is provided", http.StatusOK
+		return "Exactly one namespace is required when resource name is provided", http.StatusBadRequest
 	}
 	if resourceName != "" && len(namespacesSlice) == 1 {
 		log.Debugf("Getting resource details type: %s for resource name: %s and namespace: %s", resourceType, resourceName, namespacesSlice[0])
@@ -148,9 +166,9 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		return map[string]interface{}{
 			"response": resp,
 			"errors":   errors,
-		}, http.StatusOK
+		}, status
 	}
-	return resp, http.StatusOK
+	return resp, status
 }
 
 func calculateRateInterval(
@@ -180,7 +198,7 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 
 	interval, calcErr := calculateRateInterval(ctx, businessLayer, resourceArgs, namespace)
 	if calcErr != nil {
-		return calcErr.Error(), http.StatusOK, nil
+		return calcErr.Error(), http.StatusInternalServerError, nil
 	}
 	switch resourceArgs.ResourceType {
 	case "service":
@@ -193,7 +211,7 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 			resourceArgs.QueryTime,
 			true)
 		if err != nil {
-			return classifyError(err, "service", resourceArgs.ResourceName, namespace), http.StatusOK, nil
+			return classifyError(err, "service", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 		serviceDetails.Validations = istioConfigValidations.MergeValidations(serviceDetails.Validations)
 		return TransformServiceDetail(serviceDetails), http.StatusOK, nil
@@ -206,13 +224,13 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 		}
 		workloadDetails, err := businessLayer.Workload.GetWorkload(ctx, criteria)
 		if err != nil {
-			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), http.StatusOK, nil
+			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 		workloadDetails.Validations = istioConfigValidations
 		workloadDetails.Health, err = businessLayer.Health.GetWorkloadHealth(
 			ctx, criteria.Namespace, criteria.Cluster, criteria.WorkloadName, criteria.RateInterval, criteria.QueryTime, workloadDetails)
 		if err != nil {
-			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), http.StatusOK, nil
+			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 		return TransformWorkloadDetail(workloadDetails), http.StatusOK, nil
 	case "app":
@@ -223,14 +241,14 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 		}
 		appDetails, err := businessLayer.App.GetAppDetails(ctx, criteria)
 		if err != nil {
-			return classifyError(err, "app", resourceArgs.ResourceName, namespace), http.StatusOK, nil
+			return classifyError(err, "app", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 		return TransformAppDetail(&appDetails), http.StatusOK, nil
 	case "namespace":
 		log.Debugf("Getting namespace details for resource name: %s", resourceArgs.ResourceName)
 		namespaces, err := businessLayer.Namespace.GetNamespaces(ctx)
 		if err != nil {
-			return classifyError(err, "namespace", resourceArgs.ResourceName, namespace), http.StatusOK, nil
+			return classifyError(err, "namespace", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 		for _, ns := range namespaces {
 			if ns.Name == resourceArgs.ResourceName && ns.Cluster == resourceArgs.ClusterName {
@@ -238,10 +256,10 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 				return TransformNamespaceDetail(&ns, counts), http.StatusOK, nil
 			}
 		}
-		return fmt.Sprintf("Resource not found: namespace %q does not exist", resourceArgs.ResourceName), http.StatusOK, nil
+		return fmt.Sprintf("Resource not found: namespace %q does not exist", resourceArgs.ResourceName), http.StatusNotFound, nil
 	}
 
-	return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusOK, nil
+	return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusBadRequest, nil
 }
 
 func getNamespaceCounts(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) NamespaceCounts {
@@ -331,12 +349,12 @@ func getList(r *http.Request, conf *config.Config, kialiCache cache.KialiCache, 
 	case "namespace":
 		return GetListNamespaces(r, conf, kialiCache, businessLayer, resourceArgs)
 	default:
-		return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusOK, nil
+		return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusBadRequest, nil
 	}
 	for _, ns := range nss {
 		interval, calcErr := calculateRateInterval(r.Context(), businessLayer, resourceArgs, ns)
 		if calcErr != nil {
-			return calcErr.Error(), http.StatusOK, nil
+			return calcErr.Error(), http.StatusInternalServerError, nil
 		}
 		if serviceCriteria != nil {
 			criteria := *serviceCriteria
@@ -345,7 +363,7 @@ func getList(r *http.Request, conf *config.Config, kialiCache cache.KialiCache, 
 
 			serviceList, err := businessLayer.Svc.GetServiceList(r.Context(), criteria)
 			if err != nil {
-				return classifyError(err, "service", "", ns), http.StatusOK, nil
+				return classifyError(err, "service", "", ns), classifyErrorStatus(err), nil
 			}
 			clusterServices.Services = append(clusterServices.Services, serviceList.Services...)
 			clusterServices.Validations = clusterServices.Validations.MergeValidations(serviceList.Validations)
@@ -356,7 +374,7 @@ func getList(r *http.Request, conf *config.Config, kialiCache cache.KialiCache, 
 
 			workloadList, err := businessLayer.Workload.GetWorkloadList(r.Context(), criteria)
 			if err != nil {
-				return classifyError(err, "workload", "", ns), http.StatusOK, nil
+				return classifyError(err, "workload", "", ns), classifyErrorStatus(err), nil
 			}
 			clusterWorkloads.Workloads = append(clusterWorkloads.Workloads, workloadList.Workloads...)
 			clusterWorkloads.Validations = clusterWorkloads.Validations.MergeValidations(workloadList.Validations)
@@ -367,7 +385,7 @@ func getList(r *http.Request, conf *config.Config, kialiCache cache.KialiCache, 
 
 			appList, err := businessLayer.App.GetAppList(r.Context(), criteria)
 			if err != nil {
-				return classifyError(err, "app", "", ns), http.StatusOK, nil
+				return classifyError(err, "app", "", ns), classifyErrorStatus(err), nil
 			}
 			clusterApps.Apps = append(clusterApps.Apps, appList.Apps...)
 		}
@@ -382,14 +400,14 @@ func getList(r *http.Request, conf *config.Config, kialiCache cache.KialiCache, 
 	if clusterApps != nil {
 		return TransformAppList(clusterApps), http.StatusOK, nil
 	}
-	return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusOK, nil
+	return fmt.Sprintf("unsupported resource type %s", resourceArgs.ResourceType), http.StatusBadRequest, nil
 }
 
 func GetListNamespaces(r *http.Request, conf *config.Config, kialiCache cache.KialiCache,
 	businessLayer *business.Layer, resourceArgs ResourceDetailArgs) (interface{}, int, error) {
 	clusterNamespaces, err := businessLayer.Namespace.GetNamespaces(r.Context())
 	if err != nil {
-		return classifyError(err, "namespace", "", ""), http.StatusOK, nil
+		return classifyError(err, "namespace", "", ""), classifyErrorStatus(err), nil
 	}
 
 	namespacesToInclude := make(map[string]bool)
@@ -416,12 +434,12 @@ func GetListNamespaces(r *http.Request, conf *config.Config, kialiCache cache.Ki
 	health, _, err := businessLayer.Health.GetNamespaceHealth(r.Context(), nsNames, resourceArgs.ClusterName, healthTypes, resourceArgs.RateInterval)
 
 	if err != nil {
-		return classifyError(err, "namespace", "", ""), http.StatusOK, nil
+		return classifyError(err, "namespace", "", ""), classifyErrorStatus(err), nil
 	}
 
 	tls, err := businessLayer.TLS.ClusterWideNSmTLSStatus(r.Context(), filteredNamespaces, resourceArgs.ClusterName)
 	if err != nil {
-		return classifyError(err, "namespace", "", ""), http.StatusOK, nil
+		return classifyError(err, "namespace", "", ""), classifyErrorStatus(err), nil
 	}
 
 	tlsMap := make(map[string]string)

--- a/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
@@ -72,7 +72,7 @@ func TestExecute_MissingResourceType(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 	assert.Equal(t, "Resource type is required", resp)
 }
 
@@ -86,7 +86,7 @@ func TestExecute_InvalidResourceType(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 	assert.Contains(t, resp.(string), "unsupported resource type invalid_type")
 }
 
@@ -123,7 +123,7 @@ func TestExecute_WithResourceNameAndNamespaces(t *testing.T) {
 
 		resp, code := Execute(ki, args)
 
-		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, http.StatusBadRequest, code)
 		assert.Equal(t, "Namespaces are required when resource name is provided", resp)
 	})
 
@@ -139,7 +139,7 @@ func TestExecute_WithResourceNameAndNamespaces(t *testing.T) {
 
 		_, code := Execute(ki, args)
 
-		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, http.StatusNotFound, code)
 	})
 }
 
@@ -171,7 +171,7 @@ func TestExecute_InvalidNamespace(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "non-existent-namespace")
@@ -189,7 +189,7 @@ func TestExecute_AllInvalidNamespacesReturnsErrorMessage(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "invalid1")
@@ -208,7 +208,7 @@ func TestExecute_NamespacesWithWhitespace(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "invalid1")
@@ -228,7 +228,7 @@ func TestExecute_NamespacesWithEmptySegments(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "invalid1")
@@ -247,7 +247,7 @@ func TestExecute_ResourceNameWithMultipleNamespacesReturnsError(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "not found or not accessible")
@@ -284,7 +284,7 @@ func TestExecute_NamespaceResourceType(t *testing.T) {
 
 		resp, code := Execute(ki, args)
 
-		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, http.StatusNotFound, code)
 		respStr, ok := resp.(string)
 		assert.True(t, ok, "Expected response to be a string")
 		assert.Contains(t, respStr, "nonexistent")
@@ -303,7 +303,7 @@ func TestExecute_NamespaceDetailNotFound(t *testing.T) {
 
 	resp, code := Execute(ki, args)
 
-	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, http.StatusNotFound, code)
 	respStr, ok := resp.(string)
 	assert.True(t, ok, "Expected response to be a string")
 	assert.Contains(t, respStr, "nonexistent-namespace")
@@ -363,7 +363,7 @@ func TestRecoverFromPanic_CatchesPanic(t *testing.T) {
 		panic("simulated nil pointer dereference")
 	}()
 
-	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, http.StatusInternalServerError, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "Internal error")

--- a/ai/mcp/list_traces/list_traces.go
+++ b/ai/mcp/list_traces/list_traces.go
@@ -26,8 +26,8 @@ func Execute(
 		return "namespace and serviceName are required", http.StatusBadRequest
 	}
 
-	if errMsg := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); errMsg != "" {
-		return errMsg + fmt.Sprintf(" Cannot retrieve traces for service %q.", parsed.ServiceName), http.StatusOK
+	if nsErrMsg, nsCode := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); nsErrMsg != "" {
+		return nsErrMsg + fmt.Sprintf(" Cannot retrieve traces for service %q.", parsed.ServiceName), nsCode
 	}
 
 	conf := kialiInterface.Conf

--- a/ai/mcp/list_traces/list_traces.go
+++ b/ai/mcp/list_traces/list_traces.go
@@ -1,6 +1,7 @@
 package list_traces
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -19,12 +20,16 @@ func Execute(
 	args map[string]interface{},
 ) (interface{}, int) {
 	parsed := parseArgs(args, kialiInterface.Conf)
+	ctx := kialiInterface.Request.Context()
 
 	if parsed.Namespace == "" || parsed.ServiceName == "" {
 		return "namespace and serviceName are required", http.StatusBadRequest
 	}
 
-	ctx := kialiInterface.Request.Context()
+	if errMsg := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, parsed.Namespace, parsed.ClusterName); errMsg != "" {
+		return errMsg + fmt.Sprintf(" Cannot retrieve traces for service %q.", parsed.ServiceName), http.StatusOK
+	}
+
 	conf := kialiInterface.Conf
 	q := buildServiceQuery(parsed, conf, true)
 	traces, err := kialiInterface.BusinessLayer.Tracing.GetServiceTraces(ctx, parsed.Namespace, parsed.ServiceName, q)

--- a/ai/mcp/manage_istio_config/istio_helper.go
+++ b/ai/mcp/manage_istio_config/istio_helper.go
@@ -10,6 +10,7 @@ import (
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/log"
@@ -30,10 +31,11 @@ func audit(r *http.Request, operation, namespace, gvk, message string) {
 
 // checkNamespaceExists verifies that the target namespace exists in the cluster.
 // Returns a user-friendly (message, status) tuple if the namespace is missing,
-// or ("", 0) when it exists.
+// or ("", 0) when it exists. Always returns http.StatusOK for errors to match
+// MCP pattern of treating errors as user-facing messages.
 func checkNamespaceExists(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (string, int) {
-	if _, err := businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
-		return fmt.Sprintf("Namespace %q does not exist in cluster %q", namespace, cluster), http.StatusNotFound
+	if errMsg := mcputil.ValidateNamespaceAccess(ctx, businessLayer, namespace, cluster); errMsg != "" {
+		return errMsg, http.StatusOK
 	}
 	return "", 0
 }

--- a/ai/mcp/manage_istio_config/istio_helper.go
+++ b/ai/mcp/manage_istio_config/istio_helper.go
@@ -30,12 +30,11 @@ func audit(r *http.Request, operation, namespace, gvk, message string) {
 }
 
 // checkNamespaceExists verifies that the target namespace exists in the cluster.
-// Returns a user-friendly (message, status) tuple if the namespace is missing,
-// or ("", 0) when it exists. Always returns http.StatusOK for errors to match
-// MCP pattern of treating errors as user-facing messages.
+// Returns a user-friendly (message, status) tuple if the namespace is missing
+// or inaccessible, or ("", 0) when it exists and is accessible.
 func checkNamespaceExists(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (string, int) {
-	if errMsg := mcputil.ValidateNamespaceAccess(ctx, businessLayer, namespace, cluster); errMsg != "" {
-		return errMsg, http.StatusOK
+	if errMsg, code := mcputil.ValidateNamespaceAccess(ctx, businessLayer, namespace, cluster); errMsg != "" {
+		return errMsg, code
 	}
 	return "", 0
 }

--- a/ai/mcp/manage_istio_config/manage_istio_config.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config.go
@@ -26,6 +26,8 @@ import (
 // them to the user instead of the execution framework treating them as fatal.
 func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
 	action := mcputil.GetStringArg(args, "action")
+	namespace := mcputil.GetStringArg(args, "namespace")
+	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
 	if err := validateReadOnlyIstioConfigInput(args); err != nil {
 		return err.Error(), http.StatusOK
 	}
@@ -43,10 +45,13 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 	}
 
 	if action == "get" {
-		namespace := mcputil.GetStringArg(args, "namespace")
-		clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
 		if msg, code := checkNamespaceExists(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); code != 0 {
-			return msg, http.StatusOK
+			return msg, code
+		}
+	}
+	if action == "list" && namespace != "" {
+		if msg, code := checkNamespaceExists(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, namespace, clusterName); code != 0 {
+			return msg, code
 		}
 	}
 

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -629,7 +629,7 @@ func TestExecuteReadOnly_GetNonExistentNamespace(t *testing.T) {
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 // ---------------------------------------------------------------------------
@@ -1521,11 +1521,11 @@ func TestIstioCreate_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioCreate(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestIstioPatch_NamespaceDoesNotExist(t *testing.T) {
@@ -1542,11 +1542,11 @@ func TestIstioPatch_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioPatch(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestIstioDelete_NamespaceDoesNotExist(t *testing.T) {
@@ -1562,11 +1562,11 @@ func TestIstioDelete_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioDelete(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_CreateInNonExistentNamespace(t *testing.T) {
@@ -1585,11 +1585,11 @@ func TestExecute_CreateInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_CreatePreviewInNonExistentNamespace(t *testing.T) {
@@ -1608,11 +1608,11 @@ func TestExecute_CreatePreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_PatchInNonExistentNamespace(t *testing.T) {
@@ -1631,11 +1631,11 @@ func TestExecute_PatchInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_PatchPreviewInNonExistentNamespace(t *testing.T) {
@@ -1654,11 +1654,11 @@ func TestExecute_PatchPreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_DeletePreviewInNonExistentNamespace(t *testing.T) {
@@ -1676,11 +1676,11 @@ func TestExecute_DeletePreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestExecute_DeleteInNonExistentNamespace(t *testing.T) {
@@ -1698,11 +1698,11 @@ func TestExecute_DeleteInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist")
+	assert.Contains(t, resStr, "does not exist or is not accessible")
 }
 
 func TestCheckNamespaceExists_ExistingNamespace(t *testing.T) {
@@ -1720,9 +1720,9 @@ func TestCheckNamespaceExists_MissingNamespace(t *testing.T) {
 	r := reqWithAuth()
 
 	msg, code := checkNamespaceExists(r.Context(), businessLayer, "no-such-ns", conf.KubernetesConfig.ClusterName)
-	assert.Equal(t, http.StatusNotFound, code)
+	assert.Equal(t, http.StatusOK, code, "namespace errors return 200 for MCP pattern")
 	assert.Contains(t, msg, "no-such-ns")
-	assert.Contains(t, msg, "does not exist")
+	assert.Contains(t, msg, "does not exist or is not accessible")
 }
 
 // ---------------------------------------------------------------------------

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -551,7 +551,7 @@ func TestExecuteReadOnly_InvalidAction(t *testing.T) {
 	}
 
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "read-only errors must return 200 so the LLM sees the message")
+	assert.Equal(t, http.StatusOK, status)
 	assert.Contains(t, res, "invalid action")
 }
 
@@ -604,7 +604,7 @@ func TestExecuteReadOnly_GetNonExistentConfig(t *testing.T) {
 	}
 
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "read-only errors must return 200 so the LLM sees the message")
+	assert.Equal(t, http.StatusOK, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "not found")
@@ -625,11 +625,11 @@ func TestExecuteReadOnly_GetNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "read-only errors must return 200 so the LLM sees the message")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 // ---------------------------------------------------------------------------
@@ -689,7 +689,7 @@ func TestExecuteReadOnly_UnmanagedGVK(t *testing.T) {
 	}
 
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "read-only errors must return 200 so the LLM sees the message")
+	assert.Equal(t, http.StatusOK, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "invalid group")
@@ -711,7 +711,7 @@ func TestExecuteReadOnly_GatewayAPIv1beta1Hint(t *testing.T) {
 	}
 
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "read-only errors must return 200 so the LLM sees the message")
+	assert.Equal(t, http.StatusOK, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "invalid group")
@@ -1521,11 +1521,11 @@ func TestIstioCreate_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioCreate(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestIstioPatch_NamespaceDoesNotExist(t *testing.T) {
@@ -1542,11 +1542,11 @@ func TestIstioPatch_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioPatch(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestIstioDelete_NamespaceDoesNotExist(t *testing.T) {
@@ -1562,11 +1562,11 @@ func TestIstioDelete_NamespaceDoesNotExist(t *testing.T) {
 	}
 
 	res, status := IstioDelete(r, args, businessLayer, conf)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_CreateInNonExistentNamespace(t *testing.T) {
@@ -1585,11 +1585,11 @@ func TestExecute_CreateInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_CreatePreviewInNonExistentNamespace(t *testing.T) {
@@ -1608,11 +1608,11 @@ func TestExecute_CreatePreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_PatchInNonExistentNamespace(t *testing.T) {
@@ -1631,11 +1631,11 @@ func TestExecute_PatchInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_PatchPreviewInNonExistentNamespace(t *testing.T) {
@@ -1654,11 +1654,11 @@ func TestExecute_PatchPreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_DeletePreviewInNonExistentNamespace(t *testing.T) {
@@ -1676,11 +1676,11 @@ func TestExecute_DeletePreviewInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestExecute_DeleteInNonExistentNamespace(t *testing.T) {
@@ -1698,11 +1698,11 @@ func TestExecute_DeleteInNonExistentNamespace(t *testing.T) {
 	}
 
 	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
-	assert.Equal(t, http.StatusOK, status, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, status, "missing namespace should return 404")
 	resStr, ok := res.(string)
 	require.True(t, ok)
 	assert.Contains(t, resStr, "nonexistent-ns")
-	assert.Contains(t, resStr, "does not exist or is not accessible")
+	assert.Contains(t, resStr, "does not exist in cluster")
 }
 
 func TestCheckNamespaceExists_ExistingNamespace(t *testing.T) {
@@ -1720,9 +1720,9 @@ func TestCheckNamespaceExists_MissingNamespace(t *testing.T) {
 	r := reqWithAuth()
 
 	msg, code := checkNamespaceExists(r.Context(), businessLayer, "no-such-ns", conf.KubernetesConfig.ClusterName)
-	assert.Equal(t, http.StatusOK, code, "namespace errors return 200 for MCP pattern")
+	assert.Equal(t, http.StatusNotFound, code, "missing namespace should return 404")
 	assert.Contains(t, msg, "no-such-ns")
-	assert.Contains(t, msg, "does not exist or is not accessible")
+	assert.Contains(t, msg, "does not exist in cluster")
 }
 
 // ---------------------------------------------------------------------------

--- a/ai/mcputil/access_validations.go
+++ b/ai/mcputil/access_validations.go
@@ -13,11 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/cache"
-	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/handlers/authentication"
-	"github.com/kiali/kiali/istio"
-	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util"
@@ -34,25 +30,6 @@ func getAuthInfo(r *http.Request) (map[string]*api.AuthInfo, error) {
 	} else {
 		return nil, errors.New("authInfo missing from the request context")
 	}
-}
-
-func CheckNamespaceAccess(r *http.Request, conf *config.Config, cache cache.KialiCache, discovery *istio.Discovery, clientFactory kubernetes.ClientFactory, namespace string, cluster string) (*models.Namespace, error) {
-	authInfos, err := getAuthInfo(r)
-	if err != nil {
-		return nil, err
-	}
-
-	userClients, err := clientFactory.GetClients(authInfos)
-	if err != nil {
-		return nil, errors.New("an error occurred while attempting to use your session token, check your session token and the Kiali server logs")
-	}
-
-	namespaceService := business.NewNamespaceService(cache, conf, discovery, clientFactory.GetSAClients(), userClients)
-	ns, err := namespaceService.GetClusterNamespace(r.Context(), namespace, cluster)
-	if err != nil {
-		return nil, errors.New("cannot access namespace data: " + err.Error())
-	}
-	return ns, nil
 }
 
 func ExtractIstioMetricsQueryParams(args map[string]interface{}, q *models.IstioMetricsQuery, namespaceInfo *models.Namespace) error {

--- a/ai/mcputil/access_validations.go
+++ b/ai/mcputil/access_validations.go
@@ -1,6 +1,7 @@
 package mcputil
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -84,6 +85,16 @@ func ExtractIstioMetricsQueryParams(args map[string]interface{}, q *models.Istio
 	q.RequestProtocol = GetStringOrDefault(args, DefaultRequestProtocol, "requestProtocol")
 
 	return extractBaseMetricsQueryParams(args, &q.RangeQuery, namespaceInfo)
+}
+
+// ValidateNamespaceAccess checks that the given namespace exists and is accessible.
+// Returns an error message string if the namespace is not accessible, or empty string if it is.
+// This is designed for MCP tools that return errors as user-facing messages with HTTP 200.
+func ValidateNamespaceAccess(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) string {
+	if _, err := businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
+		return fmt.Sprintf("Namespace %q does not exist or is not accessible in cluster %q.", namespace, cluster)
+	}
+	return ""
 }
 
 func extractBaseMetricsQueryParams(args map[string]interface{}, q *prometheus.RangeQuery, namespaceInfo *models.Namespace) error {

--- a/ai/mcputil/access_validations.go
+++ b/ai/mcputil/access_validations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
@@ -88,13 +89,19 @@ func ExtractIstioMetricsQueryParams(args map[string]interface{}, q *models.Istio
 }
 
 // ValidateNamespaceAccess checks that the given namespace exists and is accessible.
-// Returns an error message string if the namespace is not accessible, or empty string if it is.
-// This is designed for MCP tools that return errors as user-facing messages with HTTP 200.
-func ValidateNamespaceAccess(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) string {
+// It returns an error message plus the HTTP status to be propagated by the tool.
+func ValidateNamespaceAccess(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (string, int) {
 	if _, err := businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
-		return fmt.Sprintf("Namespace %q does not exist or is not accessible in cluster %q.", namespace, cluster)
+		switch {
+		case business.IsAccessibleError(err), k8serrors.IsForbidden(err), k8serrors.IsUnauthorized(err):
+			return fmt.Sprintf("Namespace %q is not accessible in cluster %q.", namespace, cluster), http.StatusForbidden
+		case k8serrors.IsNotFound(err):
+			return fmt.Sprintf("Namespace %q does not exist in cluster %q.", namespace, cluster), http.StatusNotFound
+		default:
+			return fmt.Sprintf("failed to validate namespace %q in cluster %q: %v", namespace, cluster, err), http.StatusInternalServerError
+		}
 	}
-	return ""
+	return "", http.StatusOK
 }
 
 func extractBaseMetricsQueryParams(args map[string]interface{}, q *prometheus.RangeQuery, namespaceInfo *models.Namespace) error {

--- a/ai/mcputil/access_validations.go
+++ b/ai/mcputil/access_validations.go
@@ -10,27 +10,12 @@ import (
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kiali/kiali/business"
-	"github.com/kiali/kiali/handlers/authentication"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/util"
 )
-
-func getAuthInfo(r *http.Request) (map[string]*api.AuthInfo, error) {
-	authInfoContext := authentication.GetAuthInfoContext(r.Context())
-	if authInfoContext != nil {
-		if authInfo, ok := authInfoContext.(map[string]*api.AuthInfo); ok {
-			return authInfo, nil
-		} else {
-			return nil, errors.New("authInfo is not of type map[string]*api.AuthInfo")
-		}
-	} else {
-		return nil, errors.New("authInfo missing from the request context")
-	}
-}
 
 func ExtractIstioMetricsQueryParams(args map[string]interface{}, q *models.IstioMetricsQuery, namespaceInfo *models.Namespace) error {
 	q.FillDefaults()

--- a/ai/providers/execution.go
+++ b/ai/providers/execution.go
@@ -86,7 +86,14 @@ func ExecuteToolCallsInParallel(
 				if call.Name == "get_action_ui" {
 					if mcpRes, ok := mcpResult.(get_action_ui.GetActionUIResponse); ok {
 						actions = append(actions, mcpRes.Actions...)
-						content = "Success. The user's UI has been redirected to the requested view."
+						switch {
+						case len(actions) > 0:
+							content = "Success. The user's UI has been redirected to the requested view."
+						case mcpRes.Errors != "":
+							// Surface get_action_ui validation failures to the model instead of
+							// silently reporting success when no UI action was produced.
+							content = mcpRes.Errors
+						}
 					}
 				}
 				if call.Name == "get_referenced_docs" {

--- a/ai/providers/execution_test.go
+++ b/ai/providers/execution_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/kiali/kiali/ai/mcp/get_action_ui"
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/ai/types"
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/handlers/authentication"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func newTestKialiInterface(t *testing.T) *mcputil.KialiInterface {
@@ -92,6 +94,39 @@ func TestExecuteToolCallsInParallel_ExcludedToolGetReferencedDocs(t *testing.T) 
 	assert.Equal(t, "get_referenced_docs", results[0].Message.Name)
 	assert.Greater(t, len(results[0].ReferencedDocs), 0, "get_referenced_docs should produce referenced docs")
 	assert.Contains(t, results[0].Message.Content, "Documentation links")
+}
+
+func TestExecuteToolCallsInParallel_ExcludedToolGetActionUIErrorIsSurfaced(t *testing.T) {
+	require.NoError(t, mcp.LoadTools())
+
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(kubetest.NewFakeK8sClient()).Build()
+	ki := &mcputil.KialiInterface{
+		Request:       httptest.NewRequest(http.MethodPost, "/", nil),
+		Conf:          conf,
+		BusinessLayer: businessLayer,
+	}
+	toolCalls := []mcp.ToolsProcessor{
+		{
+			Name: "get_action_ui",
+			Args: map[string]any{
+				"resourceType": "workload",
+				"namespaces":   "does-not-exist",
+			},
+			ToolCallID: "tc-1",
+		},
+	}
+
+	results := ExecuteToolCallsInParallel(ki, toolCalls)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.Equal(t, http.StatusOK, results[0].Code)
+	assert.Empty(t, results[0].Actions)
+	assert.Contains(t, results[0].Message.Content, "does-not-exist")
+	assert.Contains(t, results[0].Message.Content, "Cannot generate UI actions")
 }
 
 func TestExecuteToolCallsInParallel_MultipleToolsInParallel(t *testing.T) {


### PR DESCRIPTION
### Describe the change

Validate namespace access. Returning 403 or 404 if the namespace is not accesible for the user or doesn't exist (Instead of 404). 
Return 403 for get mesh if the user doesn't have access to a control plane. 

<img width="787" height="447" alt="image" src="https://github.com/user-attachments/assets/58b509f2-cd8c-42a1-85e1-d0327c426f35" />


### Steps to test the PR
In a cluster with a user with access to bookinfo and not to istio-system:

```
# ===== Config =====
BASE="http://localhost:3000"
TOKEN="<YOUR_TOKEN>"
AUTH=(-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -H "Kiali-UI: true")

# ============================================================
# INVALID NS: istio-system (control-plane namespace for this test)
# ============================================================

# 1) get_mesh_traffic_graph (all invalid/inaccessible -> non-200)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_mesh_traffic_graph" "${AUTH[@]}" \
  -d '{"namespaces":"istio-system","graphType":"versionedApp","clusterName":"Kubernetes"}'

# 2) list_or_get_resources (list services)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"service","namespaces":"istio-system","clusterName":"Kubernetes"}'

# 3) list_or_get_resources (service details)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"service","namespaces":"istio-system","resource_name":"ratings","clusterName":"Kubernetes"}'

# 4) list_or_get_resources (workload details)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"workload","namespaces":"istio-system","resource_name":"ratings-v1","clusterName":"Kubernetes"}'

# 5) list_traces
curl -i -sS -X POST "$BASE/api/chat/mcp/list_traces" "${AUTH[@]}" \
  -d '{"namespace":"istio-system","serviceName":"ratings","clusterName":"Kubernetes"}'

# 6) get_logs (pod/workload name input)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_logs" "${AUTH[@]}" \
  -d '{"namespace":"istio-system","name":"ratings-v1","clusterName":"Kubernetes"}'

# 7) get_pod_performance
curl -i -sS -X POST "$BASE/api/chat/mcp/get_pod_performance" "${AUTH[@]}" \
  -d '{"namespace":"istio-system","workloadName":"ratings-v1","clusterName":"Kubernetes"}'

# 8) get_metrics (service)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_metrics" "${AUTH[@]}" \
  -d '{"resourceType":"service","namespace":"istio-system","resourceName":"ratings","clusterName":"Kubernetes"}'

# 9) get_metrics (workload)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_metrics" "${AUTH[@]}" \
  -d '{"resourceType":"workload","namespace":"istio-system","resourceName":"ratings-v1","clusterName":"Kubernetes"}'

# 10) manage_istio_config_read (list in namespace)
curl -i -sS -X POST "$BASE/api/chat/mcp/manage_istio_config_read" "${AUTH[@]}" \
  -d '{"action":"list","namespace":"istio-system","clusterName":"Kubernetes"}'

# 11) manage_istio_config_read (get)
curl -i -sS -X POST "$BASE/api/chat/mcp/manage_istio_config_read" "${AUTH[@]}" \
  -d '{"action":"get","namespace":"istio-system","group":"networking.istio.io","version":"v1","kind":"VirtualService","object":"ratings","clusterName":"Kubernetes"}'

# 12) manage_istio_config (preview create)
curl -i -sS -X POST "$BASE/api/chat/mcp/manage_istio_config" "${AUTH[@]}" \
  -d '{"action":"create","confirmed":false,"namespace":"istio-system","group":"networking.istio.io","version":"v1","kind":"VirtualService","object":"ratings-vs","data":"{\"apiVersion\":\"networking.istio.io/v1\",\"kind\":\"VirtualService\",\"metadata\":{\"name\":\"ratings-vs\",\"namespace\":\"istio-system\"},\"spec\":{\"hosts\":[\"ratings\"]}}","clusterName":"Kubernetes"}'

# 13) get_action_ui (single namespace + resource)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_action_ui" "${AUTH[@]}" \
  -d '{"resourceType":"workload","namespaces":"istio-system","resourceName":"ratings-v1","tab":"logs","clusterName":"Kubernetes"}'

# 14) get_action_ui (list view with invalid namespace)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_action_ui" "${AUTH[@]}" \
  -d '{"resourceType":"service","namespaces":"istio-system","clusterName":"Kubernetes"}'

# 15) get_mesh_status (with restricted token this should be non-200)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_mesh_status" "${AUTH[@]}" \
  -d '{"clusterName":"Kubernetes"}'

# ============================================================
# VALID NS: bookinfo
# ============================================================

# 16) get_mesh_traffic_graph
curl -i -sS -X POST "$BASE/api/chat/mcp/get_mesh_traffic_graph" "${AUTH[@]}" \
  -d '{"namespaces":"bookinfo","graphType":"versionedApp","clusterName":"Kubernetes"}'

# 17) list_or_get_resources (services list)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"service","namespaces":"bookinfo","clusterName":"Kubernetes"}'

# 18) list_or_get_resources (service details: ratings)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"service","namespaces":"bookinfo","resource_name":"ratings","clusterName":"Kubernetes"}'

# 19) list_or_get_resources (workload details: ratings-v1)
curl -i -sS -X POST "$BASE/api/chat/mcp/list_or_get_resources" "${AUTH[@]}" \
  -d '{"resource_type":"workload","namespaces":"bookinfo","resource_name":"ratings-v1","clusterName":"Kubernetes"}'

# 20) list_traces
curl -i -sS -X POST "$BASE/api/chat/mcp/list_traces" "${AUTH[@]}" \
  -d '{"namespace":"bookinfo","serviceName":"ratings","clusterName":"Kubernetes"}'

# 21) get_logs
curl -i -sS -X POST "$BASE/api/chat/mcp/get_logs" "${AUTH[@]}" \
  -d '{"namespace":"bookinfo","name":"ratings-v1","clusterName":"Kubernetes"}'

# 22) get_pod_performance
curl -i -sS -X POST "$BASE/api/chat/mcp/get_pod_performance" "${AUTH[@]}" \
  -d '{"namespace":"bookinfo","workloadName":"ratings-v1","clusterName":"Kubernetes"}'

# 23) get_metrics (service)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_metrics" "${AUTH[@]}" \
  -d '{"resourceType":"service","namespace":"bookinfo","resourceName":"ratings","clusterName":"Kubernetes"}'

# 24) get_metrics (workload)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_metrics" "${AUTH[@]}" \
  -d '{"resourceType":"workload","namespace":"bookinfo","resourceName":"ratings-v1","clusterName":"Kubernetes"}'

# 25) manage_istio_config_read (list)
curl -i -sS -X POST "$BASE/api/chat/mcp/manage_istio_config_read" "${AUTH[@]}" \
  -d '{"action":"list","namespace":"bookinfo","clusterName":"Kubernetes"}'

# 26) get_action_ui (service details)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_action_ui" "${AUTH[@]}" \
  -d '{"resourceType":"service","namespaces":"bookinfo","resourceName":"ratings","tab":"metrics","clusterName":"Kubernetes"}'

# 27) get_action_ui (workload details)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_action_ui" "${AUTH[@]}" \
  -d '{"resourceType":"workload","namespaces":"bookinfo","resourceName":"ratings-v1","tab":"logs","clusterName":"Kubernetes"}'

# 28) get_mesh_status
curl -i -sS -X POST "$BASE/api/chat/mcp/get_mesh_status" "${AUTH[@]}" \
  -d '{"clusterName":"Kubernetes"}'

# ============================================================
# MIXED CASES (useful for warnings + partial success)
# ============================================================

# 29) graph mixed namespaces (expected 200 + errors.namespaces warning)
curl -i -sS -X POST "$BASE/api/chat/mcp/get_mesh_traffic_graph" "${AUTH[@]}" \
  -d '{"namespaces":"bookinfo,istio-system","graphType":"versionedApp","clusterName":"Kubernetes"}'
# 30) get_action_ui with mixed namespaces list view
curl -i -sS -X POST "$BASE/api/chat/mcp/get_action_ui" "${AUTH[@]}" \
  -d '{"resourceType":"service","namespaces":"bookinfo,istio-system","clusterName":"Kubernetes"}'
```

### Automation testing

Tests updated

### Issue reference

Fixes https://github.com/kiali/kiali/issues/9582
