### PR TITLE
frontend/types: fix 'occured' -> 'occurred' typo in ParseError comment

### DIFF
--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -252,7 +252,7 @@ export type AccessLog = {
   // mixer_status: string;
   // OriginalMessage is the original raw log line.
   // original_message: string;
-  // ParseError provides a string value if a parse error occured.
+  // ParseError provides a string value if a parse error occurred.
   // parse_error: string;
 };
 


### PR DESCRIPTION
### Describe the change

Fixes 'occured' -> 'occurred' typo in a `ParseError` comment inside `frontend/src/types/IstioObjects.ts`.

### Steps to test the PR

Comment-only change. Existing frontend tests should pass unchanged.

### Automation testing

No new tests required (comment-only fix).

### Issue reference

N/A.
