### PR TITLE
Use canonical app label preference in component_status workload matching

### DIFF
--- a/business/istio_status.go
+++ b/business/istio_status.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/istio"
@@ -446,7 +444,11 @@ func (iss *IstioStatusService) getStatusOf(workloads []*models.Workload, cluster
 
 	// Map workloads there by app name
 	for _, workload := range workloads {
-		appLabel := labels.Set(workload.Labels).Get(config.IstioAppLabel)
+		appLabelName, hasAppLabel := iss.conf.GetAppLabelName(workload.Labels)
+		if !hasAppLabel {
+			continue
+		}
+		appLabel := workload.Labels[appLabelName]
 		if appLabel == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

- `getStatusOf` in `business/istio_status.go` was the only call site using the hardcoded `config.IstioAppLabel` (`"app"`) to match workloads against `component_status.components[]`. Every other site in `business/` uses `Config.GetAppLabelName(labels)`, which walks the canonical preference list (`service.istio.io/canonical-name`, `app.kubernetes.io/name`, `app`).
- Workloads following the modern `app.kubernetes.io/name` convention (common in upstream Helm charts) without the legacy `app` label were silently reported as `Unreachable`/`NotFound` in the Cluster Status panel.
- This aligns `getStatusOf` with the rest of the codebase. Backwards compatible — workloads with only `app=...` still match because `app` is the last entry in the preference list.

Based on #9619.

## Test plan

- [x] `go build ./...` succeeds
- [x] All existing `business/istio_status_test.go` tests pass (`TestComponentRunning`, `TestComponentNotRunning`, `TestNonDefaults`, `TestCustomizedAppLabel`, `TestIstiodNotReady`, `TestDaemonSetComponent*`)

Made with [Cursor](https://cursor.com)