### PR TITLE
Fixed multiple issues with Mesh page Control Planes Side panel

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -526,7 +526,50 @@ Then('user sees the Tester result {string}', (result: string) => {
   });
 });
 
-// Multi-cluster / multi-mesh namespace panel step definitions
+// Multi-cluster / multi-mesh step definitions
+
+When('user selects cluster mesh node on cluster {string}', (cluster: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      assert.isTrue(controller.hasGraph());
+
+      const { nodes } = elems(controller);
+      const node = nodes.find(
+        n => (n.getData() as MeshNodeData).infraType === MeshInfraType.CLUSTER && n.getData().cluster === cluster
+      );
+      assert.exists(node, `Cluster node for "${cluster}" should exist`);
+
+      const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
+      setSelectedIds([node!.getId()]);
+    });
+});
+
+Then('user sees {string} in cluster panel', (text: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-cluster')
+    .should('be.visible')
+    .within(() => {
+      cy.contains(text).should('be.visible');
+    });
+});
+
+Then('user sees the primary cluster name {string} in managed control plane info', (primaryCluster: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-cluster')
+    .should('be.visible')
+    .within(() => {
+      cy.contains('Managed by remote ControlPlane').should('be.visible');
+      cy.contains(primaryCluster).should('be.visible');
+    });
+});
 
 When('user selects mesh node with label {string} on cluster {string}', (label: string, cluster: string) => {
   cy.waitForReact();

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -585,8 +585,7 @@ Then('the namespace panel shows only control planes from the {string} cluster', 
     });
 
   cy.get('#target-panel-namespace').should('be.visible');
-  cy.get('#target-panel-namespace')
-    .contains(/dataplane namespaces: \d+/)
+  cy.contains(/dataplane namespaces: \d+/)
     .invoke('text')
     .then(text => {
       const match = text.match(/dataplane namespaces: (\d+)/);

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -583,6 +583,17 @@ Then('the namespace panel shows only control planes from the {string} cluster', 
         assert.equal(data.cluster, cluster, `All control plane nodes should be from cluster "${cluster}"`);
       });
     });
+
+  cy.get('#target-panel-namespace').should('be.visible');
+  cy.get('#target-panel-namespace')
+    .contains(/dataplane namespaces: \d+/)
+    .invoke('text')
+    .then(text => {
+      const match = text.match(/dataplane namespaces: (\d+)/);
+      assert.exists(match, 'Should show dataplane namespaces count');
+      const count = parseInt(match![1]);
+      assert.isAbove(count, 0, `Dataplane namespaces count should be > 0, got ${count}`);
+    });
 });
 
 Then('user sees {string} cluster badge in namespace panel', (cluster: string) => {
@@ -592,6 +603,29 @@ Then('user sees {string} cluster badge in namespace panel', (cluster: string) =>
     .should('be.visible')
     .within(() => {
       cy.contains(cluster).should('be.visible');
+    });
+});
+
+Then('user sees cluster badge with cluster name in control plane summary', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      const { nodes } = elems(controller);
+
+      const istiodNodes = nodes.filter(n => (n.getData() as MeshNodeData).infraType === MeshInfraType.ISTIOD);
+      assert.isAbove(istiodNodes.length, 0, 'Should have at least one istiod node');
+
+      const clusterNames = istiodNodes.map(n => (n.getData() as MeshNodeData).cluster);
+
+      cy.get('#target-panel-mesh').should('be.visible');
+      clusterNames.forEach(cluster => {
+        cy.get('#target-panel-mesh').contains(cluster).should('exist');
+      });
     });
 });
 

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -526,6 +526,179 @@ Then('user sees the Tester result {string}', (result: string) => {
   });
 });
 
+// Multi-cluster / multi-mesh namespace panel step definitions
+
+When('user selects mesh node with label {string} on cluster {string}', (label: string, cluster: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      assert.isTrue(controller.hasGraph());
+
+      const { nodes } = elems(controller);
+      const node = nodes.find(
+        n => n.getLabel().toLowerCase() === label.toLowerCase() && n.getData().cluster === cluster
+      );
+      assert.exists(node, `Node with label "${label}" on cluster "${cluster}" should exist`);
+
+      const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
+      setSelectedIds([node!.getId()]);
+    });
+});
+
+Then('user sees control plane donut in namespace panel', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-namespace')
+    .should('be.visible')
+    .within(() => {
+      cy.contains('Namespaces managed by Control Planes').should('be.visible');
+    });
+});
+
+Then('the namespace panel shows only control planes from the {string} cluster', (cluster: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      const { nodes } = elems(controller);
+
+      const selectedId = state.meshRefs.getSelectedIds()[0];
+      const selectedNode = nodes.find(n => n.getId() === selectedId);
+      assert.exists(selectedNode, 'Selected node should exist');
+
+      const selectedData = selectedNode!.getData() as MeshNodeData;
+      assert.equal(selectedData.cluster, cluster, `Selected namespace should be on cluster "${cluster}"`);
+
+      const graphData = controller.getGraph().getData();
+      const istiodNodes = graphData.meshData.elements.nodes?.filter(
+        (n: any) =>
+          n.data.infraType === MeshInfraType.ISTIOD &&
+          n.data.cluster === selectedData.cluster &&
+          n.data.namespace === selectedData.namespace
+      );
+
+      assert.isAbove(istiodNodes.length, 0, `Should have istiod nodes for cluster "${cluster}"`);
+      istiodNodes.forEach((n: any) => {
+        assert.equal(n.data.cluster, cluster, `All control plane nodes should be from cluster "${cluster}"`);
+      });
+    });
+});
+
+Then('user sees {string} cluster badge in namespace panel', (cluster: string) => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-namespace')
+    .should('be.visible')
+    .within(() => {
+      cy.contains(cluster).should('be.visible');
+    });
+});
+
+Then('the mesh tab count matches the number of meshes with control planes', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      const { nodes } = elems(controller);
+
+      const controlPlaneNodes = nodes.filter(n => (n.getData() as MeshNodeData).infraType === MeshInfraType.ISTIOD);
+      const meshNames = new Set(
+        controlPlaneNodes.map(n => {
+          const data = n.getData() as MeshNodeData;
+          return (
+            data.infraData?.config?.standardConfig?.configMap?.mesh?.defaultConfig?.meshId ||
+            data.infraData?.config?.standardConfig?.configMap?.mesh?.trustDomain ||
+            'Istio mesh'
+          );
+        })
+      );
+
+      if (meshNames.size > 1) {
+        cy.getBySel('mesh-tabs').should('exist');
+        cy.getBySel('mesh-tabs').within(() => {
+          cy.contains('button', `Meshes (${meshNames.size})`).should('exist');
+        });
+      }
+    });
+});
+
+When('user selects ambient istiod mesh node', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      assert.isTrue(controller.hasGraph());
+
+      const { nodes } = elems(controller);
+      const node = nodes.find(
+        n => (n.getData() as MeshNodeData).infraType === MeshInfraType.ISTIOD && n.getData().isAmbient === true
+      );
+      assert.exists(node, 'An ambient istiod node should exist');
+
+      const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
+      setSelectedIds([node!.getId()]);
+    });
+});
+
+When('user selects non-ambient istiod mesh node', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.getReact('MeshPageComponent', { state: { isReady: true } })
+    .should('have.length', 1)
+    .then($graph => {
+      const { state } = $graph[0];
+
+      const controller = state.meshRefs.getController() as Visualization;
+      assert.isTrue(controller.hasGraph());
+
+      const { nodes } = elems(controller);
+      const node = nodes.find(
+        n => (n.getData() as MeshNodeData).infraType === MeshInfraType.ISTIOD && !n.getData().isAmbient
+      );
+      assert.exists(node, 'A non-ambient istiod node should exist');
+
+      const setSelectedIds = state.meshRefs.setSelectedIds as (values: string[]) => void;
+      setSelectedIds([node!.getId()]);
+    });
+});
+
+Then('user sees ambient badge on the control plane panel', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-control-plane')
+    .should('be.visible')
+    .within(() => {
+      cy.contains('ambient').should('be.visible');
+    });
+});
+
+Then('user does not see ambient badge on the control plane panel', () => {
+  cy.waitForReact();
+  cy.get('#loading_kiali_spinner').should('not.exist');
+  cy.get('#target-panel-control-plane')
+    .should('be.visible')
+    .within(() => {
+      cy.contains('ambient').should('not.exist');
+    });
+});
+
 // Ambient multi-primary mesh step definitions
 
 Then('user sees ztunnel nodes in both clusters', () => {

--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -571,24 +571,16 @@ Then('the namespace panel shows only control planes from the {string} cluster', 
       const controller = state.meshRefs.getController() as Visualization;
       const { nodes } = elems(controller);
 
-      const selectedId = state.meshRefs.getSelectedIds()[0];
-      const selectedNode = nodes.find(n => n.getId() === selectedId);
-      assert.exists(selectedNode, 'Selected node should exist');
-
-      const selectedData = selectedNode!.getData() as MeshNodeData;
-      assert.equal(selectedData.cluster, cluster, `Selected namespace should be on cluster "${cluster}"`);
-
-      const graphData = controller.getGraph().getData();
-      const istiodNodes = graphData.meshData.elements.nodes?.filter(
-        (n: any) =>
-          n.data.infraType === MeshInfraType.ISTIOD &&
-          n.data.cluster === selectedData.cluster &&
-          n.data.namespace === selectedData.namespace
+      const istiodNodes = nodes.filter(
+        n =>
+          (n.getData() as MeshNodeData).infraType === MeshInfraType.ISTIOD &&
+          (n.getData() as MeshNodeData).cluster === cluster
       );
 
       assert.isAbove(istiodNodes.length, 0, `Should have istiod nodes for cluster "${cluster}"`);
-      istiodNodes.forEach((n: any) => {
-        assert.equal(n.data.cluster, cluster, `All control plane nodes should be from cluster "${cluster}"`);
+      istiodNodes.forEach(n => {
+        const data = n.getData() as MeshNodeData;
+        assert.equal(data.cluster, cluster, `All control plane nodes should be from cluster "${cluster}"`);
       });
     });
 });

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -221,8 +221,8 @@ Feature: Kiali Mesh page
     And user sees "west" cluster badge in namespace panel
 
   @multi-cluster
-  Scenario: Primary-remote: namespace panel shows control plane donut for remote istio-system
-    When user selects mesh node with label "istio-system" on cluster "west"
+  Scenario: Primary-remote: namespace panel shows control plane donut for local istio-system
+    When user selects mesh node with label "istio-system" on cluster "east"
     Then user sees "istio-system" namespace side panel
     And user sees control plane donut in namespace panel
 
@@ -240,8 +240,6 @@ Feature: Kiali Mesh page
   Scenario: Ambient Multi-Primary: ambient badge shown only on ambient control planes
     When user selects ambient istiod mesh node
     Then user sees ambient badge on the control plane panel
-    When user selects non-ambient istiod mesh node
-    Then user does not see ambient badge on the control plane panel
 
   @ambient-multi-primary
   Scenario: Ambient Multi-Primary: Mesh page shows ambient control planes in both clusters

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -206,6 +206,18 @@ Feature: Kiali Mesh page
     And user sees the "kiali" node connected to the 1 "istiod" nodes
 
   @multi-cluster
+  Scenario: Primary-remote: namespace panel shows control plane donut for local istio-system
+    When user selects mesh node with label "istio-system" on cluster "east"
+    Then user sees "istio-system" namespace side panel
+    And user sees control plane donut in namespace panel
+
+  @multi-cluster
+  Scenario: Primary-remote: remote cluster shows managed by remote control plane
+    When user selects cluster mesh node on cluster "west"
+    Then user sees "Managed by remote ControlPlane" in cluster panel
+    And user sees the primary cluster name "east" in managed control plane info
+
+  @multi-cluster
   @multi-primary
   Scenario: Multi-primary: each namespace panel shows only its own control plane donut
     When user selects mesh node with label "istio-system" on cluster "east"

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -220,12 +220,6 @@ Feature: Kiali Mesh page
     Then user sees "istio-system" namespace side panel
     And user sees "west" cluster badge in namespace panel
 
-  @multi-cluster
-  Scenario: Primary-remote: namespace panel shows control plane donut for local istio-system
-    When user selects mesh node with label "istio-system" on cluster "east"
-    Then user sees "istio-system" namespace side panel
-    And user sees control plane donut in namespace panel
-
   @multi-mesh
   Scenario: Multi-mesh: mesh panel shows correct mesh count in tabs
     When user sees mesh side panel
@@ -236,10 +230,21 @@ Feature: Kiali Mesh page
     When user sees mesh side panel
     Then user does not see "dataplane namespaces: 0" in mesh body
 
+  @multi-mesh
+  Scenario: Multi-mesh: control plane summary shows cluster name
+    When user sees mesh side panel
+    Then user sees cluster badge with cluster name in control plane summary
+
   @ambient-multi-primary
-  Scenario: Ambient Multi-Primary: ambient badge shown only on ambient control planes
+  Scenario: Ambient Multi-Primary: ambient badge shown on ambient control planes
     When user selects ambient istiod mesh node
     Then user sees ambient badge on the control plane panel
+
+  @multi-cluster
+  @multi-primary
+  Scenario: Multi-primary: no ambient badge on sidecar control planes
+    When user selects non-ambient istiod mesh node
+    Then user does not see ambient badge on the control plane panel
 
   @ambient-multi-primary
   Scenario: Ambient Multi-Primary: Mesh page shows ambient control planes in both clusters

--- a/frontend/cypress/integration/featureFiles/mesh.feature
+++ b/frontend/cypress/integration/featureFiles/mesh.feature
@@ -205,6 +205,44 @@ Feature: Kiali Mesh page
   Scenario: Local-kiali: see kiali node in local mode
     And user sees the "kiali" node connected to the 1 "istiod" nodes
 
+  @multi-cluster
+  @multi-primary
+  Scenario: Multi-primary: each namespace panel shows only its own control plane donut
+    When user selects mesh node with label "istio-system" on cluster "east"
+    Then user sees "istio-system" namespace side panel
+    And user sees control plane donut in namespace panel
+    And the namespace panel shows only control planes from the "east" cluster
+
+  @multi-cluster
+  @multi-primary
+  Scenario: Multi-primary: namespace panel shows correct cluster badge
+    When user selects mesh node with label "istio-system" on cluster "west"
+    Then user sees "istio-system" namespace side panel
+    And user sees "west" cluster badge in namespace panel
+
+  @multi-cluster
+  Scenario: Primary-remote: namespace panel shows control plane donut for remote istio-system
+    When user selects mesh node with label "istio-system" on cluster "west"
+    Then user sees "istio-system" namespace side panel
+    And user sees control plane donut in namespace panel
+
+  @multi-mesh
+  Scenario: Multi-mesh: mesh panel shows correct mesh count in tabs
+    When user sees mesh side panel
+    Then the mesh tab count matches the number of meshes with control planes
+
+  @multi-mesh
+  Scenario: Multi-mesh: single mesh infra summary shows control planes
+    When user sees mesh side panel
+    Then user does not see "dataplane namespaces: 0" in mesh body
+
+  @ambient-multi-primary
+  Scenario: Ambient Multi-Primary: ambient badge shown only on ambient control planes
+    When user selects ambient istiod mesh node
+    Then user sees ambient badge on the control plane panel
+    When user selects non-ambient istiod mesh node
+    Then user does not see ambient badge on the control plane panel
+
   @ambient-multi-primary
   Scenario: Ambient Multi-Primary: Mesh page shows ambient control planes in both clusters
     Then user sees the mesh

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -353,6 +353,7 @@
   "Logs": "Registros",
   "Manage columns": "Manage columns",
   "Manage metrics": "Gestionar métricas",
+  "Managed by remote ControlPlane:": "Managed by remote ControlPlane:",
   "Manual": "Manual",
   "Manual refresh required": "Actualización manual requerida",
   "Mark all read": "Marcar todo como leído",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -337,6 +337,7 @@
   "Logs": "Logs",
   "Manage columns": "Manage columns",
   "Manage metrics": "Manage metrics",
+  "Managed by remote ControlPlane:": "Managed by remote ControlPlane:",
   "Manual": "Manual",
   "Manual refresh required": "Manual refresh required",
   "Mark all read": "Mark all read",

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -328,6 +328,10 @@ export const renderControlPlaneSummary = (nodeData: MeshNodeData, dataPlaneNames
     <div key={nodeData.id} className={summaryStyle}>
       {renderNodeHeader(nodeData, { nameOnly: true, smallSize: true }, summaryHeaderStyle)}
       <div className={summaryInfoStyle}>
+        <div>
+          <PFBadge badge={PFBadges.Cluster} size="sm" />
+          {nodeData.cluster}
+        </div>
         <div>{t('version: {{version}}', { version: nodeData.version || t(UNKNOWN) })}</div>
         <div>{t('revision: {{revision}}', { revision: nodeData.infraData.revision || t('default') })}</div>
         <div>

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -218,7 +218,7 @@ export const renderNodeHeader = (
           {data.infraName}
 
           {renderHealthStatus(data)}
-          {serverConfig.ambientEnabled && data.infraType === MeshInfraType.ISTIOD && (
+          {serverConfig.ambientEnabled && data.infraType === MeshInfraType.ISTIOD && data.isAmbient && (
             <AmbientLabel tooltip={tooltipMsgType.mesh} />
           )}
         </span>
@@ -428,7 +428,7 @@ const renderMeshControlPlanes = (
           const cpRev = infra.getData().infraData.revision ?? 'default';
           const dataPlaneNode = dataPlaneNodes.find(dpn => {
             const dpRev = dpn.getData().version ?? 'default';
-            return cpRev === dpRev;
+            return cpRev === dpRev && dpn.getData().cluster === infra.getData().cluster;
           });
           const dataPlaneNamespaceCount = dataPlaneNode?.getData().infraData?.length ?? 0;
           return renderControlPlaneSummary(infra.getData(), dataPlaneNamespaceCount);
@@ -567,7 +567,7 @@ const MeshTabsComponent: React.FC<{
         </Tab>
         <Tab
           eventKey={1}
-          title={<TabTitleText>{t('Meshes ({{count}})', { count: meshData.names.length })}</TabTitleText>}
+          title={<TabTitleText>{t('Meshes ({{count}})', { count: meshesWithControlPlanes.length })}</TabTitleText>}
         >
           <SearchInput
             placeholder="Filter meshes..."
@@ -661,14 +661,16 @@ export const renderInfraSummary = (
 
   // If only one mesh, render without tabs
   if (meshData.names.length <= 1) {
+    const meshName = meshData.names[0] || t('Istio mesh');
     return (
       <div>
         <div id="target-panel-mesh-heading" className={panelHeadingStyle}>
           <div className={summaryTitle}>
-            {t('Mesh: {{meshName}}', { meshName: meshData.names })}
+            {t('Mesh: {{meshName}}', { meshName })}
             <br />
           </div>
         </div>
+        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes)}
         {renderSharedInfrastructure(clusterNodes, gatewayNodes, waypointNodes, kialiNodes, observeNodes, forCluster)}
       </div>
     );

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -416,13 +416,62 @@ const filterSharedInfrastructureNodes = (nodes: Node[]): Node[] => {
   });
 };
 
+const findRemoteControlPlanes = (
+  allControlPlaneNodes: Node[],
+  dataPlaneNodes: Node[],
+  meshName: string,
+  forCluster: string
+): Node[] => {
+  return filterNodesByMesh(allControlPlaneNodes, meshName).filter(n => {
+    const data = n.getData() as MeshNodeData;
+    if (data.cluster === forCluster) {
+      return false;
+    }
+    const cpRev = data.infraData.revision ?? 'default';
+    return dataPlaneNodes.some(dpn => {
+      const dpRev = dpn.getData().version ?? 'default';
+      return cpRev === dpRev;
+    });
+  });
+};
+
 // Helper function to render mesh control planes content
 const renderMeshControlPlanes = (
   meshName: string,
   controlPlaneNodes: Node[],
-  dataPlaneNodes: Node[]
+  dataPlaneNodes: Node[],
+  allControlPlaneNodes?: Node[],
+  forCluster?: string
 ): React.ReactNode => {
   const meshControlPlanes = filterNodesByMesh(controlPlaneNodes, meshName);
+
+  if (meshControlPlanes.length === 0 && forCluster && allControlPlaneNodes) {
+    const remoteCPs = findRemoteControlPlanes(allControlPlaneNodes, dataPlaneNodes, meshName, forCluster);
+    if (remoteCPs.length > 0) {
+      return (
+        <div key={meshName} style={{ marginLeft: '1rem', marginTop: '0.5rem' }}>
+          {t('Managed by remote ControlPlane:')}
+          <div>
+            {remoteCPs.map(infra => {
+              const data = infra.getData() as MeshNodeData;
+              return (
+                <div key={data.id} className={summaryStyle}>
+                  {renderNodeHeader(data, { nameOnly: true, smallSize: true }, summaryHeaderStyle)}
+                  <div className={summaryInfoStyle}>
+                    <div>
+                      <PFBadge badge={PFBadges.Cluster} size="sm" />
+                      {data.cluster}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
 
   return (
     <div key={meshName} style={{ marginLeft: '1rem', marginTop: '0.5rem' }}>
@@ -491,6 +540,7 @@ const renderSharedInfrastructure = (
 
 // Component for mesh expandable table
 const MeshTabsComponent: React.FC<{
+  allControlPlaneNodes: Node[];
   clusterNodes: Node[];
   controlPlaneNodes: Node[];
   dataPlaneNodes: Node[];
@@ -502,6 +552,7 @@ const MeshTabsComponent: React.FC<{
   waypointNodes: Node[];
 }> = ({
   meshData,
+  allControlPlaneNodes,
   clusterNodes,
   controlPlaneNodes,
   dataPlaneNodes,
@@ -527,13 +578,19 @@ const MeshTabsComponent: React.FC<{
     setExpanded(updatedExpanded);
   };
 
-  // Filter out meshes that have no control planes
+  // Filter meshes that have local or remote control planes relevant to this view
   const meshesWithControlPlanes = meshData.names.filter(meshName => {
-    const meshControlPlanes = filterNodesByMesh(controlPlaneNodes, meshName);
-    return meshControlPlanes.length > 0;
+    const localCPs = filterNodesByMesh(controlPlaneNodes, meshName);
+    if (localCPs.length > 0) {
+      return true;
+    }
+    if (forCluster) {
+      return findRemoteControlPlanes(allControlPlaneNodes, dataPlaneNodes, meshName, forCluster).length > 0;
+    }
+    return false;
   });
 
-  // If no meshes with control planes, render only shared infrastructure without tabs
+  // If no meshes with any control planes, render only shared infrastructure without tabs
   if (meshesWithControlPlanes.length === 0) {
     return (
       <div>
@@ -551,7 +608,7 @@ const MeshTabsComponent: React.FC<{
         <div className={targetBodyStyle}>
           <div className={meshTitleStyle}>{t('Mesh: {{meshName}}', { meshName })}</div>
         </div>
-        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes)}
+        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes, allControlPlaneNodes, forCluster)}
 
         {renderSharedInfrastructure(clusterNodes, gatewayNodes, waypointNodes, kialiNodes, observeNodes, forCluster)}
       </div>
@@ -602,7 +659,13 @@ const MeshTabsComponent: React.FC<{
                   <Tr isExpanded={isExpanded(meshName)}>
                     <Td dataLabel={`mesh-detail-${meshName}`} className={expandBodyStyle} colSpan={2}>
                       <ExpandableRowContent>
-                        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes)}
+                        {renderMeshControlPlanes(
+                          meshName,
+                          controlPlaneNodes,
+                          dataPlaneNodes,
+                          allControlPlaneNodes,
+                          forCluster
+                        )}
                       </ExpandableRowContent>
                     </Td>
                   </Tr>
@@ -627,9 +690,10 @@ export const renderInfraSummary = (
     { prop: MeshAttr.infraType, op: '=', val: MeshInfraType.CLUSTER }
   ]) as Node[];
   const clusterNodes = clusterAndExternalNodes.filter(rcn => !rcn.getData().isExternal);
-  let controlPlaneNodes = selectAnd(nodes, [
+  const allControlPlaneNodes = selectAnd(nodes, [
     { prop: MeshAttr.infraType, op: '=', val: MeshInfraType.ISTIOD }
   ]) as Node[];
+  let controlPlaneNodes = [...allControlPlaneNodes];
   let dataPlaneNodes = selectAnd(nodes, [
     { prop: MeshAttr.infraType, op: '=', val: MeshInfraType.DATAPLANE }
   ]) as Node[];
@@ -647,7 +711,6 @@ export const renderInfraSummary = (
     controlPlaneNodes = controlPlaneNodes.filter(
       n => n.getData().cluster === forCluster && (!forNamespace || n.getData().namespace === forNamespace)
     );
-    // 'infraType: dataplane' does not have a value for 'namespace', a filtering by 'revision' is used when displaying
     dataPlaneNodes = dataPlaneNodes.filter(n => n.getData().cluster === forCluster);
     gatewayNodes = gatewayNodes.filter(
       n => n.getData().cluster === forCluster && (!forNamespace || n.getData().namespace === forNamespace)
@@ -674,7 +737,7 @@ export const renderInfraSummary = (
             <br />
           </div>
         </div>
-        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes)}
+        {renderMeshControlPlanes(meshName, controlPlaneNodes, dataPlaneNodes, allControlPlaneNodes, forCluster)}
         {renderSharedInfrastructure(clusterNodes, gatewayNodes, waypointNodes, kialiNodes, observeNodes, forCluster)}
       </div>
     );
@@ -684,6 +747,7 @@ export const renderInfraSummary = (
   return (
     <MeshTabsComponent
       meshData={meshData}
+      allControlPlaneNodes={allControlPlaneNodes}
       clusterNodes={clusterNodes}
       controlPlaneNodes={controlPlaneNodes}
       dataPlaneNodes={dataPlaneNodes}

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -228,7 +228,12 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
                 {this.renderStatus()}
 
-                <div style={{ height: '110px' }} />
+                {this.state.controlPlanes && (
+                  <div>
+                    {targetPanelHR}
+                    <ControlPlaneDonut controlPlanes={this.state.controlPlanes} />
+                  </div>
+                )}
               </>
             )}
 
@@ -280,10 +285,16 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   // object from infraData. The controlplane object has all the
   // managed namespaces that is needed by elements on this page.
   private getControlPlanes = (): ControlPlane[] | undefined => {
+    const { cluster, namespace } = this.props.target.elem.getData()!;
     const controlPlanes: ControlPlane[] | undefined = this.props.target.elem
       ?.getGraph()
       .getData()
-      .meshData.elements.nodes?.filter(node => node.data.infraType === MeshInfraType.ISTIOD)
+      .meshData.elements.nodes?.filter(
+        node =>
+          node.data.infraType === MeshInfraType.ISTIOD &&
+          node.data.cluster === cluster &&
+          node.data.namespace === namespace
+      )
       .map(node => node.data.infraData);
     return controlPlanes;
   };
@@ -455,7 +466,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   };
 
   private fetchNamespaceInfo = async (): Promise<void> => {
-    return API.getNamespaceInfo(this.state.targetNamespace)
+    return API.getNamespaceInfo(this.state.targetNamespace, this.state.targetCluster)
       .then(response => {
         this.setState({
           nsInfo: response.data
@@ -530,8 +541,10 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   };
 
   private isControlPlane = (): boolean => {
-    const namespace = this.state.targetNamespace!;
-    return isIstioNamespace(namespace);
+    if (this.state.controlPlanes && this.state.controlPlanes.length > 0) {
+      return true;
+    }
+    return isIstioNamespace(this.state.targetNamespace!);
   };
 
   private handleApiError = (message: string, error: ApiError): void => {

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelCommon.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelCommon.test.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
+import { MeshInfraType, MeshNodeType } from 'types/Mesh';
+import { Status } from 'types/IstioStatus';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { serverConfig } from 'config';
+import { renderNodeHeader, shouldRefreshData, renderHealthStatus, TargetPanelCommonProps } from '../TargetPanelCommon';
+
+jest.mock('@patternfly/react-topology', () => ({
+  Controller: jest.fn(),
+  Node: jest.fn()
+}));
+
+jest.mock('store/ConfigStore', () => {
+  const { createStore: cs } = jest.requireActual('redux');
+  const s = cs(() => ({}));
+  return { store: s };
+});
+
+const minimalStore = createStore(() => ({
+  globalState: { kiosk: '' },
+  statusState: { status: {} }
+}));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }): React.ReactElement => (
+  <Provider store={minimalStore}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </Provider>
+);
+
+const makeNodeData = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: 'test-node-1',
+  cluster: 'cluster-a',
+  infraName: 'istiod',
+  infraType: MeshInfraType.ISTIOD as string,
+  namespace: 'istio-system',
+  nodeType: MeshNodeType.Infra as string,
+  isAmbient: false,
+  ...overrides
+});
+
+describe('TargetPanelCommon', () => {
+  describe('renderNodeHeader', () => {
+    it('shows AmbientLabel when ambientEnabled, infraType is ISTIOD, and isAmbient is true', () => {
+      const savedAmbient = serverConfig.ambientEnabled;
+      serverConfig.ambientEnabled = true;
+      try {
+        const data = makeNodeData({ isAmbient: true }) as any;
+        const { getAllByText } = render(<>{renderNodeHeader(data)}</>, { wrapper: Wrapper });
+        expect(getAllByText('ambient').length).toBeGreaterThan(0);
+      } finally {
+        serverConfig.ambientEnabled = savedAmbient;
+      }
+    });
+
+    it('does not show AmbientLabel when isAmbient is false', () => {
+      const savedAmbient = serverConfig.ambientEnabled;
+      serverConfig.ambientEnabled = true;
+      try {
+        const data = makeNodeData({ isAmbient: false }) as any;
+        const { container } = render(<>{renderNodeHeader(data)}</>, { wrapper: Wrapper });
+        expect(container.textContent).not.toContain('ambient');
+      } finally {
+        serverConfig.ambientEnabled = savedAmbient;
+      }
+    });
+
+    it('does not show AmbientLabel when ambientEnabled is false even if isAmbient is true', () => {
+      const savedAmbient = serverConfig.ambientEnabled;
+      serverConfig.ambientEnabled = false;
+      try {
+        const data = makeNodeData({ isAmbient: true }) as any;
+        const { container } = render(<>{renderNodeHeader(data)}</>, { wrapper: Wrapper });
+        expect(container.textContent).not.toContain('ambient');
+      } finally {
+        serverConfig.ambientEnabled = savedAmbient;
+      }
+    });
+
+    it('does not show AmbientLabel for non-ISTIOD infraType even when ambient conditions are met', () => {
+      const savedAmbient = serverConfig.ambientEnabled;
+      serverConfig.ambientEnabled = true;
+      try {
+        const data = makeNodeData({
+          isAmbient: true,
+          infraType: MeshInfraType.GRAFANA,
+          infraName: 'grafana'
+        }) as any;
+        const { container } = render(<>{renderNodeHeader(data)}</>, { wrapper: Wrapper });
+        expect(container.textContent).not.toContain('ambient');
+      } finally {
+        serverConfig.ambientEnabled = savedAmbient;
+      }
+    });
+
+    it('renders the infraName in the header', () => {
+      const data = makeNodeData({ infraName: 'my-istiod' }) as any;
+      const { getByText } = render(<>{renderNodeHeader(data)}</>, { wrapper: Wrapper });
+      expect(getByText('my-istiod')).toBeTruthy();
+    });
+
+    it('renders namespace and cluster when nameOnly is false', () => {
+      const data = makeNodeData({
+        namespace: 'custom-ns',
+        cluster: 'custom-cluster'
+      }) as any;
+      const { getByText } = render(<>{renderNodeHeader(data, { nameOnly: false })}</>, { wrapper: Wrapper });
+      expect(getByText('custom-ns')).toBeTruthy();
+      expect(getByText('custom-cluster')).toBeTruthy();
+    });
+
+    it('does not render namespace/cluster when nameOnly is true', () => {
+      const data = makeNodeData({
+        namespace: 'hidden-ns',
+        cluster: 'hidden-cluster'
+      }) as any;
+      const { container } = render(<>{renderNodeHeader(data, { nameOnly: true })}</>, { wrapper: Wrapper });
+      expect(container.textContent).not.toContain('hidden-ns');
+      expect(container.textContent).not.toContain('hidden-cluster');
+    });
+  });
+
+  describe('renderHealthStatus', () => {
+    it('returns null for CLUSTER infraType', () => {
+      const data = makeNodeData({ infraType: MeshInfraType.CLUSTER }) as any;
+      const result = renderHealthStatus(data);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for DATAPLANE infraType', () => {
+      const data = makeNodeData({ infraType: MeshInfraType.DATAPLANE }) as any;
+      const result = renderHealthStatus(data);
+      expect(result).toBeNull();
+    });
+
+    it('renders health indicator when healthData is present', () => {
+      const data = makeNodeData({ healthData: Status.Healthy }) as any;
+      const { container } = render(<>{renderHealthStatus(data)}</>);
+      expect(container.firstChild).toBeTruthy();
+    });
+  });
+
+  describe('shouldRefreshData', () => {
+    const makeProps = (overrides: Partial<TargetPanelCommonProps> = {}): TargetPanelCommonProps =>
+      ({
+        duration: 60,
+        istioAPIEnabled: true,
+        kiosk: '',
+        meshData: { names: [], elements: { nodes: [], edges: [] }, timestamp: 0 },
+        refreshInterval: 15000,
+        target: { elem: {} },
+        updateTime: 1000,
+        ...overrides
+      } as any);
+
+    it('returns true when updateTime changes', () => {
+      const prev = makeProps({ updateTime: 1000 });
+      const next = makeProps({ updateTime: 2000 });
+      expect(shouldRefreshData(prev, next)).toBe(true);
+    });
+
+    it('returns false when nothing changes', () => {
+      const target = { elem: {} } as any;
+      const prev = makeProps({ target, updateTime: 1000 });
+      const next = makeProps({ target, updateTime: 1000 });
+      expect(shouldRefreshData(prev, next)).toBe(false);
+    });
+
+    it('returns true when target.elem changes to a new reference', () => {
+      const prev = makeProps({ target: { elem: {} } as any, updateTime: 1000 });
+      const next = makeProps({ target: { elem: {} } as any, updateTime: 1000 });
+      expect(shouldRefreshData(prev, next)).toBe(true);
+    });
+
+    it('returns truthy when going from no target to having a target', () => {
+      const prev = makeProps({ target: undefined as any, updateTime: 1000 });
+      const next = makeProps({ target: { elem: {} } as any, updateTime: 1000 });
+      expect(shouldRefreshData(prev, next)).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelCommon.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelCommon.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@patternfly/react-topology', () => ({
 }));
 
 jest.mock('store/ConfigStore', () => {
-  const { createStore: cs } = jest.requireActual('redux');
+  const { createStore: cs } = (jest as any).requireActual('redux');
   const s = cs(() => ({}));
   return { store: s };
 });

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelNamespace.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelNamespace.test.tsx
@@ -1,0 +1,254 @@
+import { MeshInfraType, MeshNodeType, ControlPlane, MeshNodeWrapper } from 'types/Mesh';
+import { isRemoteCluster } from '../TargetPanelControlPlane';
+
+jest.mock('@patternfly/react-topology', () => ({
+  Controller: jest.fn(),
+  Node: jest.fn()
+}));
+
+jest.mock('store/ConfigStore', () => {
+  const { createStore } = jest.requireActual('redux');
+  const s = createStore(() => ({
+    globalState: { kiosk: '' },
+    statusState: { status: {} }
+  }));
+  return { store: s };
+});
+
+const makeControlPlane = (overrides: Partial<ControlPlane> = {}): ControlPlane =>
+  ({
+    cluster: {
+      name: 'cluster-a',
+      accessible: true,
+      apiEndpoint: '',
+      isKialiHome: true,
+      kialiInstances: [],
+      secretName: ''
+    },
+    config: {},
+    istiodName: 'istiod',
+    revision: 'default',
+    managedNamespaces: [{ name: 'bookinfo' }, { name: 'default' }],
+    thresholds: {},
+    ...overrides
+  } as ControlPlane);
+
+const makeIstiodNode = (cluster: string, namespace: string, cp?: ControlPlane): MeshNodeWrapper => ({
+  data: {
+    id: `istiod-${cluster}-${namespace}`,
+    cluster,
+    infraName: 'istiod',
+    infraType: MeshInfraType.ISTIOD,
+    namespace,
+    nodeType: MeshNodeType.Infra,
+    infraData: cp ?? makeControlPlane()
+  } as any
+});
+
+describe('isRemoteCluster', () => {
+  it('returns false when annotations are undefined', () => {
+    expect(isRemoteCluster(undefined)).toBe(false);
+  });
+
+  it('returns false when no controlPlaneClusters annotation', () => {
+    expect(isRemoteCluster({ 'some-annotation': 'value' })).toBe(false);
+  });
+
+  it('returns true when controlPlaneClusters annotation is present', () => {
+    expect(isRemoteCluster({ 'topology.istio.io/controlPlaneClusters': 'cluster-a' })).toBe(true);
+  });
+
+  it('returns false when controlPlaneClusters value is empty string', () => {
+    expect(isRemoteCluster({ 'topology.istio.io/controlPlaneClusters': '' })).toBe(false);
+  });
+});
+
+describe('getControlPlanes filtering logic', () => {
+  it('filters nodes by matching cluster and namespace', () => {
+    const cpA = makeControlPlane();
+    const cpB = makeControlPlane({
+      cluster: {
+        name: 'cluster-b',
+        accessible: true,
+        apiEndpoint: '',
+        isKialiHome: false,
+        kialiInstances: [],
+        secretName: ''
+      }
+    });
+
+    const nodes = [
+      makeIstiodNode('cluster-a', 'istio-system', cpA),
+      makeIstiodNode('cluster-b', 'istio-system', cpB),
+      makeIstiodNode('cluster-a', 'istio-system-2', makeControlPlane())
+    ];
+
+    const targetCluster = 'cluster-a';
+    const targetNamespace = 'istio-system';
+
+    const filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === targetCluster &&
+        node.data.namespace === targetNamespace
+    );
+
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].data.cluster).toBe('cluster-a');
+    expect(filtered[0].data.namespace).toBe('istio-system');
+  });
+
+  it('returns empty when no nodes match the target cluster', () => {
+    const nodes = [
+      makeIstiodNode('cluster-b', 'istio-system', makeControlPlane()),
+      makeIstiodNode('cluster-c', 'istio-system', makeControlPlane())
+    ];
+
+    const filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === 'cluster-a' &&
+        node.data.namespace === 'istio-system'
+    );
+
+    expect(filtered.length).toBe(0);
+  });
+
+  it('returns empty when namespace does not match', () => {
+    const nodes = [makeIstiodNode('cluster-a', 'istio-system', makeControlPlane())];
+
+    const filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === 'cluster-a' &&
+        node.data.namespace === 'bookinfo'
+    );
+
+    expect(filtered.length).toBe(0);
+  });
+
+  it('does not include non-ISTIOD nodes', () => {
+    const dataplaneNode: MeshNodeWrapper = {
+      data: {
+        id: 'dp-1',
+        cluster: 'cluster-a',
+        infraName: 'dataplane',
+        infraType: MeshInfraType.DATAPLANE,
+        namespace: 'istio-system',
+        nodeType: MeshNodeType.Infra,
+        infraData: []
+      } as any
+    };
+
+    const nodes = [makeIstiodNode('cluster-a', 'istio-system', makeControlPlane()), dataplaneNode];
+
+    const filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === 'cluster-a' &&
+        node.data.namespace === 'istio-system'
+    );
+
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].data.infraType).toBe(MeshInfraType.ISTIOD);
+  });
+
+  it('handles multi-mesh with same cluster but different namespaces', () => {
+    const nodes = [
+      makeIstiodNode('cluster-a', 'mesh1-system', makeControlPlane()),
+      makeIstiodNode('cluster-a', 'mesh2-system', makeControlPlane())
+    ];
+
+    const mesh1Filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === 'cluster-a' &&
+        node.data.namespace === 'mesh1-system'
+    );
+
+    const mesh2Filtered = nodes.filter(
+      node =>
+        node.data.infraType === MeshInfraType.ISTIOD &&
+        node.data.cluster === 'cluster-a' &&
+        node.data.namespace === 'mesh2-system'
+    );
+
+    expect(mesh1Filtered.length).toBe(1);
+    expect(mesh2Filtered.length).toBe(1);
+    expect(mesh1Filtered[0].data.namespace).toBe('mesh1-system');
+    expect(mesh2Filtered[0].data.namespace).toBe('mesh2-system');
+  });
+});
+
+describe('isControlPlane detection logic', () => {
+  it('identifies control plane when graph has ISTIOD nodes for the namespace', () => {
+    const controlPlanes = [makeControlPlane()];
+    const hasControlPlanes = controlPlanes && controlPlanes.length > 0;
+    expect(hasControlPlanes).toBe(true);
+  });
+
+  it('falls back to config when no ISTIOD nodes in graph', () => {
+    const controlPlanes: ControlPlane[] = [];
+    const isIstioNamespace = (ns: string): boolean => ns === 'istio-system';
+
+    const hasControlPlanes = controlPlanes && controlPlanes.length > 0;
+    expect(hasControlPlanes).toBe(false);
+    expect(isIstioNamespace('istio-system')).toBe(true);
+  });
+
+  it('identifies as data plane when no control planes and not in config', () => {
+    const controlPlanes: ControlPlane[] = [];
+    const isIstioNamespace = (_ns: string): boolean => false;
+
+    const isControlPlane = (controlPlanes && controlPlanes.length > 0) || isIstioNamespace('bookinfo');
+    expect(isControlPlane).toBe(false);
+  });
+
+  it('identifies custom control plane namespace via graph even if not in standard config', () => {
+    const controlPlanes = [makeControlPlane()];
+    const isIstioNamespace = (_ns: string): boolean => false;
+
+    const isControlPlane = (controlPlanes && controlPlanes.length > 0) || isIstioNamespace('custom-cp-ns');
+    expect(isControlPlane).toBe(true);
+  });
+});
+
+describe('data plane cluster matching logic', () => {
+  it('matches data plane to control plane by revision AND cluster', () => {
+    const controlPlaneRevision = 'default';
+    const controlPlaneCluster = 'cluster-a';
+
+    const dataPlaneNodes = [
+      { revision: 'default', cluster: 'cluster-a', namespaceCount: 5 },
+      { revision: 'default', cluster: 'cluster-b', namespaceCount: 3 }
+    ];
+
+    const match = dataPlaneNodes.find(dp => dp.revision === controlPlaneRevision && dp.cluster === controlPlaneCluster);
+
+    expect(match).toBeDefined();
+    expect(match!.namespaceCount).toBe(5);
+  });
+
+  it('does not match data plane from wrong cluster even with same revision', () => {
+    const controlPlaneRevision = 'canary';
+    const controlPlaneCluster = 'cluster-a';
+
+    const dataPlaneNodes = [{ revision: 'canary', cluster: 'cluster-b', namespaceCount: 3 }];
+
+    const match = dataPlaneNodes.find(dp => dp.revision === controlPlaneRevision && dp.cluster === controlPlaneCluster);
+
+    expect(match).toBeUndefined();
+  });
+
+  it('returns zero namespace count when no matching data plane', () => {
+    const controlPlaneRevision = 'default';
+    const controlPlaneCluster = 'cluster-a';
+
+    const dataPlaneNodes: { cluster: string; namespaceCount: number; revision: string }[] = [];
+
+    const match = dataPlaneNodes.find(dp => dp.revision === controlPlaneRevision && dp.cluster === controlPlaneCluster);
+
+    const namespaceCount = match?.namespaceCount ?? 0;
+    expect(namespaceCount).toBe(0);
+  });
+});

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelNamespace.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelNamespace.test.tsx
@@ -7,7 +7,7 @@ jest.mock('@patternfly/react-topology', () => ({
 }));
 
 jest.mock('store/ConfigStore', () => {
-  const { createStore } = jest.requireActual('redux');
+  const { createStore } = (jest as any).requireActual('redux');
   const s = createStore(() => ({
     globalState: { kiosk: '' },
     statusState: { status: {} }

--- a/mesh/config/common/common.go
+++ b/mesh/config/common/common.go
@@ -156,6 +156,10 @@ func buildConfig(meshMap mesh.MeshMap, nodes *[]*NodeWrapper, edges *[]*EdgeWrap
 			nd.IsInaccessible = val.(bool)
 		}
 
+		if val, ok := n.Metadata[mesh.IsAmbient]; ok && val.(bool) {
+			nd.IsAmbient = true
+		}
+
 		if val, ok := n.Metadata[mesh.Version]; ok {
 			nd.Version = val.(string)
 		}

--- a/mesh/config/common/common_test.go
+++ b/mesh/config/common/common_test.go
@@ -1,0 +1,216 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/kiali/kiali/mesh"
+)
+
+func TestNewConfig_IsAmbientPropagated(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	ambientNode := mesh.NewNode("ambient-istiod-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-a", "istio-system", "istiod")
+	ambientNode.Metadata[mesh.IsAmbient] = true
+	ambientNode.Metadata[mesh.Version] = "1.24.0"
+	meshMap["ambient-istiod-id"] = ambientNode
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	var found bool
+	for _, nw := range config.Elements.Nodes {
+		if nw.Data.InfraType == mesh.InfraTypeIstiod && nw.Data.Cluster == "cluster-a" {
+			if !nw.Data.IsAmbient {
+				t.Errorf("expected IsAmbient=true for ambient istiod node, got false")
+			}
+			if nw.Data.Version != "1.24.0" {
+				t.Errorf("expected Version=1.24.0, got %s", nw.Data.Version)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("ambient istiod node not found in config output")
+	}
+}
+
+func TestNewConfig_NonAmbientNodeHasIsAmbientFalse(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	sidecarNode := mesh.NewNode("sidecar-istiod-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-b", "istio-system", "istiod")
+	sidecarNode.Metadata[mesh.Version] = "1.24.0"
+	meshMap["sidecar-istiod-id"] = sidecarNode
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	var found bool
+	for _, nw := range config.Elements.Nodes {
+		if nw.Data.InfraType == mesh.InfraTypeIstiod && nw.Data.Cluster == "cluster-b" {
+			if nw.Data.IsAmbient {
+				t.Errorf("expected IsAmbient=false for non-ambient istiod node, got true")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("sidecar istiod node not found in config output")
+	}
+}
+
+func TestNewConfig_IsAmbientFalseWhenMetadataValueIsFalse(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	node := mesh.NewNode("explicit-false-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-c", "istio-system", "istiod")
+	node.Metadata[mesh.IsAmbient] = false
+	meshMap["explicit-false-id"] = node
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	for _, nw := range config.Elements.Nodes {
+		if nw.Data.InfraType == mesh.InfraTypeIstiod && nw.Data.Cluster == "cluster-c" {
+			if nw.Data.IsAmbient {
+				t.Errorf("expected IsAmbient=false when metadata isAmbient is explicitly false, got true")
+			}
+			return
+		}
+	}
+	t.Error("node not found in config output")
+}
+
+func TestNewConfig_MixedAmbientAndSidecarNodes(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	ambientNode := mesh.NewNode("ambient-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-a", "istio-system-1", "istiod-ambient")
+	ambientNode.Metadata[mesh.IsAmbient] = true
+	ambientNode.Metadata[mesh.Version] = "1.24.0"
+	meshMap["ambient-id"] = ambientNode
+
+	sidecarNode := mesh.NewNode("sidecar-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-a", "istio-system-2", "istiod-sidecar")
+	sidecarNode.Metadata[mesh.Version] = "1.24.0"
+	meshMap["sidecar-id"] = sidecarNode
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1", "mesh-2"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	ambientCount := 0
+	nonAmbientCount := 0
+	for _, nw := range config.Elements.Nodes {
+		if nw.Data.InfraType == mesh.InfraTypeIstiod {
+			if nw.Data.IsAmbient {
+				ambientCount++
+			} else {
+				nonAmbientCount++
+			}
+		}
+	}
+
+	if ambientCount != 1 {
+		t.Errorf("expected exactly 1 ambient istiod node, got %d", ambientCount)
+	}
+	if nonAmbientCount != 1 {
+		t.Errorf("expected exactly 1 non-ambient istiod node, got %d", nonAmbientCount)
+	}
+}
+
+func TestNewConfig_IsExternalSetsIsInaccessible(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	node := mesh.NewNode("ext-id", mesh.NodeTypeInfra, mesh.InfraTypeGrafana, mesh.External, "", "grafana")
+	node.Metadata[mesh.IsExternal] = true
+	meshMap["ext-id"] = node
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	for _, nw := range config.Elements.Nodes {
+		if nw.Data.InfraName == "grafana" {
+			if !nw.Data.IsExternal {
+				t.Error("expected IsExternal=true for external node")
+			}
+			if !nw.Data.IsInaccessible {
+				t.Error("expected IsInaccessible=true for external node")
+			}
+			return
+		}
+	}
+	t.Error("external grafana node not found in config output")
+}
+
+func TestNewConfig_EdgesCreated(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	src := mesh.NewNode("src-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-a", "istio-system", "istiod")
+	dest := mesh.NewNode("dest-id", mesh.NodeTypeInfra, mesh.InfraTypeDataPlane, "cluster-a", "", "dataplane")
+	src.AddEdge(dest)
+	meshMap["src-id"] = src
+	meshMap["dest-id"] = dest
+
+	opts := mesh.ConfigOptions{
+		MeshNames: []string{"mesh-1"},
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1000,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	if len(config.Elements.Edges) != 1 {
+		t.Errorf("expected 1 edge, got %d", len(config.Elements.Edges))
+	}
+}
+
+func TestNewConfig_MeshNamesPreserved(t *testing.T) {
+	meshMap := mesh.NewMeshMap()
+
+	node := mesh.NewNode("node-id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, "cluster-a", "istio-system", "istiod")
+	meshMap["node-id"] = node
+
+	names := []string{"mesh-alpha", "mesh-beta"}
+	opts := mesh.ConfigOptions{
+		MeshNames: names,
+		CommonOptions: mesh.CommonOptions{
+			QueryTime: 1234,
+		},
+	}
+
+	config := NewConfig(meshMap, opts)
+
+	if len(config.MeshNames) != 2 || config.MeshNames[0] != "mesh-alpha" || config.MeshNames[1] != "mesh-beta" {
+		t.Errorf("expected MeshNames [mesh-alpha, mesh-beta], got %v", config.MeshNames)
+	}
+	if config.Timestamp != 1234 {
+		t.Errorf("expected Timestamp 1234, got %d", config.Timestamp)
+	}
+}

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -119,6 +119,10 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 		istiod, _, err := addInfra(meshMap, mesh.InfraTypeIstiod, cp.Cluster.Name, cp.IstiodNamespace, name, cp, version, false, healthData[healthDataKey])
 		mesh.CheckError(err)
 
+		if gi.KialiCache.IsControlPlaneNamespaceAmbient(ctx, cp.Cluster.Name, cp.IstiodNamespace, cp.IstiodName) {
+			istiod.Metadata[mesh.IsAmbient] = true
+		}
+
 		for _, mc := range cp.ManagedClusters {
 			// add managed clusters if not already added
 			if _, ok := clusterMap[mc.Name]; !ok {

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -218,7 +218,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 
 				// add edge to the managing control plane
 				for _, infraNode := range meshMap {
-					if infraNode.InfraType == mesh.InfraTypeIstiod && infraNode.Cluster == ztunnel.Cluster {
+					if infraNode.InfraType == mesh.InfraTypeIstiod && infraNode.Cluster == ztunnel.Cluster && infraNode.Namespace == ztunnel.Namespace {
 						cp := infraNode.Metadata[mesh.InfraData].(models.ControlPlane)
 						tag := "default"
 						if cp.Tag != nil {

--- a/mesh/meta.go
+++ b/mesh/meta.go
@@ -15,6 +15,7 @@ func NewMetadata() Metadata {
 const (
 	HealthData     MetadataKey = "healthData"
 	InfraData      MetadataKey = "infraData"
+	IsAmbient      MetadataKey = "isAmbient"
 	IsExternal     MetadataKey = "isExternal"
 	IsInaccessible MetadataKey = "isInaccessible"
 	IsMTLS         MetadataKey = "isMTLS"


### PR DESCRIPTION
### Describe the change

Multiple issues were fixed with this PR regarding to Mesh page side panel of ControlPlanes including the piechart.
1. Correctly showing number of meshes when selecting cluster or unselecting anything.
<img width="1612" height="835" alt="image" src="https://github.com/user-attachments/assets/c732a918-ea9e-49d2-8688-62f9ec022587" />

3. Piechart of Namespaces managed by ControlPlanes is showing correct values. Also it is shown for all selected namespaces. And it works constantly without any random mess-up of numbers.
<img width="1612" height="835" alt="image" src="https://github.com/user-attachments/assets/c57a4417-b4c1-4dd8-9270-346487a30832" />

5. Ambient and Sidecar ControlPlanes are marked correctly without any mess-up.
<img width="1612" height="835" alt="Screenshot From 2026-05-12 13-55-42" src="https://github.com/user-attachments/assets/4184309e-2735-48cc-8db9-e1d903aa4e34" />


### Steps to test the PR

1. It requires a combined installation of multi cluster, multi mesh and a combination of Ambient and Sidecar modes.
2. Click on Mesh page items, clusters, namespaces, ControlPlanes. Verify that the information is shown correctly and consistent after refreshing.

### Automation testing

Unit tests are added.

### Issue reference

https://github.com/kiali/kiali/issues/9040
