### PR TITLE
Update ztunnel table header style

### DIFF
--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -63,15 +63,10 @@ export interface SortableCompareTh<T> extends SortableTh {
 
 export const yoverflow = kialiStyle({
   height: 'calc(100vh - 400px)',
-  overflow: 'auto'
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 0
 });
-
-export const stickyThead: React.CSSProperties = {
-  position: 'sticky',
-  top: 0,
-  backgroundColor: 'white',
-  zIndex: 1
-};
 
 export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfigProps) => {
   const sortedPods = (): Pod[] => {

--- a/frontend/src/components/Ambient/ZtunnelConfig.tsx
+++ b/frontend/src/components/Ambient/ZtunnelConfig.tsx
@@ -16,7 +16,7 @@ import { ToolbarDropdown } from '../Dropdown/ToolbarDropdown';
 import { PFBadge, PFBadges } from '../Pf/PfBadges';
 import { kialiStyle } from '../../styles/StyleUtils';
 import { classes } from 'typestyle';
-import { tabCardStyle, constrainedScrollStyle, flexCardStyle, flexFillStyle } from 'styles/FlexStyles';
+import { tabCardStyle, constrainedScrollStyle, flexCardStyle, flexFillStyle, noShrinkStyle } from 'styles/FlexStyles';
 import { ZtunnelServicesTable } from './ZtunnelServicesTable';
 import { ZtunnelWorkloadsTable } from './ZtunnelWorkloadsTable';
 import { t } from 'utils/I18nUtils';
@@ -60,13 +60,6 @@ const toolbarClass = kialiStyle({
 export interface SortableCompareTh<T> extends SortableTh {
   compare?: (a: T, b: T) => number;
 }
-
-export const yoverflow = kialiStyle({
-  height: 'calc(100vh - 400px)',
-  display: 'flex',
-  flexDirection: 'column',
-  minHeight: 0
-});
 
 export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfigProps) => {
   const sortedPods = (): Pod[] => {
@@ -171,8 +164,8 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
     <Tab title={t('Services')} eventKey={0} key="services">
       <Card className={classes(flexCardStyle, tabCardStyle)}>
         <CardBody>
-          <div>
-            <div className={toolbarStyle}>
+          <div className={flexFillStyle}>
+            <div className={classes(toolbarStyle, noShrinkStyle)}>
               <div key="service-icon" className={iconStyle}>
                 <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
               </div>
@@ -211,8 +204,8 @@ export const ZtunnelConfig: React.FC<ZtunnelConfigProps> = (props: ZtunnelConfig
     <Tab title={t('Workloads')} eventKey={1} key="workloads">
       <Card className={classes(flexCardStyle, tabCardStyle)}>
         <CardBody>
-          <div>
-            <div className={toolbarStyle}>
+          <div className={flexFillStyle}>
+            <div className={classes(toolbarStyle, noShrinkStyle)}>
               <div key="service-icon" className={iconStyle}>
                 <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
               </div>

--- a/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
@@ -5,7 +5,7 @@ import { SimpleTable } from '../Table/SimpleTable';
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
 import { t } from 'i18next';
-import { SortableCompareTh, stickyThead, yoverflow } from './ZtunnelConfig';
+import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
 
 type ZtunnelServicesProps = {
   config?: ZtunnelService[];
@@ -110,7 +110,7 @@ export const ZtunnelServicesTable: React.FC<ZtunnelServicesProps> = (props: Ztun
         emptyState={noServicesConfig}
         sortBy={sort}
         onSort={onSort}
-        theadStyle={stickyThead}
+        isStickyHeader
       />
     </div>
   );

--- a/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelServicesTable.tsx
@@ -4,8 +4,9 @@ import { ZtunnelEndpoint, ZtunnelService } from '../../types/IstioObjects';
 import { SimpleTable } from '../Table/SimpleTable';
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
-import { t } from 'i18next';
-import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
+import { t } from 'utils/I18nUtils';
+import { SortableCompareTh } from './ZtunnelConfig';
+import { flexFillStyle } from 'styles/FlexStyles';
 
 type ZtunnelServicesProps = {
   config?: ZtunnelService[];
@@ -101,7 +102,7 @@ export const ZtunnelServicesTable: React.FC<ZtunnelServicesProps> = (props: Ztun
   );
 
   return (
-    <div className={yoverflow}>
+    <div className={flexFillStyle}>
       <SimpleTable
         label={t('Ztunnel services config')}
         columns={columns}

--- a/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
@@ -4,8 +4,9 @@ import { ZtunnelWorkload } from '../../types/IstioObjects';
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { emtpytStyle } from './ZtunnelServicesTable';
 import { SimpleTable } from '../Table/SimpleTable';
-import { t } from 'i18next';
-import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
+import { t } from 'utils/I18nUtils';
+import { SortableCompareTh } from './ZtunnelConfig';
+import { flexFillStyle } from 'styles/FlexStyles';
 
 type ZtunnelWorkloadsProps = {
   config?: ZtunnelWorkload[];
@@ -88,7 +89,7 @@ export const ZtunnelWorkloadsTable: React.FC<ZtunnelWorkloadsProps> = (props: Zt
   );
 
   return (
-    <div className={yoverflow}>
+    <div className={flexFillStyle}>
       <SimpleTable
         label={t('Ztunnel workloads config')}
         columns={columns}

--- a/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/ZtunnelWorkloadsTable.tsx
@@ -5,7 +5,7 @@ import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react
 import { emtpytStyle } from './ZtunnelServicesTable';
 import { SimpleTable } from '../Table/SimpleTable';
 import { t } from 'i18next';
-import { SortableCompareTh, stickyThead, yoverflow } from './ZtunnelConfig';
+import { SortableCompareTh, yoverflow } from './ZtunnelConfig';
 
 type ZtunnelWorkloadsProps = {
   config?: ZtunnelWorkload[];
@@ -97,7 +97,7 @@ export const ZtunnelWorkloadsTable: React.FC<ZtunnelWorkloadsProps> = (props: Zt
         emptyState={noWorkloadsConfig}
         sortBy={sort}
         onSort={onSort}
-        theadStyle={stickyThead}
+        isStickyHeader
       />
     </div>
   );


### PR DESCRIPTION
### Describe the change

Update ztunnel table styles:
<img width="1876" height="906" alt="image" src="https://github.com/user-attachments/assets/87f316aa-6863-443f-b161-8a5c25c58cc5" />

<img width="1876" height="906" alt="image" src="https://github.com/user-attachments/assets/2e3ec033-58a7-4bc2-ad0c-b3aa98e46cd8" />


### Steps to test the PR
Go to: http://localhost:3000/console/namespaces/istio-system/workloads/ztunnel and the ztunnel tab and verify the header.


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Follow up from https://github.com/kiali/kiali/pull/9660 
