### PR TITLE
fix(lint-gherkin skill): use repo-relative path for yarn command

### DIFF
--- a/.claude/skills/lint-gherkin/SKILL.md
+++ b/.claude/skills/lint-gherkin/SKILL.md
@@ -8,8 +8,10 @@ allowed-tools: Bash(yarn *)
 Run Gherkin linting in the frontend directory:
 
 ```bash
-cd /home/scsh/work/github.com/scriptingshrimp/kiali/frontend && yarn lint:gherkin
+cd frontend && yarn lint:gherkin
 ```
+
+Run from the Kiali repository root (the directory that contains `frontend/`).
 
 The linting tool will validate all .feature files under `cypress/integration/featureFiles/` and report any syntax or formatting issues.
 


### PR DESCRIPTION
## Summary

The lint-gherkin Claude skill used a machine-specific absolute path (`/home/scsh/...`), which breaks on other clones and for other contributors.

## Changes

- Replace it with `cd frontend && yarn lint:gherkin` run from the repository root.
- Note that the command is intended to be run from the Kiali repo root.

Made with [Cursor](https://cursor.com)