### PR TITLE
fix: debounce trace tooltip metrics fetch to reduce API load on hover

### DIFF
--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { pluralize } from '@patternfly/react-core';
-import {
-  ChartLabelProps,
-	ChartCursorFlyout
-} from '@patternfly/react-charts/victory';
+import { pluralize, Spinner } from '@patternfly/react-core';
+import { ChartLabelProps, ChartCursorFlyout } from '@patternfly/react-charts/victory';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiAppState } from 'store/Store';
 import { averageSpanDuration, reduceMetricsStats, StatsMatrix } from 'utils/tracing/TraceStats';
@@ -39,12 +36,12 @@ const leftStyle = kialiStyle({ width: '35%', height: '100%', float: 'left' });
 type LabelProps = ChartLabelProps & {
   isStatsMatrixComplete: boolean;
   provider?: string;
-  trace: JaegerTrace;
   statsMatrix?: StatsMatrix;
+  trace: JaegerTrace;
 };
 
-class TraceLabel extends React.Component<LabelProps> {
-  render() {
+export class TraceLabel extends React.Component<LabelProps> {
+  render(): JSX.Element {
     const left = flyoutMargin + (this.props.x || 0) - flyoutWidth / 2;
     const top = flyoutMargin + (this.props.y || 0) - flyoutHeight / 2;
     const avgSpanDuration = averageSpanDuration(this.props.trace);
@@ -56,7 +53,15 @@ class TraceLabel extends React.Component<LabelProps> {
           <div className={titleStyle}>{this.props.trace.traceName || '(Missing root span)'}</div>
           <br />
           <div className={contentStyle}>
-            <div className={leftStyle}>{hasStats ? renderTraceHeatMap(this.props.statsMatrix!, true) : 'n/a'}</div>
+            <div className={leftStyle}>
+              {hasStats ? (
+                renderTraceHeatMap(this.props.statsMatrix!, true)
+              ) : this.props.isStatsMatrixComplete ? (
+                'n/a'
+              ) : (
+                <Spinner size="sm" />
+              )}
+            </div>
             <div>
               {formatDuration(this.props.trace.duration)}
               <br />
@@ -71,7 +76,10 @@ class TraceLabel extends React.Component<LabelProps> {
   }
 }
 
-const mapStateToProps = (state: KialiAppState, props: any) => {
+const mapStateToProps = (
+  state: KialiAppState,
+  props: any
+): { isStatsMatrixComplete: boolean; statsMatrix: StatsMatrix } => {
   const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true);
   return {
     statsMatrix: matrix,
@@ -82,7 +90,7 @@ const mapStateToProps = (state: KialiAppState, props: any) => {
 const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 
 export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineInfo>> {
-  render() {
+  render(): JSX.Element | null {
     if (this.props.activePoints && this.props.activePoints.length > 0) {
       const trace = this.props.activePoints[0].trace;
       return (

--- a/frontend/src/components/TracingIntegration/TracingScatter.tsx
+++ b/frontend/src/components/TracingIntegration/TracingScatter.tsx
@@ -67,10 +67,11 @@ const emptyStyle = kialiStyle({
   textAlign: 'center'
 });
 
-class TracingScatterComponent extends React.Component<TracingScatterProps> {
+export class TracingScatterComponent extends React.Component<TracingScatterProps> {
   isLoading = false;
   nextToLoad?: JaegerTrace = undefined;
   seletedTraceMatched: number | undefined;
+  hoverTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
   constructor(props: TracingScatterProps) {
     super(props);
@@ -80,7 +81,7 @@ class TracingScatterComponent extends React.Component<TracingScatterProps> {
     }
   }
 
-  renderFetchEmpty = (title, msg): JSX.Element => {
+  renderFetchEmpty = (title: string, msg: string): JSX.Element => {
     return (
       <div className={emptyStyle}>
         <EmptyState headingLevel="h5" titleText={<>{title}</>} variant={EmptyStateVariant.sm} data-test="empty-traces">
@@ -180,7 +181,12 @@ class TracingScatterComponent extends React.Component<TracingScatterProps> {
     );
   }
 
+  componentWillUnmount(): void {
+    clearTimeout(this.hoverTimer);
+  }
+
   private onTooltipClose = (trace?: JaegerTrace): void => {
+    clearTimeout(this.hoverTimer);
     // cancel loading the stats if we've moused out of the trace before we started loading
     if (trace === this.nextToLoad) {
       this.nextToLoad = undefined;
@@ -215,12 +221,15 @@ class TracingScatterComponent extends React.Component<TracingScatterProps> {
     if (!trace) {
       return;
     }
-    if (this.isLoading) {
-      // replace any pending load with a load for the currently hovered trace
-      this.nextToLoad = trace;
-    } else {
-      this.loadTraceTooltipMetrics(trace);
-    }
+    clearTimeout(this.hoverTimer);
+    this.hoverTimer = setTimeout(() => {
+      if (this.isLoading) {
+        // replace any pending load with a load for the currently hovered trace
+        this.nextToLoad = trace;
+      } else {
+        this.loadTraceTooltipMetrics(trace);
+      }
+    }, 400);
   };
 }
 

--- a/frontend/src/components/TracingIntegration/__tests__/TraceTooltip.test.tsx
+++ b/frontend/src/components/TracingIntegration/__tests__/TraceTooltip.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Spinner } from '@patternfly/react-core';
+
+jest.mock('@patternfly/react-charts/victory', () => ({
+  ChartCursorFlyout: () => null
+}));
+
+jest.mock('store/Store', () => ({}));
+
+jest.mock('utils/tracing/TraceStats', () => ({
+  averageSpanDuration: () => 100000,
+  reduceMetricsStats: jest.fn()
+}));
+
+jest.mock('../TracingResults/StatsComparison', () => ({
+  renderTraceHeatMap: () => require('react').createElement('div', { 'data-testid': 'heatmap' })
+}));
+
+jest.mock('components/Charts/CustomTooltip', () => ({
+  HookedChartTooltip: () => null
+}));
+
+// eslint-disable-next-line import/first
+import { TraceLabel } from '../TraceTooltip';
+// eslint-disable-next-line import/first
+import { JaegerTrace } from 'types/TracingInfo';
+// eslint-disable-next-line import/first
+import { StatsMatrix } from 'utils/tracing/TraceStats';
+
+const makeTrace = (): JaegerTrace =>
+  (({
+    traceID: 'abc123',
+    traceName: 'test-trace',
+    spans: [],
+    duration: 5000000,
+    startTime: Date.now() * 1000,
+    endTime: Date.now() * 1000 + 5000000,
+    services: [],
+    processes: {}
+  } as unknown) as JaegerTrace);
+
+const makeMatrix = (withValues: boolean): StatsMatrix => {
+  const matrix: (number | undefined)[][] = [
+    [undefined, undefined],
+    [undefined, undefined]
+  ];
+  if (withValues) {
+    matrix[0][0] = 1.5;
+  }
+  return matrix;
+};
+
+const renderLabel = (statsMatrix: StatsMatrix, isStatsMatrixComplete: boolean): ShallowWrapper =>
+  shallow(
+    <TraceLabel
+      trace={makeTrace()}
+      statsMatrix={statsMatrix}
+      isStatsMatrixComplete={isStatsMatrixComplete}
+      x={100}
+      y={100}
+    />
+  );
+
+describe('TraceLabel heatmap column rendering', () => {
+  it('renders the heatmap when stats are available', () => {
+    const wrapper = renderLabel(makeMatrix(true), true);
+
+    expect(wrapper.find('[data-testid="heatmap"]')).toHaveLength(1);
+    expect(wrapper.find(Spinner)).toHaveLength(0);
+  });
+
+  it('renders a spinner while stats are pending for a trace with Envoy spans', () => {
+    const wrapper = renderLabel(makeMatrix(false), false);
+
+    expect(wrapper.find(Spinner)).toHaveLength(1);
+    expect(wrapper.find('[data-testid="heatmap"]')).toHaveLength(0);
+  });
+
+  it('renders n/a when the trace has no Envoy spans and stats will never arrive', () => {
+    const wrapper = renderLabel(makeMatrix(false), true);
+
+    expect(wrapper.text()).toContain('n/a');
+    expect(wrapper.find(Spinner)).toHaveLength(0);
+    expect(wrapper.find('[data-testid="heatmap"]')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/TracingIntegration/__tests__/TracingScatter.test.tsx
+++ b/frontend/src/components/TracingIntegration/__tests__/TracingScatter.test.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+jest.mock('@patternfly/react-charts/victory', () => ({
+  ChartScatter: () => null
+}));
+
+jest.mock('store/Store', () => ({}));
+
+jest.mock('store/Selectors', () => ({
+  durationSelector: () => 600
+}));
+
+jest.mock('actions/MetricsStatsThunkActions', () => ({
+  MetricsStatsThunkActions: { load: jest.fn() }
+}));
+
+jest.mock('actions/TracingThunkActions', () => ({
+  TracingThunkActions: { setTraceId: jest.fn() }
+}));
+
+jest.mock('app/History', () => ({
+  HistoryManager: { getParam: () => undefined },
+  URLParam: { TRACING_TRACE_ID: 'traceId' }
+}));
+
+jest.mock('utils/tracing/TraceStats', () => ({
+  averageSpanDuration: () => undefined,
+  buildQueriesFromSpans: () => []
+}));
+
+jest.mock('components/Charts/ChartWithLegend', () => ({
+  ChartWithLegend: () => null
+}));
+
+jest.mock('../TraceTooltip', () => ({
+  TraceTooltip: () => null
+}));
+
+// eslint-disable-next-line import/first
+import { TracingScatterComponent } from '../TracingScatter';
+// eslint-disable-next-line import/first
+import { JaegerTrace } from 'types/TracingInfo';
+
+const makeTrace = (id = 'abc123'): JaegerTrace =>
+  (({
+    traceID: id,
+    traceName: 'test-trace',
+    spans: [],
+    duration: 5000000,
+    startTime: Date.now() * 1000,
+    endTime: Date.now() * 1000 + 5000000,
+    services: [],
+    processes: {}
+  } as unknown) as JaegerTrace);
+
+const makeProps = (
+  overrides: object = {}
+): {
+  duration: number;
+  loadMetricsStats: jest.Mock<any>;
+  setTraceId: jest.Mock<any>;
+  showSpansAverage: boolean;
+  traces: JaegerTrace[];
+} => ({
+  duration: 600,
+  loadMetricsStats: jest.fn().mockResolvedValue(undefined),
+  setTraceId: jest.fn(),
+  showSpansAverage: false,
+  traces: [],
+  ...overrides
+});
+
+describe('TracingScatterComponent debounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not call loadMetricsStats before 400ms have elapsed', () => {
+    const props = makeProps();
+    const wrapper = shallow(<TracingScatterComponent {...(props as any)} />);
+    const instance = wrapper.instance() as any;
+
+    instance.onTooltipOpen(makeTrace());
+    jest.advanceTimersByTime(399);
+
+    expect(props.loadMetricsStats).not.toHaveBeenCalled();
+  });
+
+  it('calls loadMetricsStats after 400ms of sustained hover', () => {
+    const props = makeProps();
+    const wrapper = shallow(<TracingScatterComponent {...(props as any)} />);
+    const instance = wrapper.instance() as any;
+
+    instance.onTooltipOpen(makeTrace());
+    jest.advanceTimersByTime(400);
+
+    expect(props.loadMetricsStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call loadMetricsStats when mouse leaves before 400ms', () => {
+    const props = makeProps();
+    const wrapper = shallow(<TracingScatterComponent {...(props as any)} />);
+    const instance = wrapper.instance() as any;
+
+    const trace = makeTrace();
+    instance.onTooltipOpen(trace);
+    jest.advanceTimersByTime(200);
+    instance.onTooltipClose(trace);
+    jest.advanceTimersByTime(400);
+
+    expect(props.loadMetricsStats).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadMetricsStats when component unmounts before 400ms', () => {
+    const props = makeProps();
+    const wrapper = shallow(<TracingScatterComponent {...(props as any)} />);
+    const instance = wrapper.instance() as any;
+
+    instance.onTooltipOpen(makeTrace());
+    jest.advanceTimersByTime(200);
+    wrapper.unmount();
+    jest.advanceTimersByTime(400);
+
+    expect(props.loadMetricsStats).not.toHaveBeenCalled();
+  });
+
+  it('queues the second trace rather than firing a concurrent request when one is already in flight', () => {
+    const neverResolves = new Promise<void>(() => {});
+    const loadMetricsStats = jest.fn().mockReturnValue(neverResolves);
+    const props = makeProps({ loadMetricsStats });
+    const wrapper = shallow(<TracingScatterComponent {...(props as any)} />);
+    const instance = wrapper.instance() as any;
+
+    const trace1 = makeTrace('trace-1');
+    const trace2 = makeTrace('trace-2');
+
+    instance.onTooltipOpen(trace1);
+    jest.advanceTimersByTime(400);
+    expect(loadMetricsStats).toHaveBeenCalledTimes(1);
+
+    instance.onTooltipOpen(trace2);
+    jest.advanceTimersByTime(400);
+    expect(loadMetricsStats).toHaveBeenCalledTimes(1);
+    expect(instance.nextToLoad).toBe(trace2);
+  });
+});


### PR DESCRIPTION
On the Traces tab scatter plot, hovering over any dot immediately fired an API request to fetch metrics stats for the heatmap. Rapidly mousing across many dots caused a burst of concurrent requests and Redux re-renders, degrading performance with large tracing datasets.

Introduce a 400ms debounce on tooltip hover: the tooltip appears immediately, showing trace name, duration, and span count. The compact heatmap in the left column is replaced with a PatternFly Spinner while stats are pending for traces with Envoy spans, and shows "n/a" for traces with no Envoy spans (where stats will never arrive). After 400ms of sustained hover the metrics stats request fires and the heatmap renders in place. Mousing away before 400ms cancels the timer entirely, producing no API call. A componentWillUnmount guard prevents the timer from firing on an unmounted component if the user navigates away.

Unit tests are added for both the debounce behavior (TracingScatter) and the three-state heatmap column rendering (TraceLabel).

Fixes: https://github.com/kiali/kiali/issues/6915