### PR TITLE
fix(istio_status): match component_status workloads via canonical app label preference

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
@@ -446,7 +444,16 @@ func (iss *IstioStatusService) getStatusOf(workloads []*models.Workload, cluster
 
 	// Map workloads there by app name
 	for _, workload := range workloads {
-		appLabel := labels.Set(workload.Labels).Get(config.IstioAppLabel)
+		// Resolve which label key identifies the app on this workload. Falls back through
+		// the canonical preference list ("service.istio.io/canonical-name", "app.kubernetes.io/name", "app"),
+		// or honors a custom IstioLabels.AppLabelName if configured. This lets component_status
+		// match workloads that use the modern "app.kubernetes.io/name" convention without
+		// requiring a legacy "app" label.
+		appLabelName, hasAppLabel := iss.conf.GetAppLabelName(workload.Labels)
+		if !hasAppLabel {
+			continue
+		}
+		appLabel := workload.Labels[appLabelName]
 		if appLabel == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

`business/istio_status.go`'s `getStatusOf` loop was hardcoded to read only the legacy `app=` label key when matching workloads against entries in `external_services.istio.component_status.components[]`:

```go
appLabel := labels.Set(workload.Labels).Get(config.IstioAppLabel)
```

The rest of the codebase (e.g. `business/apps.go:570`, `business/services.go:604/927`, every `graph/telemetry/istio/appender/*`) uses `Config.GetAppLabelName(labels)`, which consults the canonical preference list (`[service.istio.io/canonical-name, app.kubernetes.io/name, app]`) and respects any user-provided `IstioLabels.AppLabelName` / `VersionLabelName` override.

`getStatusOf` was the one site that missed this abstraction.

## Why this matters

Workloads that follow the [recommended Kubernetes labels convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) (`app.kubernetes.io/name=...`) and *don't* set the legacy `app=` label — which today includes nearly every modern upstream Helm chart, including Grafana's own [Mimir](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed), [Tempo](https://github.com/grafana/helm-charts/tree/main/charts/tempo-distributed), and the [Grafana chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana) — are silently reported as `Unreachable` / `NotFound` in Kiali's Cluster Status panel even when they're healthy and Kiali is happily querying them via the configured Prometheus URL.

This is especially surprising because the `IstioLabels.AppLabelName` config field looks like it should resolve this. It does work for app graphs, workloads listing, and tracing — but not for component_status, because of the hardcoded `IstioAppLabel` constant at the matching call site.

## The change

```diff
-		appLabel := labels.Set(workload.Labels).Get(config.IstioAppLabel)
+		appLabelName, hasAppLabel := iss.conf.GetAppLabelName(workload.Labels)
+		if !hasAppLabel {
+			continue
+		}
+		appLabel := workload.Labels[appLabelName]
 		if appLabel == "" {
 			continue
 		}
```

Plus removing the now-unused `k8s.io/apimachinery/pkg/labels` import.

## What this preserves

- **No new config knob** — uses the existing `IstioLabels.AppLabelName`, which was already documented and respected elsewhere.
- **Backwards compatibility** — workloads with only `app=...` (vanilla Istio sidecars, istiod, istio-ingressgateway) still match because `app` remains the last entry in the canonical preference list. All existing `business/istio_status_test.go` tests pass unchanged.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./business/ -count=1` — all tests pass (including `TestComponentRunning`, `TestComponentNotRunning`, `TestNonDefaults`, `TestCustomizedAppLabel`, `TestIstiodNotReady`, `TestDaemonSetComponent*`)
- [x] Manually verified against a Kiali 2.25.0 install pointed at a Grafana Mimir backend — before this change, the `prometheus` Cluster Status pill was perpetually orange/Unreachable; with the patch wired in, it correctly reflects the configured `mimir-nginx` workload's health.

I considered adding a regression test that constructs a workload with only `app.kubernetes.io/name=...` and verifies it matches a custom component, but the existing `business/...` test suite has a pre-existing one-time-init issue with the package-level `appLabelNames` slice (initialized on the first `config.Set` call and locked-in afterwards) that makes such a test order-dependent. Happy to address that as a follow-up if the maintainers would like coverage for this scenario.