### PR TITLE
[AI] Implement job to clean stale store data

### DIFF
--- a/.github/workflows/integration-tests-frontend-chat.yml
+++ b/.github/workflows/integration-tests-frontend-chat.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install frontend dependencies
       working-directory: ./frontend
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
 
     - name: Run frontend chat integration tests
       run: hack/run-integration-tests.sh --test-suite ai-chatbot --stern ${{ inputs.stern_logs }} $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -83,7 +83,7 @@ jobs:
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
   integration_tests_frontend_chat:
-    name: Run frontend integration tests
+    name: Run frontend AI integration tests
     uses: ./.github/workflows/integration-tests-frontend-chat.yml
     needs: [initialize, build_backend]
     with:
@@ -231,57 +231,57 @@ jobs:
     if: ${{ success() }}
     name: Merge & Upload Coverage to Codecov
     needs:
-      - integration_tests_backend
-      - integration_tests_backend_multicluster_external_controlplane
-      - test_backend
+    - integration_tests_backend
+    - integration_tests_backend_multicluster_external_controlplane
+    - test_backend
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
+    - name: Checkout repo
+      uses: actions/checkout@v6
 
-      # -------------------------------
-      # Download artifacts
-      # -------------------------------
-      - name: Download backend coverage
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-backend
-          path: coverage
+    # -------------------------------
+    # Download artifacts
+    # -------------------------------
+    - name: Download backend coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-backend
+        path: coverage
 
-      - name: Download multicluster coverage
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-multicluster
-          path: coverage
-      
-      - name: Download unit coverage
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-unit
-          path: coverage
+    - name: Download multicluster coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-multicluster
+        path: coverage
 
-      # -------------------------------
-      # Merge coverage (no gocovmerge)
-      # -------------------------------
-      - name: Merge coverage files
-        run: |
-          echo "mode: set" > coverage.out
-          grep -h -v "^mode:" coverage/coverage-unit.out >> coverage.out
-          grep -h -v "^mode:" coverage/coverage-backend.out >> coverage.out
-          grep -h -v "^mode:" coverage/coverage-multicluster.out >> coverage.out
+    - name: Download unit coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-unit
+        path: coverage
 
-      # -------------------------------
-      # Upload to Codecov
-      # -------------------------------
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          fail_ci_if_error: false
-          files: coverage.out
-          flags: integration
-          slug: kiali/kiali
-          token: ${{ secrets.CODECOV_TOKEN }}
-          use_oidc: true
+    # -------------------------------
+    # Merge coverage (no gocovmerge)
+    # -------------------------------
+    - name: Merge coverage files
+      run: |
+        echo "mode: set" > coverage.out
+        grep -h -v "^mode:" coverage/coverage-unit.out >> coverage.out
+        grep -h -v "^mode:" coverage/coverage-backend.out >> coverage.out
+        grep -h -v "^mode:" coverage/coverage-multicluster.out >> coverage.out
+
+    # -------------------------------
+    # Upload to Codecov
+    # -------------------------------
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        fail_ci_if_error: false
+        files: coverage.out
+        flags: integration
+        slug: kiali/kiali
+        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -20,13 +20,13 @@ on:
         default: "main"
   push:
     paths:
-    - 'kiali/routing/routes.go'
+    - 'routing/routes.go'
     branches:
     - master
     - 'v*.*'
   pull_request:
     paths:
-    - 'kiali/routing/routes.go'
+    - 'routing/routes.go'
     branches:
     - master
     - 'v*.*'
@@ -52,12 +52,11 @@ jobs:
       CI: 1
       # avoid warnings like "tput: No value for $TERM and no -T specified"
       TERM: xterm
-    continue-on-error: true
     steps:
     - name: Check out Kiali code
       uses: actions/checkout@v6
       with:
-        ref: ${{ inputs.build_branch }}
+        ref: ${{ env.BUILD_BRANCH }}
 
     - name: Install Helm
       uses: Azure/setup-helm@v5.0.0
@@ -165,7 +164,6 @@ jobs:
 
     - name: Get debug info when tests fail
       if: failure()
-      working-directory: kiali
       run: |
         mkdir -p debug-output
         hack/ci-get-debug-info.sh --output-directory debug-output || true
@@ -175,5 +173,5 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: debug-info-mcp-contract-tests
-        path: kiali/debug-output
+        path: debug-output
 

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -24,6 +24,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'master' }}
+
 jobs:
   check-trigger:
     name: Check if evaluation should run
@@ -83,7 +86,7 @@ jobs:
     if: needs.check-trigger.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: ${{ github.base_ref || 'master' }}
+      TARGET_BRANCH: ${{ github.base_ref || env.DEFAULT_BRANCH }}
       BUILD_BRANCH: ${{ needs.check-trigger.outputs.pr-sha }}
       KUBERNETES_MCP_SERVER_REPO: ${{ needs.check-trigger.outputs.kubernetes-mcp-server-repo }}
     steps:
@@ -179,10 +182,10 @@ jobs:
         MCPCHECKER="$(go env GOPATH)/bin/mcpchecker"
         PR_RAW="tests/evals/results/mcpchecker-gemini-eval-out.json"
 
-        git fetch origin master
+        git fetch origin "${DEFAULT_BRANCH}"
         BASE_TMP="$(mktemp)"
-        if ! git show "origin/master:tests/evals/results/mcpchecker-gemini-eval-out.json" > "${BASE_TMP}" 2>/dev/null; then
-          echo "::warning::No MCP eval baseline on origin/master (tests/evals/results/mcpchecker-gemini-eval-out.json)"
+        if ! git show "origin/${DEFAULT_BRANCH}:tests/evals/results/mcpchecker-gemini-eval-out.json" > "${BASE_TMP}" 2>/dev/null; then
+          echo "::warning::No MCP eval baseline on origin/${DEFAULT_BRANCH} (tests/evals/results/mcpchecker-gemini-eval-out.json)"
           rm -f "${BASE_TMP}"
           BASE_TMP=""
         fi
@@ -199,7 +202,7 @@ jobs:
             "${MCPCHECKER}" diff --base "${BASE_TMP}" --current "${PR_RAW}" --output markdown || \
                echo "⚠ Diff comparison not available. See [workflow run](${RUN_URL}) for evaluation results."
           else
-            echo "⚠️ Could not compare runs: baseline on master or PR results is missing."
+            echo "⚠️ Could not compare runs: baseline on ${DEFAULT_BRANCH} or PR results is missing."
           fi
         } > "${COMMENT_FILE}"
 
@@ -227,10 +230,10 @@ jobs:
       needs.check-trigger.outputs.is-pr != 'true'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout master
+    - name: Checkout default branch
       uses: actions/checkout@v6
       with:
-        ref: master
+        ref: ${{ env.DEFAULT_BRANCH }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -282,7 +285,7 @@ jobs:
         if [[ "${PREVIOUS_EXISTS}" -eq 1 ]]; then
           "${MCPCHECKER}" diff --base "${PREVIOUS}" --current tests/evals/results/mcpchecker-gemini-eval-out.json --output markdown > baseline-pr-diff.md
         else
-          echo "_No previous committed baseline on \`master\` at this path — first update or new file._" > baseline-pr-diff.md
+          echo "_No previous committed baseline on \`${DEFAULT_BRANCH}\` at this path — first update or new file._" > baseline-pr-diff.md
         fi
 
         make mcp-update-token-readme
@@ -315,7 +318,7 @@ jobs:
         {
           echo "## MCP Evaluation Token Baseline Update"
           echo ""
-          echo "Updates the committed MCP evaluation results (\`tests/evals/results/mcpchecker-gemini-eval-out.json\`) and the token consumption section in \`ai/mcp/README.md\` from the latest **MCP-Checker Evaluation** run on \`master\`."
+          echo "Updates the committed MCP evaluation results (\`tests/evals/results/mcpchecker-gemini-eval-out.json\`) and the token consumption section in \`ai/mcp/README.md\` from the latest **MCP-Checker Evaluation** run on \`${DEFAULT_BRANCH}\`."
           echo ""
           echo "### mcpchecker diff (previous baseline → new baseline)"
           echo ""
@@ -337,6 +340,6 @@ jobs:
           gh pr create \
             --title "chore: update MCP evaluation token baseline" \
             --body-file pr-body.md \
-            --base master \
+            --base "${DEFAULT_BRANCH}" \
             --head "$BRANCH"
         fi

--- a/ai/providers/google/google.go
+++ b/ai/providers/google/google.go
@@ -84,7 +84,10 @@ func (p *GoogleAIProvider) SendChat(kialiInterface *mcputil.KialiInterface, req 
 			return &types.AIResponse{Error: fmt.Sprintf("google reached max tool iterations (%d)", maxToolIterations)}, http.StatusInternalServerError
 		}
 
-		tools, toolNames := p.TransformToolCallToToolsProcessor(functionCalls)
+		tools, toolNames, err := p.TransformToolCallToToolsProcessor(functionCalls)
+		if err != nil {
+			return &types.AIResponse{Error: err.Error()}, http.StatusInternalServerError
+		}
 		log.Debugf("Google provider tool names (iter=%d): %v", iter, toolNames)
 		toolResults := providers.ExecuteToolCallsInParallel(kialiInterface, tools)
 		if err := ctx.Err(); err != nil {
@@ -151,11 +154,11 @@ func (p *GoogleAIProvider) SendChat(kialiInterface *mcputil.KialiInterface, req 
 	return response, http.StatusOK
 }
 
-func (p *GoogleAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string) {
+func (p *GoogleAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string, error) {
 	toolsSlice, ok := toolCall.([]*genai.FunctionCall)
 	toolNames := make([]string, len(toolsSlice))
 	if !ok {
-		return []mcp.ToolsProcessor{}, []string{}
+		return []mcp.ToolsProcessor{}, []string{}, nil
 	}
 	tools := make([]mcp.ToolsProcessor, len(toolsSlice))
 	for i, tool := range toolsSlice {
@@ -166,7 +169,7 @@ func (p *GoogleAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]mc
 			ToolCallID: tool.ID,
 		}
 	}
-	return tools, toolNames
+	return tools, toolNames, nil
 }
 
 func (p *GoogleAIProvider) InitializeConversation(conversation *[]types.ConversationMessage, req types.AIRequest) {
@@ -247,35 +250,12 @@ func (p *GoogleAIProvider) ProviderToConversation(providerMessage interface{}) t
 }
 
 func (p *GoogleAIProvider) ReduceConversation(ctx context.Context, conversation []types.ConversationMessage, reduceThreshold int) []types.ConversationMessage {
-	// Threshold: Only reduce if conversation gets long (e.g., > 10 messages)
-	// You could also use a token counter here for more precision.
-	if len(conversation) < reduceThreshold {
+	instructions, toSummarize, recentMessages, ok := providers.SplitConversationForReduction(conversation, reduceThreshold, 4)
+	if !ok {
 		return conversation
 	}
-	// Usually: [0] is SystemInstruction, [1] is Context JSON
-	// We want to keep these "Instructional" messages separate from the "Dialogue"
-	anchorIndex := 0
-	for i, msg := range conversation {
-		if i < 2 && msg.Role == genai.RoleModel {
-			anchorIndex = i // Keep up to the first two system messages (Instructions + Kiali Context)
-		} else {
-			break
-		}
-	}
 
-	// Keep the last 4 messages (usually the latest User prompt, Tool calls, and Assistant answer)
-	keepCount := 4
-	if len(conversation)-anchorIndex <= keepCount {
-		return conversation // Not enough dialogue to summarize yet
-	}
-
-	splitPoint := len(conversation) - keepCount
-
-	instructions := conversation[:anchorIndex+1]
-	toSummarize := conversation[anchorIndex+1 : splitPoint]
-	recentMessages := conversation[splitPoint:]
-
-	chat, err := p.client.Chats.Create(ctx, p.model, &genai.GenerateContentConfig{}, p.ConversationToProvider(conversation).([]*genai.Content))
+	chat, err := p.client.Chats.Create(ctx, p.model, &genai.GenerateContentConfig{}, nil)
 	if err != nil {
 		log.Warningf("[Chat AI] Failed to create chat in reduce conversation: %v", err)
 		return conversation // Return original if chat creation fails

--- a/ai/providers/helpers.go
+++ b/ai/providers/helpers.go
@@ -199,6 +199,31 @@ func AddContextToConversation(conversation []types.ConversationMessage, req type
 	return result
 }
 
+func SplitConversationForReduction(
+	conversation []types.ConversationMessage,
+	reduceThreshold int,
+	keepCount int,
+) (instructions []types.ConversationMessage, toSummarize []types.ConversationMessage, recentMessages []types.ConversationMessage, ok bool) {
+	if len(conversation) < reduceThreshold {
+		return nil, nil, nil, false
+	}
+
+	anchorCount := 0
+	for i, msg := range conversation {
+		if i >= 2 || msg.Role != "system" {
+			break
+		}
+		anchorCount++
+	}
+
+	if len(conversation)-anchorCount <= keepCount {
+		return nil, nil, nil, false
+	}
+
+	splitPoint := len(conversation) - keepCount
+	return conversation[:anchorCount], conversation[anchorCount:splitPoint], conversation[splitPoint:], true
+}
+
 func FormatToolContent(result interface{}) (string, error) {
 	switch v := result.(type) {
 	case string:

--- a/ai/providers/helpers_test.go
+++ b/ai/providers/helpers_test.go
@@ -78,8 +78,8 @@ func (f *fakeProvider) GetToolDefinitions() interface{} {
 	return nil
 }
 
-func (f *fakeProvider) TransformToolCallToToolsProcessor(_ any) ([]mcp.ToolsProcessor, []string) {
-	return nil, nil
+func (f *fakeProvider) TransformToolCallToToolsProcessor(_ any) ([]mcp.ToolsProcessor, []string, error) {
+	return nil, nil, nil
 }
 
 func (f *fakeProvider) ConversationToProvider(_ []types.ConversationMessage) interface{} {
@@ -140,6 +140,46 @@ func TestFormatToolContent(t *testing.T) {
 	out, err = FormatToolContent(map[string]any{"a": "b"})
 	require.NoError(t, err)
 	assert.Contains(t, out, `"a":"b"`)
+}
+
+func TestSplitConversationForReduction_PreservesTwoLeadingSystemMessages(t *testing.T) {
+	conversation := []types.ConversationMessage{
+		{Role: "system", Content: "base"},
+		{Role: "system", Content: "summary"},
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "u3"},
+		{Role: "assistant", Content: "a3"},
+	}
+
+	instructions, toSummarize, recentMessages, ok := SplitConversationForReduction(conversation, 6, 4)
+
+	require.True(t, ok)
+	require.Len(t, instructions, 2)
+	assert.Equal(t, []string{"base", "summary"}, []string{instructions[0].Content, instructions[1].Content})
+	assert.Len(t, toSummarize, 2)
+	assert.Equal(t, []string{"u1", "a1"}, []string{toSummarize[0].Content, toSummarize[1].Content})
+	assert.Len(t, recentMessages, 4)
+	assert.Equal(t, []string{"u2", "a2", "u3", "a3"}, []string{
+		recentMessages[0].Content,
+		recentMessages[1].Content,
+		recentMessages[2].Content,
+		recentMessages[3].Content,
+	})
+}
+
+func TestSplitConversationForReduction_SkipsShortConversation(t *testing.T) {
+	conversation := []types.ConversationMessage{
+		{Role: "system", Content: "base"},
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+	}
+
+	_, _, _, ok := SplitConversationForReduction(conversation, 10, 4)
+
+	assert.False(t, ok)
 }
 
 func TestGetStoreConversation(t *testing.T) {

--- a/ai/providers/openai/openai.go
+++ b/ai/providers/openai/openai.go
@@ -88,7 +88,10 @@ func (p *OpenAIProvider) SendChat(kialiInterface *mcputil.KialiInterface, req ty
 		}
 		messagesForModel = append(messagesForModel, openai.ChatCompletionMessageParamUnion{OfAssistant: &assistantWithToolCalls})
 
-		tools, toolNames := p.TransformToolCallToToolsProcessor(msg.ToolCalls)
+		tools, toolNames, err := p.TransformToolCallToToolsProcessor(msg.ToolCalls)
+		if err != nil {
+			return &types.AIResponse{Error: err.Error()}, http.StatusInternalServerError
+		}
 		log.Debugf("[Chat AI] OpenAI provider tool calls (iter=%d): %v", iter, toolNames)
 
 		toolResults := providers.ExecuteToolCallsInParallel(kialiInterface, tools)
@@ -170,33 +173,10 @@ func (p *OpenAIProvider) InitializeConversation(conversation *[]types.Conversati
 }
 
 func (p *OpenAIProvider) ReduceConversation(ctx context.Context, conversation []types.ConversationMessage, reduceThreshold int) []types.ConversationMessage {
-	// Threshold: Only reduce if conversation gets long (e.g., > 10 messages)
-	// You could also use a token counter here for more precision.
-	if len(conversation) < reduceThreshold {
+	instructions, toSummarize, recentMessages, ok := providers.SplitConversationForReduction(conversation, reduceThreshold, 4)
+	if !ok {
 		return conversation
 	}
-	// Usually: [0] is SystemInstruction, [1] is Context JSON
-	// We want to keep these "Instructional" messages separate from the "Dialogue"
-	anchorIndex := 0
-	for i, msg := range conversation {
-		if i < 2 && msg.Role == "system" {
-			anchorIndex = i // Keep up to the first two system messages (Instructions + Kiali Context)
-		} else {
-			break
-		}
-	}
-
-	// Keep the last 4 messages (usually the latest User prompt, Tool calls, and Assistant answer)
-	keepCount := 4
-	if len(conversation)-anchorIndex <= keepCount {
-		return conversation // Not enough dialogue to summarize yet
-	}
-
-	splitPoint := len(conversation) - keepCount
-
-	instructions := conversation[:anchorIndex+1]
-	toSummarize := conversation[anchorIndex+1 : splitPoint]
-	recentMessages := conversation[splitPoint:]
 
 	resp, err := p.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Model: openai.ChatModel(p.model),

--- a/ai/providers/openai/openai_provider.go
+++ b/ai/providers/openai/openai_provider.go
@@ -100,22 +100,24 @@ func (p *OpenAIProvider) GetToolDefinitions() interface{} {
 	return tools
 }
 
-func (p *OpenAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string) {
+func (p *OpenAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string, error) {
 	toolsSlice, ok := toolCall.([]openai.ChatCompletionMessageToolCallUnion)
 	toolNames := make([]string, len(toolsSlice))
 	if !ok {
-		return []mcp.ToolsProcessor{}, []string{}
+		return []mcp.ToolsProcessor{}, []string{}, nil
 	}
 	tools := make([]mcp.ToolsProcessor, len(toolsSlice))
 	for i, tool := range toolsSlice {
 		toolNames[i] = tool.Function.Name
 		args := map[string]any{}
-		_ = json.Unmarshal([]byte(tool.Function.Arguments), &args)
+		if err := json.Unmarshal([]byte(tool.Function.Arguments), &args); err != nil {
+			return nil, nil, fmt.Errorf("invalid arguments for tool %q: %w", tool.Function.Name, err)
+		}
 		tools[i] = mcp.ToolsProcessor{
 			Args:       args,
 			Name:       tool.Function.Name,
 			ToolCallID: tool.ID,
 		}
 	}
-	return tools, toolNames
+	return tools, toolNames, nil
 }

--- a/ai/providers/openai/openai_provider_test.go
+++ b/ai/providers/openai/openai_provider_test.go
@@ -3,6 +3,7 @@ package openai_provider
 import (
 	"testing"
 
+	openai "github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -58,4 +59,20 @@ func TestGetProviderOptions_UnsupportedProviderConfig(t *testing.T) {
 	_, err := getProviderOptions(conf, provider, model)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported provider config type")
+}
+
+func TestTransformToolCallToToolsProcessor_InvalidJSON(t *testing.T) {
+	provider := &OpenAIProvider{}
+
+	_, _, err := provider.TransformToolCallToToolsProcessor([]openai.ChatCompletionMessageToolCallUnion{{
+		ID:   "call-1",
+		Type: "function",
+		Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+			Name:      "get_logs",
+			Arguments: "{not-json}",
+		},
+	}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid arguments for tool "get_logs"`)
 }

--- a/ai/providers/provider.go
+++ b/ai/providers/provider.go
@@ -13,7 +13,7 @@ type AIProvider interface {
 	InitializeConversation(conversation *[]types.ConversationMessage, req types.AIRequest)
 	ReduceConversation(ctx context.Context, conversation []types.ConversationMessage, reduceThreshold int) []types.ConversationMessage
 	GetToolDefinitions() interface{}
-	TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string)
+	TransformToolCallToToolsProcessor(toolCall any) ([]mcp.ToolsProcessor, []string, error)
 	ConversationToProvider(conversation []types.ConversationMessage) interface{}
 	ProviderToConversation(providerMessage interface{}) types.ConversationMessage
 	SendChat(kialiInterface *mcputil.KialiInterface,

--- a/ai/store.go
+++ b/ai/store.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"sort"
@@ -22,10 +23,11 @@ type AIChatConversation struct {
 }
 
 type AiStoreConfig struct {
-	Enabled          bool
-	MaxCacheMemoryMB int  // Maximum memory for all conversations
-	ReduceWithAI     bool // Reduce conversations with AI if memory limit is reached
-	ReduceThreshold  int  // Threshold for reducing conversations
+	Enabled           bool
+	InactivityTimeout time.Duration
+	MaxCacheMemoryMB  int  // Maximum memory for all conversations
+	ReduceWithAI      bool // Reduce conversations with AI if memory limit is reached
+	ReduceThreshold   int  // Threshold for reducing conversations
 }
 
 type AIStoreImpl struct {
@@ -37,19 +39,26 @@ type AIStoreImpl struct {
 
 // NewAIStore creates a new AI store instance
 func NewAIStore(ctx context.Context, config *AiStoreConfig) types.AIStore {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if config == nil {
 		// Default configuration
 		config = &AiStoreConfig{
-			Enabled:          true,
-			MaxCacheMemoryMB: 1024,
-			ReduceWithAI:     false,
-			ReduceThreshold:  15,
+			Enabled:           true,
+			InactivityTimeout: 30 * time.Minute,
+			MaxCacheMemoryMB:  1024,
+			ReduceWithAI:      false,
+			ReduceThreshold:   15,
 		}
 	}
 	self := &AIStoreImpl{
 		config:        config,
 		ctx:           ctx,
 		conversations: make(map[string]*AIChatConversation),
+	}
+	if self.config.Enabled && self.config.InactivityTimeout > 0 {
+		go self.startInactivityCleanupLoop()
 	}
 	return self
 }
@@ -120,6 +129,11 @@ func (s *AIStoreImpl) SetConversation(sessionID string, conversationID string, c
 // checkMemoryLimits ensures we don't exceed memory limits
 // Must be called with write lock held
 func (s *AIStoreImpl) checkMemoryLimits(sessionID string, conversationID string, newConversation *types.Conversation) error {
+	maxMemoryMB := float64(s.config.MaxCacheMemoryMB)
+	if newConversation.EstimatedMB > maxMemoryMB {
+		return fmt.Errorf("conversation [%s] requires %.2f MB but max cache memory is %d MB", conversationID, newConversation.EstimatedMB, s.config.MaxCacheMemoryMB)
+	}
+
 	// Calculate current memory usage
 	currentMemory := s.totalMemoryMBLocked()
 
@@ -138,11 +152,26 @@ func (s *AIStoreImpl) checkMemoryLimits(sessionID string, conversationID string,
 	projectedMemory := currentMemory + newConversation.EstimatedMB
 
 	// If over limit, evict LRU sessions until under limit
-	if projectedMemory > float64(s.config.MaxCacheMemoryMB) {
+	if projectedMemory > maxMemoryMB {
 		log.Debugf("Approaching AI store memory limit: %.2f MB / %d MB", projectedMemory, s.config.MaxCacheMemoryMB)
 
-		excessMB := projectedMemory - float64(s.config.MaxCacheMemoryMB)
+		excessMB := projectedMemory - maxMemoryMB
 		s.evictLRUConversations(excessMB)
+
+		currentMemory = s.totalMemoryMBLocked()
+		if sessionConversation, exists := s.conversations[sessionID]; exists {
+			sessionConversation.mu.RLock()
+			if conversation, exists := sessionConversation.Conversation[conversationID]; exists {
+				conversation.Mu.RLock()
+				currentMemory -= conversation.EstimatedMB
+				conversation.Mu.RUnlock()
+			}
+			sessionConversation.mu.RUnlock()
+		}
+		projectedMemory = currentMemory + newConversation.EstimatedMB
+		if projectedMemory > maxMemoryMB {
+			return fmt.Errorf("conversation [%s] cannot be stored without exceeding max cache memory (%0.2f MB > %d MB)", conversationID, projectedMemory, s.config.MaxCacheMemoryMB)
+		}
 	}
 
 	return nil
@@ -195,6 +224,9 @@ func (s *AIStoreImpl) evictLRUConversations(targetMB float64) {
 			session.memoryMB)
 
 		delete(s.conversations[session.sessionID].Conversation, session.conversationID)
+		if len(s.conversations[session.sessionID].Conversation) == 0 {
+			delete(s.conversations, session.sessionID)
+		}
 		internalmetrics.GetAIStoreEvictionsTotalMetric().Inc()
 		freedMB += session.memoryMB
 		evictedCount++
@@ -233,8 +265,9 @@ func (s *AIStoreImpl) GetConversationIDs(sessionID string) []string {
 		log.Debugf("Returned empty list for session [%s]: no session found", sessionID)
 		return []string{}
 	}
-	sessionConversation.mu.RLock()
-	defer sessionConversation.mu.RUnlock()
+	sessionConversation.mu.Lock()
+	defer sessionConversation.mu.Unlock()
+	sessionConversation.LastAccessed = time.Now()
 	return slices.Collect(maps.Keys(sessionConversation.Conversation))
 }
 
@@ -249,6 +282,7 @@ func (s *AIStoreImpl) DeleteConversations(sessionID string, conversationIDs []st
 	}
 	sessionConversation.mu.Lock()
 	defer sessionConversation.mu.Unlock()
+	sessionConversation.LastAccessed = time.Now()
 
 	for _, conversationID := range conversationIDs {
 		if _, exists := sessionConversation.Conversation[conversationID]; exists {
@@ -258,12 +292,20 @@ func (s *AIStoreImpl) DeleteConversations(sessionID string, conversationIDs []st
 			log.Debugf("Conversation [%s] not found for session [%s]", conversationID, sessionID)
 		}
 	}
+	if len(sessionConversation.Conversation) == 0 {
+		delete(s.conversations, sessionID)
+	}
 	internalmetrics.SetAIStoreConversationsTotal(s.totalConversationsLocked())
 	return nil
 }
 
 // LoadAIStoreConfig loads AI store configuration from Kiali config
 func LoadAIStoreConfig(cfg *config.Config) *AiStoreConfig { // Parse duration strings from config
+	inactivityTimeout, err := cfg.ChatAI.StoreConfig.InactivityTimeout.ToDuration()
+	if err != nil || inactivityTimeout <= 0 {
+		log.Warningf("Invalid chat_ai.store_config.inactivity_timeout %q, using default 30m", cfg.ChatAI.StoreConfig.InactivityTimeout)
+		inactivityTimeout = 30 * time.Minute
+	}
 	maxMemory := cfg.ChatAI.StoreConfig.MaxCacheMemoryMB
 	if maxMemory <= 0 {
 		log.Warningf("Invalid chat_ai.store_config.max_cache_memory_mb %d, using default 1024", maxMemory)
@@ -271,11 +313,68 @@ func LoadAIStoreConfig(cfg *config.Config) *AiStoreConfig { // Parse duration st
 	}
 
 	return &AiStoreConfig{
-		Enabled:          cfg.ChatAI.Enabled && cfg.ChatAI.StoreConfig.Enabled,
-		MaxCacheMemoryMB: maxMemory,
-		ReduceWithAI:     cfg.ChatAI.StoreConfig.ReduceWithAI,
-		ReduceThreshold:  cfg.ChatAI.StoreConfig.ReduceThreshold,
+		Enabled:           cfg.ChatAI.Enabled && cfg.ChatAI.StoreConfig.Enabled,
+		InactivityTimeout: inactivityTimeout,
+		MaxCacheMemoryMB:  maxMemory,
+		ReduceWithAI:      cfg.ChatAI.StoreConfig.ReduceWithAI,
+		ReduceThreshold:   cfg.ChatAI.StoreConfig.ReduceThreshold,
 	}
+}
+
+func (s *AIStoreImpl) startInactivityCleanupLoop() {
+	cleanupInterval := s.config.InactivityTimeout / 2
+	if cleanupInterval <= 0 {
+		cleanupInterval = time.Minute
+	}
+	if cleanupInterval > time.Minute {
+		cleanupInterval = time.Minute
+	}
+	if cleanupInterval < 50*time.Millisecond {
+		cleanupInterval = 50 * time.Millisecond
+	}
+
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			s.purgeInactiveSessions(time.Now())
+		}
+	}
+}
+
+func (s *AIStoreImpl) purgeInactiveSessions(now time.Time) int {
+	if s.config.InactivityTimeout <= 0 {
+		return 0
+	}
+
+	cutoff := now.Add(-s.config.InactivityTimeout)
+	purgedConversations := 0
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for sessionID, sessionConversation := range s.conversations {
+		sessionConversation.mu.RLock()
+		lastAccessed := sessionConversation.LastAccessed
+		conversationCount := len(sessionConversation.Conversation)
+		sessionConversation.mu.RUnlock()
+
+		if lastAccessed.Before(cutoff) {
+			delete(s.conversations, sessionID)
+			purgedConversations += conversationCount
+		}
+	}
+
+	if purgedConversations > 0 {
+		log.Debugf("Purged %d inactive AI store conversations older than %s", purgedConversations, s.config.InactivityTimeout)
+		internalmetrics.SetAIStoreConversationsTotal(s.totalConversationsLocked())
+	}
+
+	return purgedConversations
 }
 
 func EstimateConversationMemory(conversation []types.ConversationMessage) float64 {

--- a/ai/store_test.go
+++ b/ai/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -22,20 +23,23 @@ func TestNewAIStore_DefaultConfig(t *testing.T) {
 	assert.True(t, store.Enabled())
 	assert.False(t, store.ReduceWithAI())
 	assert.Equal(t, 15, store.ReduceThreshold())
+	assert.Equal(t, 30*time.Minute, store.(*AIStoreImpl).config.InactivityTimeout)
 }
 
 func TestNewAIStore_CustomConfig(t *testing.T) {
 	cfg := &AiStoreConfig{
-		Enabled:          true,
-		MaxCacheMemoryMB: 512,
-		ReduceWithAI:     true,
-		ReduceThreshold:  10,
+		Enabled:           true,
+		InactivityTimeout: 45 * time.Minute,
+		MaxCacheMemoryMB:  512,
+		ReduceWithAI:      true,
+		ReduceThreshold:   10,
 	}
 	store := NewAIStore(context.Background(), cfg)
 	require.NotNil(t, store)
 	assert.True(t, store.Enabled())
 	assert.True(t, store.ReduceWithAI())
 	assert.Equal(t, 10, store.ReduceThreshold())
+	assert.Equal(t, 45*time.Minute, store.(*AIStoreImpl).config.InactivityTimeout)
 }
 
 func TestNewAIStore_DisabledConfig(t *testing.T) {
@@ -187,14 +191,27 @@ func TestStore_DeleteConversations_NonexistentConversation(t *testing.T) {
 	assert.Len(t, ids, 1, "existing conversation should not be deleted")
 }
 
+func TestStore_DeleteConversations_RemovesEmptySession(t *testing.T) {
+	store := NewAIStore(context.Background(), nil)
+	conv := &types.Conversation{
+		Conversation: []types.ConversationMessage{{Role: "user", Content: "hi"}},
+	}
+	require.NoError(t, store.SetConversation("session-1", "conv-1", conv))
+
+	require.NoError(t, store.DeleteConversations("session-1", []string{"conv-1"}))
+
+	assert.Empty(t, store.GetConversationIDs("session-1"))
+}
+
 // --- Memory management tests ---
 
 func TestStore_EvictsLRUWhenOverMemoryLimit(t *testing.T) {
 	cfg := &AiStoreConfig{
-		Enabled:          true,
-		MaxCacheMemoryMB: 1, // 1 MB limit
-		ReduceWithAI:     false,
-		ReduceThreshold:  15,
+		Enabled:           true,
+		InactivityTimeout: 30 * time.Minute,
+		MaxCacheMemoryMB:  1, // 1 MB limit
+		ReduceWithAI:      false,
+		ReduceThreshold:   15,
 	}
 	store := NewAIStore(context.Background(), cfg)
 
@@ -215,6 +232,28 @@ func TestStore_EvictsLRUWhenOverMemoryLimit(t *testing.T) {
 
 	_, found = store.GetConversation("s2", "c2")
 	assert.True(t, found, "newest conversation should remain")
+}
+
+func TestStore_RejectsSingleConversationLargerThanLimit(t *testing.T) {
+	cfg := &AiStoreConfig{
+		Enabled:           true,
+		InactivityTimeout: 30 * time.Minute,
+		MaxCacheMemoryMB:  1,
+		ReduceWithAI:      false,
+		ReduceThreshold:   15,
+	}
+	store := NewAIStore(context.Background(), cfg)
+
+	conv := &types.Conversation{
+		Conversation: []types.ConversationMessage{{Role: "user", Content: makeTestString(2 * 1024 * 1024)}},
+	}
+
+	err := store.SetConversation("s1", "c1", conv)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires")
+
+	_, found := store.GetConversation("s1", "c1")
+	assert.False(t, found)
 }
 
 func TestStore_EstimateConversationMemory(t *testing.T) {
@@ -240,6 +279,7 @@ func TestLoadAIStoreConfig_FromConfig(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ChatAI.Enabled = true
 	conf.ChatAI.StoreConfig.Enabled = true
+	conf.ChatAI.StoreConfig.InactivityTimeout = "45m"
 	conf.ChatAI.StoreConfig.MaxCacheMemoryMB = 2048
 	conf.ChatAI.StoreConfig.ReduceWithAI = true
 	conf.ChatAI.StoreConfig.ReduceThreshold = 20
@@ -247,6 +287,7 @@ func TestLoadAIStoreConfig_FromConfig(t *testing.T) {
 	storeCfg := LoadAIStoreConfig(conf)
 
 	assert.True(t, storeCfg.Enabled)
+	assert.Equal(t, 45*time.Minute, storeCfg.InactivityTimeout)
 	assert.Equal(t, 2048, storeCfg.MaxCacheMemoryMB)
 	assert.True(t, storeCfg.ReduceWithAI)
 	assert.Equal(t, 20, storeCfg.ReduceThreshold)
@@ -279,6 +320,17 @@ func TestLoadAIStoreConfig_ZeroMemoryUsesDefault(t *testing.T) {
 
 	storeCfg := LoadAIStoreConfig(conf)
 	assert.Equal(t, 1024, storeCfg.MaxCacheMemoryMB, "zero memory should default to 1024")
+}
+
+func TestLoadAIStoreConfig_InvalidTimeoutUsesDefault(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	conf.ChatAI.StoreConfig.Enabled = true
+	conf.ChatAI.StoreConfig.InactivityTimeout = "not-a-duration"
+
+	storeCfg := LoadAIStoreConfig(conf)
+
+	assert.Equal(t, 30*time.Minute, storeCfg.InactivityTimeout, "invalid timeout should default to 30m")
 }
 
 // --- Concurrent access tests ---
@@ -384,10 +436,11 @@ func TestStore_MetricsConversationsTotalUpdatedOnDelete(t *testing.T) {
 
 func TestStore_MetricsEvictionsTotalIncrementedOnEviction(t *testing.T) {
 	cfg := &AiStoreConfig{
-		Enabled:          true,
-		MaxCacheMemoryMB: 1,
-		ReduceWithAI:     false,
-		ReduceThreshold:  15,
+		Enabled:           true,
+		InactivityTimeout: 30 * time.Minute,
+		MaxCacheMemoryMB:  1,
+		ReduceWithAI:      false,
+		ReduceThreshold:   15,
 	}
 	store := NewAIStore(context.Background(), cfg)
 
@@ -428,6 +481,31 @@ func TestStore_MetricsConversationsTotalAccurateAcrossOperations(t *testing.T) {
 	delta := afterThreeAdds - afterTwoDeletes
 	assert.InDelta(t, 2.0, delta, 0.01,
 		"deleting 2 of 3 conversations should reduce the gauge by 2")
+}
+
+func TestStore_PurgesInactiveSessions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := NewAIStore(ctx, &AiStoreConfig{
+		Enabled:           true,
+		InactivityTimeout: 100 * time.Millisecond,
+		MaxCacheMemoryMB:  1024,
+		ReduceWithAI:      false,
+		ReduceThreshold:   15,
+	}).(*AIStoreImpl)
+
+	conv := &types.Conversation{
+		Conversation: []types.ConversationMessage{{Role: "user", Content: "hi"}},
+	}
+	require.NoError(t, store.SetConversation("stale-session", "conv-1", conv))
+
+	require.Eventually(t, func() bool {
+		store.mu.RLock()
+		defer store.mu.RUnlock()
+		_, exists := store.conversations["stale-session"]
+		return !exists
+	}, time.Second, 25*time.Millisecond)
 }
 
 func makeTestString(n int) string {

--- a/config/config.go
+++ b/config/config.go
@@ -774,10 +774,11 @@ type Validations struct {
 
 // AiStoreConfig defines configuration for the AI store subsystem
 type AiStoreConfig struct {
-	Enabled          bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`                      // Default:  true
-	MaxCacheMemoryMB int  `yaml:"max_cache_memory_mb,omitempty" json:"maxCacheMemoryMB,omitempty"` // Default: 1024
-	ReduceWithAI     bool `yaml:"reduce_with_ai,omitempty" json:"reduceWithAI,omitempty"`          // Default: false
-	ReduceThreshold  int  `yaml:"reduce_threshold,omitempty" json:"reduceThreshold,omitempty"`     // Default: 15 messages
+	Enabled           bool           `yaml:"enabled,omitempty" json:"enabled,omitempty"`                      // Default: true
+	InactivityTimeout DurationString `yaml:"inactivity_timeout,omitempty" json:"inactivityTimeout,omitempty"` // Default: "30m"
+	MaxCacheMemoryMB  int            `yaml:"max_cache_memory_mb,omitempty" json:"maxCacheMemoryMB,omitempty"` // Default: 1024
+	ReduceWithAI      bool           `yaml:"reduce_with_ai,omitempty" json:"reduceWithAI,omitempty"`          // Default: false
+	ReduceThreshold   int            `yaml:"reduce_threshold,omitempty" json:"reduceThreshold,omitempty"`     // Default: 15 messages
 }
 
 type AIModel struct {
@@ -1019,10 +1020,11 @@ func NewConfig() (c *Config) {
 			DefaultProvider: "",
 			Providers:       []ProviderConfig{},
 			StoreConfig: AiStoreConfig{
-				Enabled:          true,
-				MaxCacheMemoryMB: 1024,
-				ReduceWithAI:     false,
-				ReduceThreshold:  15,
+				Enabled:           true,
+				InactivityTimeout: "30m",
+				MaxCacheMemoryMB:  1024,
+				ReduceWithAI:      false,
+				ReduceThreshold:   15,
 			},
 		},
 		Clustering: Clustering{

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -137,7 +137,7 @@ func ChatAI(
 		}
 		var req aiTypes.AIRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			RespondWithError(w, http.StatusBadRequest, "Invalid request body")
 			return
 		}
 		if conf.Auth.Strategy != config.AuthStrategyAnonymous {
@@ -162,7 +162,6 @@ func ChatAI(
 			return
 		}
 
-		internalmetrics.GetAIRequestsTotalMetric(providerName, modelName).Inc()
 		requestTimer := internalmetrics.GetAIRequestDurationPrometheusTimer(providerName, modelName)
 		defer requestTimer.ObserveDuration()
 		kialiInterface, err := GetKialiInterface(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, perses, discovery)
@@ -170,6 +169,7 @@ func ChatAI(
 			RespondWithError(w, http.StatusInternalServerError, "AI initialization error: "+err.Error())
 			return
 		}
+		internalmetrics.GetAIRequestsTotalMetric(providerName, modelName).Inc()
 		resp, code := provider.SendChat(kialiInterface, req, aiStore)
 
 		if resp == nil {
@@ -178,6 +178,10 @@ func ChatAI(
 		}
 		if code != http.StatusOK && resp.Error != "" {
 			RespondWithError(w, code, resp.Error)
+			return
+		}
+		if code != http.StatusOK {
+			RespondWithError(w, code, http.StatusText(code))
 			return
 		}
 		RespondWithJSONIndent(w, code, resp)

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -479,6 +479,10 @@ func TestChatAI_InvalidRequestBody(t *testing.T) {
 	t.Cleanup(func() { resp.Body.Close() })
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "invalid JSON body should return 400")
+
+	var payload map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "Invalid request body", payload["error"])
 }
 
 func TestChatAI_ProviderNotFound(t *testing.T) {


### PR DESCRIPTION
### Describe the change

- Implement job to clean stale store data. By default, inactivity timeout is set to 30m. Added inactivity-based chat session cleanup with configurable chat_ai.store_config.inactivity_timeout (default 30m).

Other improvements: 
- Normalized Chat AI error handling and moved request metric counting later so failed initialization does not inflate usage metrics.
- Made tool-call parsing stricter by surfacing invalid OpenAI tool JSON instead of silently executing tools with empty arguments.
- Unified conversation reduction logic across providers and fixed the Google reduction path to summarize the correct portion of the conversation.
- Hardened the AI store by rejecting oversized single conversations, re-checking limits after eviction, and removing empty sessions.
- Fixed MCP-related CI workflows: corrected contract-test path/branch/debug behavior, aligned frontend chat dependency install, clarified the AI job name, and removed master assumptions from mcpchecker.
- Added and updated tests to cover the new handler, provider, store, timeout, and workflow-adjacent behavior.

### Steps to test the PR

The config `chat_ai.store_config.inactivity_timeout` can be changed to 2m. Start a chat, wait for more than 2 minutes, and continue the conversation. In the debug logs: 

`2026-05-05T15:31:47+01:00 DBG Purged 1 inactive AI store conversations older than 2m0s`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9143 

- Operator PR: https://github.com/kiali/kiali-operator/pull/1033
- Helm charts PR: https://github.com/kiali/helm-charts/pull/402