### PR TITLE
frontend/Charts: fix 'occured' -> 'occurred' typo in user-facing error message

### DIFF
--- a/frontend/src/components/Charts/KChart.tsx
+++ b/frontend/src/components/Charts/KChart.tsx
@@ -263,7 +263,7 @@ export class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, 
       >
         <EmptyState variant={EmptyStateVariant.sm} className={emptyStyle} {...conditionalIcon}>
           <EmptyStateBody className={emptyStyle}>
-            An error occured while fetching this metric:
+            An error occurred while fetching this metric:
             <p>
               <i>{this.props.chart.error}</i>
             </p>


### PR DESCRIPTION
Fixes a typo in the user-visible chart error message in `frontend/src/components/Charts/KChart.tsx`.