### PR TITLE
Skip showing links from potential hallucinations of LLM.

### DIFF
--- a/ai/mcp/get_action_ui/get_action_ui.go
+++ b/ai/mcp/get_action_ui/get_action_ui.go
@@ -175,7 +175,12 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 			actions = append(actions, action...)
 		}
 	default:
-		if resourceName != "" && namespaces != "" && namespaces != "all" && !strings.Contains(namespaces, ",") {
+		if resourceName != "" {
+			if namespaces == "" || namespaces == "all" || strings.Contains(namespaces, ",") {
+				return GetActionUIResponse{
+					Errors: fmt.Sprintf("A single namespace is required to view %s %q details. Please specify the exact namespace.", resourceType, resourceName),
+				}, http.StatusOK
+			}
 			if errMsg := validateResourceExists(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, clusterName, namespaces, resourceType, resourceName); errMsg != "" {
 				return GetActionUIResponse{Errors: errMsg}, http.StatusOK
 			}

--- a/ai/mcp/get_action_ui/get_action_ui_test.go
+++ b/ai/mcp/get_action_ui/get_action_ui_test.go
@@ -243,6 +243,174 @@ func TestExecute(t *testing.T) {
 		assert.Empty(t, resp.Actions)
 		assert.Contains(t, resp.Errors, `Application "no-such-app" not found in namespace "bookinfo"`)
 	})
+
+	t.Run("Resource Detail With Empty Namespace Returns Error", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "service",
+			"resourceName": "productpage",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		assert.Empty(t, resp.Actions)
+		assert.Contains(t, resp.Errors, "A single namespace is required")
+		assert.Contains(t, resp.Errors, `"productpage"`)
+	})
+
+	t.Run("Resource Detail With All Namespaces Returns Error", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "workload",
+			"namespaces":   "all",
+			"resourceName": "details-v1",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		assert.Empty(t, resp.Actions)
+		assert.Contains(t, resp.Errors, "A single namespace is required")
+		assert.Contains(t, resp.Errors, `"details-v1"`)
+	})
+
+	t.Run("Resource Detail With Multiple Namespaces Returns Error", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "app",
+			"namespaces":   "bookinfo,istio-system",
+			"resourceName": "ratings",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		assert.Empty(t, resp.Actions)
+		assert.Contains(t, resp.Errors, "A single namespace is required")
+		assert.Contains(t, resp.Errors, `"ratings"`)
+	})
+
+	t.Run("Service List Action", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "service",
+			"namespaces":   "bookinfo",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View services List", resp.Actions[0].Title)
+		assert.Equal(t, "/services?namespaces=bookinfo", resp.Actions[0].Payload)
+	})
+
+	t.Run("App List Action", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "app",
+			"namespaces":   "bookinfo",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View applications List", resp.Actions[0].Title)
+		assert.Equal(t, "/applications?namespaces=bookinfo", resp.Actions[0].Payload)
+	})
+
+	t.Run("Service Details Default Tab", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "service",
+			"namespaces":   "bookinfo",
+			"resourceName": "productpage",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View service Details", resp.Actions[0].Title)
+		assert.Equal(t, "/namespaces/bookinfo/services/productpage?tab=info", resp.Actions[0].Payload)
+	})
+
+	t.Run("Namespaces Action", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "namespaces",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View Namespaces", resp.Actions[0].Title)
+		assert.Equal(t, "/namespaces", resp.Actions[0].Payload)
+	})
+
+	t.Run("Graph Action With Custom GraphType", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "graph",
+			"namespaces":   "bookinfo",
+			"graphType":    "app",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Contains(t, resp.Actions[0].Payload, "graphType=app")
+	})
+
+	t.Run("Graph Action With All Namespaces", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "graph",
+			"namespaces":   "all",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Contains(t, resp.Actions[0].Payload, "/graph/namespaces?namespaces=")
+		assert.Contains(t, resp.Actions[0].Title, "View Traffic Graph for :")
+	})
+
+	t.Run("Service List With All Namespaces", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "service",
+			"namespaces":   "all",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View services List", resp.Actions[0].Title)
+		assert.Equal(t, "/services", resp.Actions[0].Payload)
+	})
+
+	t.Run("Service List With Empty Namespace", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "service",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, "View services List", resp.Actions[0].Title)
+		assert.Equal(t, "/services", resp.Actions[0].Payload)
+	})
+
+	t.Run("Invalid Namespace In Multi-Namespace List Returns Error", func(t *testing.T) {
+		args := map[string]interface{}{
+			"resourceType": "workload",
+			"namespaces":   "bookinfo,does-not-exist",
+		}
+		req := httptest.NewRequest("GET", "http://kiali/api/ai/mcp/get_action_ui", nil)
+		res, status := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, Conf: conf}, args)
+		assert.Equal(t, http.StatusOK, status)
+		resp := res.(GetActionUIResponse)
+		assert.Empty(t, resp.Actions)
+		assert.Contains(t, resp.Errors, "does-not-exist")
+	})
 }
 
 func TestGetTabLabel(t *testing.T) {

--- a/frontend/src/components/ChatBot/ChatMessage/ChatMessage.tsx
+++ b/frontend/src/components/ChatBot/ChatMessage/ChatMessage.tsx
@@ -78,7 +78,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
       messageProps.loadingWord = 'Thinking...';
     }
 
-    const NavigationAction = actions && actions.filter(action => action.kind === 'navigation').length > 0;
+    const hasNavigationActions = actions != null && actions.some(action => action.kind === 'navigation');
     const FileAction = actions && actions.filter(action => action.kind === 'file').length > 0;
 
     const safeContent =
@@ -87,6 +87,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
       <ChatMessageMarkdown
         content={safeContent}
         codeBlockProps={message.codeBlockProps}
+        hasNavigationActions={hasNavigationActions}
         openLinkInNewTab={messageProps.openLinkInNewTab}
       />
     ) : null;
@@ -113,7 +114,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
         <Message {...safeMessage} {...messageProps} />
         {actions && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', margin: '0 0 1rem 5rem' }}>
-            {NavigationAction && (
+            {hasNavigationActions && (
               <div
                 style={{ display: 'flex', flexDirection: 'column', gap: '10px', margin: '0 0 1rem' }}
                 data-testid="chatbot-navigation-action"

--- a/frontend/src/components/ChatBot/ChatMessage/ChatMessageMarkdown.tsx
+++ b/frontend/src/components/ChatBot/ChatMessage/ChatMessageMarkdown.tsx
@@ -23,6 +23,7 @@ import { MessageProps } from '@patternfly/chatbot';
 type ChatMessageMarkdownProps = {
   codeBlockProps?: MessageProps['codeBlockProps'];
   content: string;
+  hasNavigationActions?: boolean;
   openLinkInNewTab?: boolean;
 };
 
@@ -154,6 +155,7 @@ const LinkMessage: React.FC<
 export const ChatMessageMarkdown: React.FC<ChatMessageMarkdownProps> = ({
   content,
   codeBlockProps,
+  hasNavigationActions = false,
   openLinkInNewTab = true
 }) => {
   if (!content) {
@@ -177,7 +179,9 @@ export const ChatMessageMarkdown: React.FC<ChatMessageMarkdownProps> = ({
     ul: (props: any) => <UnorderedListMessage {...props} />,
     ol: (props: any) => <OrderedListMessage {...props} />,
     li: (props: any) => <ListItemMessage {...props} />,
-    a: (props: any) => <LinkMessage openLinkInNewTab={openLinkInNewTab} {...props} />
+    a: hasNavigationActions
+      ? (props: any) => <span>{props.children}</span>
+      : (props: any) => <LinkMessage openLinkInNewTab={openLinkInNewTab} {...props} />
   };
 
   return (


### PR DESCRIPTION
### Describe the change

When a chatbot response includes navigation action buttons, any markdown links the LLM hallucinated in the text are rendered as plain text instead of clickable links, so broken URLs will not be shown as links, as we have corectly generated URL which include validations of objects existence. 

The initial issue was not seen for a while, but this solution is for being on a safe side.

Edit: Another potential issue with generated URL is caught when a glitch causes namespaces to be empty. So it will not take all namespaces when resource is provided.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

https://github.com/kiali/kiali/issues/9150
