### PR TITLE
[v2.4] Upgrade follow-redirects to 1.16.0

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9616,12 +9616,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Backport: Upgrades `follow-redirects` from 1.15.x to 1.16.0 to fix CVE-2026-40895
- `follow-redirects` prior to 1.16.0 forwards custom authentication headers to cross-domain redirect targets
- Transitive dependency — only `yarn.lock` is modified

## Test plan

- [x] `yarn install` completes successfully

Made with [Cursor](https://cursor.com)