### PR TITLE
[CI] Fix mcpchecker workflow file

### DIFF
--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -86,7 +86,7 @@ jobs:
     if: needs.check-trigger.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: ${{ github.base_ref || env.DEFAULT_BRANCH }}
+      TARGET_BRANCH: ${{ github.base_ref || github.event.repository.default_branch || 'master' }}
       BUILD_BRANCH: ${{ needs.check-trigger.outputs.pr-sha }}
       KUBERNETES_MCP_SERVER_REPO: ${{ needs.check-trigger.outputs.kubernetes-mcp-server-repo }}
     steps:


### PR DESCRIPTION
### Describe the change

Fix mcpchecker workflow file: 
```
Invalid workflow file: .github/workflows/mcpchecker.yml#L1
(Line: 89, Col: 22): Unrecognized named-value: 'env'. Located at position 20 within expression: github.base_ref || env.DEFAULT_BRANCH
```

### Steps to test the PR

Run `actionlint .github/workflows/mcpchecker.yml` and validate there are no errors

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
