### PR TITLE
Fix trace tab styles

### DIFF
--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -13,19 +13,19 @@ import { HookedChartTooltip, HookedTooltipProps } from 'components/Charts/Custom
 import { formatDuration } from 'utils/tracing/TracingHelper';
 
 const flyoutWidth = 300;
-const flyoutHeight = 160;
-const flyoutMargin = 10;
+const flyoutHeight = 100;
+const flyoutMargin = 5;
 const innerWidth = flyoutWidth - 2 * flyoutMargin;
 const innerHeight = flyoutHeight - 2 * flyoutMargin;
 
 const tooltipStyle = kialiStyle({
   color: PFColors.ColorLight100,
-  backgroundColor: PFColors.Color100,
-  borderRadius: '4px',
-  padding: '10px',
+  backgroundColor: 'transparent',
+  borderRadius: '0.25rem',
+  padding: '0.625rem',
   width: innerWidth,
   height: innerHeight,
-  fontSize: '12px',
+  fontSize: '0.75rem',
   lineHeight: '1.4'
 });
 
@@ -34,7 +34,7 @@ const titleStyle = kialiStyle({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   fontWeight: 'bold',
-  marginBottom: '8px'
+  marginBottom: '0.5rem'
 });
 
 const contentStyle = kialiStyle({
@@ -44,7 +44,7 @@ const contentStyle = kialiStyle({
 
 const leftStyle = kialiStyle({
   width: '80px',
-  marginRight: '12px',
+  marginRight: '0.75rem',
   flexShrink: 0
 });
 
@@ -108,26 +108,33 @@ const mapStateToProps = (
 
 const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 
+type FlyoutOrientation = 'top' | 'bottom' | 'left' | 'right';
+type FlyoutOrientationProps = Pick<ChartLabelProps, 'x' | 'y' | 'width'>;
+
+export const computeFlyoutOrientation = (props: FlyoutOrientationProps): FlyoutOrientation => {
+  const x = typeof props.x === 'number' ? props.x : 0;
+  const y = typeof props.y === 'number' ? props.y : 0;
+  const width = typeof props.width === 'number' ? props.width : 0;
+
+  const horizontalMargin = flyoutWidth / 2 + flyoutMargin;
+  const verticalMargin = flyoutHeight / 2 + flyoutMargin;
+
+  if (x <= horizontalMargin) {
+    return 'right';
+  }
+  if (width > 0 && x >= width - horizontalMargin) {
+    return 'left';
+  }
+  if (y <= verticalMargin) {
+    return 'bottom';
+  }
+  return 'top';
+};
+
 export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineInfo>> {
-  private getOrientation = (props: any): 'top' | 'bottom' | 'left' | 'right' => {
-    const x = props.x || 0;
-    const y = props.y || 0;
-    const width = typeof props.width === 'number' ? props.width : 0;
-
-    const horizontalMargin = flyoutWidth / 2 + flyoutMargin;
-    const verticalMargin = flyoutHeight / 2 + flyoutMargin;
-
-    if (x < horizontalMargin) {
-      return 'right';
-    }
-    if (width > 0 && x > width - horizontalMargin) {
-      return 'left';
-    }
-    if (y < verticalMargin) {
-      return 'bottom';
-    }
-    return 'top';
-  };
+  // Victory passes callback args that are broader than ChartLabelProps.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getOrientation = (props: any): FlyoutOrientation => computeFlyoutOrientation(props);
 
   render(): JSX.Element | null {
     if (this.props.activePoints && this.props.activePoints.length > 0) {
@@ -139,7 +146,7 @@ export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineI
           flyoutWidth={flyoutWidth}
           flyoutHeight={flyoutHeight}
           orientation={this.getOrientation}
-          flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.9 }} />}
+          flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6, pointerEvents: 'none' }} />}
           labelComponent={<TraceLabelContainer trace={trace} />}
         />
       );

--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -109,14 +109,36 @@ const mapStateToProps = (
 const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 
 export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineInfo>> {
+  private getOrientation = (props: any): 'top' | 'bottom' | 'left' | 'right' => {
+    const x = props.x || 0;
+    const y = props.y || 0;
+    const width = typeof props.width === 'number' ? props.width : 0;
+
+    const horizontalMargin = flyoutWidth / 2 + flyoutMargin;
+    const verticalMargin = flyoutHeight / 2 + flyoutMargin;
+
+    if (x < horizontalMargin) {
+      return 'right';
+    }
+    if (width > 0 && x > width - horizontalMargin) {
+      return 'left';
+    }
+    if (y < verticalMargin) {
+      return 'bottom';
+    }
+    return 'top';
+  };
+
   render(): JSX.Element | null {
     if (this.props.activePoints && this.props.activePoints.length > 0) {
       const trace = this.props.activePoints[0].trace;
       return (
         <HookedChartTooltip
           {...this.props}
+          constrainToVisibleArea={false}
           flyoutWidth={flyoutWidth}
           flyoutHeight={flyoutHeight}
+          orientation={this.getOrientation}
           flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.9 }} />}
           labelComponent={<TraceLabelContainer trace={trace} />}
         />

--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -12,26 +12,45 @@ import { PFColors } from 'components/Pf/PfColors';
 import { HookedChartTooltip, HookedTooltipProps } from 'components/Charts/CustomTooltip';
 import { formatDuration } from 'utils/tracing/TracingHelper';
 
-const flyoutWidth = 280;
-const flyoutHeight = 130;
+const flyoutWidth = 300;
+const flyoutHeight = 160;
 const flyoutMargin = 10;
 const innerWidth = flyoutWidth - 2 * flyoutMargin;
 const innerHeight = flyoutHeight - 2 * flyoutMargin;
 
 const tooltipStyle = kialiStyle({
   color: PFColors.ColorLight100,
+  backgroundColor: PFColors.Color100,
+  borderRadius: '4px',
+  padding: '10px',
   width: innerWidth,
-  height: innerHeight
+  height: innerHeight,
+  fontSize: '12px',
+  lineHeight: '1.4'
 });
 
 const titleStyle = kialiStyle({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
-  textOverflow: 'ellipsis'
+  textOverflow: 'ellipsis',
+  fontWeight: 'bold',
+  marginBottom: '8px'
 });
 
-const contentStyle = kialiStyle({ width: '100%', height: '100%' });
-const leftStyle = kialiStyle({ width: '35%', height: '100%', float: 'left' });
+const contentStyle = kialiStyle({
+  display: 'flex',
+  alignItems: 'center'
+});
+
+const leftStyle = kialiStyle({
+  width: '80px',
+  marginRight: '12px',
+  flexShrink: 0
+});
+
+const rightStyle = kialiStyle({
+  lineHeight: '1.6'
+});
 
 type LabelProps = ChartLabelProps & {
   isStatsMatrixComplete: boolean;
@@ -51,7 +70,6 @@ export class TraceLabel extends React.Component<LabelProps> {
       <foreignObject width={innerWidth} height={innerHeight} x={left} y={top}>
         <div className={tooltipStyle}>
           <div className={titleStyle}>{this.props.trace.traceName || '(Missing root span)'}</div>
-          <br />
           <div className={contentStyle}>
             <div className={leftStyle}>
               {hasStats ? (
@@ -62,12 +80,13 @@ export class TraceLabel extends React.Component<LabelProps> {
                 <Spinner size="sm" />
               )}
             </div>
-            <div>
-              {formatDuration(this.props.trace.duration)}
-              <br />
-              {`${pluralize(this.props.trace.spans.length, 'span')}, avg=${
-                avgSpanDuration ? formatDuration(avgSpanDuration) : 'n/a'
-              }`}
+            <div className={rightStyle}>
+              <div>{formatDuration(this.props.trace.duration)}</div>
+              <div>
+                {`${pluralize(this.props.trace.spans.length, 'span')}, avg=${
+                  avgSpanDuration ? formatDuration(avgSpanDuration) : 'n/a'
+                }`}
+              </div>
             </div>
           </div>
         </div>
@@ -98,7 +117,7 @@ export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineI
           {...this.props}
           flyoutWidth={flyoutWidth}
           flyoutHeight={flyoutHeight}
-          flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6 }} />}
+          flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.9 }} />}
           labelComponent={<TraceLabelContainer trace={trace} />}
         />
       );

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -44,9 +44,8 @@ import { GetTracingUrlProvider } from 'utils/tracing/UrlProviders';
 import { ExternalServiceInfo } from 'types/StatusState';
 import { retrieveTimeRange } from '../Time/TimeRangeHelper';
 import { isParentKiosk, kioskTracingAction } from '../Kiosk/KioskActions';
-import { classes } from 'typestyle';
 import { kialiStyle } from 'styles/StyleUtils';
-import { tabCardStyle, flexFillStyle } from 'styles/FlexStyles';
+import { tabCardStyle } from 'styles/FlexStyles';
 
 type ReduxProps = {
   externalServices: ExternalServiceInfo[];
@@ -87,7 +86,15 @@ const traceDetailsTab = 0;
 const spansDetailsTab = 1;
 
 const containerStyle = kialiStyle({
-  paddingRight: '0.5rem'
+  paddingRight: '0.5rem',
+  flex: 1,
+  overflowY: 'auto',
+  minHeight: 0,
+  $nest: {
+    '& svg': {
+      overflow: 'visible'
+    }
+  }
 });
 
 class TracesComp extends React.Component<TracesProps, TracesState> {
@@ -287,7 +294,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
     const tracingURL = this.getTracingUrl();
     return (
       <>
-        <div className={classes(flexFillStyle, containerStyle)}>
+        <div className={containerStyle}>
           <Card className={tabCardStyle}>
             <CardBody>
               <Toolbar style={{ padding: 0 }}>
@@ -358,11 +365,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
             </CardBody>
           </Card>
           {this.props.selectedTrace && (
-            <div
-              style={{
-                marginTop: 25
-              }}
-            >
+            <div style={{ marginTop: 25 }}>
               <div className={subTabStyle}>
                 <Tabs
                   id="trace-details"

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -86,15 +86,7 @@ const traceDetailsTab = 0;
 const spansDetailsTab = 1;
 
 const containerStyle = kialiStyle({
-  paddingRight: '0.5rem',
-  flex: 1,
-  overflowY: 'auto',
-  minHeight: 0,
-  $nest: {
-    '& svg': {
-      overflow: 'visible'
-    }
-  }
+  paddingRight: '0.5rem'
 });
 
 class TracesComp extends React.Component<TracesProps, TracesState> {

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -357,7 +357,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
             </CardBody>
           </Card>
           {this.props.selectedTrace && (
-            <div style={{ marginTop: 25 }}>
+            <div style={{ marginTop: '2rem' }}>
               <div className={subTabStyle}>
                 <Tabs
                   id="trace-details"

--- a/frontend/src/components/TracingIntegration/__tests__/TraceTooltip.test.tsx
+++ b/frontend/src/components/TracingIntegration/__tests__/TraceTooltip.test.tsx
@@ -21,7 +21,7 @@ jest.mock('components/Charts/CustomTooltip', () => ({
 }));
 
 // eslint-disable-next-line import/first
-import { TraceLabel } from '../TraceTooltip';
+import { computeFlyoutOrientation, TraceLabel } from '../TraceTooltip';
 // eslint-disable-next-line import/first
 import { JaegerTrace } from 'types/TracingInfo';
 // eslint-disable-next-line import/first
@@ -85,5 +85,19 @@ describe('TraceLabel heatmap column rendering', () => {
     expect(screen.getByText('n/a')).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     expect(screen.queryByTestId('heatmap')).not.toBeInTheDocument();
+  });
+});
+
+describe('computeFlyoutOrientation', () => {
+  it.each([
+    ['near left edge', { x: 100, y: 100, width: 500 }, 'right'],
+    ['left boundary equality', { x: 135, y: 100, width: 500 }, 'right'],
+    ['near right edge', { x: 400, y: 100, width: 500 }, 'left'],
+    ['right boundary equality', { x: 365, y: 100, width: 500 }, 'left'],
+    ['missing width skips right-edge check', { x: 400, y: 100, width: 0 }, 'top'],
+    ['near top edge', { x: 200, y: 55, width: 500 }, 'bottom'],
+    ['default placement', { x: 200, y: 100, width: 500 }, 'top']
+  ] as const)('returns %s', (_, props, expected) => {
+    expect(computeFlyoutOrientation(props)).toBe(expected);
   });
 });


### PR DESCRIPTION
### Describe the change

- Fix text in tracing tooltip
- Fix scroll in Scatter chart
- Fix tracing tooltip hidden issue in the scatter chart section. Changing position
<img width="1893" height="969" alt="image" src="https://github.com/user-attachments/assets/b7d495b0-3aba-4e3a-947e-31cce8490829" />

- Fix issue when click in "Span Details" made disapear the Scatter tooltip

<img width="1893" height="969" alt="image" src="https://github.com/user-attachments/assets/7b6040d5-6103-4aa9-a70a-c5f867f5e4e4" />

### Steps to test the PR

- Go to the traces tab and review fixed issues

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/9631
