### PR TITLE
[CI] Istio versions: copy ca bundle

### DIFF
--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -14,6 +14,64 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${SCRIPT_DIR}/env.sh "$@"
 
+ensure_remote_validating_webhook_cabundle() {
+  local context="${1}"
+  local namespace="${2:-istio-system}"
+  local timeout_seconds="${3:-120}"
+  local sleep_seconds=5
+  local elapsed=0
+  local validator_config=""
+  local validator_index=""
+  local validator_len=0
+  local mutating_cabundle=""
+
+  validator_config=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfigurations -o json | \
+    jq -r '.items[] | select(any(.webhooks[]?; .name=="validation.istio.io" and .clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'")) | .metadata.name' | head -n1)
+  if [ -z "${validator_config}" ]; then
+    echo "WARNING: No Istio validating webhook configuration found in context [${context}]"
+    return 0
+  fi
+
+  validator_index=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfiguration "${validator_config}" -o json | \
+    jq -r '.webhooks | to_entries[] | select(.value.name=="validation.istio.io") | .key')
+  if [ -z "${validator_index}" ]; then
+    echo "WARNING: validation.istio.io webhook not found in configuration [${validator_config}]"
+    return 0
+  fi
+
+  while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
+    validator_len=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfiguration "${validator_config}" -o json | \
+      jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
+    if [ "${validator_len}" -gt 0 ]; then
+      echo "Istio validating webhook caBundle is ready in context [${context}]"
+      return 0
+    fi
+
+    mutating_cabundle=$(${CLIENT_EXE} --context="${context}" get mutatingwebhookconfigurations -o json | \
+      jq -r '.items[] | .webhooks[]? | select(.clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'" and (.clientConfig.caBundle | length) > 0) | .clientConfig.caBundle' | head -n1)
+    if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
+      echo "Patching Istio validating webhook caBundle in context [${context}] from mutating webhook"
+      ${CLIENT_EXE} --context="${context}" patch validatingwebhookconfiguration "${validator_config}" --type='json' -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
+
+      validator_len=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
+      if [ "${validator_len}" -gt 0 ]; then
+        return 0
+      fi
+
+      echo "ERROR: Istio validating webhook caBundle is still empty after patching in context [${context}]"
+      return 1
+    fi
+
+    echo "Waiting for Istio validating webhook caBundle in context [${context}]"
+    sleep "${sleep_seconds}"
+    elapsed=$((elapsed + sleep_seconds))
+  done
+
+  echo "ERROR: Could not find a non-empty Istio mutating webhook caBundle in context [${context}]"
+  return 1
+}
+
 # Start up two minikube instances if requested
 if [ "${MANAGE_MINIKUBE}" == "true" ]; then
   echo "Starting minikube instances"
@@ -118,6 +176,7 @@ install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
 # If we don't wait until the RBAC is created by istio, then the Sail reconiliation will fail because istioctl create-remote-secret
 # also creates the RBAC and if that happens Sail can't take ownership of those resources.
 kubectl --context="${CLUSTER2_CONTEXT}" wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}="readiness probe on remote istiod failed"' istios/default --timeout=1m
+ensure_remote_validating_webhook_cabundle "${CLUSTER2_CONTEXT}" "${ISTIO_NAMESPACE}" "120"
 
 # For kind we need to use the container IP otherwise the unresolvable localhost will be used.
 SERVER_FLAG=""

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -17,13 +17,19 @@ source ${SCRIPT_DIR}/env.sh "$@"
 ensure_remote_validating_webhook_cabundle() {
   local context="${1}"
   local namespace="${2:-istio-system}"
-  local timeout_seconds="${3:-120}"
+  local timeout_seconds="${3:-30}"
   local sleep_seconds=5
   local elapsed=0
+  local attempt=1
+  local max_attempts=1
   local validator_config=""
   local validator_index=""
   local validator_len=0
   local mutating_cabundle=""
+
+  if [[ "${timeout_seconds}" =~ ^[0-9]+$ ]] && [ "${timeout_seconds}" -gt 0 ]; then
+    max_attempts=$(((timeout_seconds + sleep_seconds - 1) / sleep_seconds))
+  fi
 
   validator_config=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfigurations -o json | \
     jq -r '.items[] | select(any(.webhooks[]?; .name=="validation.istio.io" and .clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'")) | .metadata.name' | head -n1)
@@ -50,12 +56,13 @@ ensure_remote_validating_webhook_cabundle() {
     mutating_cabundle=$(${CLIENT_EXE} --context="${context}" get mutatingwebhookconfigurations -o json | \
       jq -r '.items[] | .webhooks[]? | select(.clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'" and (.clientConfig.caBundle | length) > 0) | .clientConfig.caBundle' | head -n1)
     if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
-      echo "Patching Istio validating webhook caBundle in context [${context}] from mutating webhook"
+      echo "Istio validating webhook caBundle is empty in context [${context}]; copying CA bundle from mutating webhook"
       ${CLIENT_EXE} --context="${context}" patch validatingwebhookconfiguration "${validator_config}" --type='json' -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
 
       validator_len=$(${CLIENT_EXE} --context="${context}" get validatingwebhookconfiguration "${validator_config}" -o json | \
         jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
       if [ "${validator_len}" -gt 0 ]; then
+        echo "Istio validating webhook caBundle copied successfully in context [${context}]"
         return 0
       fi
 
@@ -63,9 +70,10 @@ ensure_remote_validating_webhook_cabundle() {
       return 1
     fi
 
-    echo "Waiting for Istio validating webhook caBundle in context [${context}]"
+    echo "Waiting for Istio validating webhook caBundle in context [${context}] (${attempt}/${max_attempts})"
     sleep "${sleep_seconds}"
     elapsed=$((elapsed + sleep_seconds))
+    attempt=$((attempt + 1))
   done
 
   echo "ERROR: Could not find a non-empty Istio mutating webhook caBundle in context [${context}]"
@@ -176,7 +184,6 @@ install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
 # If we don't wait until the RBAC is created by istio, then the Sail reconiliation will fail because istioctl create-remote-secret
 # also creates the RBAC and if that happens Sail can't take ownership of those resources.
 kubectl --context="${CLUSTER2_CONTEXT}" wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}="readiness probe on remote istiod failed"' istios/default --timeout=1m
-ensure_remote_validating_webhook_cabundle "${CLUSTER2_CONTEXT}" "${ISTIO_NAMESPACE}" "120"
 
 # For kind we need to use the container IP otherwise the unresolvable localhost will be used.
 SERVER_FLAG=""
@@ -185,6 +192,7 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     SERVER_FLAG="--server=https://${CLUSTER2_CONTAINER_IP}:6443"
 fi
 ${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2_NAME} ${SERVER_FLAG} | ${CLIENT_EXE} apply -f - --context="${CLUSTER1_CONTEXT}"
+ensure_remote_validating_webhook_cabundle "${CLUSTER2_CONTEXT}" "${ISTIO_NAMESPACE}" "30"
 
 helm install istio-eastwestgateway gateway \
   --repo https://istio-release.storage.googleapis.com/charts \


### PR DESCRIPTION
### Describe the change

Adds a workaround for the `primary-remote` multicluster setup when using Sail Operator `main` with the latest Istio version.
In the remote cluster, the Istio validating webhook can be created with an empty `caBundle`, which causes admission requests for Istio resources to fail with `x509: certificate signed by unknown authority`. 
This PR updates the `primary-remote` install flow to check the validating webhook CA bundle after the remote secret is created and, if needed, copy the CA bundle from the Istio mutating webhook so the validating webhook becomes usable before Bookinfo and traffic-shifting resources are applied.

Example of a failure: https://github.com/kiali/kiali/actions/runs/25424826814/job/74601432179 

This PR was verified here: https://github.com/josunect/kiali/actions/runs/25448450830/job/74660662574  

### Steps to test the PR

Run the primary-remote integration setup with Sail Operator `main` and the latest Istio version:
`hack/run-integration-tests.sh --test-suite frontend-primary-remote --sail-operator-git-ref main`

Check the logs for one of these messages in the remote cluster setup:
`Istio validating webhook caBundle is ready in context [kind-west]`
`Istio validating webhook caBundle is empty in context [kind-west]; copying CA bundle from mutating webhook`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
