### PR TITLE
[AI] Update trace details and add test coverage

### DIFF
--- a/ai/mcp/get_trace_details/get_trace_details.go
+++ b/ai/mcp/get_trace_details/get_trace_details.go
@@ -2,15 +2,13 @@ package get_trace_details
 
 import (
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/models"
 	jaegerModels "github.com/kiali/kiali/tracing/jaeger/model/json"
 )
-
-var validTraceIDRe = regexp.MustCompile(`^[a-fA-F0-9]{1,32}$`)
 
 func Execute(
 	kialiInterface *mcputil.KialiInterface,
@@ -20,7 +18,7 @@ func Execute(
 	if traceID == "" {
 		return "trace_id is required", http.StatusBadRequest
 	}
-	if !validTraceIDRe.MatchString(traceID) {
+	if !models.ValidTraceIDRe.MatchString(traceID) {
 		return "Invalid trace_id format: must be 1-32 hex characters", http.StatusBadRequest
 	}
 

--- a/ai/mcp/get_trace_details/get_trace_details.go
+++ b/ai/mcp/get_trace_details/get_trace_details.go
@@ -2,12 +2,15 @@ package get_trace_details
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/kiali/kiali/ai/mcputil"
 	jaegerModels "github.com/kiali/kiali/tracing/jaeger/model/json"
 )
+
+var validTraceIDRe = regexp.MustCompile(`^[a-fA-F0-9]{1,32}$`)
 
 func Execute(
 	kialiInterface *mcputil.KialiInterface,
@@ -16,6 +19,9 @@ func Execute(
 	traceID := mcputil.GetStringArg(args, "trace_id", "traceId")
 	if traceID == "" {
 		return "trace_id is required", http.StatusBadRequest
+	}
+	if !validTraceIDRe.MatchString(traceID) {
+		return "Invalid trace_id format: must be 1-32 hex characters", http.StatusBadRequest
 	}
 
 	ctx := kialiInterface.Request.Context()

--- a/ai/mcp/get_trace_details/get_trace_details_test.go
+++ b/ai/mcp/get_trace_details/get_trace_details_test.go
@@ -1,13 +1,46 @@
 package get_trace_details
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tracing"
+	tracingModel "github.com/kiali/kiali/tracing/jaeger/model"
 	jaegerModels "github.com/kiali/kiali/tracing/jaeger/model/json"
 )
+
+type fakeTracingClient struct {
+	traceDetail *tracingModel.TracingSingleTrace
+	detailErr   error
+}
+
+func (f *fakeTracingClient) GetAppTraces(_ context.Context, _, _ string, _ models.TracingQuery) (*tracingModel.TracingResponse, error) {
+	return nil, nil
+}
+
+func (f *fakeTracingClient) GetTraceDetail(_ context.Context, _ string) (*tracingModel.TracingSingleTrace, error) {
+	return f.traceDetail, f.detailErr
+}
+
+func (f *fakeTracingClient) GetErrorTraces(_ context.Context, _, _ string, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeTracingClient) GetServiceStatus(_ context.Context) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeTracingClient) GetServices(_ context.Context) ([]string, error) {
+	return nil, nil
+}
 
 func TestExecute_Validation(t *testing.T) {
 	conf := config.NewConfig()
@@ -269,5 +302,153 @@ func TestGetParentSpanID(t *testing.T) {
 	s3 := &jaegerModels.Span{}
 	if getParentSpanID(s3) != "" {
 		t.Errorf("expected empty parent, got %s", getParentSpanID(s3))
+	}
+}
+
+func TestExecute_InvalidTraceIDFormat(t *testing.T) {
+	conf := config.NewConfig()
+	req, _ := http.NewRequest("GET", "/", nil)
+
+	cases := []struct {
+		name    string
+		traceID string
+	}{
+		{"non-hex characters", "xyz-not-hex!"},
+		{"too long", "aabbccddaabbccddaabbccddaabbccdda"},
+		{"spaces", "abc def"},
+		{"special characters", "'; DROP TABLE--"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := map[string]interface{}{"traceId": tc.traceID}
+			res, code := Execute(&mcputil.KialiInterface{Request: req, Conf: conf}, args)
+			if code != http.StatusBadRequest {
+				t.Errorf("expected 400 for traceId=%q, got %d", tc.traceID, code)
+			}
+			if s, ok := res.(string); !ok || s == "" {
+				t.Errorf("expected error message string, got %v", res)
+			}
+		})
+	}
+}
+
+func TestExecute_ValidTraceIDFormats(t *testing.T) {
+	cases := []string{
+		"a",
+		"abcdef0123456789",
+		"ABCDEF0123456789abcdef0123456789",
+	}
+	for _, id := range cases {
+		if !validTraceIDRe.MatchString(id) {
+			t.Errorf("expected valid trace ID %q to pass regex", id)
+		}
+	}
+}
+
+func newTestKialiInterface(t *testing.T, conf *config.Config, fake tracing.ClientInterface) *mcputil.KialiInterface {
+	t.Helper()
+	config.Set(conf)
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("bookinfo"))
+	layer := business.NewLayerBuilder(t, conf).
+		WithClient(k8s).
+		WithTraceLoader(func() tracing.ClientInterface { return fake }).
+		Build()
+	req, _ := http.NewRequest("GET", "/", nil)
+	return &mcputil.KialiInterface{
+		Request:       req,
+		BusinessLayer: layer,
+		Conf:          conf,
+	}
+}
+
+func TestExecute_BackendError_Returns503(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{detailErr: errors.New("tempo unavailable")}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{"traceId": "abcdef1234567890"}
+	res, code := Execute(ki, args)
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d: %v", code, res)
+	}
+}
+
+func TestExecute_TraceNotFound_Returns404(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{traceDetail: nil, detailErr: nil}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{"traceId": "abcdef1234567890"}
+	res, code := Execute(ki, args)
+	if code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %v", code, res)
+	}
+}
+
+func TestExecute_EmptySpansWithErrors_Returns404(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{
+		traceDetail: &tracingModel.TracingSingleTrace{
+			Data:   jaegerModels.Trace{Spans: []jaegerModels.Span{}},
+			Errors: []tracingModel.StructuredError{{Msg: "partial failure"}},
+		},
+	}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{"traceId": "abcdef1234567890"}
+	res, code := Execute(ki, args)
+	if code != http.StatusNotFound {
+		t.Errorf("expected 404 for empty spans with errors, got %d: %v", code, res)
+	}
+}
+
+func TestExecute_ValidTrace_Returns200WithHierarchy(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{
+		traceDetail: &tracingModel.TracingSingleTrace{
+			Data: jaegerModels.Trace{
+				Processes: map[jaegerModels.ProcessID]jaegerModels.Process{
+					"p1": {ServiceName: "productpage"},
+				},
+				Spans: []jaegerModels.Span{
+					{
+						SpanID:        "s1",
+						OperationName: "GET /",
+						ProcessID:     "p1",
+						StartTime:     1000,
+						Duration:      5000,
+						Tags:          []jaegerModels.KeyValue{{Key: "http.status_code", Type: "string", Value: "200"}},
+					},
+				},
+			},
+		},
+	}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{"traceId": "abcdef1234567890"}
+	res, code := Execute(ki, args)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %v", code, res)
+	}
+	resp, ok := res.(GetTraceDetailResponse)
+	if !ok {
+		t.Fatalf("expected GetTraceDetailResponse, got %T", res)
+	}
+	if resp.TraceID != "abcdef1234567890" {
+		t.Errorf("expected trace_id=abcdef1234567890, got %s", resp.TraceID)
+	}
+	if resp.Hierarchy == nil {
+		t.Fatal("expected non-nil hierarchy")
+	}
+	if resp.Hierarchy.Service != "productpage" {
+		t.Errorf("expected root service=productpage, got %s", resp.Hierarchy.Service)
 	}
 }

--- a/ai/mcp/get_trace_details/get_trace_details_test.go
+++ b/ai/mcp/get_trace_details/get_trace_details_test.go
@@ -339,7 +339,7 @@ func TestExecute_ValidTraceIDFormats(t *testing.T) {
 		"ABCDEF0123456789abcdef0123456789",
 	}
 	for _, id := range cases {
-		if !validTraceIDRe.MatchString(id) {
+		if !models.ValidTraceIDRe.MatchString(id) {
 			t.Errorf("expected valid trace ID %q to pass regex", id)
 		}
 	}

--- a/ai/mcp/list_traces/list_traces.go
+++ b/ai/mcp/list_traces/list_traces.go
@@ -143,8 +143,8 @@ func parseArgs(args map[string]interface{}, conf *config.Config) GetTracesArgs {
 	out.ErrorOnly = mcputil.AsBoolFromArgs(args, "errorOnly", "error_only")
 
 	out.Limit = mcputil.AsIntOrDefault(args, mcputil.DefaultTracesLimit, "limit")
-	if out.Limit > mcputil.MaxTracesLimit {
-		out.Limit = mcputil.MaxTracesLimit
+	if out.Limit > models.MaxTracingLimit {
+		out.Limit = models.MaxTracingLimit
 	}
 	out.LookbackSeconds = mcputil.AsIntOrDefault(args, mcputil.DefaultLookbackSeconds, "lookback_seconds", "lookbackSeconds")
 

--- a/ai/mcp/list_traces/list_traces.go
+++ b/ai/mcp/list_traces/list_traces.go
@@ -143,6 +143,9 @@ func parseArgs(args map[string]interface{}, conf *config.Config) GetTracesArgs {
 	out.ErrorOnly = mcputil.AsBoolFromArgs(args, "errorOnly", "error_only")
 
 	out.Limit = mcputil.AsIntOrDefault(args, mcputil.DefaultTracesLimit, "limit")
+	if out.Limit > mcputil.MaxTracesLimit {
+		out.Limit = mcputil.MaxTracesLimit
+	}
 	out.LookbackSeconds = mcputil.AsIntOrDefault(args, mcputil.DefaultLookbackSeconds, "lookback_seconds", "lookbackSeconds")
 
 	return out

--- a/ai/mcp/list_traces/list_traces_test.go
+++ b/ai/mcp/list_traces/list_traces_test.go
@@ -305,8 +305,8 @@ func TestParseArgs_LimitCap(t *testing.T) {
 	conf := config.NewConfig()
 	args := map[string]interface{}{"limit": 999999}
 	parsed := parseArgs(args, conf)
-	if parsed.Limit != mcputil.MaxTracesLimit {
-		t.Errorf("expected limit capped at %d, got %d", mcputil.MaxTracesLimit, parsed.Limit)
+	if parsed.Limit != models.MaxTracingLimit {
+		t.Errorf("expected limit capped at %d, got %d", models.MaxTracingLimit, parsed.Limit)
 	}
 }
 

--- a/ai/mcp/list_traces/list_traces_test.go
+++ b/ai/mcp/list_traces/list_traces_test.go
@@ -1,13 +1,72 @@
 package list_traces
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tracing"
+	tracingModel "github.com/kiali/kiali/tracing/jaeger/model"
 	jaegerModels "github.com/kiali/kiali/tracing/jaeger/model/json"
+	"github.com/kiali/kiali/util"
 )
+
+type fakeTracingClient struct {
+	appTraces   *tracingModel.TracingResponse
+	appErr      error
+	traceDetail *tracingModel.TracingSingleTrace
+	detailErr   error
+}
+
+func (f *fakeTracingClient) GetAppTraces(_ context.Context, _, _ string, _ models.TracingQuery) (*tracingModel.TracingResponse, error) {
+	return f.appTraces, f.appErr
+}
+
+func (f *fakeTracingClient) GetTraceDetail(_ context.Context, _ string) (*tracingModel.TracingSingleTrace, error) {
+	return f.traceDetail, f.detailErr
+}
+
+func (f *fakeTracingClient) GetErrorTraces(_ context.Context, _, _ string, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeTracingClient) GetServiceStatus(_ context.Context) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeTracingClient) GetServices(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func newTestKialiInterface(t *testing.T, conf *config.Config, fake tracing.ClientInterface, extraObjs ...runtime.Object) *mcputil.KialiInterface {
+	t.Helper()
+	util.Clock = util.RealClock{}
+	config.Set(conf)
+
+	objs := []runtime.Object{kubetest.FakeNamespace("bookinfo")}
+	objs = append(objs, extraObjs...)
+	k8s := kubetest.NewFakeK8sClient(objs...)
+
+	layer := business.NewLayerBuilder(t, conf).
+		WithClient(k8s).
+		WithTraceLoader(func() tracing.ClientInterface { return fake }).
+		Build()
+	req, _ := http.NewRequest("GET", "/", nil)
+	return &mcputil.KialiInterface{
+		Request:       req,
+		BusinessLayer: layer,
+		Conf:          conf,
+	}
+}
 
 func TestParseArgs_Defaults(t *testing.T) {
 	conf := config.NewConfig()
@@ -239,5 +298,139 @@ func TestTraceSummaryToListItem_EmptyNamespace(t *testing.T) {
 	// When namespace is empty we format as "service (Xms)" without ".namespace"
 	if item.SlowestService != "reviews (3.5ms)" {
 		t.Errorf("expected slowest_service without namespace suffix when namespace empty, got %q", item.SlowestService)
+	}
+}
+
+func TestParseArgs_LimitCap(t *testing.T) {
+	conf := config.NewConfig()
+	args := map[string]interface{}{"limit": 999999}
+	parsed := parseArgs(args, conf)
+	if parsed.Limit != mcputil.MaxTracesLimit {
+		t.Errorf("expected limit capped at %d, got %d", mcputil.MaxTracesLimit, parsed.Limit)
+	}
+}
+
+func TestParseArgs_LimitBelowCap(t *testing.T) {
+	conf := config.NewConfig()
+	args := map[string]interface{}{"limit": 50}
+	parsed := parseArgs(args, conf)
+	if parsed.Limit != 50 {
+		t.Errorf("expected limit 50, got %d", parsed.Limit)
+	}
+}
+
+func TestExecute_BackendError_Returns503(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{appErr: errors.New("connection refused")}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{
+		"namespace":   "bookinfo",
+		"serviceName": "ratings",
+	}
+	res, code := Execute(ki, args)
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d: %v", code, res)
+	}
+}
+
+func TestExecute_EmptyTraces_Returns200WithZero(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	fake := &fakeTracingClient{
+		appTraces: &tracingModel.TracingResponse{Data: nil},
+	}
+	svc := kubetest.FakeService("bookinfo", "ratings")
+	ki := newTestKialiInterface(t, conf, fake, &svc)
+
+	args := map[string]interface{}{
+		"namespace":   "bookinfo",
+		"serviceName": "ratings",
+	}
+	res, code := Execute(ki, args)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %v", code, res)
+	}
+	resp, ok := res.(GetTracesListResponse)
+	if !ok {
+		t.Fatalf("expected GetTracesListResponse, got %T", res)
+	}
+	if resp.Summary == nil || resp.Summary.TotalFound != 0 {
+		t.Errorf("expected total_found=0, got %+v", resp.Summary)
+	}
+}
+
+func TestExecute_WithTraces_Returns200WithSummary(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = true
+
+	sampleTrace := jaegerModels.Trace{
+		TraceID: "aabb",
+		Processes: map[jaegerModels.ProcessID]jaegerModels.Process{
+			"p1": {ServiceName: "ratings"},
+		},
+		Spans: []jaegerModels.Span{
+			{
+				SpanID:        "s1",
+				OperationName: "GET /ratings",
+				ProcessID:     "p1",
+				StartTime:     1000,
+				Duration:      5000,
+				Tags:          []jaegerModels.KeyValue{{Key: "http.status_code", Type: "string", Value: "200"}},
+			},
+		},
+	}
+
+	fake := &fakeTracingClient{
+		appTraces: &tracingModel.TracingResponse{
+			Data: []jaegerModels.Trace{sampleTrace},
+		},
+		traceDetail: &tracingModel.TracingSingleTrace{
+			Data: sampleTrace,
+		},
+	}
+	svc := kubetest.FakeService("bookinfo", "ratings")
+	ki := newTestKialiInterface(t, conf, fake, &svc)
+
+	args := map[string]interface{}{
+		"namespace":   "bookinfo",
+		"serviceName": "ratings",
+	}
+	res, code := Execute(ki, args)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %v", code, res)
+	}
+	resp, ok := res.(GetTracesListResponse)
+	if !ok {
+		t.Fatalf("expected GetTracesListResponse, got %T", res)
+	}
+	if resp.Summary == nil || resp.Summary.TotalFound != 1 {
+		t.Errorf("expected total_found=1, got %+v", resp.Summary)
+	}
+	if len(resp.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(resp.Traces))
+	}
+	if resp.Traces[0].SpansCount != 1 {
+		t.Errorf("expected spans_count=1, got %d", resp.Traces[0].SpansCount)
+	}
+}
+
+func TestExecute_TracingDisabled_Returns503(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ExternalServices.Tracing.Enabled = false
+
+	fake := &fakeTracingClient{}
+	ki := newTestKialiInterface(t, conf, fake)
+
+	args := map[string]interface{}{
+		"namespace":   "bookinfo",
+		"serviceName": "ratings",
+	}
+	_, code := Execute(ki, args)
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when tracing disabled, got %d", code)
 	}
 }

--- a/ai/mcputil/defaults.go
+++ b/ai/mcputil/defaults.go
@@ -33,4 +33,5 @@ const (
 	DefaultLookbackSeconds = 600 // 10m
 	DefaultMaxSpans        = 7
 	DefaultTracesLimit     = 10
+	MaxTracesLimit         = 10000
 )

--- a/ai/mcputil/defaults.go
+++ b/ai/mcputil/defaults.go
@@ -33,5 +33,4 @@ const (
 	DefaultLookbackSeconds = 600 // 10m
 	DefaultMaxSpans        = 7
 	DefaultTracesLimit     = 10
-	MaxTracesLimit         = 10000
 )

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -21,8 +20,6 @@ import (
 	"github.com/kiali/kiali/prometheus"
 	"github.com/kiali/kiali/tracing"
 )
-
-var validTraceIDRe = regexp.MustCompile(`^[a-fA-F0-9]{1,32}$`)
 
 // Get TracingInfo provides the Tracing URL and other info
 func GetTracingInfo(conf *config.Config) http.HandlerFunc {
@@ -211,7 +208,7 @@ func TraceDetails(
 		}
 		params := mux.Vars(r)
 		traceID := params["traceID"]
-		if !validTraceIDRe.MatchString(traceID) {
+		if !models.ValidTraceIDRe.MatchString(traceID) {
 			RespondWithError(w, http.StatusBadRequest, "Invalid trace ID format")
 			return
 		}
@@ -367,9 +364,8 @@ func readQuery(conf *config.Config, values url.Values) (models.TracingQuery, err
 			if num <= 0 {
 				return models.TracingQuery{}, fmt.Errorf("parameter 'limit' must be positive")
 			}
-			const maxTracingLimit = 10000
-			if num > maxTracingLimit {
-				num = maxTracingLimit
+			if num > models.MaxTracingLimit {
+				num = models.MaxTracingLimit
 			}
 			q.Limit = num
 		} else {

--- a/models/tracing.go
+++ b/models/tracing.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/kiali/kiali/config"
@@ -8,7 +9,13 @@ import (
 
 const (
 	IstioClusterTag string = "istio.cluster_id"
+
+	// MaxTracingLimit is the upper bound for trace query limit parameters.
+	MaxTracingLimit = 10000
 )
+
+// ValidTraceIDRe validates trace IDs: 1-32 hexadecimal characters (Jaeger/Tempo compatible).
+var ValidTraceIDRe = regexp.MustCompile(`^[a-fA-F0-9]{1,32}$`)
 
 type TracingInfo struct {
 	Enabled              bool               `json:"enabled"`


### PR DESCRIPTION
### Describe the change

- Added trace ID format validation matching the REST API's ^[a-fA-F0-9]{1,32}$ regex. Invalid IDs now return 400 instead of being passed unchecked to the tracing backend.

- Added MaxTracesLimit = 10000 constant, aligned with the REST API's cap in handlers/tracing.go.

- Added limit cap in parseArgs: if limit > MaxTracesLimit, it's clamped to 10000. This prevents arbitrarily large queries to the tracing backend.

Add test coverage: 

TestExecute_InvalidTraceIDFormat -- 4 subtests (non-hex, too long, spaces, special chars)
TestExecute_ValidTraceIDFormats -- verifies valid hex IDs pass the regex
TestExecute_BackendError_Returns503 -- mocked backend error returns 503
TestExecute_TraceNotFound_Returns404 -- nil trace returns 404
TestExecute_EmptySpansWithErrors_Returns404 -- empty spans + errors returns 404
TestExecute_ValidTrace_Returns200WithHierarchy -- full happy-path with hierarchy

TestParseArgs_LimitCap -- verifies limit is capped at 10000
TestParseArgs_LimitBelowCap -- verifies limits below cap are preserved
TestExecute_BackendError_Returns503 -- mocked connection error returns 503
TestExecute_EmptyTraces_Returns200WithZero -- empty result returns 200 with total_found: 0
TestExecute_WithTraces_Returns200WithSummary -- full happy-path with trace data
TestExecute_TracingDisabled_Returns503 -- disabled tracing returns 503

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/9368
