### PR TITLE
[CI] Adapt to ipv6

### DIFF
--- a/hack/istio/ambient/install-sidecars-ambient.sh
+++ b/hack/istio/ambient/install-sidecars-ambient.sh
@@ -97,15 +97,6 @@ users:
 SCC
 }
 
-format_http_host() {
-  local host="$1"
-  if [[ "${host}" == *:* ]]; then
-    printf '[%s]' "${host}"
-  else
-    printf '%s' "${host}"
-  fi
-}
-
 CLIENT_EXE=`which ${CLIENT_EXE}`
 if [ "$?" = "0" ]; then
   echo "The cluster client executable is found here: ${CLIENT_EXE}"
@@ -144,22 +135,6 @@ fi
 # Create the echo service
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n ${AMBIENT_NS}
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n ${SIDECAR_NS}
-${CLIENT_EXE} rollout status deployment/echo-server -n ${AMBIENT_NS} --timeout=120s
-${CLIENT_EXE} rollout status deployment/echo-server -n ${SIDECAR_NS} --timeout=120s
-
-AMBIENT_ECHO_POD_IP=$(${CLIENT_EXE} get pod -l app=echo-server -n ${AMBIENT_NS} -o jsonpath="{.items[0].status.podIP}")
-SIDECAR_ECHO_POD_IP=$(${CLIENT_EXE} get pod -l app=echo-server -n ${SIDECAR_NS} -o jsonpath="{.items[0].status.podIP}")
-
-if [ -z "${AMBIENT_ECHO_POD_IP}" ] || [ -z "${SIDECAR_ECHO_POD_IP}" ]; then
-  echo "Failed to determine echo-server pod IPs in ${AMBIENT_NS} or ${SIDECAR_NS}"
-  exit 1
-fi
-
-AMBIENT_ECHO_POD_HOST=$(format_http_host "${AMBIENT_ECHO_POD_IP}")
-SIDECAR_ECHO_POD_HOST=$(format_http_host "${SIDECAR_ECHO_POD_IP}")
-
-echo "Creating client in ns ${SIDECAR_NS} with ambient echo pod IP ${AMBIENT_ECHO_POD_IP}"
-echo "Creating client in ns ${AMBIENT_NS} with sidecar echo pod IP ${SIDECAR_ECHO_POD_IP}"
 
 # Create the curl client deployment for sidecar namespace
 cat <<NAD | ${CLIENT_EXE} -n ${SIDECAR_NS} apply -f -
@@ -184,14 +159,7 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - |
-          while true; do
-            echo "Calling ambient echo pod at ${AMBIENT_ECHO_POD_IP}..."
-            if ! curl -g -sSf --connect-timeout 5 --max-time 15 "http://${AMBIENT_ECHO_POD_HOST}/" >/dev/null; then
-              echo "[${SIDECAR_NS}] curl failed for baked-in ambient echo pod IP ${AMBIENT_ECHO_POD_IP}. If echo-server was recreated, this IP is stale (curl Deployment args are fixed at apply time). Re-run this install script or patch/reapply curl-client with the current pod IP."
-            fi
-            sleep 5
-          done
+        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-ambient; sleep 5; done;
 NAD
 
 # Create the curl client deployment for ambient namespace
@@ -217,14 +185,7 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - |
-          while true; do
-            echo "Calling sidecar echo pod at ${SIDECAR_ECHO_POD_IP}..."
-            if ! curl -g -sSf --connect-timeout 5 --max-time 15 "http://${SIDECAR_ECHO_POD_HOST}/" >/dev/null; then
-              echo "[${AMBIENT_NS}] curl failed for baked-in sidecar echo pod IP ${SIDECAR_ECHO_POD_IP}. If echo-server was recreated, this IP is stale (curl Deployment args are fixed at apply time). Re-run this install script or patch/reapply curl-client with the current pod IP."
-            fi
-            sleep 5
-          done
+        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-sidecar; sleep 5; done;
 NAD
 
 # Use waypoint?

--- a/hack/istio/ambient/install-sidecars-ambient.sh
+++ b/hack/istio/ambient/install-sidecars-ambient.sh
@@ -97,6 +97,15 @@ users:
 SCC
 }
 
+format_http_host() {
+  local host="$1"
+  if [[ "${host}" == *:* ]]; then
+    printf '[%s]' "${host}"
+  else
+    printf '%s' "${host}"
+  fi
+}
+
 CLIENT_EXE=`which ${CLIENT_EXE}`
 if [ "$?" = "0" ]; then
   echo "The cluster client executable is found here: ${CLIENT_EXE}"
@@ -135,6 +144,22 @@ fi
 # Create the echo service
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n ${AMBIENT_NS}
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n ${SIDECAR_NS}
+${CLIENT_EXE} rollout status deployment/echo-server -n ${AMBIENT_NS} --timeout=120s
+${CLIENT_EXE} rollout status deployment/echo-server -n ${SIDECAR_NS} --timeout=120s
+
+AMBIENT_ECHO_POD_IP=$(${CLIENT_EXE} get pod -l app=echo-server -n ${AMBIENT_NS} -o jsonpath="{.items[0].status.podIP}")
+SIDECAR_ECHO_POD_IP=$(${CLIENT_EXE} get pod -l app=echo-server -n ${SIDECAR_NS} -o jsonpath="{.items[0].status.podIP}")
+
+if [ -z "${AMBIENT_ECHO_POD_IP}" ] || [ -z "${SIDECAR_ECHO_POD_IP}" ]; then
+  echo "Failed to determine echo-server pod IPs in ${AMBIENT_NS} or ${SIDECAR_NS}"
+  exit 1
+fi
+
+AMBIENT_ECHO_POD_HOST=$(format_http_host "${AMBIENT_ECHO_POD_IP}")
+SIDECAR_ECHO_POD_HOST=$(format_http_host "${SIDECAR_ECHO_POD_IP}")
+
+echo "Creating client in ns ${SIDECAR_NS} with ambient echo pod IP ${AMBIENT_ECHO_POD_IP}"
+echo "Creating client in ns ${AMBIENT_NS} with sidecar echo pod IP ${SIDECAR_ECHO_POD_IP}"
 
 # Create the curl client deployment for sidecar namespace
 cat <<NAD | ${CLIENT_EXE} -n ${SIDECAR_NS} apply -f -
@@ -159,7 +184,14 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-ambient; sleep 5; done;
+        - |
+          while true; do
+            echo "Calling ambient echo pod at ${AMBIENT_ECHO_POD_IP}..."
+            if ! curl -g -sSf --connect-timeout 5 --max-time 15 "http://${AMBIENT_ECHO_POD_HOST}/" >/dev/null; then
+              echo "[${SIDECAR_NS}] curl failed for baked-in ambient echo pod IP ${AMBIENT_ECHO_POD_IP}. If echo-server was recreated, this IP is stale (curl Deployment args are fixed at apply time). Re-run this install script or patch/reapply curl-client with the current pod IP."
+            fi
+            sleep 5
+          done
 NAD
 
 # Create the curl client deployment for ambient namespace
@@ -185,7 +217,14 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-sidecar; sleep 5; done;
+        - |
+          while true; do
+            echo "Calling sidecar echo pod at ${SIDECAR_ECHO_POD_IP}..."
+            if ! curl -g -sSf --connect-timeout 5 --max-time 15 "http://${SIDECAR_ECHO_POD_HOST}/" >/dev/null; then
+              echo "[${AMBIENT_NS}] curl failed for baked-in sidecar echo pod IP ${SIDECAR_ECHO_POD_IP}. If echo-server was recreated, this IP is stale (curl Deployment args are fixed at apply time). Re-run this install script or patch/reapply curl-client with the current pod IP."
+            fi
+            sleep 5
+          done
 NAD
 
 # Use waypoint?

--- a/hack/istio/ambient/install-waypoints.sh
+++ b/hack/istio/ambient/install-waypoints.sh
@@ -71,6 +71,15 @@ users:
 SCC
 }
 
+format_http_host() {
+  local host="$1"
+  if [[ "${host}" == *:* ]]; then
+    printf '[%s]' "${host}"
+  else
+    printf '%s' "${host}"
+  fi
+}
+
 # Go to the main output directory and try to find an Istio there.
 HACK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="${OUTPUT_DIR:-${HACK_SCRIPT_DIR}/../../../_output}"
@@ -160,6 +169,7 @@ ${CLIENT_EXE} wait --for=condition=Ready pod -l gateway.networking.k8s.io/gatewa
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-server-waypoint-forworkload.yaml -n waypoint-forworkload
 ${CLIENT_EXE} rollout status deployment/echo-server -n waypoint-forworkload --timeout=120s
 POD_IP=$($CLIENT_EXE get pod -l app=echo-server -n waypoint-forworkload -o jsonpath="{.items[0].status.podIP}")
+POD_HOST=$(format_http_host "${POD_IP}")
 echo "Creating client in ns waypoint-forworkload with echo pod IP ${POD_IP}"
 cat <<NAD | $CLIENT_EXE -n waypoint-forworkload apply -f -
 apiVersion: apps/v1
@@ -186,7 +196,7 @@ spec:
             - |
               while true; do
                 echo "Calling echo pod at ${POD_IP}..."
-                if ! curl -sSf --connect-timeout 5 --max-time 15 "http://${POD_IP}/" >/dev/null; then
+                if ! curl -g -sSf --connect-timeout 5 --max-time 15 "http://${POD_HOST}/" >/dev/null; then
                   echo "[waypoint-forworkload] curl failed for baked-in echo pod IP ${POD_IP}. If echo-server was recreated, this IP is stale (curl Deployment args are fixed at apply time). Re-run this install script for waypoint-forworkload or patch/reapply curl-client with the current pod IP."
                 fi
                 sleep 5


### PR DESCRIPTION
### Describe the change
The waypoint for workload is configured to use the pod IP so the traffic is redirected to the waypoint, and the IPv6 direction was not well interpreted, as it needed []. 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9688
