### PR TITLE
Disable MCP contract tests in CI

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -188,14 +188,14 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  mcp_contract_tests:
-    name: MCP Contract Tests (kubernetes-mcp-server)
-    uses: ./.github/workflows/mcp-contract-tests.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
-      istio_version: ""
+  # mcp_contract_tests:
+  #   name: MCP Contract Tests (kubernetes-mcp-server)
+  #   uses: ./.github/workflows/mcp-contract-tests.yml
+  #   needs: [initialize, build_backend]
+  #   with:
+  #     target_branch: ${{ needs.initialize.outputs.target-branch }}
+  #     build_branch: ${{ needs.initialize.outputs.build-branch }}
+  #     istio_version: ""
 
   store_pr_metadata:
     name: Store PR metadata


### PR DESCRIPTION
This change comments out the `mcp_contract_tests` job in `.github/workflows/kiali-ci.yml` so the kubernetes-mcp-server MCP contract tests are not run on every pull request.

Made with [Cursor](https://cursor.com)