### PR TITLE
Metrics: Include waypoint reporter based on frontend query param

### DIFF
--- a/business/metrics.go
+++ b/business/metrics.go
@@ -232,11 +232,11 @@ func (in *MetricsService) getSingleQueryStats(ctx context.Context, q *models.Met
 
 func createStatsMetricsLabelsBuilder(q *models.MetricsStatsQuery, conf *config.Config) *MetricsLabelsBuilder {
 	lb := NewMetricsLabelsBuilder(q.Direction, conf)
-	includeAmbient := true
-	if q.IncludeAmbient != nil {
-		includeAmbient = *q.IncludeAmbient
+	if len(q.Reporters) == 0 {
+		lb.SelfReporter()
+	} else {
+		lb.Reporters(q.Reporters)
 	}
-	lb.Reporter(lb.side, includeAmbient)
 	switch q.Target.Kind {
 	case "app":
 		lb.App(q.Target.Name, q.Target.Namespace)

--- a/business/metrics.go
+++ b/business/metrics.go
@@ -232,7 +232,11 @@ func (in *MetricsService) getSingleQueryStats(ctx context.Context, q *models.Met
 
 func createStatsMetricsLabelsBuilder(q *models.MetricsStatsQuery, conf *config.Config) *MetricsLabelsBuilder {
 	lb := NewMetricsLabelsBuilder(q.Direction, conf)
-	lb.SelfReporter()
+	includeAmbient := true
+	if q.IncludeAmbient != nil {
+		includeAmbient = *q.IncludeAmbient
+	}
+	lb.Reporter(lb.side, includeAmbient)
 	switch q.Target.Kind {
 	case "app":
 		lb.App(q.Target.Name, q.Target.Namespace)

--- a/business/metrics_labels_builder.go
+++ b/business/metrics_labels_builder.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/kiali/kiali/config"
@@ -57,6 +58,28 @@ func (lb *MetricsLabelsBuilder) Reporter(name string, includeAmbient bool) *Metr
 		return lb.AddOp("reporter", fmt.Sprintf("%s|%s", name, "waypoint"), "=~")
 	}
 	return lb.Add("reporter", name)
+}
+
+func (lb *MetricsLabelsBuilder) Reporters(reporters []string) *MetricsLabelsBuilder {
+	if len(reporters) == 0 {
+		return lb
+	}
+
+	normalized := make([]string, 0, len(reporters))
+	seen := make(map[string]struct{}, len(reporters))
+	for _, reporter := range reporters {
+		if _, found := seen[reporter]; found {
+			continue
+		}
+		seen[reporter] = struct{}{}
+		normalized = append(normalized, reporter)
+	}
+
+	sort.Strings(normalized)
+	if len(normalized) == 1 {
+		return lb.Add("reporter", normalized[0])
+	}
+	return lb.AddOp("reporter", strings.Join(normalized, "|"), "=~")
 }
 
 func (lb *MetricsLabelsBuilder) SelfReporter() *MetricsLabelsBuilder {

--- a/business/metrics_test.go
+++ b/business/metrics_test.go
@@ -377,6 +377,26 @@ func TestCreateStatsMetricsLabelsBuilder(t *testing.T) {
 		QueryTime: time.Now(),
 	}
 	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
+	assert.Equal(`{reporter=~"destination|waypoint",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
+}
+
+func TestCreateStatsMetricsLabelsBuilderWithoutAmbient(t *testing.T) {
+	assert := assert.New(t)
+	includeAmbient := false
+	q := models.MetricsStatsQuery{
+		Target: models.Target{
+			Namespace: "ns3",
+			Name:      "foo",
+			Kind:      "app",
+		},
+		IncludeAmbient: &includeAmbient,
+		Direction:      "inbound",
+		Interval:       "3h",
+		Avg:            true,
+		Quantiles:      []string{"0.90", "0.5"},
+		QueryTime:      time.Now(),
+	}
+	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
 	assert.Equal(`{reporter="destination",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
 }
 
@@ -400,7 +420,7 @@ func TestCreateStatsMetricsLabelsBuilderWithPeer(t *testing.T) {
 		QueryTime: time.Now(),
 	}
 	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
-	assert.Equal(`{reporter="destination",destination_workload_namespace="ns3",destination_canonical_service="foo",source_workload_namespace="ns4",source_canonical_service="bar"}`, lb.Build())
+	assert.Equal(`{reporter=~"destination|waypoint",destination_workload_namespace="ns3",destination_canonical_service="foo",source_workload_namespace="ns4",source_canonical_service="bar"}`, lb.Build())
 }
 
 func TestGetMetricsStats(t *testing.T) {
@@ -449,8 +469,8 @@ func TestGetMetricsStats(t *testing.T) {
 	q1P95 := model.Vector{createSample(8)}
 	q2P50 := model.Vector{createSample(6.3)}
 	q2P95 := model.Vector{createSample(9.3)}
-	q1Labels := `reporter="source",source_workload_namespace="ns1",source_canonical_service="foo"`
-	q2Labels := `reporter="destination",destination_service_name="bar",destination_service_namespace="ns2",source_workload_namespace="ns3",source_workload="w1"`
+	q1Labels := `reporter=~"source|waypoint",source_workload_namespace="ns1",source_canonical_service="foo"`
+	q2Labels := `reporter=~"destination|waypoint",destination_service_name="bar",destination_service_namespace="ns2",source_workload_namespace="ns3",source_workload="w1"`
 	api.MockHistoValue(context.Background(), "istio_request_duration_milliseconds", "{"+q1Labels+"}[30m]", q1Avg, v0, q1P95, v0)
 	api.MockHistoValue(context.Background(), "istio_request_duration_milliseconds", "{"+q2Labels+"}[3h]", v0, q2P50, q2P95, v0)
 

--- a/business/metrics_test.go
+++ b/business/metrics_test.go
@@ -377,27 +377,26 @@ func TestCreateStatsMetricsLabelsBuilder(t *testing.T) {
 		QueryTime: time.Now(),
 	}
 	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
-	assert.Equal(`{reporter=~"destination|waypoint",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
+	assert.Equal(`{reporter="destination",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
 }
 
-func TestCreateStatsMetricsLabelsBuilderWithoutAmbient(t *testing.T) {
+func TestCreateStatsMetricsLabelsBuilderWithWaypointReporter(t *testing.T) {
 	assert := assert.New(t)
-	includeAmbient := false
 	q := models.MetricsStatsQuery{
 		Target: models.Target{
 			Namespace: "ns3",
 			Name:      "foo",
 			Kind:      "app",
 		},
-		IncludeAmbient: &includeAmbient,
-		Direction:      "inbound",
-		Interval:       "3h",
-		Avg:            true,
-		Quantiles:      []string{"0.90", "0.5"},
-		QueryTime:      time.Now(),
+		Reporters: []string{"destination", "waypoint"},
+		Direction: "inbound",
+		Interval:  "3h",
+		Avg:       true,
+		Quantiles: []string{"0.90", "0.5"},
+		QueryTime: time.Now(),
 	}
 	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
-	assert.Equal(`{reporter="destination",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
+	assert.Equal(`{reporter=~"destination|waypoint",destination_workload_namespace="ns3",destination_canonical_service="foo"}`, lb.Build())
 }
 
 func TestCreateStatsMetricsLabelsBuilderWithPeer(t *testing.T) {
@@ -420,7 +419,7 @@ func TestCreateStatsMetricsLabelsBuilderWithPeer(t *testing.T) {
 		QueryTime: time.Now(),
 	}
 	lb := createStatsMetricsLabelsBuilder(&q, config.Get())
-	assert.Equal(`{reporter=~"destination|waypoint",destination_workload_namespace="ns3",destination_canonical_service="foo",source_workload_namespace="ns4",source_canonical_service="bar"}`, lb.Build())
+	assert.Equal(`{reporter="destination",destination_workload_namespace="ns3",destination_canonical_service="foo",source_workload_namespace="ns4",source_canonical_service="bar"}`, lb.Build())
 }
 
 func TestGetMetricsStats(t *testing.T) {
@@ -438,6 +437,7 @@ func TestGetMetricsStats(t *testing.T) {
 			Name:      "foo",
 			Kind:      "app",
 		},
+		Reporters:    []string{"source", "waypoint"},
 		Direction:    "outbound",
 		Interval:     "30m",
 		RawInterval:  "30m",
@@ -455,6 +455,7 @@ func TestGetMetricsStats(t *testing.T) {
 			Name:      "w1",
 			Kind:      "workload",
 		},
+		Reporters:    []string{"destination", "waypoint"},
 		Direction:    "inbound",
 		Interval:     "3h",
 		RawInterval:  "3h",
@@ -479,8 +480,8 @@ func TestGetMetricsStats(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(stats, 2)
 	fmt.Printf("%v\n", stats)
-	assert.Equal([]models.Stat{{Name: "0.95", Value: 8.0}, {Name: "avg", Value: 5.0}}, stats["ns1:app:foo::outbound:30m"].ResponseTimes)
-	assert.Equal([]models.Stat{{Name: "0.5", Value: 6.3}, {Name: "0.95", Value: 9.3}}, stats["ns2:service:bar:ns3:workload:w1:inbound:3h"].ResponseTimes)
+	assert.Equal([]models.Stat{{Name: "0.95", Value: 8.0}, {Name: "avg", Value: 5.0}}, stats["ns1:app:foo::outbound:30m:source,waypoint"].ResponseTimes)
+	assert.Equal([]models.Stat{{Name: "0.5", Value: 6.3}, {Name: "0.95", Value: 9.3}}, stats["ns2:service:bar:ns3:workload:w1:inbound:3h:destination,waypoint"].ResponseTimes)
 }
 
 func TestGetZtunnelMetrics(t *testing.T) {

--- a/frontend/cypress/integration/common/apps.ts
+++ b/frontend/cypress/integration/common/apps.ts
@@ -130,6 +130,34 @@ Then('user sees trace details', () => {
   cy.getBySel('trace-details-dropdown').contains('View on Graph');
 });
 
+When('user hovers over a trace with at least {int} spans', (spans: number) => {
+  cy.getBySel('tracing-scatterplot').within(() => {
+    // Victory can render points in an initial transient position before settling them.
+    // Give the scatter plot a moment to stabilize before resolving the target point.
+    cy.wait(5000);
+    cy.waitForReact();
+    cy.getReact('*oint', { props: { symbol: 'circle' } })
+      .should('have.length.at.least', 1)
+      .then(($points: any) => {
+        const pointWithTraceName = $points.filter(point => point.props?.datum?.trace?.spans.length >= spans)[0];
+        const dataPointInGraph = pointWithTraceName.children[0].props.d;
+
+        cy.get(`path[d="${dataPointInGraph}"]`)
+          .should('be.visible')
+          .trigger('mouseover', { force: true })
+          .trigger('mouseenter', { force: true })
+          .trigger('mousemove', { force: true });
+      });
+  });
+});
+
+Then('user sees the tracing tooltip heat map', () => {
+  cy.getBySel('trace-tooltip', { timeout: 10000 }).should('be.visible');
+  cy.getBySel('trace-tooltip-heatmap', { timeout: 20000 }).should('be.visible');
+  cy.getBySel('trace-tooltip-heatmap-area').should('not.contain', 'n/a');
+  cy.getBySel('trace-tooltip').find('[role="progressbar"]').should('not.exist');
+});
+
 When('user selects a trace', function () {
   Step(this, 'user selects a trace with at least 0 spans');
 });

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -4,6 +4,19 @@ import { getCellsForCol } from './table';
 import { Pod } from 'types/IstioObjects';
 import { enableKialiFeature, USE_WAYPOINT_NAME_CONFIG } from './kiali-config';
 
+const tracingPathByTarget = (targetType: string, namespace: string, name: string): string => {
+  switch (targetType) {
+    case 'app':
+      return `${Cypress.config('baseUrl')}/api/namespaces/${namespace}/apps/${name}/traces`;
+    case 'service':
+      return `${Cypress.config('baseUrl')}/api/namespaces/${namespace}/services/${name}/traces`;
+    case 'workload':
+      return `${Cypress.config('baseUrl')}/api/namespaces/${namespace}/workloads/${name}/traces`;
+    default:
+      throw new Error(`Unsupported tracing target type: ${targetType}`);
+  }
+};
+
 // waitForWorkloadEnrolled waits until Kiali returns the namespace labels updated
 // Adding the waypoint label into the bookinfo namespace
 // This is usually enough (Slower) to have the workloads enrolled
@@ -199,6 +212,60 @@ const waitForWorkloadTracesInApi = (
   });
 };
 
+const waitForTargetTracesInApi = (
+  targetType: string,
+  namespace: string,
+  name: string,
+  clusterName?: string,
+  maxRetries = 18,
+  retryCount = 0
+): void => {
+  if (retryCount >= maxRetries) {
+    throw new Error(
+      `Tracing data not found after ${maxRetries} retries (targetType=${targetType}, namespace=${namespace}, name=${name}, cluster=${
+        clusterName ?? ''
+      }, baseUrl=${Cypress.config('baseUrl')})`
+    );
+  }
+
+  const nowMicros = Date.now() * 1000;
+  const qs: Record<string, any> = {
+    startMicros: nowMicros - 10 * 60 * 1000 * 1000,
+    endMicros: nowMicros,
+    tags: '{}',
+    limit: 100
+  };
+  if (clusterName) {
+    qs.clusterName = clusterName;
+  }
+
+  cy.request({
+    method: 'GET',
+    url: tracingPathByTarget(targetType, namespace, name),
+    qs,
+    failOnStatusCode: false
+  }).then(response => {
+    expect(response.status).to.equal(200);
+    const traces = response.body?.data;
+    if (Array.isArray(traces) && traces.length > 0) {
+      return;
+    }
+
+    if (retryCount === 0 || retryCount % 5 === 0) {
+      Cypress.log({
+        name: 'waitForTargetTraces',
+        message: `retry=${retryCount}/${maxRetries} targetType=${targetType} namespace=${namespace} name=${name} tracesCount=${
+          Array.isArray(traces) ? traces.length : -1
+        } baseUrl=${Cypress.config('baseUrl')}`
+      });
+    }
+
+    return cy
+      .wait(10000)
+      .then(() => waitForTargetTracesInApi(targetType, namespace, name, clusterName, maxRetries, retryCount + 1));
+  });
+};
+
 const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: string): void => {
   const maxRetries = 20;
   let requestUrl = `${Cypress.config(
@@ -369,6 +436,11 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
   // Poll the traces endpoint so downstream assertions on tracing UI don't flake.
   waitForWorkloadTracesInApi(namespace, workload);
+});
+
+Then('the tracing data is ready for the {string} {string}', (targetType: string, namespacedName: string) => {
+  const [namespace, name] = namespacedName.split('/');
+  waitForTargetTracesInApi(targetType, namespace, name);
 });
 
 const waitForWaypointNodeInGraph = (namespace: string, maxRetries = 30, retryCount = 0): void => {

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -63,3 +63,11 @@ Feature: Kiali App Details page
     When user selects a trace with at least 4 spans
     Then user sees span details
     And user can filter spans by app "details" by "waypoint"
+
+  @waypoint-tracing
+  Scenario: See tracing tooltip heat map for flights app in travel-agency
+    Given the tracing data is ready for the "app" "travel-agency/flights"
+    And user is at the details page for the "app" "travel-agency/flights" located in the "" cluster
+    And user sees trace information
+    When user hovers over a trace with at least 4 spans
+    Then user sees the tracing tooltip heat map

--- a/frontend/cypress/integration/featureFiles/app_details.feature
+++ b/frontend/cypress/integration/featureFiles/app_details.feature
@@ -65,9 +65,10 @@ Feature: Kiali App Details page
     And user can filter spans by app "details" by "waypoint"
 
   @waypoint-tracing
-  Scenario: See tracing tooltip heat map for flights app in travel-agency
-    Given the tracing data is ready for the "app" "travel-agency/flights"
-    And user is at the details page for the "app" "travel-agency/flights" located in the "" cluster
+  # TODO: Switch this back to travel-agency/flights once the travels demo image is updated.
+  Scenario: See tracing tooltip heat map for reviews app in bookinfo
+    Given the tracing data is ready for the "app" "bookinfo/reviews"
+    And user is at the details page for the "app" "bookinfo/reviews" located in the "" cluster
     And user sees trace information
     When user hovers over a trace with at least 4 spans
     Then user sees the tracing tooltip heat map

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -83,9 +83,10 @@ Feature: Kiali Service Details page
     Then user sees span details
 
   @waypoint-tracing
-  Scenario: See tracing tooltip heat map for insurances service in travel-agency
-    Given the tracing data is ready for the "service" "travel-agency/insurances"
-    And user is at the details page for the "service" "travel-agency/insurances" located in the "" cluster
+  # TODO: Switch this back to travel-agency/insurances once the travels demo image is updated.
+  Scenario: See tracing tooltip heat map for reviews service in bookinfo
+    Given the tracing data is ready for the "service" "bookinfo/reviews"
+    And user is at the details page for the "service" "bookinfo/reviews" located in the "" cluster
     And user sees trace information
     When user hovers over a trace with at least 4 spans
     Then user sees the tracing tooltip heat map

--- a/frontend/cypress/integration/featureFiles/service_details.feature
+++ b/frontend/cypress/integration/featureFiles/service_details.feature
@@ -82,6 +82,14 @@ Feature: Kiali Service Details page
     When user selects a trace with at least 4 spans
     Then user sees span details
 
+  @waypoint-tracing
+  Scenario: See tracing tooltip heat map for insurances service in travel-agency
+    Given the tracing data is ready for the "service" "travel-agency/insurances"
+    And user is at the details page for the "service" "travel-agency/insurances" located in the "" cluster
+    And user sees trace information
+    When user hovers over a trace with at least 4 spans
+    Then user sees the tracing tooltip heat map
+
   @ambient-multi-primary
   # TODO: offline - ambient support.
   Scenario: See ambient label for service

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -46,21 +46,6 @@ Feature: Kiali Waypoint related features
     And the user sees the L7 "waypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
 
-  @selected
-  @waypoint-tracing
-  Scenario Outline: [Tracing tooltip] Travel agency waypoint targets show a heat map
-    Given the tracing data is ready for the "<detail>" "travel-agency/<name>"
-    And user is at the details page for the "<detail>" "travel-agency/<name>" located in the "" cluster
-    And user sees trace information
-    When user hovers over a trace with at least 4 spans
-    Then user sees the tracing tooltip heat map
-
-    Examples:
-      | detail   | name       |
-      | service  | insurances |
-      | app      | flights    |
-      | workload | travels-v1 |
-
   Scenario: [Workload details - waypoint] The workload details for a waypoint are valid
     And user is at the details page for the "workload" "bookinfo/waypoint" located in the "" cluster
     Then the user sees the waypoint attribute

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -46,6 +46,21 @@ Feature: Kiali Waypoint related features
     And the user sees the L7 "waypoint" link
     And the link for the waypoint "waypoint" should redirect to a valid workload details
 
+  @selected
+  @waypoint-tracing
+  Scenario Outline: [Tracing tooltip] Travel agency waypoint targets show a heat map
+    Given the tracing data is ready for the "<detail>" "travel-agency/<name>"
+    And user is at the details page for the "<detail>" "travel-agency/<name>" located in the "" cluster
+    And user sees trace information
+    When user hovers over a trace with at least 4 spans
+    Then user sees the tracing tooltip heat map
+
+    Examples:
+      | detail   | name       |
+      | service  | insurances |
+      | app      | flights    |
+      | workload | travels-v1 |
+
   Scenario: [Workload details - waypoint] The workload details for a waypoint are valid
     And user is at the details page for the "workload" "bookinfo/waypoint" located in the "" cluster
     Then the user sees the waypoint attribute

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -72,6 +72,14 @@ Feature: Kiali Workload Details page
     And user sees span details
     And user can filter spans by workload "details-v1"
 
+  @waypoint-tracing
+  Scenario: See tracing tooltip heat map for travels-v1 workload in travel-agency
+    Given the tracing data is ready for the "workload" "travel-agency/travels-v1"
+    And user is at the details page for the "workload" "travel-agency/travels-v1" located in the "" cluster
+    And user sees trace information
+    When user hovers over a trace with at least 4 spans
+    Then user sees the tracing tooltip heat map
+
   @bookinfo-app
   @tracing
   # TODO: offline - tracing.

--- a/frontend/cypress/integration/featureFiles/workloads_details.feature
+++ b/frontend/cypress/integration/featureFiles/workloads_details.feature
@@ -73,9 +73,10 @@ Feature: Kiali Workload Details page
     And user can filter spans by workload "details-v1"
 
   @waypoint-tracing
-  Scenario: See tracing tooltip heat map for travels-v1 workload in travel-agency
-    Given the tracing data is ready for the "workload" "travel-agency/travels-v1"
-    And user is at the details page for the "workload" "travel-agency/travels-v1" located in the "" cluster
+  # TODO: Switch this back to travel-agency/travels-v1 once the travels demo image is updated.
+  Scenario: See tracing tooltip heat map for reviews-v2 workload in bookinfo
+    Given the tracing data is ready for the "workload" "bookinfo/reviews-v2"
+    And user is at the details page for the "workload" "bookinfo/reviews-v2" located in the "" cluster
     And user sees trace information
     When user hovers over a trace with at least 4 spans
     Then user sees the tracing tooltip heat map

--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -68,12 +68,12 @@ export class TraceLabel extends React.Component<LabelProps> {
 
     return (
       <foreignObject width={innerWidth} height={innerHeight} x={left} y={top}>
-        <div className={tooltipStyle}>
+        <div className={tooltipStyle} data-test="trace-tooltip">
           <div className={titleStyle}>{this.props.trace.traceName || '(Missing root span)'}</div>
           <div className={contentStyle}>
-            <div className={leftStyle}>
+            <div className={leftStyle} data-test="trace-tooltip-heatmap-area">
               {hasStats ? (
-                renderTraceHeatMap(this.props.statsMatrix!, true)
+                <div data-test="trace-tooltip-heatmap">{renderTraceHeatMap(this.props.statsMatrix!, true)}</div>
               ) : this.props.isStatsMatrixComplete ? (
                 'n/a'
               ) : (

--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -10,7 +10,7 @@ import { JaegerTrace } from 'types/TracingInfo';
 import { renderTraceHeatMap } from './TracingResults/StatsComparison';
 import { PFColors } from 'components/Pf/PfColors';
 import { HookedChartTooltip, HookedTooltipProps } from 'components/Charts/CustomTooltip';
-import { formatDuration } from 'utils/tracing/TracingHelper';
+import { formatDuration, isWaypointProxySpan } from 'utils/tracing/TracingHelper';
 
 const flyoutWidth = 300;
 const flyoutHeight = 100;
@@ -52,12 +52,17 @@ const rightStyle = kialiStyle({
   lineHeight: '1.6'
 });
 
-type LabelProps = ChartLabelProps & {
-  isStatsMatrixComplete: boolean;
-  provider?: string;
-  statsMatrix?: StatsMatrix;
+type TraceLabelOwnProps = {
+  includeAmbient?: boolean;
   trace: JaegerTrace;
 };
+
+type LabelProps = ChartLabelProps &
+  TraceLabelOwnProps & {
+    isStatsMatrixComplete: boolean;
+    provider?: string;
+    statsMatrix?: StatsMatrix;
+  };
 
 export class TraceLabel extends React.Component<LabelProps> {
   render(): JSX.Element {
@@ -97,9 +102,10 @@ export class TraceLabel extends React.Component<LabelProps> {
 
 const mapStateToProps = (
   state: KialiAppState,
-  props: any
+  props: TraceLabelOwnProps
 ): { isStatsMatrixComplete: boolean; statsMatrix: StatsMatrix } => {
-  const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true);
+  const includeAmbient = !!props.includeAmbient || props.trace.spans.some(span => isWaypointProxySpan(span));
+  const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true, includeAmbient);
   return {
     statsMatrix: matrix,
     isStatsMatrixComplete: isComplete
@@ -110,6 +116,9 @@ const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 
 type FlyoutOrientation = 'top' | 'bottom' | 'left' | 'right';
 type FlyoutOrientationProps = Pick<ChartLabelProps, 'x' | 'y' | 'width'>;
+type TooltipProps = HookedTooltipProps<JaegerLineInfo> & {
+  includeAmbient?: boolean;
+};
 
 export const computeFlyoutOrientation = (props: FlyoutOrientationProps): FlyoutOrientation => {
   const x = typeof props.x === 'number' ? props.x : 0;
@@ -131,7 +140,7 @@ export const computeFlyoutOrientation = (props: FlyoutOrientationProps): FlyoutO
   return 'top';
 };
 
-export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineInfo>> {
+export class TraceTooltip extends React.Component<TooltipProps> {
   // Victory passes callback args that are broader than ChartLabelProps.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private getOrientation = (props: any): FlyoutOrientation => computeFlyoutOrientation(props);
@@ -147,7 +156,7 @@ export class TraceTooltip extends React.Component<HookedTooltipProps<JaegerLineI
           flyoutHeight={flyoutHeight}
           orientation={this.getOrientation}
           flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6, pointerEvents: 'none' }} />}
-          labelComponent={<TraceLabelContainer trace={trace} />}
+          labelComponent={<TraceLabelContainer trace={trace} includeAmbient={this.props.includeAmbient} />}
         />
       );
     }

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -60,6 +60,7 @@ type ReduxProps = {
 type TracesProps = ReduxProps & {
   cluster?: string;
   fromWaypoint: boolean;
+  includeAmbient?: boolean;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   target: string;
@@ -189,6 +190,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
   };
 
   private fetchPercentiles = (): Promise<Map<string, number>> => {
+    const includeAmbient = this.shouldIncludeAmbient();
     // We'll fetch percentiles on a large enough interval (unrelated to the selected interval)
     // in order to have stable values and avoid constantly fetching again
     const query: MetricsStatsQuery = {
@@ -202,6 +204,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
       interval: '1h',
       direction: 'inbound',
       avg: false,
+      includeAmbient,
       quantiles: percentilesOptions.map(p => p.id).filter(id => id !== 'all')
     };
     const queries: MetricsStatsQuery[] =
@@ -253,6 +256,8 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
 
   private getUrlProvider = (): TracingUrlProvider | undefined =>
     GetTracingUrlProvider(this.props.externalServices, this.props.provider);
+
+  private shouldIncludeAmbient = (): boolean => !!this.props.includeAmbient || this.props.fromWaypoint;
 
   private getTracingUrl = (): string | undefined => {
     if (!this.urlProvider || !this.state.targetApp || !this.urlProvider.HomeUrl()) {
@@ -352,6 +357,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                 traces={this.state.traces}
                 errorFetchTraces={this.state.tracingErrors}
                 errorTraces={true}
+                includeAmbient={this.shouldIncludeAmbient()}
                 cluster={this.props.cluster ? this.props.cluster : ''} // TODO: Test single cluster
               />
             </CardBody>
@@ -372,6 +378,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                       targetKind={this.props.targetKind}
                       tracingURLProvider={this.urlProvider}
                       otherTraces={this.state.traces}
+                      includeAmbient={this.shouldIncludeAmbient()}
                       cluster={this.props.cluster ? this.props.cluster : ''}
                       provider={this.props.provider}
                     />
@@ -385,6 +392,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                       traceID={this.props.selectedTrace.traceID}
                       cluster={this.props.cluster ? this.props.cluster : ''}
                       fromWaypoint={this.props.fromWaypoint}
+                      includeAmbient={this.shouldIncludeAmbient()}
                       waypointServiceFilter={this.props.waypointServiceFilter}
                     />
                   </Tab>

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -34,7 +34,7 @@ import {
 } from 'types/Common';
 import { timeRangeSelector } from 'store/Selectors';
 import { DisplaySettings, percentilesOptions, QuerySettings, TracesDisplayOptions } from './TracesDisplayOptions';
-import { Direction, genStatsKey, MetricsStatsQuery } from 'types/MetricsOptions';
+import { Direction, genStatsKey, getStatsReporters, MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsResult } from 'types/Metrics';
 import { getSpanId } from 'utils/SearchParamUtils';
 import { TimeDurationIndicator } from '../Time/TimeDurationIndicator';
@@ -204,11 +204,13 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
       interval: '1h',
       direction: 'inbound',
       avg: false,
-      includeAmbient,
+      reporters: getStatsReporters('inbound', includeAmbient),
       quantiles: percentilesOptions.map(p => p.id).filter(id => id !== 'all')
     };
     const queries: MetricsStatsQuery[] =
-      this.props.targetKind === 'service' ? [query] : [query, { ...query, direction: 'outbound' }];
+      this.props.targetKind === 'service'
+        ? [query]
+        : [query, { ...query, direction: 'outbound', reporters: getStatsReporters('outbound', includeAmbient) }];
     return API.getMetricsStats(queries).then(r => this.percentilesFetched(query, r.data));
   };
 
@@ -218,7 +220,8 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
     }
     const [mapInbound, mapOutbound] = (['inbound', 'outbound'] as Direction[]).map(dir => {
       const map = new Map<string, number>();
-      const key = genStatsKey(q.target, undefined, dir, q.interval);
+      const includeWaypoint = !!q.reporters?.includes('waypoint');
+      const key = genStatsKey(q.target, undefined, dir, q.interval, getStatsReporters(dir, includeWaypoint));
       if (key) {
         const statsForKey = r.stats[key];
         if (statsForKey) {

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
@@ -15,6 +15,7 @@ interface SpanDetailsProps {
   cluster?: string;
   externalURLProvider?: TracingUrlProvider;
   fromWaypoint: boolean;
+  includeAmbient?: boolean;
   items: RichSpanData[];
   namespace: string;
   target: string;
@@ -45,6 +46,7 @@ export const SpanDetails: React.FC<SpanDetailsProps> = (props: SpanDetailsProps)
             namespace={props.namespace}
             externalURLProvider={props.externalURLProvider}
             cluster={props.cluster}
+            includeAmbient={props.includeAmbient}
             target={props.waypointServiceFilter ? props.waypointServiceFilter : props.target}
             traceID={props.traceID}
             fromWaypoint={props.fromWaypoint}

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
@@ -40,6 +40,7 @@ type Props = ReduxProps &
     cluster?: string;
     externalURLProvider?: TracingUrlProvider;
     fromWaypoint: boolean; // If the traces come from a waypoint proxy
+    includeAmbient?: boolean;
     items: RichSpanData[];
     namespace: string;
     target: string;
@@ -202,7 +203,7 @@ class SpanTableComponent extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(items: RichSpanData[]): void {
-    const queries = buildQueriesFromSpans(items, false);
+    const queries = buildQueriesFromSpans(items, false, !!this.props.includeAmbient);
     this.props.loadMetricsStats(queries, false);
   }
 

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
@@ -9,7 +9,7 @@ import { KialiAppState } from 'store/Store';
 import { MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsThunkActions } from 'actions/MetricsStatsThunkActions';
 import { EnvoySpanInfo, OpenTracingHTTPInfo, OpenTracingTCPInfo, RichSpanData } from 'types/TracingInfo';
-import { sameSpans } from 'utils/tracing/TracingHelper';
+import { isWaypointProxySpan, sameSpans } from 'utils/tracing/TracingHelper';
 import { buildQueriesFromSpans } from 'utils/tracing/TraceStats';
 import { getParamsSeparator, getSpanId } from '../../../utils/SearchParamUtils';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -203,9 +203,12 @@ class SpanTableComponent extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(items: RichSpanData[]): void {
-    const queries = buildQueriesFromSpans(items, false, !!this.props.includeAmbient);
+    const queries = buildQueriesFromSpans(items, false, this.shouldIncludeAmbient());
     this.props.loadMetricsStats(queries, false);
   }
+
+  private shouldIncludeAmbient = (): boolean =>
+    !!this.props.includeAmbient || this.props.items.some(item => isWaypointProxySpan(item));
 
   private rows = (): IRow[] => {
     const compare = columns[this.state.sortIndex].compare;
@@ -552,8 +555,12 @@ class SpanTableComponent extends React.Component<Props, State> {
         </div>
 
         {item.type === 'envoy' &&
-          renderMetricsComparison(item, !this.isExpanded(item.spanID), this.props.metricsStats, () =>
-            this.fetchComparisonMetrics([item])
+          renderMetricsComparison(
+            item,
+            !this.isExpanded(item.spanID),
+            this.props.metricsStats,
+            this.shouldIncludeAmbient(),
+            () => this.fetchComparisonMetrics([item])
           )}
       </div>
     );

--- a/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
@@ -75,9 +75,10 @@ export const renderMetricsComparison = (
   item: RichSpanData,
   isCompact: boolean,
   metricsStats: Map<string, MetricsStats>,
+  includeAmbient: boolean,
   load: () => void
 ): React.ReactNode => {
-  const itemStats = getSpanStats(item, metricsStats, isCompact);
+  const itemStats = getSpanStats(item, metricsStats, isCompact, includeAmbient);
   const key = `${item.spanID}-metcomp`;
 
   if (itemStats.length > 0) {

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -46,6 +46,7 @@ type StateProps = {
 type Props = ReduxProps &
   StateProps & {
     cluster?: string;
+    includeAmbient?: boolean;
     namespace: string;
     otherTraces: JaegerTrace[];
     provider?: string;
@@ -88,7 +89,7 @@ class TraceDetailsComponent extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(spans: RichSpanData[]): void {
-    const queries = buildQueriesFromSpans(spans, false);
+    const queries = buildQueriesFromSpans(spans, false, !!this.props.includeAmbient);
     this.props.loadMetricsStats(queries, false, this.props.cluster);
   }
 

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -28,7 +28,7 @@ import { MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsThunkActions } from 'actions/MetricsStatsThunkActions';
 import { renderTraceHeatMap } from './StatsComparison';
 import { HeatMap, healthColorMap } from 'components/HeatMap/HeatMap';
-import { formatDuration, sameSpans } from 'utils/tracing/TracingHelper';
+import { formatDuration, isWaypointProxySpan, sameSpans } from 'utils/tracing/TracingHelper';
 import { TracingUrlProvider } from 'types/Tracing';
 import _ from 'lodash';
 
@@ -43,17 +43,18 @@ type StateProps = {
   trace?: JaegerTrace;
 };
 
-type Props = ReduxProps &
-  StateProps & {
-    cluster?: string;
-    includeAmbient?: boolean;
-    namespace: string;
-    otherTraces: JaegerTrace[];
-    provider?: string;
-    target: string;
-    targetKind: TargetKind;
-    tracingURLProvider?: TracingUrlProvider;
-  };
+type OwnProps = {
+  cluster?: string;
+  includeAmbient?: boolean;
+  namespace: string;
+  otherTraces: JaegerTrace[];
+  provider?: string;
+  target: string;
+  targetKind: TargetKind;
+  tracingURLProvider?: TracingUrlProvider;
+};
+
+type Props = ReduxProps & StateProps & OwnProps;
 
 interface State {}
 
@@ -268,9 +269,16 @@ class TraceDetailsComponent extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: KialiAppState): StateProps => {
+const mapStateToProps = (state: KialiAppState, props: OwnProps): StateProps => {
   if (state.tracingState.selectedTrace) {
-    const { matrix, isComplete } = reduceMetricsStats(state.tracingState.selectedTrace, state.metricsStats.data, false);
+    const includeAmbient =
+      !!props.includeAmbient || state.tracingState.selectedTrace.spans.some(span => isWaypointProxySpan(span));
+    const { matrix, isComplete } = reduceMetricsStats(
+      state.tracingState.selectedTrace,
+      state.metricsStats.data,
+      false,
+      includeAmbient
+    );
 
     return {
       trace: state.tracingState.selectedTrace,

--- a/frontend/src/components/TracingIntegration/TracingScatter.tsx
+++ b/frontend/src/components/TracingIntegration/TracingScatter.tsx
@@ -36,6 +36,7 @@ interface TracingScatterProps {
   duration: number;
   errorFetchTraces?: TracingError[];
   errorTraces?: boolean;
+  includeAmbient?: boolean;
   loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) => Promise<any>;
   provider?: string;
   selectedTrace?: JaegerTrace;
@@ -199,7 +200,7 @@ export class TracingScatterComponent extends React.Component<TracingScatterProps
       this.seletedTraceMatched = trace.matched;
     }
 
-    const queries = buildQueriesFromSpans(trace.spans, true);
+    const queries = buildQueriesFromSpans(trace.spans, true, !!this.props.includeAmbient);
 
     this.props
       .loadMetricsStats(queries, true)

--- a/frontend/src/components/TracingIntegration/TracingScatter.tsx
+++ b/frontend/src/components/TracingIntegration/TracingScatter.tsx
@@ -172,7 +172,7 @@ export class TracingScatterComponent extends React.Component<TracingScatterProps
             onClick={dp => this.props.setTraceId(this.props.cluster, dp.trace.traceID)}
             onTooltipClose={dp => this.onTooltipClose(dp.trace)}
             onTooltipOpen={dp => this.onTooltipOpen(dp.trace)}
-            labelComponent={<TraceTooltip />}
+            labelComponent={<TraceTooltip includeAmbient={this.props.includeAmbient} />}
             pointer={true}
           />
         </div>

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -250,6 +250,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
                 target={this.props.appId.app}
                 targetKind={'app'}
                 fromWaypoint={fromWaypoint}
+                includeAmbient={fromWaypoint || !!this.state.app?.isAmbient}
               />
             </Tab>
           );

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -291,6 +291,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
             target={this.props.serviceId.service}
             targetKind={'service'}
             fromWaypoint={fromWaypoint}
+            includeAmbient={fromWaypoint || !!this.state.serviceDetails?.isAmbient}
           />
         </Tab>
       );

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -269,6 +269,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
               target={this.props.workloadId.workload}
               targetKind="workload"
               fromWaypoint={fromWaypoint}
+              includeAmbient={fromWaypoint || !!this.state.workload?.isAmbient}
               waypointServiceFilter={this.state.waypointServiceFilter}
             />
           </Tab>

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -31,6 +31,7 @@ export interface IstioMetricsOptions extends MetricsQuery {
 
 export type Reporter = 'source' | 'destination' | 'both';
 export type Direction = 'inbound' | 'outbound';
+export type StatsReporter = Exclude<Reporter, 'both'> | 'waypoint';
 
 export interface Target {
   cluster?: string;
@@ -42,23 +43,42 @@ export interface Target {
 export interface MetricsStatsQuery {
   avg: boolean;
   direction: Direction;
-  includeAmbient?: boolean;
   interval: string;
   peerTarget?: Target;
   quantiles: string[];
   queryTime: number;
+  reporters?: StatsReporter[];
   target: Target;
 }
 
 export const statsQueryToKey = (q: MetricsStatsQuery): string =>
-  genStatsKey(q.target, q.peerTarget, q.direction, q.interval);
+  genStatsKey(q.target, q.peerTarget, q.direction, q.interval, q.reporters);
 
 // !! genStatsKey HAS to mirror backend's models.MetricsStatsQuery#GenKey in models/metrics.go
-export const genStatsKey = (target: Target, peer: Target | undefined, direction: string, interval: string): string => {
+export const genStatsKey = (
+  target: Target,
+  peer: Target | undefined,
+  direction: Direction,
+  interval: string,
+  reporters?: StatsReporter[]
+): string => {
   const peerKey = peer ? genTargetKey(peer) : '';
-  return `${genTargetKey(target)}:${peerKey}:${direction}:${interval}`;
+  return `${genTargetKey(target)}:${peerKey}:${direction}:${interval}:${normalizeStatsReporters(
+    direction,
+    reporters
+  ).join(',')}`;
 };
 
 const genTargetKey = (target: Target): string => {
   return `${target.namespace}:${target.kind}:${target.name}`;
+};
+
+export const getStatsReporters = (direction: Direction, includeWaypoint = false): StatsReporter[] => {
+  const sideReporter: StatsReporter = direction === 'outbound' ? 'source' : 'destination';
+  return includeWaypoint ? [sideReporter, 'waypoint'] : [sideReporter];
+};
+
+const normalizeStatsReporters = (direction: Direction, reporters?: StatsReporter[]): StatsReporter[] => {
+  const statsReporters = reporters && reporters.length > 0 ? reporters : getStatsReporters(direction);
+  return Array.from(new Set(statsReporters)).sort();
 };

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -23,10 +23,10 @@ export type Aggregator = 'sum' | 'avg' | 'min' | 'max' | 'stddev' | 'stdvar';
 
 export interface IstioMetricsOptions extends MetricsQuery {
   direction: Direction;
-  includeAmbient: boolean;
   filters?: string[];
-  requestProtocol?: string;
+  includeAmbient: boolean;
   reporter: Reporter;
+  requestProtocol?: string;
 }
 
 export type Reporter = 'source' | 'destination' | 'both';
@@ -42,6 +42,7 @@ export interface Target {
 export interface MetricsStatsQuery {
   avg: boolean;
   direction: Direction;
+  includeAmbient?: boolean;
   interval: string;
   peerTarget?: Target;
   quantiles: string[];

--- a/frontend/src/utils/tracing/TraceStats.ts
+++ b/frontend/src/utils/tracing/TraceStats.ts
@@ -1,6 +1,6 @@
 import { EnvoySpanInfo, JaegerTrace, RichSpanData } from 'types/TracingInfo';
 import { MetricsStats } from 'types/Metrics';
-import { genStatsKey, MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
+import { genStatsKey, getStatsReporters, MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
 import { average } from '../MathUtils';
 import { isWaypointProxySpan } from './TracingHelper';
 
@@ -96,11 +96,11 @@ export const buildQueriesFromSpans = (
       const query: MetricsStatsQuery = {
         avg: true,
         direction: info.direction,
-        includeAmbient: shouldIncludeAmbient,
         interval: '', // placeholder
         peerTarget: statsPerPeer ? info.peer : undefined,
         quantiles: isCompact ? compactStatsQuantiles : statsQuantiles,
         queryTime: queryTime,
+        reporters: getStatsReporters(info.direction, shouldIncludeAmbient),
         target: {
           namespace: item.namespace,
           name: name,
@@ -149,7 +149,8 @@ export const statsToMatrix = (itemStats: StatsWithIntervalIndex[], intervals: st
 export const getSpanStats = (
   item: RichSpanData,
   metricsStats: Map<string, MetricsStats>,
-  isCompact: boolean
+  isCompact: boolean,
+  includeAmbient: boolean
 ): StatsWithIntervalIndex[] => {
   const intervals = isCompact ? compactStatsIntervals : statsIntervals;
 
@@ -161,7 +162,13 @@ export const getSpanStats = (
       kind: statsCompareKind,
       cluster: item.cluster
     };
-    const key = genStatsKey(target, statsPerPeer ? info.peer : undefined, info.direction!, interval);
+    const key = genStatsKey(
+      target,
+      statsPerPeer ? info.peer : undefined,
+      info.direction!,
+      interval,
+      getStatsReporters(info.direction!, includeAmbient)
+    );
     if (key) {
       const stats = metricsStats.get(key);
       if (stats) {
@@ -179,7 +186,8 @@ export const getSpanStats = (
 export const reduceMetricsStats = (
   trace: JaegerTrace,
   allStats: Map<string, MetricsStats>,
-  isCompact: boolean
+  isCompact: boolean,
+  includeAmbient: boolean
 ): { isComplete: boolean; matrix: StatsMatrix } => {
   let isComplete = true;
   const intervals = isCompact ? compactStatsIntervals : statsIntervals;
@@ -191,7 +199,7 @@ export const reduceMetricsStats = (
   trace.spans
     .filter(s => s.type === 'envoy')
     .forEach(span => {
-      const spanStats = getSpanStats(span, allStats, isCompact);
+      const spanStats = getSpanStats(span, allStats, isCompact, includeAmbient);
       if (spanStats.length > 0) {
         spanStats.forEach(statsPerInterval => {
           statsPerInterval.responseTimes.forEach(stat => {

--- a/frontend/src/utils/tracing/TraceStats.ts
+++ b/frontend/src/utils/tracing/TraceStats.ts
@@ -2,6 +2,7 @@ import { EnvoySpanInfo, JaegerTrace, RichSpanData } from 'types/TracingInfo';
 import { MetricsStats } from 'types/Metrics';
 import { genStatsKey, MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
 import { average } from '../MathUtils';
+import { isWaypointProxySpan } from './TracingHelper';
 
 export const averageSpanDuration = (trace: JaegerTrace): number | undefined => {
   const spansWithDuration = trace.spans.filter(s => s.duration && s.duration > 0);
@@ -66,8 +67,13 @@ export const compactStatsIntervals = ['60m', '3h'];
 export const statsPerPeer = false;
 export let statsCompareKind: 'app' | 'workload' = 'workload';
 
-export const buildQueriesFromSpans = (items: RichSpanData[], isCompact: boolean) => {
+export const buildQueriesFromSpans = (
+  items: RichSpanData[],
+  isCompact: boolean,
+  includeAmbient = false
+): MetricsStatsQuery[] => {
   const queryTime = Math.floor(Date.now() / 1000);
+  const shouldIncludeAmbient = includeAmbient || items.some(item => isWaypointProxySpan(item));
   // Load stats for up to 8 spans to limit the heavy loading. More stats can be loaded individually.
   const queries = items
     .filter(s => s.type === 'envoy')
@@ -90,6 +96,7 @@ export const buildQueriesFromSpans = (items: RichSpanData[], isCompact: boolean)
       const query: MetricsStatsQuery = {
         avg: true,
         direction: info.direction,
+        includeAmbient: shouldIncludeAmbient,
         interval: '', // placeholder
         peerTarget: statsPerPeer ? info.peer : undefined,
         quantiles: isCompact ? compactStatsQuantiles : statsQuantiles,
@@ -106,7 +113,7 @@ export const buildQueriesFromSpans = (items: RichSpanData[], isCompact: boolean)
   return deduplicateMetricQueries(queries);
 };
 
-const deduplicateMetricQueries = (queries: MetricsStatsQuery[]) => {
+const deduplicateMetricQueries = (queries: MetricsStatsQuery[]): MetricsStatsQuery[] => {
   // Exclude redundant queries based on this keygen as a merger, + hashmap
   const dedup = new Map<string, MetricsStatsQuery>();
   queries.forEach(q => {
@@ -169,13 +176,17 @@ export const getSpanStats = (
   });
 };
 
-export const reduceMetricsStats = (trace: JaegerTrace, allStats: Map<string, MetricsStats>, isCompact: boolean) => {
+export const reduceMetricsStats = (
+  trace: JaegerTrace,
+  allStats: Map<string, MetricsStats>,
+  isCompact: boolean
+): { isComplete: boolean; matrix: StatsMatrix } => {
   let isComplete = true;
   const intervals = isCompact ? compactStatsIntervals : statsIntervals;
   const quantilesWithAvg = isCompact ? compactStatsQuantilesWithAvg : statsQuantilesWithAvg;
 
   // Aggregate all spans stats, per stat name/interval, into a temporary map
-  type AggregatedStat = { name: string; intervalIndex: number; values: number[] };
+  type AggregatedStat = { intervalIndex: number; name: string; values: number[] };
   const aggregatedStats = new Map<string, AggregatedStat>();
   trace.spans
     .filter(s => s.type === 'envoy')
@@ -184,7 +195,7 @@ export const reduceMetricsStats = (trace: JaegerTrace, allStats: Map<string, Met
       if (spanStats.length > 0) {
         spanStats.forEach(statsPerInterval => {
           statsPerInterval.responseTimes.forEach(stat => {
-            const aggKey = stat.name + '@' + statsPerInterval.intervalIndex;
+            const aggKey = `${stat.name}@${statsPerInterval.intervalIndex}`;
             const aggStat = aggregatedStats.get(aggKey);
             if (aggStat) {
               aggStat.values.push(stat.value);

--- a/frontend/src/utils/tracing/__tests__/TraceStats.test.ts
+++ b/frontend/src/utils/tracing/__tests__/TraceStats.test.ts
@@ -56,18 +56,34 @@ const traceDifferentOperations = {
   ] as Span[]
 } as JaegerTrace;
 
-const mockEnvoySpan = (op: string, duration: number, wkd: string): RichSpanData => {
+const mockEnvoySpan = (op: string, duration: number, wkd: string, waypoint = false): RichSpanData => {
   const spanInfo = { direction: 'inbound' } as EnvoySpanInfo;
   return {
+    app: 'app',
+    component: 'proxy',
     type: 'envoy',
     info: spanInfo,
+    logs: [],
     operationName: op,
     duration: duration * 1000,
     namespace: 'ns',
-    workload: wkd
+    processID: 'p1',
+    workload: wkd,
+    process: { serviceName: waypoint ? 'waypoint.ns' : 'proxy.ns', tags: [] },
+    depth: 0,
+    hasChildren: false,
+    references: [],
+    relativeStartTime: 0,
+    spanID: `${op}-${wkd}`,
+    startTime: 0,
+    tags: waypoint
+      ? [{ key: 'node_id', type: 'string', value: 'waypoint~10.0.0.1~waypoint-abc.ns~ns.svc.cluster.local' }]
+      : [],
+    traceID: 'trace-1',
+    warnings: []
   } as RichSpanData;
 };
-const mockStats = (avg: number, p50: number, p90: number, p99: number, isCompact = false) => {
+const mockStats = (avg: number, p50: number, p90: number, p99: number, isCompact = false): MetricsStats => {
   return {
     isCompact: isCompact,
     responseTimes: [
@@ -175,6 +191,7 @@ describe('TraceStats.buildQueriesFromSpans', () => {
   it('should build one query per workload and time interval', () => {
     const queries = buildQueriesFromSpans(spans, false);
     expect(queries).toHaveLength(6);
+    expect(queries.every(q => q.includeAmbient === false)).toBe(true);
     expect(queries.map(q => statsQueryToKey(q))).toEqual([
       'ns:workload:w1::inbound:10m',
       'ns:workload:w1::inbound:60m',
@@ -187,10 +204,16 @@ describe('TraceStats.buildQueriesFromSpans', () => {
 
   it('should cap to eight spans', () => {
     const spans = new Array(20).fill(0).map((_, idx) => {
-      return mockEnvoySpan('operation', 1, 'worload-' + idx);
+      return mockEnvoySpan('operation', 1, `worload-${idx}`);
     });
     expect(spans).toHaveLength(20);
     const queries = buildQueriesFromSpans(spans, false);
     expect(queries).toHaveLength(8 * 3); // three intervals x 8-capped number of spans/workloads
+  });
+
+  it('should include ambient when waypoint spans are present', () => {
+    const queries = buildQueriesFromSpans([mockEnvoySpan('op1', 3, 'w1', true)], true);
+    expect(queries).toHaveLength(2);
+    expect(queries.every(q => q.includeAmbient === true)).toBe(true);
   });
 });

--- a/frontend/src/utils/tracing/__tests__/TraceStats.test.ts
+++ b/frontend/src/utils/tracing/__tests__/TraceStats.test.ts
@@ -1,6 +1,6 @@
 import { EnvoySpanInfo, JaegerTrace, Span, RichSpanData } from 'types/TracingInfo';
 import { MetricsStats } from 'types/Metrics';
-import { statsQueryToKey } from 'types/MetricsOptions';
+import { MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
 import { averageSpanDuration, buildQueriesFromSpans, isSimilarTrace, reduceMetricsStats } from '../TraceStats';
 
 const traceBase = {
@@ -136,13 +136,13 @@ describe('TraceStats.reduceMetricsStats', () => {
 
   it('should reduce span matrices with complete stats', () => {
     const metricsStats = new Map<string, MetricsStats>([
-      ['ns:workload:w1::inbound:10m', mockStats(3, 2, 5, 7)],
-      ['ns:workload:w1::inbound:60m', mockStats(2, 2, 6, 10)],
-      ['ns:workload:w2::inbound:10m', mockStats(1, 1, 1, 1)],
-      ['ns:workload:w2::inbound:60m', mockStats(1, 1, 1, 1)]
+      ['ns:workload:w1::inbound:10m:destination', mockStats(3, 2, 5, 7)],
+      ['ns:workload:w1::inbound:60m:destination', mockStats(2, 2, 6, 10)],
+      ['ns:workload:w2::inbound:10m:destination', mockStats(1, 1, 1, 1)],
+      ['ns:workload:w2::inbound:60m:destination', mockStats(1, 1, 1, 1)]
     ]);
 
-    const reduced = reduceMetricsStats(trace, metricsStats, false);
+    const reduced = reduceMetricsStats(trace, metricsStats, false, false);
 
     expect(reduced.isComplete).toBe(true);
     expect(reduced.matrix).toHaveLength(4);
@@ -161,11 +161,11 @@ describe('TraceStats.reduceMetricsStats', () => {
 
   it('should reduce span matrices with incomplete stats', () => {
     const metricsStats = new Map<string, MetricsStats>([
-      ['ns:workload:w1::inbound:10m', mockStats(3, 2, 5, 7)],
-      ['ns:workload:w1::inbound:60m', mockStats(2, 2, 6, 10)]
+      ['ns:workload:w1::inbound:10m:destination', mockStats(3, 2, 5, 7)],
+      ['ns:workload:w1::inbound:60m:destination', mockStats(2, 2, 6, 10)]
     ]);
 
-    const reduced = reduceMetricsStats(trace, metricsStats, false);
+    const reduced = reduceMetricsStats(trace, metricsStats, false, false);
 
     expect(reduced.isComplete).toBe(false);
     expect(reduced.matrix).toHaveLength(4);
@@ -191,14 +191,14 @@ describe('TraceStats.buildQueriesFromSpans', () => {
   it('should build one query per workload and time interval', () => {
     const queries = buildQueriesFromSpans(spans, false);
     expect(queries).toHaveLength(6);
-    expect(queries.every(q => q.includeAmbient === false)).toBe(true);
+    expect(queries.every(q => q.reporters?.join(',') === 'destination')).toBe(true);
     expect(queries.map(q => statsQueryToKey(q))).toEqual([
-      'ns:workload:w1::inbound:10m',
-      'ns:workload:w1::inbound:60m',
-      'ns:workload:w1::inbound:3h',
-      'ns:workload:w2::inbound:10m',
-      'ns:workload:w2::inbound:60m',
-      'ns:workload:w2::inbound:3h'
+      'ns:workload:w1::inbound:10m:destination',
+      'ns:workload:w1::inbound:60m:destination',
+      'ns:workload:w1::inbound:3h:destination',
+      'ns:workload:w2::inbound:10m:destination',
+      'ns:workload:w2::inbound:60m:destination',
+      'ns:workload:w2::inbound:3h:destination'
     ]);
   });
 
@@ -214,6 +214,27 @@ describe('TraceStats.buildQueriesFromSpans', () => {
   it('should include ambient when waypoint spans are present', () => {
     const queries = buildQueriesFromSpans([mockEnvoySpan('op1', 3, 'w1', true)], true);
     expect(queries).toHaveLength(2);
-    expect(queries.every(q => q.includeAmbient === true)).toBe(true);
+    expect(queries.every(q => q.reporters?.join(',') === 'destination,waypoint')).toBe(true);
+  });
+
+  it('should keep mixed reporters queries distinct', () => {
+    const baseQuery: MetricsStatsQuery = {
+      avg: true,
+      direction: 'inbound',
+      interval: '10m',
+      quantiles: ['0.5'],
+      queryTime: 1,
+      reporters: ['destination'],
+      target: {
+        namespace: 'ns',
+        name: 'w1',
+        kind: 'workload'
+      }
+    };
+
+    expect(statsQueryToKey(baseQuery)).toBe('ns:workload:w1::inbound:10m:destination');
+    expect(statsQueryToKey({ ...baseQuery, reporters: ['waypoint', 'destination'] })).toBe(
+      'ns:workload:w1::inbound:10m:destination,waypoint'
+    );
   });
 });

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -741,6 +741,7 @@ elif [ "${TEST_SUITE}" == "${FRONTEND_AMBIENT}" ]; then
 
     # Install demo apps
     "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" --ambient true --use-gateway-api true --bookinfo-only ${BOOKINFO_ONLY}
+    "${SCRIPT_DIR}"/istio/install-travel-agency-demo.sh -c kubectl -ai false -di travel-control,travel-agency,travel-portal -w true
   fi
 
   ensureKialiServerReady

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -68,15 +68,16 @@ type Target struct {
 }
 
 type MetricsStatsQuery struct {
-	Target       Target
-	PeerTarget   *Target
-	RawQueryTime int64     `json:"queryTime"`
-	QueryTime    time.Time `json:"-"`
-	RawInterval  string    `json:"interval"`
-	Interval     string    `json:"-"`
-	Direction    string    // outbound | inbound
-	Avg          bool
-	Quantiles    []string
+	Target         Target
+	PeerTarget     *Target
+	IncludeAmbient *bool     `json:"includeAmbient,omitempty"`
+	RawQueryTime   int64     `json:"queryTime"`
+	QueryTime      time.Time `json:"-"`
+	RawInterval    string    `json:"interval"`
+	Interval       string    `json:"-"`
+	Direction      string    // outbound | inbound
+	Avg            bool
+	Quantiles      []string
 }
 
 func (q *MetricsStatsQuery) Validate() *util.Errors {

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -68,16 +68,16 @@ type Target struct {
 }
 
 type MetricsStatsQuery struct {
-	Target         Target
-	PeerTarget     *Target
-	IncludeAmbient *bool     `json:"includeAmbient,omitempty"`
-	RawQueryTime   int64     `json:"queryTime"`
-	QueryTime      time.Time `json:"-"`
-	RawInterval    string    `json:"interval"`
-	Interval       string    `json:"-"`
-	Direction      string    // outbound | inbound
-	Avg            bool
-	Quantiles      []string
+	Target       Target
+	PeerTarget   *Target
+	Reporters    []string  `json:"reporters,omitempty"`
+	RawQueryTime int64     `json:"queryTime"`
+	QueryTime    time.Time `json:"-"`
+	RawInterval  string    `json:"interval"`
+	Interval     string    `json:"-"`
+	Direction    string    // outbound | inbound
+	Avg          bool
+	Quantiles    []string
 }
 
 func (q *MetricsStatsQuery) Validate() *util.Errors {
@@ -94,6 +94,9 @@ func (q *MetricsStatsQuery) Validate() *util.Errors {
 	if q.Direction != "inbound" && q.Direction != "outbound" {
 		errs.AddString("bad request: 'direction' must be either 'inbound' or 'outbound'")
 	}
+	if err := q.validateReporters(); err != nil {
+		errs.Merge(err)
+	}
 	if q.RawQueryTime == 0 {
 		errs.AddString("bad request: 'queryTime' must be defined")
 	}
@@ -104,13 +107,75 @@ func (q *MetricsStatsQuery) Validate() *util.Errors {
 	return errs.OrNil()
 }
 
-// GenKey !! HAS to mirror frontend's genStatsKey in SpanTable.tsx
+// GenKey !! HAS to mirror frontend's genStatsKey in frontend/src/types/MetricsOptions.ts
 func (q *MetricsStatsQuery) GenKey() string {
 	peer := ""
 	if q.PeerTarget != nil {
 		peer = q.PeerTarget.GenKey()
 	}
-	return strings.Join([]string{q.Target.GenKey(), peer, q.Direction, q.RawInterval}, ":")
+	return strings.Join([]string{
+		q.Target.GenKey(),
+		peer,
+		q.Direction,
+		q.RawInterval,
+		strings.Join(q.normalizedReporters(), ","),
+	}, ":")
+}
+
+func (q *MetricsStatsQuery) validateReporters() *util.Errors {
+	var errs util.Errors
+	if q.Direction != "inbound" && q.Direction != "outbound" {
+		return nil
+	}
+
+	sideReporter := q.sideReporter()
+	if len(q.Reporters) == 0 {
+		return nil
+	}
+
+	hasSideReporter := false
+	for _, reporter := range q.Reporters {
+		if reporter == sideReporter {
+			hasSideReporter = true
+			continue
+		}
+		if reporter != "waypoint" {
+			errs.AddString(fmt.Sprintf("bad request: 'reporters' can only include '%s' or 'waypoint' for direction '%s'", sideReporter, q.Direction))
+			return errs.OrNil()
+		}
+	}
+
+	if !hasSideReporter {
+		errs.AddString(fmt.Sprintf("bad request: 'reporters' must include '%s' for direction '%s'", sideReporter, q.Direction))
+	}
+	return errs.OrNil()
+}
+
+func (q *MetricsStatsQuery) normalizedReporters() []string {
+	reporters := q.Reporters
+	if len(reporters) == 0 {
+		reporters = []string{q.sideReporter()}
+	}
+
+	normalized := make([]string, 0, len(reporters))
+	seen := make(map[string]struct{}, len(reporters))
+	for _, reporter := range reporters {
+		if _, found := seen[reporter]; found {
+			continue
+		}
+		seen[reporter] = struct{}{}
+		normalized = append(normalized, reporter)
+	}
+
+	sort.Strings(normalized)
+	return normalized
+}
+
+func (q *MetricsStatsQuery) sideReporter() string {
+	if q.Direction == "outbound" {
+		return "source"
+	}
+	return "destination"
 }
 
 func (t *Target) GenKey() string {

--- a/models/metrics_test.go
+++ b/models/metrics_test.go
@@ -1,0 +1,45 @@
+package models
+
+import "testing"
+
+func TestMetricsStatsQueryGenKeyIncludesReporters(t *testing.T) {
+	base := MetricsStatsQuery{
+		Target: Target{
+			Namespace: "bookinfo",
+			Kind:      "workload",
+			Name:      "reviews-v1",
+		},
+		Direction:   "inbound",
+		RawInterval: "10m",
+	}
+
+	withDefaultReporter := base
+	withWaypoint := base
+	withWaypoint.Reporters = []string{"waypoint", "destination"}
+
+	if got, want := withDefaultReporter.GenKey(), "bookinfo:workload:reviews-v1::inbound:10m:destination"; got != want {
+		t.Fatalf("GenKey() = %q, want %q", got, want)
+	}
+
+	if got, want := withWaypoint.GenKey(), "bookinfo:workload:reviews-v1::inbound:10m:destination,waypoint"; got != want {
+		t.Fatalf("GenKey() = %q, want %q", got, want)
+	}
+}
+
+func TestMetricsStatsQueryValidateRejectsReporterWithoutDirectionSide(t *testing.T) {
+	q := MetricsStatsQuery{
+		Target: Target{
+			Namespace: "bookinfo",
+			Kind:      "workload",
+			Name:      "reviews-v1",
+		},
+		Direction:    "inbound",
+		RawInterval:  "10m",
+		RawQueryTime: 1,
+		Reporters:    []string{"waypoint"},
+	}
+
+	if err := q.Validate(); err == nil {
+		t.Fatal("Validate() expected error, got nil")
+	}
+}


### PR DESCRIPTION
### Describe the change

Include waypoint reporter based on frontend query param
<img width="1895" height="974" alt="image" src="https://github.com/user-attachments/assets/77121f1f-a2e5-4cbf-a3c6-dedab4a36543" />

The tracing metrics stats are updated to add an includeAmbient flag to MetricsStatsQuery and propagate it from the frontend based on real target/trace context, such as ambient workloads/services, waypoint-backed targets, or detected waypoint spans. On the backend, stats queries build the Prometheus reporter label from that flag instead of not including the waypoint reporter, while keeping a fallback for older callers. As a result, tracing percentile lookups and heatmap comparisons in the traces list, scatter tooltip, trace details, and span details can correctly retrieve `istio_request_duration_milliseconds` data in Ambient environments without affecting the performance in non Ambient meshes.

- Added cypress tests to validate the heat maps in travels demo: 

<img width="1351" height="876" alt="image" src="https://github.com/user-attachments/assets/2c9a2b66-f226-4271-a43b-d66b32631728" />


### Steps to test the PR
- Install Kiali and Ambient
- Install travels demo: `istio/install-travel-agency-demo.sh -c kubectl -ai false -di travel-control,travel-agency,travel-portal -w true` 
- Go to traces > Hover over one trace: The heapmap should appear

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes https://github.com/kiali/kiali/issues/9685 


