### PR TITLE
Fix TypeError when clicking chart data points

### DIFF
--- a/frontend/src/components/Charts/ChartWithLegend.tsx
+++ b/frontend/src/components/Charts/ChartWithLegend.tsx
@@ -258,8 +258,10 @@ export class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extend
       // Victory data-level handlers receive (event, victoryProps) but the VCEvent
       // type only declares (event).  We cast to any to bridge the mismatch.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const dataClickHandler: any = (_evt: MouseEvent, victoryProps: { datum: RawOrBucket<O> }) => {
-        onClick(victoryProps.datum);
+      const dataClickHandler: any = (_evt: MouseEvent, victoryProps: { datum?: RawOrBucket<O> }) => {
+        if (victoryProps.datum) {
+          onClick(victoryProps.datum);
+        }
         return [];
       };
 

--- a/frontend/src/components/Charts/__tests__/ChartWithLegend.test.tsx
+++ b/frontend/src/components/Charts/__tests__/ChartWithLegend.test.tsx
@@ -71,15 +71,27 @@ jest.mock('regression', () => ({
 // eslint-disable-next-line import/first -- must import after jest.mock calls
 import { ChartWithLegend, CHART_LEGEND_GAP, LEGEND_HEIGHT, MIN_HEIGHT_YAXIS } from '../ChartWithLegend';
 
-const makeSeries = (names: string[]): VCLines<RichDataPoint> =>
-  names.map((name, idx) => ({
-    color: ['#06c', '#c00', '#0a0', '#f80'][idx % 4],
-    datapoints: [{ name, x: new Date('2025-01-01T00:00:00Z'), y: idx + 1, color: '#06c' }],
-    legendItem: {
-      name,
-      symbol: { fill: ['#06c', '#c00', '#0a0', '#f80'][idx % 4], type: 'circle' }
-    }
-  }));
+const COLORS = ['#06c', '#c00', '#0a0', '#f80'];
+
+const makeSeries = (names: string[], pointCount = 5): VCLines<RichDataPoint> =>
+  names.map((name, idx) => {
+    const color = COLORS[idx % COLORS.length];
+    const base = new Date('2025-01-01T00:00:00Z').getTime();
+    const step = 60_000; // 1 minute between points
+    return {
+      color,
+      datapoints: Array.from({ length: pointCount }, (_, i) => ({
+        name,
+        x: new Date(base + i * step),
+        y: 10 * (idx + 1) + Math.sin(i) * 5,
+        color
+      })),
+      legendItem: {
+        name,
+        symbol: { fill: color, type: 'circle' }
+      }
+    };
+  });
 
 describe('ChartWithLegend', () => {
   it('renders legend items for each series', () => {

--- a/frontend/src/components/Charts/__tests__/ChartWithLegend.test.tsx
+++ b/frontend/src/components/Charts/__tests__/ChartWithLegend.test.tsx
@@ -18,10 +18,17 @@ jest.mock('utils/VictoryChartsUtils', () => ({
   toBuckets: jest.fn()
 }));
 
+let lastChartEvents: any[] = [];
+
 jest.mock('@patternfly/react-charts/victory', () => {
   const React = require('react');
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const MockChart = (props: any) => React.createElement('div', { 'data-test': 'chart', ...props }, props.children);
+  const MockChart = (props: any) => {
+    // Capture events so click-handler tests can invoke them directly
+    const { events, ...rest } = props;
+    lastChartEvents = events || [];
+    return React.createElement('div', { 'data-test': 'chart', ...rest }, props.children);
+  };
   MockChart.displayName = 'Chart';
   return {
     Chart: MockChart,
@@ -239,6 +246,59 @@ describe('ChartWithLegend', () => {
 
     const toggleAfterFit = screen.getAllByRole('button').find(b => !(b.textContent || '').includes('Series'));
     expect(toggleAfterFit).toBeUndefined();
+  });
+
+  it('calls onClick when data click handler receives a valid datum', () => {
+    const data = makeSeries(['Series A']);
+    const onClickSpy = jest.fn();
+    render(
+      <ChartWithLegend
+        data={data}
+        unit="ops"
+        seriesComponent={<div />}
+        fill={false}
+        stroke={true}
+        onClick={onClickSpy}
+      />
+    );
+
+    expect(lastChartEvents).toHaveLength(1);
+
+    const handler = lastChartEvents[0].eventHandlers.onClick;
+    const datum = data[0].datapoints[0];
+    handler({}, { datum });
+
+    expect(onClickSpy).toHaveBeenCalledTimes(1);
+    expect(onClickSpy).toHaveBeenCalledWith(datum);
+  });
+
+  it('does not call onClick when data click handler receives undefined datum', () => {
+    const data = makeSeries(['Series A']);
+    const onClickSpy = jest.fn();
+    render(
+      <ChartWithLegend
+        data={data}
+        unit="ops"
+        seriesComponent={<div />}
+        fill={false}
+        stroke={true}
+        onClick={onClickSpy}
+      />
+    );
+
+    const handler = lastChartEvents[0].eventHandlers.onClick;
+    handler({}, { datum: undefined });
+
+    expect(onClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not register click events when onClick prop is not provided', () => {
+    const data = makeSeries(['Series A']);
+    render(
+      <ChartWithLegend data={data} unit="ops" seriesComponent={<div />} fill={false} stroke={true} />
+    );
+
+    expect(lastChartEvents).toHaveLength(0);
   });
 
   it('toggles legendExpanded state when toggle button is clicked', async () => {

--- a/frontend/src/mocks/handlers/utils.ts
+++ b/frontend/src/mocks/handlers/utils.ts
@@ -136,7 +136,6 @@ const generateRandomSeries = (
   metricName: string,
   baseValue: number,
   variance: number,
-  reporter: string,
   extraLabels?: Record<string, string>,
   stat?: string
 ): Array<Record<string, unknown>> => {
@@ -145,14 +144,13 @@ const generateRandomSeries = (
 
   return workloadNames.slice(0, count).map((wl, i) => ({
     datapoints: generateDatapoints(baseValue * (1 + i * 0.15), variance),
-    labels: { reporter, source_workload: wl, ...extraLabels },
+    labels: { source_workload: wl, ...extraLabels },
     name: metricName,
     ...(stat ? { stat } : {})
   }));
 };
 
 export const generateMockDashboard = (entityType: string, direction: string): Record<string, unknown> => {
-  const reporter = direction === 'inbound' ? 'destination' : 'source';
   const directionLabel = direction === 'inbound' ? 'Inbound' : 'Outbound';
 
   return {
@@ -162,18 +160,18 @@ export const generateMockDashboard = (entityType: string, direction: string): Re
         name: 'Request volume',
         unit: 'ops',
         spans: 3,
-        metrics: generateRandomSeries('request_count', 10, 5, reporter, {
+        metrics: generateRandomSeries('request_count', 10, 5, {
           request_protocol: 'http',
           response_code: '200'
         }),
-        chartType: 'area',
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'Request duration',
         unit: 'ms',
         spans: 3,
-        metrics: generateRandomSeries('request_duration_millis', 30, 10, reporter, {}, 'avg'),
+        metrics: generateRandomSeries('request_duration_millis', 30, 10, {}, 'avg'),
         chartType: 'line',
         xAxis: 'time'
       },
@@ -181,80 +179,80 @@ export const generateMockDashboard = (entityType: string, direction: string): Re
         name: 'Request size',
         unit: 'B',
         spans: 3,
-        metrics: generateRandomSeries('request_size', 360, 20, reporter, {}, 'avg'),
-        chartType: 'area',
+        metrics: generateRandomSeries('request_size', 360, 20, {}, 'avg'),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'Response size',
         unit: 'B',
         spans: 3,
-        metrics: generateRandomSeries('response_size', 190, 10, reporter, {}, 'avg'),
-        chartType: 'area',
+        metrics: generateRandomSeries('response_size', 190, 10, {}, 'avg'),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'Request throughput',
         unit: 'kbit/s',
         spans: 3,
-        metrics: generateRandomSeries('request_throughput', 900, 300, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('request_throughput', 900, 300),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'Response throughput',
         unit: 'bit/s',
         spans: 3,
-        metrics: generateRandomSeries('response_throughput', 450, 150, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('response_throughput', 450, 150),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'gRPC received',
         unit: 'msg/s',
         spans: 3,
-        metrics: generateRandomSeries('grpc_received', 5, 2, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('grpc_received', 5, 2),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'gRPC sent',
         unit: 'msg/s',
         spans: 3,
-        metrics: generateRandomSeries('grpc_sent', 5, 2, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('grpc_sent', 5, 2),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'TCP opened',
         unit: 'conn/s',
         spans: 3,
-        metrics: generateRandomSeries('tcp_opened', 0.3, 0.15, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('tcp_opened', 0.3, 0.15),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'TCP closed',
         unit: 'conn/s',
         spans: 3,
-        metrics: generateRandomSeries('tcp_closed', 0.3, 0.15, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('tcp_closed', 0.3, 0.15),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'TCP received',
         unit: 'bit/s',
         spans: 3,
-        metrics: generateRandomSeries('tcp_received', 80, 30, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('tcp_received', 80, 30),
+        chartType: 'line',
         xAxis: 'time'
       },
       {
         name: 'TCP sent',
         unit: 'bit/s',
         spans: 3,
-        metrics: generateRandomSeries('tcp_sent', 70, 25, reporter),
-        chartType: 'area',
+        metrics: generateRandomSeries('tcp_sent', 70, 25),
+        chartType: 'line',
         xAxis: 'time'
       }
     ],


### PR DESCRIPTION
## Summary
- Guard against `undefined` datum in the Victory data-level click handler in `ChartWithLegend`, which caused a `TypeError` when clicking chart areas where Victory fires the event without an associated data point
- Export `CHART_LEGEND_GAP` and fix the chart height unit test assertion to account for the gap between chart and legend
- Improve test mock data to use realistic multi-point line series instead of single-point data
- Update MSW mock dashboard charts to render as line charts without `reporter` labels, matching typical Kiali deployments

<img width="1604" height="802" alt="image" src="https://github.com/user-attachments/assets/3e20858d-6634-4572-9bdc-4d813e390022" />

Fixes #9624

## Test plan
- [x] Unit tests pass (`ChartWithLegend.test.tsx` — 11/11 passing)
- [ ] Verify clicking chart data points no longer throws TypeError
- [ ] Verify mock API charts render as line charts (not stacked area)

Made with [Cursor](https://cursor.com)