### PR TITLE
fix more issues

### DIFF
--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -274,7 +274,7 @@ func (in *OpenshiftOAuthService) Logout(ctx context.Context, token string, clust
 	sha256Prefix := "sha256~"
 	h := sha256.Sum256([]byte(strings.TrimPrefix(token, sha256Prefix)))
 	oauthTokenName := sha256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
-	log.Debugf("Logging out by deleting OAuth access token [%v] which was converted from access token [%v]", oauthTokenName, token)
+	log.Debugf("Logging out by deleting OAuth access token [%v]", oauthTokenName)
 
 	// Delete the access token from the API server using OpenShift 4.6+ access token name
 	kialiSAClient := in.kialiSAClients[cluster]

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -79,8 +79,8 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		case config.AuthStrategyToken, config.AuthStrategyOpenId, config.AuthStrategyOpenshift, config.AuthStrategyHeader:
 			sessions, err := aHandler.authController.ValidateSession(r, w)
 			if err != nil {
-				if errors.Is(err, authentication.ErrSessionNotFound) {
-					// Session doesn't exist - user needs to authenticate
+				if errors.Is(err, authentication.ErrSessionNotFound) || errors.Is(err, authentication.ErrSubjectMismatch) {
+					// Session doesn't exist or has an integrity violation - user needs to authenticate
 					statusCode = http.StatusUnauthorized
 				} else if k8serrors.IsUnauthorized(err) {
 					// Kubernetes API rejected the token as invalid/expired.
@@ -166,7 +166,10 @@ func Authenticate(conf *config.Config, authController authentication.AuthControl
 					if e.HttpStatus != 0 {
 						status = e.HttpStatus
 					}
-					RespondWithError(w, status, e.Error())
+					if e.Detail != nil {
+						log.Warningf("Authentication failure [%s]: %v", e.Reason, e.Detail)
+					}
+					RespondWithError(w, status, e.Reason)
 				} else {
 					RespondWithError(w, http.StatusInternalServerError, err.Error())
 				}

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -173,7 +173,7 @@ func Authenticate(conf *config.Config, authController authentication.AuthControl
 					RespondWithError(w, status, e.Reason)
 				} else {
 					log.Errorf("Unexpected authentication error [client: %s]: %s", r.RemoteAddr, err.Error())
-					RespondWithError(w, http.StatusInternalServerError, err.Error())
+					RespondWithError(w, http.StatusInternalServerError, "Internal server error")
 				}
 			} else {
 				if response.AuthInfo != nil {

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
@@ -94,10 +95,10 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 					// However, this check is still useful for cases where the fallback fails or
 					// for other K8s API calls that may return Forbidden.
 					statusCode = http.StatusForbidden
-					log.Errorf("User does not have sufficient privileges: %s", err.Error())
+					log.Errorf("User does not have sufficient privileges [client: %s]: %s", r.RemoteAddr, err.Error())
 				} else {
 					// Unexpected server error during validation
-					log.Errorf("Failed to validate session: %s", err.Error())
+					log.Errorf("Failed to validate session [client: %s]: %s", r.RemoteAddr, err.Error())
 					statusCode = http.StatusInternalServerError
 				}
 			} else {
@@ -118,7 +119,7 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		case http.StatusOK:
 			if len(userSessions) == 0 {
 				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-				log.Errorf("No active user session: %v", http.StatusBadRequest)
+				log.Errorf("No active user session [client: %s]: %v", r.RemoteAddr, http.StatusBadRequest)
 				return
 			}
 			ctx := authentication.SetAuthInfoContext(r.Context(), userSessions.GetAuthInfos())
@@ -131,7 +132,7 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 		case http.StatusUnauthorized:
 			err := aHandler.authController.TerminateSession(r, w)
 			if err != nil {
-				log.Errorf("Failed to clean a stale session: %s", err.Error())
+				log.Errorf("Failed to clean a stale session [client: %s]: %s", r.RemoteAddr, err.Error())
 			}
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		case http.StatusForbidden:
@@ -139,7 +140,7 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		default:
 			http.Error(w, http.StatusText(statusCode), statusCode)
-			log.Errorf("Cannot send response to user: %v", statusCode)
+			log.Errorf("Cannot send response to user [client: %s]: %v", r.RemoteAddr, statusCode)
 		}
 	})
 }
@@ -167,13 +168,21 @@ func Authenticate(conf *config.Config, authController authentication.AuthControl
 						status = e.HttpStatus
 					}
 					if e.Detail != nil {
-						log.Warningf("Authentication failure [%s]: %v", e.Reason, e.Detail)
+						log.Warningf("Authentication failure [%s] [client: %s]: %v", e.Reason, r.RemoteAddr, e.Detail)
 					}
 					RespondWithError(w, status, e.Reason)
 				} else {
+					log.Errorf("Unexpected authentication error [client: %s]: %s", r.RemoteAddr, err.Error())
 					RespondWithError(w, http.StatusInternalServerError, err.Error())
 				}
 			} else {
+				if response.AuthInfo != nil {
+					// Truncated SHA-256 hash (16 hex chars) for log correlation without exposing the full token
+					tokenFingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(response.AuthInfo.Token)))[:16]
+					log.Infof("Authentication successful for user [%s] [client: %s] [token: %s]", response.Username, r.RemoteAddr, tokenFingerprint)
+				} else {
+					log.Infof("Authentication successful for user [%s] [client: %s]", response.Username, r.RemoteAddr)
+				}
 				RespondWithJSONIndent(w, http.StatusOK, response)
 			}
 		case config.AuthStrategyAnonymous:
@@ -229,16 +238,20 @@ func AuthenticationInfo(conf *config.Config, authController authentication.AuthC
 func Logout(conf *config.Config, authController authentication.AuthController) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if conf.Auth.Strategy == config.AuthStrategyAnonymous {
+			log.Infof("Logout requested [client: %s] (anonymous strategy)", r.RemoteAddr)
 			RespondWithCode(w, http.StatusNoContent)
 		} else {
+			log.Infof("Logout initiated [client: %s]", r.RemoteAddr)
 			err := authController.TerminateSession(r, w)
 			if err != nil {
+				log.Errorf("Logout failed [client: %s]: %s", r.RemoteAddr, err.Error())
 				if e, ok := err.(*authentication.TerminateSessionError); ok {
 					RespondWithError(w, e.HttpStatus, e.Error())
 				} else {
 					RespondWithError(w, http.StatusInternalServerError, err.Error())
 				}
 			} else {
+				log.Infof("Logout completed [client: %s]", r.RemoteAddr)
 				RespondWithCode(w, http.StatusNoContent)
 			}
 		}

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -248,7 +248,7 @@ func Logout(conf *config.Config, authController authentication.AuthController) h
 				if e, ok := err.(*authentication.TerminateSessionError); ok {
 					RespondWithError(w, e.HttpStatus, e.Error())
 				} else {
-					RespondWithError(w, http.StatusInternalServerError, err.Error())
+					RespondWithError(w, http.StatusInternalServerError, "Internal server error")
 				}
 			} else {
 				log.Infof("Logout completed [client: %s]", r.RemoteAddr)

--- a/handlers/authentication/auth_controller.go
+++ b/handlers/authentication/auth_controller.go
@@ -113,6 +113,10 @@ func (e *AuthenticationFailureError) Error() string {
 	return e.Reason
 }
 
+// ErrSubjectMismatch is returned when the subject claim in a token does not match
+// the stored subject, indicating a potential session integrity violation.
+var ErrSubjectMismatch = fmt.Errorf("subject mismatch")
+
 func nonceCookieName(cluster string) string {
 	return NonceCookieName + "-" + cluster
 }

--- a/handlers/authentication/header_auth_controller.go
+++ b/handlers/authentication/header_auth_controller.go
@@ -77,20 +77,19 @@ func (c headerAuthController) Authenticate(r *http.Request, w http.ResponseWrite
 		return nil, err
 	}
 
-	// The token has been validated via k8s TokenReview, extract the subject for the ui to display
-	// from either the subject (via the TokenReview) or the impersonation header
-	var tokenSubject string
+	tokenOwner := strings.TrimPrefix(subjectFromToken, "system:serviceaccount:")
 
-	if authInfo.Impersonate == "" {
-		tokenSubject = subjectFromToken
-		tokenSubject = strings.TrimPrefix(tokenSubject, "system:serviceaccount:") // Shorten the subject displayed in UI.
+	var displayName string
+	if authInfo.Impersonate != "" {
+		displayName = authInfo.Impersonate
+		log.Infof("Header auth: token owner [%s] is impersonating [%s]", tokenOwner, authInfo.Impersonate)
 	} else {
-		tokenSubject = authInfo.Impersonate
+		displayName = tokenOwner
 	}
 
 	// Create the session
 	timeExpire := util.Clock.Now().Add(time.Second * time.Duration(conf.LoginToken.ExpirationSeconds))
-	sessionData, err := NewSessionData(conf.KubernetesConfig.ClusterName, config.AuthStrategyHeader, timeExpire, &headerSessionPayload{Token: authInfo.Token, Subject: tokenSubject})
+	sessionData, err := NewSessionData(conf.KubernetesConfig.ClusterName, config.AuthStrategyHeader, timeExpire, &headerSessionPayload{Token: authInfo.Token, Subject: displayName})
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +102,7 @@ func (c headerAuthController) Authenticate(r *http.Request, w http.ResponseWrite
 		AuthInfo:  authInfo,
 		ExpiresOn: timeExpire,
 		SessionID: sessionData.SessionID,
-		Username:  tokenSubject,
+		Username:  displayName,
 	}, nil
 }
 
@@ -141,6 +140,13 @@ func (c headerAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 		expiration = sData.ExpiresOn
 		sessionID = sData.SessionID
 		subject = sData.Payload.Subject
+	}
+
+	// Use the verified token identity for audit, not the session display name which
+	// may be a user-supplied impersonation header value.
+	tokenSubject, err := c.homeClusterSAClient.GetTokenSubject(authInfo)
+	if err == nil {
+		r.Header.Set("Kiali-User", strings.TrimPrefix(tokenSubject, "system:serviceaccount:"))
 	}
 
 	return UserSessions{

--- a/handlers/authentication/header_auth_controller.go
+++ b/handlers/authentication/header_auth_controller.go
@@ -147,6 +147,8 @@ func (c headerAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 	tokenSubject, err := c.homeClusterSAClient.GetTokenSubject(authInfo)
 	if err == nil {
 		r.Header.Set("Kiali-User", strings.TrimPrefix(tokenSubject, "system:serviceaccount:"))
+	} else {
+		log.Warningf("Could not verify token subject for audit header [client: %s]: %v", r.RemoteAddr, err)
 	}
 
 	return UserSessions{

--- a/handlers/authentication/openid_auth_controller.go
+++ b/handlers/authentication/openid_auth_controller.go
@@ -232,9 +232,14 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 			return nil, fmt.Errorf("cannot parse the payload of the id_token: %w", err)
 		}
 
-		if userClaim, ok := claims[c.conf.Auth.OpenId.UsernameClaim]; ok && sData.Payload.Subject != userClaim {
-			log.Warning("Kiali token rejected because of subject claim mismatch")
-			return nil, fmt.Errorf("session [%w]: token subject does not match stored subject", ErrSubjectMismatch)
+		if userClaim, ok := claims[c.conf.Auth.OpenId.UsernameClaim]; ok {
+			if s, ok := userClaim.(string); !ok {
+				log.Warningf("Kiali token rejected: username claim %q is not a string", c.conf.Auth.OpenId.UsernameClaim)
+				return nil, fmt.Errorf("session [%w]: username claim is not a string type", ErrSubjectMismatch)
+			} else if sData.Payload.Subject != s {
+				log.Warning("Kiali token rejected because of subject claim mismatch")
+				return nil, fmt.Errorf("session [%w]: token subject does not match stored subject", ErrSubjectMismatch)
+			}
 		}
 	}
 

--- a/handlers/authentication/openid_auth_controller.go
+++ b/handlers/authentication/openid_auth_controller.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -31,17 +32,17 @@ import (
 	"github.com/kiali/kiali/util/httputil"
 )
 
-// cachedOpenIdKeySet stores the metadata obtained from the /.well-known/openid-configuration
+// cachedOpenIdMetadata stores the metadata obtained from the /.well-known/openid-configuration
 // endpoint of the OpenId server. Once the metadata is obtained for the first time, subsequent
 // retrievals are served from this cached value rather than doing another request to the
 // metadata endpoint of the OpenId server.
-var cachedOpenIdMetadata *openIdMetadata
+var cachedOpenIdMetadata atomic.Pointer[openIdMetadata]
 
 // cachedOpenIdKeySet stores the public key sets used for verification of the received
 // id_tokens from the OpenId server. Its purpose is to prevent repeated queries to the JWKS
 // endpoint of the OpenId server. However, since the keys can rotate, this is refreshed
 // each time an id_token is signed with a key that is not present in the cached key set.
-var cachedOpenIdKeySet *jose.JSONWebKeySet
+var cachedOpenIdKeySet atomic.Pointer[jose.JSONWebKeySet]
 
 // openIdFlightGroup is used to synchronize different threads of different HTTP requests so
 // that only one request active to the metadata or jwks endpoints of the OpenId server. This
@@ -132,6 +133,10 @@ type OpenIdAuthController struct {
 // given persistor and the given businessInstantiator. The businessInstantiator can be nil and
 // the initialized contoller will use the business.Get function.
 func NewOpenIdAuthController(kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory, conf *config.Config, discovery *istio.Discovery) (*OpenIdAuthController, error) {
+	if conf.Server.WebFQDN == "" {
+		log.Warning("OpenID auth strategy is active but server.web_fqdn is not set. The OIDC redirect_uri will be derived from request headers, which can be manipulated if Kiali is not behind a trusted proxy. Set server.web_fqdn to a known hostname to prevent this.")
+	}
+
 	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
 	if err != nil {
 		return nil, err
@@ -205,7 +210,7 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 	// The OpenId token must be present in the session
 	if len(sData.Payload.Token) == 0 {
 		log.Warning("Session is invalid: the OIDC token is absent")
-		return nil, nil
+		return nil, fmt.Errorf("session [%w]: OIDC token is absent", ErrSessionNotFound)
 	}
 
 	// If the id_token is being used to make calls to the cluster API, it's known that
@@ -229,7 +234,7 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 
 		if userClaim, ok := claims[c.conf.Auth.OpenId.UsernameClaim]; ok && sData.Payload.Subject != userClaim {
 			log.Warning("Kiali token rejected because of subject claim mismatch")
-			return nil, nil
+			return nil, fmt.Errorf("session [%w]: token subject does not match stored subject", ErrSubjectMismatch)
 		}
 	}
 
@@ -272,7 +277,7 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 	}
 
 	// Internal header used to propagate the subject of the request for audit purpose
-	r.Header.Add("Kiali-User", sData.Payload.Subject)
+	r.Header.Set("Kiali-User", sData.Payload.Subject)
 
 	return userSessions, nil
 }
@@ -795,8 +800,10 @@ func (p *openidFlowHelper) parseOpenIdToken() *openidFlowHelper {
 
 	// Extract the name of the user from the id_token. The "subject" is passed to the front-end to be displayed.
 	p.Subject = "OpenId User" // Set a default value
-	if userClaim, ok := claims[p.conf.Auth.OpenId.UsernameClaim]; ok && len(userClaim.(string)) > 0 {
-		p.Subject = userClaim.(string)
+	if userClaim, ok := claims[p.conf.Auth.OpenId.UsernameClaim]; ok {
+		if s, ok := userClaim.(string); ok && len(s) > 0 {
+			p.Subject = s
+		}
 	}
 
 	return p
@@ -814,7 +821,16 @@ func (p *openidFlowHelper) validateOpenIdNonceCode() *openidFlowHelper {
 
 	// Parse the received id_token from the IdP and check nonce code
 	nonceHashHex := fmt.Sprintf("%x", p.NonceHash)
-	if nonceClaim, ok := p.IdTokenPayload["nonce"]; !ok || nonceHashHex != nonceClaim.(string) {
+	nonceClaim, ok := p.IdTokenPayload["nonce"]
+	if !ok {
+		p.Error = &AuthenticationFailureError{
+			HttpStatus: http.StatusForbidden,
+			Reason:     "OpenId token rejected: nonce claim is absent",
+		}
+		return p
+	}
+	nonceStr, nonceIsString := nonceClaim.(string)
+	if !nonceIsString || nonceHashHex != nonceStr {
 		p.Error = &AuthenticationFailureError{
 			HttpStatus: http.StatusForbidden,
 			Reason:     "OpenId token rejected: nonce code mismatch",
@@ -935,7 +951,7 @@ func (p *openidFlowHelper) requestOpenIdToken(redirect_uri string) *openidFlowHe
 	}
 
 	if response.StatusCode != 200 {
-		log.Debugf("OpenId token request failed with response: %s", string(rawTokenResponse))
+		log.Debugf("OpenId token request failed with status %s (response body: %d bytes)", response.Status, len(rawTokenResponse))
 		p.Error = fmt.Errorf("request failed (HTTP response status = %s)", response.Status)
 		return p
 	}
@@ -1125,9 +1141,9 @@ func getJwkFromKeySet(conf *config.Config, keyId string) (*jose.JSONWebKey, erro
 		return nil
 	}
 
-	if cachedOpenIdKeySet != nil {
+	if ks := cachedOpenIdKeySet.Load(); ks != nil {
 		// If key-set is cached, try to find the key in the cached key-set
-		foundKey := findJwkFunc(keyId, cachedOpenIdKeySet)
+		foundKey := findJwkFunc(keyId, ks)
 		if foundKey != nil {
 			return foundKey, nil
 		}
@@ -1186,8 +1202,8 @@ func getOpenIdJwks(conf *config.Config) (*jose.JSONWebKeySet, error) {
 			return nil, fmt.Errorf("cannot parse OpenId JWKS document: %s", err.Error())
 		}
 
-		cachedOpenIdKeySet = &oidcKeys // Store the keyset in a "cache"
-		return cachedOpenIdKeySet, nil
+		cachedOpenIdKeySet.Store(&oidcKeys)
+		return &oidcKeys, nil
 	})
 
 	if fetchError != nil {
@@ -1208,8 +1224,8 @@ func getOpenIdJwks(conf *config.Config) (*jose.JSONWebKeySet, error) {
 //
 // The result is cached after the first successful call; subsequent calls return the cached metadata.
 func getOpenIdMetadata(conf *config.Config) (*openIdMetadata, error) {
-	if cachedOpenIdMetadata != nil {
-		return cachedOpenIdMetadata, nil
+	if md := cachedOpenIdMetadata.Load(); md != nil {
+		return md, nil
 	}
 
 	fetchedMetadata, fetchError, _ := openIdFlightGroup.Do("metadata", func() (interface{}, error) {
@@ -1311,8 +1327,8 @@ func getOpenIdMetadata(conf *config.Config) (*openIdMetadata, error) {
 		}
 
 		// Return parsed metadata
-		cachedOpenIdMetadata = &metadata
-		return cachedOpenIdMetadata, nil
+		cachedOpenIdMetadata.Store(&metadata)
+		return &metadata, nil
 	})
 
 	if fetchError != nil {

--- a/handlers/authentication/openid_auth_controller_test.go
+++ b/handlers/authentication/openid_auth_controller_test.go
@@ -283,7 +283,7 @@ func TestValidateOpenIdTokenInHouse(t *testing.T) {
 	// we start with a good token - our second test will switch this to the token with the bad aud value
 	openIdTestTokenToUse := openIdTestTokenWithGoodAud
 
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	var jwksResponseBytes []byte
 	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -490,7 +490,7 @@ func TestOpenIdAuthControllerRejectsImplicitFlow(t *testing.T) {
 /*** Authorization code flow tests ***/
 
 func TestOpenIdAuthControllerAuthenticatesCorrectlyWithAuthorizationCodeFlow(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -595,7 +595,7 @@ func TestOpenIdAuthControllerAuthenticatesCorrectlyWithAuthorizationCodeFlow(t *
 }
 
 func TestOpenIdCodeFlowShouldFailWithMissingIdTokenFromOpenIdServer(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -676,7 +676,7 @@ func TestOpenIdCodeFlowShouldFailWithMissingIdTokenFromOpenIdServer(t *testing.T
 }
 
 func TestOpenIdCodeFlowShouldFailWithBadResponseFromTokenEndpoint(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -755,7 +755,7 @@ func TestOpenIdCodeFlowShouldFailWithBadResponseFromTokenEndpoint(t *testing.T) 
 }
 
 func TestOpenIdCodeFlowShouldFailWithNonJsonResponse(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -834,7 +834,7 @@ func TestOpenIdCodeFlowShouldFailWithNonJsonResponse(t *testing.T) {
 }
 
 func TestOpenIdCodeFlowShouldFailWithNonJwtIdToken(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -956,7 +956,7 @@ func TestOpenIdCodeFlowShouldRejectMissingAuthorizationCode(t *testing.T) {
 }
 
 func TestOpenIdCodeFlowShouldFailWithIdTokenWithoutExpiration(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -1037,7 +1037,7 @@ func TestOpenIdCodeFlowShouldFailWithIdTokenWithoutExpiration(t *testing.T) {
 }
 
 func TestOpenIdCodeFlowShouldFailWithIdTokenWithNonNumericExpClaim(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -1295,7 +1295,7 @@ func TestOpenIdCodeFlowShouldRejectMissingNonceCookie(t *testing.T) {
 }
 
 func TestOpenIdCodeFlowShouldRejectMissingNonceInToken(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
@@ -1368,7 +1368,7 @@ func TestOpenIdCodeFlowShouldRejectMissingNonceInToken(t *testing.T) {
 
 	// Redirection to boot the UI
 	q := url.Values{}
-	q.Add("openid_error", "OpenId token rejected: nonce code mismatch")
+	q.Add("openid_error", "OpenId token rejected: nonce claim is absent")
 	assert.Equal(t, "/kiali-test/?"+q.Encode(), response.Header.Get("Location"))
 	assert.Equal(t, http.StatusFound, response.StatusCode)
 }
@@ -1499,11 +1499,11 @@ func TestRequestOpenIdToken_UsesGetCredential(t *testing.T) {
 		}
 
 		// Mock the metadata to point to our token server
-		cachedOpenIdMetadata = &openIdMetadata{
+		cachedOpenIdMetadata.Store(&openIdMetadata{
 			Issuer:   "https://example.com",
 			TokenURL: tokenServer.URL,
-		}
-		defer func() { cachedOpenIdMetadata = nil }()
+		})
+		defer func() { cachedOpenIdMetadata.Store(nil) }()
 
 		flow.requestOpenIdToken("http://localhost/callback")
 
@@ -1552,11 +1552,11 @@ func TestRequestOpenIdToken_UsesGetCredential(t *testing.T) {
 		}
 
 		// Mock the metadata
-		cachedOpenIdMetadata = &openIdMetadata{
+		cachedOpenIdMetadata.Store(&openIdMetadata{
 			Issuer:   "https://example.com",
 			TokenURL: tokenServer.URL,
-		}
-		defer func() { cachedOpenIdMetadata = nil }()
+		})
+		defer func() { cachedOpenIdMetadata.Store(nil) }()
 
 		flow.requestOpenIdToken("http://localhost/callback")
 
@@ -1590,11 +1590,11 @@ func TestRequestOpenIdToken_UsesGetCredential(t *testing.T) {
 		}
 
 		// Mock the metadata
-		cachedOpenIdMetadata = &openIdMetadata{
+		cachedOpenIdMetadata.Store(&openIdMetadata{
 			Issuer:   "https://example.com",
 			TokenURL: "https://example.com/token",
-		}
-		defer func() { cachedOpenIdMetadata = nil }()
+		})
+		defer func() { cachedOpenIdMetadata.Store(nil) }()
 
 		flow.requestOpenIdToken("http://localhost/callback")
 
@@ -1607,7 +1607,7 @@ func TestRequestOpenIdToken_UsesGetCredential(t *testing.T) {
 /*** Explicit OIDC endpoints tests ***/
 
 func TestOpenIdAuthControllerUsesExplicitEndpointsWhenProvided(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	// Test server that should NOT be called for auto-discovery
 	autoDiscoveryCallCount := 0
@@ -1675,7 +1675,7 @@ func TestOpenIdAuthControllerUsesExplicitEndpointsWhenProvided(t *testing.T) {
 }
 
 func TestOpenIdAuthControllerDiscoveryOverride(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	autoDiscoveryCallCount := 0
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1730,7 +1730,7 @@ func TestOpenIdAuthControllerDiscoveryOverride(t *testing.T) {
 }
 
 func TestOpenIdAuthControllerFallsBackToAutoDiscoveryWhenExplicitEndpointsMissing(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	autoDiscoveryCallCount := 0
 	var oidcMetadata []byte
@@ -1776,7 +1776,7 @@ func TestOpenIdAuthControllerFallsBackToAutoDiscoveryWhenExplicitEndpointsMissin
 }
 
 func TestOpenIdAuthControllerRequiresBothAuthorizationAndTokenEndpointsForDiscoveryOverride(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	autoDiscoveryCallCount := 0
 	var oidcMetadata []byte
@@ -1814,7 +1814,7 @@ func TestOpenIdAuthControllerRequiresBothAuthorizationAndTokenEndpointsForDiscov
 	assert.Equal(t, 1, autoDiscoveryCallCount, "Auto-discovery should be called when token_endpoint is missing in DiscoveryOverride")
 
 	// Reset for next test
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	autoDiscoveryCallCount = 0
 
 	// Test case 2: Only token_endpoint in DiscoveryOverride (should use auto-discovery)
@@ -1830,7 +1830,7 @@ func TestOpenIdAuthControllerRequiresBothAuthorizationAndTokenEndpointsForDiscov
 }
 
 func TestOpenIdAuthControllerHandlesOptionalUserInfoEndpointWithDiscoveryOverride(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	conf := config.NewConfig()
 	conf.Auth.OpenId.IssuerUri = "https://example.com"
@@ -1855,7 +1855,7 @@ func TestOpenIdAuthControllerHandlesOptionalUserInfoEndpointWithDiscoveryOverrid
 	// Test with UserInfoEndpoint provided in DiscoveryOverride
 	conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint = "https://example.com/userinfo"
 	config.Set(conf)
-	cachedOpenIdMetadata = nil // Reset cache
+	cachedOpenIdMetadata.Store(nil) // Reset cache
 
 	metadata, err = getOpenIdMetadata(conf)
 	require.NoError(t, err)
@@ -1873,7 +1873,7 @@ func TestOpenIdAuthControllerHandlesOptionalUserInfoEndpointWithDiscoveryOverrid
 // authorization code to the client that requested it. Without proper PKCE implementation, the authentication
 // flow would be vulnerable to malicious actors intercepting and using authorization codes.
 func TestOpenIdRedirectHandlerGeneratesPKCEParameters(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 
 	// Setup mock OIDC server
 	var oidcMetadata []byte
@@ -2031,7 +2031,7 @@ func TestOpenIdCodeFlowShouldRejectMissingCodeVerifierCookie(t *testing.T) {
 // sending PKCE parameters but not requiring provider validation, we provide enhanced security for modern
 // providers while maintaining compatibility with legacy systems.
 func TestOpenIdPKCEWorksWithProviderThatIgnoresIt(t *testing.T) {
-	cachedOpenIdMetadata = nil
+	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte
 
 	// Setup mock OIDC server that ignores PKCE parameters (simulates older provider)

--- a/handlers/authentication/openshift_auth_controller.go
+++ b/handlers/authentication/openshift_auth_controller.go
@@ -213,6 +213,10 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 			SessionID: "",
 			Username:  user.Name,
 		}
+		// WARNING: Reading the bearer token from a URL query parameter exposes it in proxy/access
+		// logs, browser history, and Referer headers. This path exists because OpenShift's OAuth
+		// server redirects back with the token as a query parameter. Operators should configure
+		// their proxy/ingress to strip or mask the oauth_token parameter from access logs.
 	} else if authToken := r.URL.Query().Get("oauth_token"); len(authToken) != 0 {
 		token := strings.TrimSpace(authToken)
 		expires := util.Clock.Now().Add(time.Second * time.Duration(o.conf.LoginToken.ExpirationSeconds))
@@ -265,7 +269,7 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 		return nil, fmt.Errorf("no valid session found for home cluster")
 	} else {
 		// Internal header used to propagate the subject of the request for audit purposes
-		r.Header.Add("Kiali-User", homeClusterUserSession.Username)
+		r.Header.Set("Kiali-User", homeClusterUserSession.Username)
 	}
 
 	return userSessions, nil

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -127,6 +127,7 @@ func validSession(t *testing.T, authController *authentication.OpenshiftAuthCont
 func TestOpenshiftAuthController(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
 	conf.KubernetesConfig.ClusterName = "test-cluster"
 	conf.LoginToken.SigningKey = "kiali67890123456"
 
@@ -266,6 +267,7 @@ func TestUnauthorizedUserSessionGetsDropped(t *testing.T) {
 func TestMulticlusterUnauthorizedUserSessionGetsDropped(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
 	conf.KubernetesConfig.ClusterName = "east"
 	conf.LoginToken.SigningKey = "kiali67890123456"
 
@@ -341,6 +343,7 @@ func TestMulticlusterUnauthorizedUserSessionGetsDropped(t *testing.T) {
 func TestTerminateSession(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
 	conf.KubernetesConfig.ClusterName = "east"
 	conf.LoginToken.SigningKey = "kiali67890123456"
 

--- a/handlers/authentication/session_persistor.go
+++ b/handlers/authentication/session_persistor.go
@@ -447,6 +447,21 @@ func (p *cookieSessionPersistor[T]) ReadAllSessions(r *http.Request, w http.Resp
 				log.Debugf("Skipping cookie [%s] (not a valid session or failed to decrypt): %v", cookie.Name, err)
 				continue
 			}
+
+			sessionKey := extractKeyFromSessionCookieName(cookie.Name)
+
+			if sData.Strategy != p.conf.Auth.Strategy {
+				log.Debugf("Session is invalid because it was created with authentication strategy [%s], but current authentication strategy is [%s]", sData.Strategy, p.conf.Auth.Strategy)
+				p.TerminateSession(r, w, sessionKey)
+				continue
+			}
+
+			if !util.Clock.Now().Before(sData.ExpiresOn) {
+				log.Debugf("Session is invalid because it expired on %s", sData.ExpiresOn.Format(time.RFC822))
+				p.TerminateSession(r, w, sessionKey)
+				continue
+			}
+
 			sessions = append(sessions, sData)
 		}
 	}

--- a/handlers/authentication/session_persistor_test.go
+++ b/handlers/authentication/session_persistor_test.go
@@ -1075,3 +1075,125 @@ func TestReadAllSessions_WorksWithNumericEndingKeys(t *testing.T) {
 
 	assert.Empty(t, readRR.Result().Cookies(), "No cookies should be dropped")
 }
+
+func TestReadAllSessions_RejectsExpiredSession(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.Server.WebRoot = "/kiali-app"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.Auth.Strategy = "test"
+
+	clockTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	persistor, err := NewCookieSessionPersistor[testSessionPayload](conf)
+	require.NoError(err)
+
+	payload := testSessionPayload{FirstField: "expired-session"}
+	expiresTime := clockTime.Add(time.Hour)
+	cookies := newValidSessionCookies(t, persistor, "cluster1", conf.Auth.Strategy, expiresTime, payload)
+
+	// Advance clock past the session's expiry
+	util.Clock = util.ClockMock{Time: clockTime.Add(2 * time.Hour)}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	for _, c := range cookies {
+		request.AddCookie(c)
+	}
+
+	readRR := httptest.NewRecorder()
+	sessions, err := persistor.ReadAllSessions(request, readRR)
+
+	require.Error(err)
+	require.Nil(sessions)
+	assert.True(t, errors.Is(err, ErrSessionNotFound))
+
+	// The expired session cookie should have been terminated
+	droppedCookies := readRR.Result().Cookies()
+	assert.NotEmpty(t, droppedCookies, "Expired session cookie should be terminated")
+}
+
+func TestReadAllSessions_RejectsMismatchedStrategy(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.Server.WebRoot = "/kiali-app"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.Auth.Strategy = "openshift"
+
+	clockTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	persistor, err := NewCookieSessionPersistor[testSessionPayload](conf)
+	require.NoError(err)
+
+	payload := testSessionPayload{FirstField: "old-strategy-session"}
+	expiresTime := clockTime.Add(time.Hour)
+	cookies := newValidSessionCookies(t, persistor, "cluster1", conf.Auth.Strategy, expiresTime, payload)
+
+	// Reconfigure to a different strategy
+	conf.Auth.Strategy = "token"
+
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	for _, c := range cookies {
+		request.AddCookie(c)
+	}
+
+	readRR := httptest.NewRecorder()
+	sessions, err := persistor.ReadAllSessions(request, readRR)
+
+	require.Error(err)
+	require.Nil(sessions)
+	assert.True(t, errors.Is(err, ErrSessionNotFound))
+
+	// The mismatched-strategy session cookie should have been terminated
+	droppedCookies := readRR.Result().Cookies()
+	assert.NotEmpty(t, droppedCookies, "Mismatched strategy session cookie should be terminated")
+}
+
+func TestReadAllSessions_MixedValidAndInvalidSessions(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.Server.WebRoot = "/kiali-app"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.Auth.Strategy = "test"
+
+	clockTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	persistor, err := NewCookieSessionPersistor[testSessionPayload](conf)
+	require.NoError(err)
+
+	// Create a session that will expire in 1 hour (valid)
+	validPayload := testSessionPayload{FirstField: "valid-session"}
+	validCookies := newValidSessionCookies(t, persistor, "good-cluster", conf.Auth.Strategy, clockTime.Add(time.Hour), validPayload)
+
+	// Create a session that expires in 30 minutes (will be expired when we advance the clock)
+	expiredPayload := testSessionPayload{FirstField: "expired-session"}
+	expiredCookies := newValidSessionCookies(t, persistor, "expired-cluster", conf.Auth.Strategy, clockTime.Add(30*time.Minute), expiredPayload)
+
+	// Advance clock to 45 minutes: the 30-minute session is expired, the 1-hour session is still valid
+	util.Clock = util.ClockMock{Time: clockTime.Add(45 * time.Minute)}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	for _, c := range validCookies {
+		request.AddCookie(c)
+	}
+	for _, c := range expiredCookies {
+		request.AddCookie(c)
+	}
+
+	readRR := httptest.NewRecorder()
+	sessions, err := persistor.ReadAllSessions(request, readRR)
+
+	require.NoError(err)
+	require.Len(sessions, 1, "Only the valid session should be returned")
+	assert.Equal(t, "good-cluster", sessions[0].Cluster)
+	assert.Equal(t, "valid-session", sessions[0].Payload.FirstField)
+
+	// The expired session should have been terminated
+	droppedCookies := readRR.Result().Cookies()
+	assert.NotEmpty(t, droppedCookies, "Expired session cookie should be terminated")
+}

--- a/handlers/authentication/token_auth_controller.go
+++ b/handlers/authentication/token_auth_controller.go
@@ -154,7 +154,7 @@ func (c *tokenAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 	}
 
 	// If we are here, the session looks valid. Return the session details.
-	r.Header.Add("Kiali-User", extractSubjectFromK8sToken(sData.Payload.Token)) // Internal header used to propagate the subject of the request for audit purposes
+	r.Header.Set("Kiali-User", extractSubjectFromK8sToken(sData.Payload.Token)) // Internal header used to propagate the subject of the request for audit purposes
 	return UserSessions{
 		c.conf.KubernetesConfig.ClusterName: &UserSessionData{
 			AuthInfo:  &api.AuthInfo{Token: sData.Payload.Token},

--- a/server/server.go
+++ b/server/server.go
@@ -60,7 +60,7 @@ func NewServer(ctx context.Context,
 		tracingProvider = observability.InitTracer(conf.Server.Observability.Tracing.CollectorURL)
 	}
 
-	middlewares := []mux.MiddlewareFunc{securityHeaders}
+	middlewares := []mux.MiddlewareFunc{securityHeaders(conf.IsServerHTTPS())}
 	if conf.Server.CORSAllowAll {
 		middlewares = append(middlewares, corsAllowed)
 	}
@@ -159,13 +159,18 @@ func (s *Server) Stop() {
 	s.conf.Close()
 }
 
-func securityHeaders(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("X-XSS-Protection", "1; mode=block")
-		next.ServeHTTP(w, r)
-	})
+func securityHeaders(isServerHTTPS bool) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("X-XSS-Protection", "1; mode=block")
+			if isServerHTTPS {
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func corsAllowed(next http.Handler) http.Handler {


### PR DESCRIPTION
## Security hardening for the authentication layer

Fixes several bugs and security issues identified during a focused review of the auth code.

**Bugs fixed:**
- **BUG-1:** `ReadAllSessions` now enforces expiry and strategy checks, matching `ReadSession` behavior
- **BUG-2:** Safe type assertion for non-string OIDC username claims (prevents panic)
- **BUG-3:** `ValidateSession` returns typed errors instead of `nil, nil` — subject mismatch and missing token now produce 401 instead of 400
- **BUG-4:** Restructured nonce validation to avoid panic on non-string nonce claims
- **BUG-5:** Replaced plain pointer variables for cached OIDC metadata/keyset with `atomic.Pointer` to eliminate data races

**Security fixes:**
- **SEC-1:** Removed raw tokens from debug log output in OpenShift OAuth logout and OIDC token exchange failure paths
- **SEC-2:** Added documentation about `oauth_token` query parameter log-exposure risk
- **SEC-3:** Startup warning when `WebFQDN` is empty with OpenID auth strategy
- **SEC-4:** Header auth now uses the cluster-verified identity for audit logs while preserving the impersonated identity for UI display
- **SEC-5:** HTTP error responses send only the safe `Reason` string; raw `Detail` is logged server-side only
- **SEC-6:** Added conditional `Strict-Transport-Security` header when serving over HTTPS
- **SEC-7:** Changed `Header.Add` to `Header.Set` for `Kiali-User` audit header in all auth controllers, preventing client-supplied header spoofing

**Tested:** All unit tests pass. All molecule tests pass on both minikube (19/19) and OpenShift/CRC (21/21).

Generated-by: Cursor

In addition, this is addressed (reported via this [discussion](https://github.com/kiali/kiali/discussions/9679#discussioncomment-16893405))

```
Include r.RemoteAddr in all auth middleware warn/error log lines
for traceability on unauthorized, forbidden, and internal errors.
Add audit logging to Logout() (initiation, completion, failure)
and success logging to Authenticate() with username and a truncated
SHA-256 token fingerprint. Log unexpected non-AuthenticationFailureError
errors that were previously silent.
```