### PR TITLE
[v2.4] Upgrade axios to 1.15.1+ to fix CVE-2026-42035

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "@patternfly/react-core": "^5.4.0",
     "@patternfly/react-table": "^5.4.0",
     "@patternfly/react-topology": "^5.4.1",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "bootstrap-slider-without-jquery": "10.0.0",
     "cy-node-html-label": "2.0.0",
     "cytoscape": "3.15.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3100,7 +3100,7 @@ __metadata:
     "@types/react-router-dom": "npm:^5.2.0"
     "@types/react-virtualized": "npm:9.x"
     "@wojtekmaj/enzyme-adapter-react-17": "npm:^0.6.7"
-    axios: "npm:^1.15.0"
+    axios: "npm:^1.15.1"
     axios-mock-adapter: "npm:^1.22.0"
     bootstrap-slider-without-jquery: "npm:10.0.0"
     cy-node-html-label: "npm:2.0.0"
@@ -5587,14 +5587,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.15.1":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Backport of #9611 to v2.4 (OSSM 3.0).
- Upgrades axios from ^1.15.0 to ^1.15.1 (resolves to 1.15.2) to fix CVE-2026-42035

## Test plan

- [x] yarn install succeeds


Made with [Cursor](https://cursor.com)