### PR TITLE
Fix ztunnel config dump. Add tests

### DIFF
--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -159,6 +159,13 @@ Then('the user sees the metrics tab', () => {
   cy.get('[data-test="metrics-chart"]').should('have.length.greaterThan', 0);
 });
 
+Then('the user sees the ztunnel services table', () => {
+  openTab('Ztunnel');
+  cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
+  cy.get('table[aria-label="Ztunnel services config"]').should('be.visible');
+  cy.get('table[aria-label="Ztunnel services config"]').find('th[data-label="Service VIP"]').should('be.visible');
+});
+
 Then('the user can see the {string} link', (link: string) => {
   cy.getBySel('view-in-tracing').contains(link);
 });

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -62,6 +62,7 @@ Feature: Kiali Waypoint related features
     Given user is at the details page for the daemonset "ztunnel/ztunnel" located in the "" cluster
     Then the user cannot see the "missing-sidecar" badge for "ztunnel" workload in "istio-system" namespace
     And the proxy status is "healthy"
+    And the user sees the ztunnel services table
     And the user validates the Ztunnel tab for the "bookinfo" namespace
 
   Scenario: [Traffic Graph] User sees ztunnel traffic

--- a/kubernetes/ztunnel.go
+++ b/kubernetes/ztunnel.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 )
 
 type ZtunnelConfigDump struct {
@@ -138,6 +139,38 @@ type DNSResolverOptions struct {
 type TimeDuration struct {
 	Nanos int `json:"nanos"`
 	Secs  int `json:"secs"`
+}
+
+func (d *TimeDuration) UnmarshalJSON(data []byte) (err error) {
+	type durationAlias TimeDuration
+
+	var objectVal durationAlias
+	if err := json.Unmarshal(data, &objectVal); err == nil {
+		*d = TimeDuration(objectVal)
+		return nil
+	}
+
+	var intVal int
+	if err := json.Unmarshal(data, &intVal); err == nil {
+		*d = TimeDuration{Secs: intVal}
+		return nil
+	}
+
+	var floatVal float64
+	if err := json.Unmarshal(data, &floatVal); err == nil {
+		secs, nanos := math.Modf(floatVal)
+		*d = TimeDuration{
+			Secs:  int(secs),
+			Nanos: int(math.Round(nanos * 1e9)),
+		}
+		if d.Nanos == 1e9 {
+			d.Secs++
+			d.Nanos = 0
+		}
+		return nil
+	}
+
+	return err
 }
 
 type SocketAddress struct {

--- a/kubernetes/ztunnel_test.go
+++ b/kubernetes/ztunnel_test.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeDurationUnmarshalJSONObject(t *testing.T) {
+	var duration TimeDuration
+
+	err := json.Unmarshal([]byte(`{"secs":5,"nanos":12}`), &duration)
+
+	require.NoError(t, err)
+	require.Equal(t, TimeDuration{Secs: 5, Nanos: 12}, duration)
+}
+
+func TestTimeDurationUnmarshalJSONNumberAsSeconds(t *testing.T) {
+	var duration TimeDuration
+
+	err := json.Unmarshal([]byte(`5`), &duration)
+
+	require.NoError(t, err)
+	require.Equal(t, TimeDuration{Secs: 5}, duration)
+}
+
+func TestDNSResolverOptionsUnmarshalMixedVersionFields(t *testing.T) {
+	var opts DNSResolverOptions
+
+	err := json.Unmarshal([]byte(`{"timeout":5,"use_hosts_file":true}`), &opts)
+
+	require.NoError(t, err)
+	require.Equal(t, TimeDuration{Secs: 5}, opts.Timeout)
+	require.Equal(t, BoolOrString("true"), opts.UseHostsFile)
+}


### PR DESCRIPTION
### Describe the change
- Fix ztunnel config dump deserialization of dnsResolverOpts.timeout
- Add unit tests
- Add cypress test to validate the ztunnel services tab

### Steps to test the PR
- Install Ambient and Istio 1.30 RC
- Go to the ztunnel workload details and the ztunnel tab: http://localhost:3000/console/namespaces/istio-system/workloads/ztunnel
- Verify the table is seen as expected:
<img width="1876" height="906" alt="image" src="https://github.com/user-attachments/assets/391644dd-1bf6-4fde-ba55-4c5fbeee5435" />


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9658 
