### PR TITLE
[perf] Optimize IstioAppender graph generation for large meshes

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -14,20 +14,27 @@ import (
 
 func NewGlobalIstioInfo() *GlobalIstioInfo {
 	return &GlobalIstioInfo{
-		AmbientWaypoints:  make(map[graph.NodeKey]bool),
-		AppsMap:           make(map[string]map[string]*models.AppListItem),
-		ServiceEntryHosts: make(map[string]serviceEntryHosts),
-		ServiceLists:      make(map[string]*models.ServiceList),
-		WorkloadLists:     make(map[string]*models.WorkloadList),
+		AllWorkloads:        make(map[string]models.Workloads),
+		AmbientWaypoints:    make(map[graph.NodeKey]bool),
+		AppsMap:             make(map[string]map[string]*models.AppListItem),
+		ClusterServiceLists: make(map[string]*models.ServiceList),
+		ServiceEntryHosts:   make(map[string]serviceEntryHosts),
+		ServiceLists:        make(map[string]*models.ServiceList),
+		WorkloadLists:       make(map[string]*models.WorkloadList),
 	}
 }
 
 // GlobalIstioInfo contains structured information for Istio telemetry vendor
 type GlobalIstioInfo struct {
+	// AllWorkloads caches full workload models by cluster name, populated by populateWorkloadMap.
+	// Used by decorateGateways to filter locally instead of re-fetching per gateway.
+	AllWorkloads map[string]models.Workloads
 	// AmbientWaypoints maps waypoint keys to their availability status
 	AmbientWaypoints any
 	// AppsMap contains application list items keyed by cluster:namespace
 	AppsMap map[string]map[string]*models.AppListItem
+	// ClusterServiceLists caches cluster-wide service lists by cluster name
+	ClusterServiceLists map[string]*models.ServiceList
 	// ServiceEntryHosts maps composite keys (serviceEntryHostsKey:cluster:namespace) to service entry hosts
 	ServiceEntryHosts map[string]serviceEntryHosts
 	// ServiceLists caches service lists by cluster:namespace key
@@ -496,12 +503,16 @@ func getTrafficClusters(trafficMap graph.TrafficMap, namespace string, gi *Globa
 }
 
 // populateWorkloadMap populates the globalInfo.WorkloadMap with the workloads from the trafficMap.
+// It also caches the full workload models in AllWorkloads so that decorateGateways can
+// filter locally by label selector instead of re-fetching workloads per gateway.
 func populateWorkloadMap(ctx context.Context, business *business.Layer, globalInfo *GlobalInfo, trafficMap graph.TrafficMap) {
 	for _, cluster := range globalInfo.Clusters {
 		workloads, err := business.Workload.GetAllWorkloads(ctx, cluster.Name, "")
 		if err != nil {
 			graph.Error(fmt.Sprintf("Error fetching workloads: %s", err.Error()))
 		}
+
+		globalInfo.Vendor.AllWorkloads[cluster.Name] = workloads
 
 		for _, workload := range workloads {
 			globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: workload.Cluster, Namespace: workload.Namespace, Name: workload.Name}] = nil

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/sliceutil"
 )
@@ -509,7 +510,8 @@ func populateWorkloadMap(ctx context.Context, business *business.Layer, globalIn
 	for _, cluster := range globalInfo.Clusters {
 		workloads, err := business.Workload.GetAllWorkloads(ctx, cluster.Name, "")
 		if err != nil {
-			graph.Error(fmt.Sprintf("Error fetching workloads: %s", err.Error()))
+			log.FromContext(ctx).Warn().Msgf("Error fetching workloads for cluster [%s], gateway decoration may be incomplete: %s", cluster.Name, err.Error())
+			continue
 		}
 
 		globalInfo.Vendor.AllWorkloads[cluster.Name] = workloads

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -79,87 +79,45 @@ func (a IstioAppender) AppendGraph(ctx context.Context, trafficMap graph.Traffic
 	addLabels(ctx, trafficMap, globalInfo, globalInfo.Vendor.ClusterServiceLists)
 }
 
-// cbSubsetInfo holds pre-computed circuit breaker info for a single DR subset.
-type cbSubsetInfo struct {
-	// version is the version label value from subset.Labels (via GetVersionLabelName).
-	// Empty means the subset has no version label -- it does NOT match versioned queries
-	// (where the caller knows the specific version). It only matches unversioned queries
-	// (where the caller passes version="").
-	version string
-}
-
-// drEntry holds pre-computed circuit breaker info for a single DestinationRule.
-type drEntry struct {
-	cbSubsets []cbSubsetInfo
-	dr        *networkingv1.DestinationRule
-	hasCB     bool // true if top-level TrafficPolicy has CB
-}
-
 // hostIndexKey is the canonical index key for DR and VS host lookup.
 func hostIndexKey(namespace, serviceName string) string {
 	return namespace + "/" + serviceName
 }
 
-// buildDRIndex pre-indexes DestinationRules by their normalized target host for O(1) lookup.
-func buildDRIndex(destinationRules []*networkingv1.DestinationRule) map[string][]*drEntry {
-	conf := config.Get()
-	idx := make(map[string][]*drEntry, len(destinationRules))
-
-	for _, dr := range destinationRules {
-		entry := &drEntry{
-			dr:    dr,
-			hasCB: models.IsCB(dr.Spec.TrafficPolicy),
-		}
-
-		for _, subset := range dr.Spec.Subsets {
-			if subset == nil {
-				continue
-			}
-			if models.IsCB(subset.TrafficPolicy) {
-				info := cbSubsetInfo{}
-				if verLabelName, found := conf.GetVersionLabelName(subset.Labels); found {
-					if v, ok := subset.Labels[verLabelName]; ok {
-						info.version = v
-					}
-				}
-				entry.cbSubsets = append(entry.cbSubsets, info)
-			}
-		}
-
-		if !entry.hasCB && len(entry.cbSubsets) == 0 {
-			continue
-		}
-
-		ns, svc := kubernetes.NormalizeHost(dr.Spec.Host, dr.Namespace)
-		key := hostIndexKey(ns, svc)
-		idx[key] = append(idx[key], entry)
-	}
-
-	return idx
-}
-
-// drMatchesCB checks whether a pre-indexed drEntry matches a CB query for the given
-// namespace, service, version, and identityDomain. It uses FilterByHost to confirm
-// the match (narrow-then-confirm pattern).
-func drMatchesCB(entry *drEntry, namespace, serviceName, version, identityDomain string) bool {
-	if !kubernetes.FilterByHost(entry.dr.Spec.Host, entry.dr.Namespace, serviceName, namespace, identityDomain) {
-		return false
-	}
-
-	if entry.hasCB {
+// hasCBConfig checks whether a DestinationRule has any circuit breaker configuration
+// (ConnectionPool or OutlierDetection) at the top level or in any subset.
+func hasCBConfig(dr *networkingv1.DestinationRule) bool {
+	tp := dr.Spec.TrafficPolicy
+	if tp != nil && (tp.ConnectionPool != nil || tp.OutlierDetection != nil) {
 		return true
 	}
-
-	if version == "" {
-		return len(entry.cbSubsets) > 0
-	}
-
-	for _, sub := range entry.cbSubsets {
-		if sub.version == version {
+	for _, subset := range dr.Spec.Subsets {
+		if subset == nil {
+			continue
+		}
+		stp := subset.TrafficPolicy
+		if stp != nil && (stp.ConnectionPool != nil || stp.OutlierDetection != nil) {
 			return true
 		}
 	}
 	return false
+}
+
+// buildDRIndex pre-indexes DestinationRules by their normalized target host
+// for O(1) lookup. Only DRs with CB config are indexed to avoid unnecessary
+// FilterByHost allocations at lookup time. The confirmation step uses
+// models.HasDRCircuitBreaker for full host-matching and version semantics.
+func buildDRIndex(destinationRules []*networkingv1.DestinationRule) map[string][]*networkingv1.DestinationRule {
+	idx := make(map[string][]*networkingv1.DestinationRule, len(destinationRules))
+	for _, dr := range destinationRules {
+		if !hasCBConfig(dr) {
+			continue
+		}
+		ns, svc := kubernetes.NormalizeHost(dr.Spec.Host, dr.Namespace)
+		key := hostIndexKey(ns, svc)
+		idx[key] = append(idx[key], dr)
+	}
+	return idx
 }
 
 func applyCircuitBreakers(trafficMap graph.TrafficMap, destinationRules []*networkingv1.DestinationRule, identityDomain string) {
@@ -175,8 +133,8 @@ NODES:
 		switch {
 		case n.NodeType == graph.NodeTypeService:
 			key := hostIndexKey(n.Namespace, n.Service)
-			for _, entry := range idx[key] {
-				if drMatchesCB(entry, n.Namespace, n.Service, "", identityDomain) {
+			for _, dr := range idx[key] {
+				if models.HasDRCircuitBreaker(dr, n.Namespace, n.Service, "", identityDomain) {
 					n.Metadata[graph.HasCB] = true
 					continue NODES
 				}
@@ -185,8 +143,8 @@ NODES:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					key := hostIndexKey(ds.Namespace, ds.Name)
-					for _, entry := range idx[key] {
-						if drMatchesCB(entry, ds.Namespace, ds.Name, "", identityDomain) {
+					for _, dr := range idx[key] {
+						if models.HasDRCircuitBreaker(dr, ds.Namespace, ds.Name, "", identityDomain) {
 							n.Metadata[graph.HasCB] = true
 							continue NODES
 						}
@@ -197,8 +155,8 @@ NODES:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
 					key := hostIndexKey(ds.Namespace, ds.Name)
-					for _, entry := range idx[key] {
-						if drMatchesCB(entry, ds.Namespace, ds.Name, n.Version, identityDomain) {
+					for _, dr := range idx[key] {
+						if models.HasDRCircuitBreaker(dr, ds.Namespace, ds.Name, n.Version, identityDomain) {
 							n.Metadata[graph.HasCB] = true
 							continue NODES
 						}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -6,6 +6,7 @@ import (
 
 	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
@@ -45,54 +46,137 @@ func (a IstioAppender) AppendGraph(ctx context.Context, trafficMap graph.Traffic
 		populateWorkloadMap(ctx, globalInfo.Business, globalInfo, trafficMap)
 	}
 
-	serviceLists := map[string]*models.ServiceList{}
+	// Fetch cluster-wide service lists once per cluster for use by addLabels.
 	for _, cluster := range globalInfo.Clusters {
-		svcs, err := globalInfo.Business.Svc.GetServiceListForCluster(ctx,
-			business.ServiceCriteria{Cluster: cluster.Name, IncludeOnlyDefinitions: true, IncludeHealth: false},
-			cluster.Name,
-		)
-		graph.CheckError(err)
-
-		serviceLists[cluster.Name] = svcs
+		if _, ok := globalInfo.Vendor.ClusterServiceLists[cluster.Name]; !ok {
+			svcs, err := globalInfo.Business.Svc.GetServiceListForCluster(ctx,
+				business.ServiceCriteria{Cluster: cluster.Name, IncludeOnlyDefinitions: true, IncludeHealth: false},
+				cluster.Name,
+			)
+			graph.CheckError(err)
+			globalInfo.Vendor.ClusterServiceLists[cluster.Name] = svcs
+		}
 	}
 
-	addBadging(ctx, trafficMap, globalInfo)
-	addLabels(ctx, trafficMap, globalInfo, serviceLists)
+	// Fetch all needed Istio config (DRs, VSes, Gateways) in a single call per cluster
+	// to avoid redundant GetIstioConfigList and GetClusterNamespaces calls.
 	for _, cluster := range globalInfo.Clusters {
-		a.decorateGateways(ctx, cluster.Name, globalInfo)
-	}
-}
-
-func addBadging(ctx context.Context, trafficMap graph.TrafficMap, globalInfo *GlobalInfo) {
-	for _, cluster := range globalInfo.Clusters {
-		// Currently no other appenders use DestinationRules or VirtualServices, so they are not cached in AppenderNamespaceInfo
 		istioConfig, err := globalInfo.Business.IstioConfig.GetIstioConfigList(ctx, cluster.Name, business.IstioConfigCriteria{
 			IncludeDestinationRules: true,
+			IncludeGateways:         true,
+			IncludeK8sGateways:      true,
 			IncludeVirtualServices:  true,
 		})
 		graph.CheckError(err)
 
 		identityDomain := globalInfo.Business.Svc.ResolveIdentityDomain(ctx, cluster.Name)
+
 		applyCircuitBreakers(trafficMap, istioConfig.DestinationRules, identityDomain)
 		applyVirtualServices(trafficMap, istioConfig.VirtualServices, identityDomain)
+		decorateGateways(ctx, cluster.Name, globalInfo, istioConfig.Gateways, istioConfig.K8sGateways)
 	}
+
+	addLabels(ctx, trafficMap, globalInfo, globalInfo.Vendor.ClusterServiceLists)
+}
+
+// cbSubsetInfo holds pre-computed circuit breaker info for a single DR subset.
+type cbSubsetInfo struct {
+	// version is the version label value from subset.Labels (via GetVersionLabelName).
+	// Empty means the subset has no version label -- it does NOT match versioned queries
+	// (where the caller knows the specific version). It only matches unversioned queries
+	// (where the caller passes version="").
+	version string
+}
+
+// drEntry holds pre-computed circuit breaker info for a single DestinationRule.
+type drEntry struct {
+	cbSubsets []cbSubsetInfo
+	dr        *networkingv1.DestinationRule
+	hasCB     bool // true if top-level TrafficPolicy has CB
+}
+
+// drKey is the canonical index key for DR/VS host lookup.
+func drKey(namespace, serviceName string) string {
+	return namespace + "/" + serviceName
+}
+
+// buildDRIndex pre-indexes DestinationRules by their normalized target host for O(1) lookup.
+func buildDRIndex(destinationRules []*networkingv1.DestinationRule) map[string][]*drEntry {
+	conf := config.Get()
+	idx := make(map[string][]*drEntry, len(destinationRules))
+
+	for _, dr := range destinationRules {
+		entry := &drEntry{
+			dr:    dr,
+			hasCB: models.IsCB(dr.Spec.TrafficPolicy),
+		}
+
+		for _, subset := range dr.Spec.Subsets {
+			if subset == nil {
+				continue
+			}
+			if models.IsCB(subset.TrafficPolicy) {
+				info := cbSubsetInfo{}
+				if verLabelName, found := conf.GetVersionLabelName(subset.Labels); found {
+					if v, ok := subset.Labels[verLabelName]; ok {
+						info.version = v
+					}
+				}
+				entry.cbSubsets = append(entry.cbSubsets, info)
+			}
+		}
+
+		if !entry.hasCB && len(entry.cbSubsets) == 0 {
+			continue
+		}
+
+		ns, svc := kubernetes.NormalizeHost(dr.Spec.Host, dr.Namespace)
+		key := drKey(ns, svc)
+		idx[key] = append(idx[key], entry)
+	}
+
+	return idx
+}
+
+// drMatchesCB checks whether a pre-indexed drEntry matches a CB query for the given
+// namespace, service, version, and identityDomain. It uses FilterByHost to confirm
+// the match (narrow-then-confirm pattern).
+func drMatchesCB(entry *drEntry, namespace, serviceName, version, identityDomain string) bool {
+	if !kubernetes.FilterByHost(entry.dr.Spec.Host, entry.dr.Namespace, serviceName, namespace, identityDomain) {
+		return false
+	}
+
+	if entry.hasCB {
+		return true
+	}
+
+	if version == "" {
+		return len(entry.cbSubsets) > 0
+	}
+
+	for _, sub := range entry.cbSubsets {
+		if sub.version == version {
+			return true
+		}
+	}
+	return false
 }
 
 func applyCircuitBreakers(trafficMap graph.TrafficMap, destinationRules []*networkingv1.DestinationRule, identityDomain string) {
+	idx := buildDRIndex(destinationRules)
+
 NODES:
 	for _, n := range trafficMap {
-		// Skip nodes that are outside the requested namespaces.
 		if outside, ok := n.Metadata[graph.IsOutside].(bool); ok && outside {
 			continue
 		}
 
-		// Note, Because DestinationRules are applied to services we limit CB badges to service nodes and app nodes.
-		// Whether we should add to workload nodes is debatable, we could add it later if needed.
 		versionOk := graph.IsOK(n.Version)
 		switch {
 		case n.NodeType == graph.NodeTypeService:
-			for _, destinationRule := range destinationRules {
-				if models.HasDRCircuitBreaker(destinationRule, n.Namespace, n.Service, "", identityDomain) {
+			key := drKey(n.Namespace, n.Service)
+			for _, entry := range idx[key] {
+				if drMatchesCB(entry, n.Namespace, n.Service, "", identityDomain) {
 					n.Metadata[graph.HasCB] = true
 					continue NODES
 				}
@@ -100,8 +184,9 @@ NODES:
 		case !versionOk && (n.NodeType == graph.NodeTypeApp):
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
-					for _, destinationRule := range destinationRules {
-						if models.HasDRCircuitBreaker(destinationRule, ds.Namespace, ds.Name, "", identityDomain) {
+					key := drKey(ds.Namespace, ds.Name)
+					for _, entry := range idx[key] {
+						if drMatchesCB(entry, ds.Namespace, ds.Name, "", identityDomain) {
 							n.Metadata[graph.HasCB] = true
 							continue NODES
 						}
@@ -111,8 +196,9 @@ NODES:
 		case versionOk:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
-					for _, destinationRule := range destinationRules {
-						if models.HasDRCircuitBreaker(destinationRule, ds.Namespace, ds.Name, n.Version, identityDomain) {
+					key := drKey(ds.Namespace, ds.Name)
+					for _, entry := range idx[key] {
+						if drMatchesCB(entry, ds.Namespace, ds.Name, n.Version, identityDomain) {
 							n.Metadata[graph.HasCB] = true
 							continue NODES
 						}
@@ -125,61 +211,125 @@ NODES:
 	}
 }
 
+// vsEntry holds pre-computed feature flags for a single VirtualService.
+type vsEntry struct {
+	hasFaultInjection  bool
+	hasMirroring       bool
+	hasRequestRouting  bool
+	hasRequestTimeout  bool
+	hasTCPShifting     bool
+	hasTrafficShifting bool
+	isK8sGatewayAPI    bool
+	vs                 *networkingv1.VirtualService
+}
+
+// buildVSIndex pre-indexes VirtualServices by the normalized hosts of their route
+// destinations. A single VS may appear under multiple keys. The slice for each key
+// preserves the original VS list order from GetIstioConfigList.
+func buildVSIndex(virtualServices []*networkingv1.VirtualService) map[string][]*vsEntry {
+	idx := make(map[string][]*vsEntry, len(virtualServices))
+
+	for _, vs := range virtualServices {
+		entry := &vsEntry{
+			hasFaultInjection:  models.HasVSFaultInjection(vs),
+			hasMirroring:       models.HasVSMirroring(vs),
+			hasRequestRouting:  models.HasVSRequestRouting(vs),
+			hasRequestTimeout:  models.HasVSRequestTimeout(vs),
+			hasTCPShifting:     models.HasVSTCPTrafficShifting(vs),
+			hasTrafficShifting: models.HasVSTrafficShifting(vs),
+			isK8sGatewayAPI:    kubernetes.IsAutogenerated(vs.Name),
+			vs:                 vs,
+		}
+
+		seen := make(map[string]bool)
+		addHost := func(host string) {
+			ns, svc := kubernetes.NormalizeHost(host, vs.Namespace)
+			key := drKey(ns, svc)
+			if !seen[key] {
+				seen[key] = true
+				idx[key] = append(idx[key], entry)
+			}
+		}
+
+		for _, httpRoute := range vs.Spec.Http {
+			for _, dest := range httpRoute.Route {
+				if dest.Destination != nil {
+					addHost(dest.Destination.Host)
+				}
+			}
+		}
+		for _, tcpRoute := range vs.Spec.Tcp {
+			for _, dest := range tcpRoute.Route {
+				if dest.Destination != nil {
+					addHost(dest.Destination.Host)
+				}
+			}
+		}
+		for _, tlsRoute := range vs.Spec.Tls {
+			for _, dest := range tlsRoute.Route {
+				if dest.Destination != nil {
+					addHost(dest.Destination.Host)
+				}
+			}
+		}
+	}
+
+	return idx
+}
+
 func applyVirtualServices(trafficMap graph.TrafficMap, virtualServices []*networkingv1.VirtualService, identityDomain string) {
+	idx := buildVSIndex(virtualServices)
+
 NODES:
 	for _, n := range trafficMap {
 		var isOutsider bool
 		if outside, ok := n.Metadata[graph.IsOutside].(bool); ok {
 			isOutsider = outside
 		}
-		// Skip nodes that are outside the requested namespaces.
 		if n.NodeType != graph.NodeTypeService || isOutsider {
 			continue
 		}
 
-		for _, virtualService := range virtualServices {
-			if models.IsVSValidHost(virtualService, n.Namespace, n.Service, identityDomain) {
-				var vsMetadata graph.VirtualServicesMetadata
-				var vsOk bool
-				if vsMetadata, vsOk = n.Metadata[graph.HasVS].(graph.VirtualServicesMetadata); !vsOk {
-					vsMetadata = make(graph.VirtualServicesMetadata)
-					n.Metadata[graph.HasVS] = vsMetadata
-				}
-
-				if len(virtualService.Spec.Hosts) != 0 {
-					vsMetadata[virtualService.Name] = virtualService.Spec.Hosts
-				}
-
-				if models.HasVSRequestRouting(virtualService) {
-					n.Metadata[graph.HasRequestRouting] = true
-				}
-
-				if models.HasVSRequestTimeout(virtualService) {
-					n.Metadata[graph.HasRequestTimeout] = true
-				}
-
-				if models.HasVSFaultInjection(virtualService) {
-					n.Metadata[graph.HasFaultInjection] = true
-				}
-
-				if models.HasVSTrafficShifting(virtualService) {
-					n.Metadata[graph.HasTrafficShifting] = true
-				}
-
-				if models.HasVSTCPTrafficShifting(virtualService) {
-					n.Metadata[graph.HasTCPTrafficShifting] = true
-				}
-
-				if models.HasVSMirroring(virtualService) {
-					n.Metadata[graph.HasMirroring] = true
-				}
-
-				if kubernetes.IsAutogenerated(virtualService.Name) {
-					n.Metadata[graph.IsK8sGatewayAPI] = true
-				}
-
-				continue NODES
+		key := drKey(n.Namespace, n.Service)
+		for _, entry := range idx[key] {
+			if !models.IsVSValidHost(entry.vs, n.Namespace, n.Service, identityDomain) {
+				continue
 			}
+
+			var vsMetadata graph.VirtualServicesMetadata
+			var vsOk bool
+			if vsMetadata, vsOk = n.Metadata[graph.HasVS].(graph.VirtualServicesMetadata); !vsOk {
+				vsMetadata = make(graph.VirtualServicesMetadata)
+				n.Metadata[graph.HasVS] = vsMetadata
+			}
+
+			if len(entry.vs.Spec.Hosts) != 0 {
+				vsMetadata[entry.vs.Name] = entry.vs.Spec.Hosts
+			}
+
+			if entry.hasRequestRouting {
+				n.Metadata[graph.HasRequestRouting] = true
+			}
+			if entry.hasRequestTimeout {
+				n.Metadata[graph.HasRequestTimeout] = true
+			}
+			if entry.hasFaultInjection {
+				n.Metadata[graph.HasFaultInjection] = true
+			}
+			if entry.hasTrafficShifting {
+				n.Metadata[graph.HasTrafficShifting] = true
+			}
+			if entry.hasTCPShifting {
+				n.Metadata[graph.HasTCPTrafficShifting] = true
+			}
+			if entry.hasMirroring {
+				n.Metadata[graph.HasMirroring] = true
+			}
+			if entry.isK8sGatewayAPI {
+				n.Metadata[graph.IsK8sGatewayAPI] = true
+			}
+
+			continue NODES
 		}
 	}
 }
@@ -193,7 +343,6 @@ type serviceKey struct {
 // addLabels is a chance to add any missing label info to nodes when the telemetry does not provide enough information.
 // For example, service injection has this problem.
 func addLabels(ctx context.Context, trafficMap graph.TrafficMap, gi *GlobalInfo, serviceLists map[string]*models.ServiceList) {
-	// build map for quick lookup
 	svcMap := map[serviceKey]models.ServiceOverview{}
 	for cluster, serviceList := range serviceLists {
 		for _, sd := range serviceList.Services {
@@ -206,12 +355,9 @@ func addLabels(ctx context.Context, trafficMap graph.TrafficMap, gi *GlobalInfo,
 		if outside, ok := n.Metadata[graph.IsOutside].(bool); ok {
 			isOutsider = outside
 		}
-		// make sure service nodes have the defined app label so it can be used for app grouping in the UI.
 		if n.NodeType != graph.NodeTypeService || n.App != "" || isOutsider {
 			continue
 		}
-		// For service nodes that are a service entries, use the `hosts` property of the SE to find
-		// a matching Kubernetes Svc for adding missing labels
 		if _, ok := n.Metadata[graph.IsServiceEntry]; ok {
 			seInfo := n.Metadata[graph.IsServiceEntry].(*graph.SEInfo)
 			for _, host := range seInfo.Hosts {
@@ -234,7 +380,6 @@ func addLabels(ctx context.Context, trafficMap graph.TrafficMap, gi *GlobalInfo,
 			}
 			continue
 		}
-		// A service node that is an Istio egress cluster will not have a service definition
 		if _, ok := n.Metadata[graph.IsEgressCluster]; ok {
 			continue
 		}
@@ -251,27 +396,24 @@ func addLabels(ctx context.Context, trafficMap graph.TrafficMap, gi *GlobalInfo,
 	}
 }
 
-// decorateGateways gets all the Gateway CRDs and GatewayAPI CRDs for the given cluster and namespace and adds the hostnames to the node metadata.
-func (a IstioAppender) decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInfo) {
-	l, err := globalInfo.Business.IstioConfig.GetIstioConfigList(ctx, cluster, business.IstioConfigCriteria{
-		IncludeGateways:    true,
-		IncludeK8sGateways: true,
-	})
-	graph.CheckError(err)
+// decorateGateways decorates workload nodes with gateway metadata. It uses the
+// pre-cached AllWorkloads to filter locally by label selector instead of calling
+// GetAllWorkloads/GetWorkloadList per gateway.
+func decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInfo, gateways []*networkingv1.Gateway, k8sGateways []*k8s_networking_v1.Gateway) {
+	allWorkloads := globalInfo.Vendor.AllWorkloads[cluster]
 
-	for _, gw := range l.Gateways {
+	for _, gw := range gateways {
 		selector := labels.Set(gw.Spec.Selector).AsSelector()
-		wk, err := globalInfo.Business.Workload.GetAllWorkloads(ctx, cluster, selector.String())
-		if err != nil {
-			log.FromContext(ctx).Warn().Msgf("Skipping gateway [%s]/[%s] with selector [%s]: %v", gw.Namespace, gw.Name, selector.String(), err)
-			continue
-		}
+
 		var hostnames []string
 		for _, gwServer := range gw.Spec.Servers {
-			gwHosts := gwServer.Hosts
-			hostnames = append(hostnames, gwHosts...)
+			hostnames = append(hostnames, gwServer.Hosts...)
 		}
-		for _, w := range wk {
+
+		for _, w := range allWorkloads {
+			if !selector.Matches(labels.Set(w.Labels)) {
+				continue
+			}
 			node := globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: w.Cluster, Namespace: w.Namespace, Name: w.Name}]
 			if node != nil {
 				// TODO: This doesn't work for the generic gateway chart.
@@ -285,30 +427,35 @@ func (a IstioAppender) decorateGateways(ctx context.Context, cluster string, glo
 		}
 	}
 
-	for _, gw := range l.K8sGateways {
-		wl, err := globalInfo.Business.Workload.GetWorkloadList(ctx, business.WorkloadCriteria{
-			Cluster:       cluster,
-			LabelSelector: labels.Set(map[string]string{config.GatewayLabel: gw.Name}).String(),
-		})
-		graph.CheckError(err)
-		if wlLen := len(wl.Workloads); wlLen == 0 {
+	k8sGwSelector := func(gwName string) labels.Selector {
+		return labels.Set(map[string]string{config.GatewayLabel: gwName}).AsSelector()
+	}
+
+	for _, gw := range k8sGateways {
+		sel := k8sGwSelector(gw.Name)
+
+		var matched []*models.Workload
+		for _, w := range allWorkloads {
+			if sel.Matches(labels.Set(w.Labels)) {
+				matched = append(matched, w)
+			}
+		}
+
+		if len(matched) == 0 {
 			continue
-		} else if wlLen > 1 {
+		} else if len(matched) > 1 {
 			log.FromContext(ctx).Warn().Msgf("Multiple workloads found for GatewayAPI %s in namespace %s", gw.Name, gw.Namespace)
 		}
 
-		workload := wl.Workloads[0]
+		workload := matched[0]
 		node := globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: workload.Cluster, Namespace: workload.Namespace, Name: workload.Name}]
 		if node != nil {
-			gwListeners := gw.Spec.Listeners
 			var hostnames []string
-
-			for _, gwListener := range gwListeners {
+			for _, gwListener := range gw.Spec.Listeners {
 				if gwListener.Hostname != nil {
 					hostnames = append(hostnames, string(*gwListener.Hostname))
 				}
 			}
-			// Hostnames are not required. Adding * to be processed by the frontend (Indicates the kind of GW).
 			if len(hostnames) == 0 {
 				hostnames = append(hostnames, "*")
 			}

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -95,8 +95,8 @@ type drEntry struct {
 	hasCB     bool // true if top-level TrafficPolicy has CB
 }
 
-// drKey is the canonical index key for DR/VS host lookup.
-func drKey(namespace, serviceName string) string {
+// hostIndexKey is the canonical index key for DR and VS host lookup.
+func hostIndexKey(namespace, serviceName string) string {
 	return namespace + "/" + serviceName
 }
 
@@ -131,7 +131,7 @@ func buildDRIndex(destinationRules []*networkingv1.DestinationRule) map[string][
 		}
 
 		ns, svc := kubernetes.NormalizeHost(dr.Spec.Host, dr.Namespace)
-		key := drKey(ns, svc)
+		key := hostIndexKey(ns, svc)
 		idx[key] = append(idx[key], entry)
 	}
 
@@ -174,7 +174,7 @@ NODES:
 		versionOk := graph.IsOK(n.Version)
 		switch {
 		case n.NodeType == graph.NodeTypeService:
-			key := drKey(n.Namespace, n.Service)
+			key := hostIndexKey(n.Namespace, n.Service)
 			for _, entry := range idx[key] {
 				if drMatchesCB(entry, n.Namespace, n.Service, "", identityDomain) {
 					n.Metadata[graph.HasCB] = true
@@ -184,7 +184,7 @@ NODES:
 		case !versionOk && (n.NodeType == graph.NodeTypeApp):
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
-					key := drKey(ds.Namespace, ds.Name)
+					key := hostIndexKey(ds.Namespace, ds.Name)
 					for _, entry := range idx[key] {
 						if drMatchesCB(entry, ds.Namespace, ds.Name, "", identityDomain) {
 							n.Metadata[graph.HasCB] = true
@@ -196,7 +196,7 @@ NODES:
 		case versionOk:
 			if destServices, ok := n.Metadata[graph.DestServices]; ok {
 				for _, ds := range destServices.(graph.DestServicesMetadata) {
-					key := drKey(ds.Namespace, ds.Name)
+					key := hostIndexKey(ds.Namespace, ds.Name)
 					for _, entry := range idx[key] {
 						if drMatchesCB(entry, ds.Namespace, ds.Name, n.Version, identityDomain) {
 							n.Metadata[graph.HasCB] = true
@@ -244,7 +244,7 @@ func buildVSIndex(virtualServices []*networkingv1.VirtualService) map[string][]*
 		seen := make(map[string]bool)
 		addHost := func(host string) {
 			ns, svc := kubernetes.NormalizeHost(host, vs.Namespace)
-			key := drKey(ns, svc)
+			key := hostIndexKey(ns, svc)
 			if !seen[key] {
 				seen[key] = true
 				idx[key] = append(idx[key], entry)
@@ -252,6 +252,9 @@ func buildVSIndex(virtualServices []*networkingv1.VirtualService) map[string][]*
 		}
 
 		for _, httpRoute := range vs.Spec.Http {
+			if httpRoute == nil {
+				continue
+			}
 			for _, dest := range httpRoute.Route {
 				if dest.Destination != nil {
 					addHost(dest.Destination.Host)
@@ -259,6 +262,9 @@ func buildVSIndex(virtualServices []*networkingv1.VirtualService) map[string][]*
 			}
 		}
 		for _, tcpRoute := range vs.Spec.Tcp {
+			if tcpRoute == nil {
+				continue
+			}
 			for _, dest := range tcpRoute.Route {
 				if dest.Destination != nil {
 					addHost(dest.Destination.Host)
@@ -266,6 +272,9 @@ func buildVSIndex(virtualServices []*networkingv1.VirtualService) map[string][]*
 			}
 		}
 		for _, tlsRoute := range vs.Spec.Tls {
+			if tlsRoute == nil {
+				continue
+			}
 			for _, dest := range tlsRoute.Route {
 				if dest.Destination != nil {
 					addHost(dest.Destination.Host)
@@ -290,7 +299,7 @@ NODES:
 			continue
 		}
 
-		key := drKey(n.Namespace, n.Service)
+		key := hostIndexKey(n.Namespace, n.Service)
 		for _, entry := range idx[key] {
 			if !models.IsVSValidHost(entry.vs, n.Namespace, n.Service, identityDomain) {
 				continue

--- a/graph/telemetry/istio/appender/istio_details_bench_test.go
+++ b/graph/telemetry/istio/appender/istio_details_bench_test.go
@@ -397,6 +397,7 @@ func BenchmarkIstioAppender(b *testing.B) {
 		{namespaces: 50, appsPerNs: 5, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 5, k8sGateways: 5},
 		{namespaces: 50, appsPerNs: 10, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 10, k8sGateways: 10},
 		{namespaces: 50, appsPerNs: 10, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 0, k8sGateways: 0},
+		{namespaces: 500, appsPerNs: 5, versionsPerApp: 2, drsPerNs: 5, vsPerNs: 5, istioGateways: 3, k8sGateways: 3},
 	}
 
 	for _, s := range scenarios {

--- a/graph/telemetry/istio/appender/istio_details_bench_test.go
+++ b/graph/telemetry/istio/appender/istio_details_bench_test.go
@@ -1,0 +1,407 @@
+// Benchmarks for IstioAppender performance. These are not unit tests -- they are
+// only executed when explicitly requested via the -bench flag. They generate
+// synthetic traffic maps with configurable numbers of namespaces, apps,
+// DestinationRules, VirtualServices, and gateways, then measure the execution
+// time of IstioAppender.AppendGraph.
+//
+// Run benchmarks:
+//
+//	go test -run='^$' -bench=BenchmarkIstioAppender -benchmem -count=5 -timeout=600s \
+//	  ./graph/telemetry/istio/appender/
+//
+// Save results to a file for comparison:
+//
+//	go test -run='^$' -bench=BenchmarkIstioAppender -benchmem -count=5 -timeout=600s \
+//	  ./graph/telemetry/istio/appender/ > before.txt
+//
+// After making changes, run again and compare with benchstat
+// (install via: go install golang.org/x/perf/cmd/benchstat@latest):
+//
+//	benchstat before.txt after.txt
+package appender
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api_networking_v1 "istio.io/api/networking/v1"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/graph"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/models"
+)
+
+type benchScenario struct {
+	namespaces     int
+	appsPerNs      int
+	versionsPerApp int
+	drsPerNs       int
+	vsPerNs        int
+	istioGateways  int
+	k8sGateways    int
+}
+
+func (s benchScenario) String() string {
+	return fmt.Sprintf(
+		"%dns_%dapps_%dver_%ddr_%dvs_%digw_%dk8sgw",
+		s.namespaces, s.appsPerNs, s.versionsPerApp,
+		s.drsPerNs, s.vsPerNs, s.istioGateways, s.k8sGateways,
+	)
+}
+
+func buildBenchData(b *testing.B, s benchScenario) (*business.Layer, graph.TrafficMap) {
+	b.Helper()
+
+	clusterName := config.DefaultClusterID
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = clusterName
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	var objects []runtime.Object
+	trafficMap := graph.NewTrafficMap()
+
+	for ns := 0; ns < s.namespaces; ns++ {
+		nsName := fmt.Sprintf("ns-%d", ns)
+		objects = append(objects, kubetest.FakeNamespace(nsName))
+
+		for app := 0; app < s.appsPerNs; app++ {
+			appName := fmt.Sprintf("app-%d", app)
+			svcName := appName
+
+			objects = append(objects, &core_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      svcName,
+					Namespace: nsName,
+					Labels:    map[string]string{"app": appName},
+				},
+				Spec: core_v1.ServiceSpec{
+					Ports: []core_v1.ServicePort{{Port: 8080}},
+				},
+			})
+
+			svcNode, _ := graph.NewNode(clusterName, nsName, svcName, nsName, graph.Unknown, graph.Unknown, graph.Unknown, graph.GraphTypeVersionedApp)
+			trafficMap[svcNode.ID] = svcNode
+
+			appNode, _ := graph.NewNode(clusterName, nsName, svcName, nsName, graph.Unknown, appName, "", graph.GraphTypeVersionedApp)
+			appNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add(
+				fmt.Sprintf("%s %s", nsName, svcName),
+				graph.ServiceName{Namespace: nsName, Name: svcName},
+			)
+			trafficMap[appNode.ID] = appNode
+
+			for ver := 0; ver < s.versionsPerApp; ver++ {
+				version := fmt.Sprintf("v%d", ver)
+				wlName := fmt.Sprintf("%s-%s", appName, version)
+
+				objects = append(objects,
+					&apps_v1.Deployment{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      wlName,
+							Namespace: nsName,
+							Labels:    map[string]string{"app": appName, "version": version},
+						},
+						Spec: apps_v1.DeploymentSpec{
+							Selector: &meta_v1.LabelSelector{
+								MatchLabels: map[string]string{"app": appName, "version": version},
+							},
+							Template: core_v1.PodTemplateSpec{
+								ObjectMeta: meta_v1.ObjectMeta{
+									Labels: map[string]string{"app": appName, "version": version},
+								},
+								Spec: core_v1.PodSpec{
+									Containers: []core_v1.Container{{
+										Name:  "main",
+										Image: "test:latest",
+									}},
+								},
+							},
+						},
+					},
+					&apps_v1.ReplicaSet{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      wlName + "-rs",
+							Namespace: nsName,
+							Labels:    map[string]string{"app": appName, "version": version},
+							OwnerReferences: []meta_v1.OwnerReference{{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+								Name:       wlName,
+								Controller: boolPtr(true),
+							}},
+						},
+					},
+					&core_v1.Pod{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      wlName + "-pod-0",
+							Namespace: nsName,
+							Labels:    map[string]string{"app": appName, "version": version},
+							OwnerReferences: []meta_v1.OwnerReference{{
+								APIVersion: "apps/v1",
+								Kind:       "ReplicaSet",
+								Name:       wlName + "-rs",
+								Controller: boolPtr(true),
+							}},
+						},
+						Status: core_v1.PodStatus{Phase: core_v1.PodRunning},
+					},
+				)
+
+				wlNode, _ := graph.NewNode(clusterName, nsName, svcName, nsName, wlName, appName, version, graph.GraphTypeVersionedApp)
+				wlNode.Metadata[graph.DestServices] = graph.NewDestServicesMetadata().Add(
+					fmt.Sprintf("%s %s", nsName, svcName),
+					graph.ServiceName{Namespace: nsName, Name: svcName},
+				)
+				trafficMap[wlNode.ID] = wlNode
+			}
+		}
+
+		for dr := 0; dr < s.drsPerNs; dr++ {
+			targetApp := fmt.Sprintf("app-%d", dr%s.appsPerNs)
+			objects = append(objects, &networking_v1.DestinationRule{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      fmt.Sprintf("dr-%d", dr),
+					Namespace: nsName,
+				},
+				Spec: api_networking_v1.DestinationRule{
+					Host: targetApp,
+					TrafficPolicy: &api_networking_v1.TrafficPolicy{
+						ConnectionPool: &api_networking_v1.ConnectionPoolSettings{
+							Http: &api_networking_v1.ConnectionPoolSettings_HTTPSettings{
+								MaxRequestsPerConnection: 100,
+							},
+						},
+					},
+				},
+			})
+		}
+
+		for vs := 0; vs < s.vsPerNs; vs++ {
+			targetApp := fmt.Sprintf("app-%d", vs%s.appsPerNs)
+			objects = append(objects, &networking_v1.VirtualService{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      fmt.Sprintf("vs-%d", vs),
+					Namespace: nsName,
+				},
+				Spec: api_networking_v1.VirtualService{
+					Hosts: []string{targetApp},
+					Http: []*api_networking_v1.HTTPRoute{{
+						Route: []*api_networking_v1.HTTPRouteDestination{{
+							Destination: &api_networking_v1.Destination{
+								Host: targetApp,
+							},
+						}},
+					}},
+				},
+			})
+		}
+	}
+
+	gwNs := "istio-system"
+	objects = append(objects, kubetest.FakeNamespace(gwNs))
+
+	for gw := 0; gw < s.istioGateways; gw++ {
+		gwName := fmt.Sprintf("istio-gw-%d", gw)
+		wlName := fmt.Sprintf("istio-ingressgateway-%d", gw)
+
+		objects = append(objects,
+			&networking_v1.Gateway{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      gwName,
+					Namespace: gwNs,
+				},
+				Spec: api_networking_v1.Gateway{
+					Selector: map[string]string{"istio": wlName},
+					Servers: []*api_networking_v1.Server{{
+						Hosts: []string{"*.example.com"},
+						Port:  &api_networking_v1.Port{Number: 80, Name: "http", Protocol: "HTTP"},
+					}},
+				},
+			},
+			&apps_v1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName,
+					Namespace: gwNs,
+					Labels: map[string]string{
+						"istio":                       wlName,
+						"operator.istio.io/component": "IngressGateways",
+					},
+				},
+				Spec: apps_v1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{
+						MatchLabels: map[string]string{"istio": wlName},
+					},
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Labels: map[string]string{
+								"istio":                       wlName,
+								"operator.istio.io/component": "IngressGateways",
+							},
+						},
+						Spec: core_v1.PodSpec{
+							Containers: []core_v1.Container{{Name: "istio-proxy", Image: "istio-proxy:latest"}},
+						},
+					},
+				},
+			},
+			&apps_v1.ReplicaSet{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName + "-rs",
+					Namespace: gwNs,
+					Labels: map[string]string{
+						"istio":                       wlName,
+						"operator.istio.io/component": "IngressGateways",
+					},
+					OwnerReferences: []meta_v1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       wlName,
+						Controller: boolPtr(true),
+					}},
+				},
+			},
+			&core_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName + "-pod-0",
+					Namespace: gwNs,
+					Labels: map[string]string{
+						"istio":                       wlName,
+						"operator.istio.io/component": "IngressGateways",
+					},
+					OwnerReferences: []meta_v1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "ReplicaSet",
+						Name:       wlName + "-rs",
+						Controller: boolPtr(true),
+					}},
+				},
+				Status: core_v1.PodStatus{Phase: core_v1.PodRunning},
+			},
+		)
+
+		wlNode, _ := graph.NewNode(clusterName, gwNs, "", gwNs, wlName, graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+		trafficMap[wlNode.ID] = wlNode
+	}
+
+	for gw := 0; gw < s.k8sGateways; gw++ {
+		gwName := fmt.Sprintf("k8s-gw-%d", gw)
+		wlName := fmt.Sprintf("k8s-gateway-%d", gw)
+		hostname := k8s_networking_v1.Hostname(fmt.Sprintf("gw-%d.example.com", gw))
+
+		objects = append(objects,
+			&k8s_networking_v1.Gateway{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      gwName,
+					Namespace: gwNs,
+				},
+				Spec: k8s_networking_v1.GatewaySpec{
+					GatewayClassName: "istio",
+					Listeners: []k8s_networking_v1.Listener{{
+						Name:     "http",
+						Port:     80,
+						Protocol: k8s_networking_v1.HTTPProtocolType,
+						Hostname: &hostname,
+					}},
+				},
+			},
+			&apps_v1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName,
+					Namespace: gwNs,
+					Labels:    map[string]string{config.GatewayLabel: gwName},
+				},
+				Spec: apps_v1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{
+						MatchLabels: map[string]string{config.GatewayLabel: gwName},
+					},
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Labels: map[string]string{config.GatewayLabel: gwName},
+						},
+						Spec: core_v1.PodSpec{
+							Containers: []core_v1.Container{{Name: "istio-proxy", Image: "istio-proxy:latest"}},
+						},
+					},
+				},
+			},
+			&apps_v1.ReplicaSet{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName + "-rs",
+					Namespace: gwNs,
+					Labels:    map[string]string{config.GatewayLabel: gwName},
+					OwnerReferences: []meta_v1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       wlName,
+						Controller: boolPtr(true),
+					}},
+				},
+			},
+			&core_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      wlName + "-pod-0",
+					Namespace: gwNs,
+					Labels:    map[string]string{config.GatewayLabel: gwName},
+					OwnerReferences: []meta_v1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "ReplicaSet",
+						Name:       wlName + "-rs",
+						Controller: boolPtr(true),
+					}},
+				},
+				Status: core_v1.PodStatus{Phase: core_v1.PodRunning},
+			},
+		)
+
+		wlNode, _ := graph.NewNode(clusterName, gwNs, "", gwNs, wlName, graph.Unknown, graph.Unknown, graph.GraphTypeWorkload)
+		trafficMap[wlNode.ID] = wlNode
+	}
+
+	k8s := kubetest.NewFakeK8sClient(objects...)
+	biz := business.NewLayerBuilder(b, conf).WithClient(k8s).Build()
+
+	return biz, trafficMap
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func runBenchmark(b *testing.B, s benchScenario) {
+	biz, trafficMap := buildBenchData(b, s)
+	conf := config.Get()
+
+	clusters := []models.KubeCluster{{Name: conf.KubernetesConfig.ClusterName}}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		gi := graph.NewGlobalInfo(biz, nil, conf, clusters, NewGlobalIstioInfo())
+		gi.Clusters = clusters
+		a := IstioAppender{}
+		a.AppendGraph(context.Background(), trafficMap, gi, nil)
+	}
+}
+
+func BenchmarkIstioAppender(b *testing.B) {
+	scenarios := []benchScenario{
+		{namespaces: 5, appsPerNs: 5, versionsPerApp: 2, drsPerNs: 3, vsPerNs: 3, istioGateways: 1, k8sGateways: 1},
+		{namespaces: 20, appsPerNs: 5, versionsPerApp: 2, drsPerNs: 5, vsPerNs: 5, istioGateways: 3, k8sGateways: 3},
+		{namespaces: 50, appsPerNs: 5, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 5, k8sGateways: 5},
+		{namespaces: 50, appsPerNs: 10, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 10, k8sGateways: 10},
+		{namespaces: 50, appsPerNs: 10, versionsPerApp: 3, drsPerNs: 10, vsPerNs: 10, istioGateways: 0, k8sGateways: 0},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.String(), func(b *testing.B) {
+			runBenchmark(b, s)
+		})
+	}
+}

--- a/graph/telemetry/istio/appender/istio_details_test.go
+++ b/graph/telemetry/istio/appender/istio_details_test.go
@@ -166,125 +166,104 @@ func TestCBSubset(t *testing.T) {
 	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
 }
 
-// TODO: Re-add following two tests. A way for testing code that *requires* the cache to be enabled is needed.
-//func TestVS(t *testing.T) {
-//	assert := assert.New(t)
-//	config.Set(config.NewConfig())
-//
-//	k8s := kubetest.NewK8SClientMock()
-//	vService := &networking_v1.VirtualService{}
-//	vService.Name = "vService-1"
-//	vService.Namespace = "testNamespace"
-//	vService.Spec.Hosts = []string{"ratings"}
-//	vService.Spec.Http = []*api_networking_v1.HTTPRoute{
-//		{
-//			Route: []*api_networking_v1.HTTPRouteDestination{
-//				{
-//					Destination: &api_networking_v1.Destination{
-//						Host: "foo",
-//					},
-//				},
-//			},
-//		},
-//	}
-//	k8s.MockIstio(vService)
-//
-//	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
-//	k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{}, nil)
-//	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
-//	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{{}}, nil)
-//
-//	businessLayer := business.NewWithBackends(t, k8s, nil, nil)
-//	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, fooSvcNodeId := setupTrafficMap()
-//
-//	assert.Equal(7, len(trafficMap))
-//	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeV1Id].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeV2Id].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[appNodeV1Id].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[appNodeV2Id].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
-//
-//	globalInfo := graph.NewGlobalInfo(, NewIstioInfo())
-//	globalInfo.Business = businessLayer
-//	namespaceInfo := NewAppenderNamespaceInfo("testNamespace")
-//
-//	a := IstioAppender{}
-//	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
-//
-//	assert.Equal(7, len(trafficMap))
-//	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeV1Id].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeV2Id].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasCB])
-//	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[appNodeV1Id].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[appNodeV2Id].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasVS])
-//
-//	assert.NotNil(trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
-//	assert.IsType(graph.VirtualServicesMetadata{}, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
-//	assert.Len(trafficMap[fooSvcNodeId].Metadata[graph.HasVS], 1)
-//	assert.Len(trafficMap[fooSvcNodeId].Metadata[graph.HasVS].(graph.VirtualServicesMetadata)["vService-1"], 1)
-//	assert.Equal("ratings", trafficMap[fooSvcNodeId].Metadata[graph.HasVS].(graph.VirtualServicesMetadata)["vService-1"][0])
-//}
-//
-//func TestVSWithRoutingBadges(t *testing.T) {
-//	assert := assert.New(t)
-//	config.Set(config.NewConfig())
-//
-//	k8s := kubetest.NewK8SClientMock()
-//	vService := &networking_v1.VirtualService{}
-//	vService.Name = "vService-1"
-//	vService.Namespace = "testNamespace"
-//	vService.Spec.Hosts = []string{"ratings"}
-//	vService.Spec.Http = []*api_networking_v1.HTTPRoute{
-//		{
-//			Route: []*api_networking_v1.HTTPRouteDestination{
-//				{
-//					Destination: &api_networking_v1.Destination{
-//						Host: "foo",
-//					},
-//					Weight: 20,
-//				},
-//				{
-//					Destination: &api_networking_v1.Destination{
-//						Host: "bar",
-//					},
-//					Weight: 80,
-//				},
-//			},
-//		},
-//	}
-//	k8s.MockIstio(vService)
-//	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
-//	k8s.On("GetProjects", mock.AnythingOfType("string")).Return([]osproject_v1.Project{}, nil)
-//	k8s.On("GetEndpoints", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&core_v1.Endpoints{}, nil)
-//	k8s.On("GetServices", mock.AnythingOfType("string"), mock.Anything).Return([]core_v1.Service{{}}, nil)
-//
-//	businessLayer := business.NewWithBackends(t, k8s, nil, nil)
-//	trafficMap, _, _, _, _, _, fooSvcNodeId := setupTrafficMap()
-//
-//	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
-//	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
-//	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasRequestRouting])
-//
-//	globalInfo := graph.NewGlobalInfo(, NewIstioInfo())
-//	globalInfo.Business = businessLayer
-//	namespaceInfo := NewAppenderNamespaceInfo("testNamespace")
-//
-//	a := IstioAppender{}
-//	a.AppendGraph(trafficMap, globalInfo, namespaceInfo)
-//
-//	assert.Equal(true, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
-//}
+func TestVS(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = config.DefaultClusterID
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	vService := &networking_v1.VirtualService{}
+	vService.Name = "vService-1"
+	vService.Namespace = "testNamespace"
+	vService.Spec.Hosts = []string{"ratings"}
+	vService.Spec.Http = []*api_networking_v1.HTTPRoute{
+		{
+			Route: []*api_networking_v1.HTTPRouteDestination{
+				{
+					Destination: &api_networking_v1.Destination{
+						Host: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	k8s := kubetest.NewFakeK8sClient(vService, kubetest.FakeNamespace("testNamespace"))
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	trafficMap, appNodeId, appNodeV1Id, appNodeV2Id, svcNodeId, wlNodeId, fooSvcNodeId, _ := setupTrafficMap()
+
+	assert.Equal(7, len(trafficMap))
+	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
+
+	globalInfo := graph.NewGlobalInfo(businessLayer, nil, config.Get(), []models.KubeCluster{}, NewGlobalIstioInfo())
+	globalInfo.Clusters = []models.KubeCluster{{Name: config.DefaultClusterID}}
+	namespaceInfo := NewAppenderNamespaceInfo("testNamespace")
+
+	a := IstioAppender{}
+	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(7, len(trafficMap))
+	assert.Equal(nil, trafficMap[appNodeId].Metadata[graph.HasCB])
+	assert.Equal(nil, trafficMap[appNodeV1Id].Metadata[graph.HasCB])
+	assert.Equal(nil, trafficMap[appNodeV2Id].Metadata[graph.HasCB])
+	assert.Equal(nil, trafficMap[svcNodeId].Metadata[graph.HasCB])
+	assert.Equal(nil, trafficMap[wlNodeId].Metadata[graph.HasCB])
+
+	assert.NotNil(trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
+	assert.IsType(graph.VirtualServicesMetadata{}, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
+	assert.Len(trafficMap[fooSvcNodeId].Metadata[graph.HasVS], 1)
+	assert.Len(trafficMap[fooSvcNodeId].Metadata[graph.HasVS].(graph.VirtualServicesMetadata)["vService-1"], 1)
+	assert.Equal("ratings", trafficMap[fooSvcNodeId].Metadata[graph.HasVS].(graph.VirtualServicesMetadata)["vService-1"][0])
+}
+
+func TestVSWithRoutingBadges(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = config.DefaultClusterID
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	vService := &networking_v1.VirtualService{}
+	vService.Name = "vService-1"
+	vService.Namespace = "testNamespace"
+	vService.Spec.Hosts = []string{"ratings"}
+	vService.Spec.Http = []*api_networking_v1.HTTPRoute{
+		{
+			Route: []*api_networking_v1.HTTPRouteDestination{
+				{
+					Destination: &api_networking_v1.Destination{
+						Host: "foo",
+					},
+					Weight: 20,
+				},
+				{
+					Destination: &api_networking_v1.Destination{
+						Host: "bar",
+					},
+					Weight: 80,
+				},
+			},
+		},
+	}
+
+	k8s := kubetest.NewFakeK8sClient(vService, kubetest.FakeNamespace("testNamespace"))
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	trafficMap, _, _, _, _, _, fooSvcNodeId, _ := setupTrafficMap()
+
+	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasVS])
+	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
+	assert.Equal(nil, trafficMap[fooSvcNodeId].Metadata[graph.HasRequestRouting])
+
+	globalInfo := graph.NewGlobalInfo(businessLayer, nil, config.Get(), []models.KubeCluster{}, NewGlobalIstioInfo())
+	globalInfo.Clusters = []models.KubeCluster{{Name: config.DefaultClusterID}}
+	namespaceInfo := NewAppenderNamespaceInfo("testNamespace")
+
+	a := IstioAppender{}
+	a.AppendGraph(context.Background(), trafficMap, globalInfo, namespaceInfo)
+
+	assert.Equal(true, trafficMap[fooSvcNodeId].Metadata[graph.HasTrafficShifting])
+}
 
 func TestSEInAppBox(t *testing.T) {
 	check := assert.New(t)

--- a/kubernetes/filters.go
+++ b/kubernetes/filters.go
@@ -74,6 +74,27 @@ func FilterByHost(host, hostNamespace, serviceName, svcNamespace, identityDomain
 	return false
 }
 
+// NormalizeHost extracts a canonical (namespace, serviceName) pair from a host string
+// that may be in any of the forms accepted by FilterByHost:
+//   - "ratings"                              -> (resourceNamespace, "ratings")
+//   - "ratings.testNs"                       -> ("testNs", "ratings")
+//   - "ratings.testNs.svc"                   -> ("testNs", "ratings")
+//   - "ratings.testNs.svc.cluster.local"     -> ("testNs", "ratings")
+//
+// resourceNamespace is used when the host is a short name (no dots) -- in that case
+// the host is scoped to the namespace of the Istio resource that defines it.
+//
+// Wildcard hosts (e.g. "*.testNs.svc.cluster.local") normalize to ("testNs", "*").
+// Since no graph node has service name "*", these will never match during index lookup,
+// which is consistent with FilterByHost's behavior (it has no wildcard logic).
+func NormalizeHost(host, resourceNamespace string) (namespace, serviceName string) {
+	parts := strings.Split(host, ".")
+	if len(parts) == 1 {
+		return resourceNamespace, parts[0]
+	}
+	return parts[1], parts[0]
+}
+
 func FilterDestinationRulesByHostname(allDr []*networking_v1.DestinationRule, hostname string) []*networking_v1.DestinationRule {
 	destinationRules := []*networking_v1.DestinationRule{}
 	for _, destinationRule := range allDr {

--- a/kubernetes/filters_test.go
+++ b/kubernetes/filters_test.go
@@ -270,3 +270,79 @@ func createHTTPRoute(name string, namespace string, serviceName string, serviceN
 	rt.Spec.Rules = append(rt.Spec.Rules, rule)
 	return &rt
 }
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		host              string
+		resourceNamespace string
+		wantNamespace     string
+		wantService       string
+	}{
+		{host: "ratings", resourceNamespace: "testNs", wantNamespace: "testNs", wantService: "ratings"},
+		{host: "ratings.prodNs", resourceNamespace: "testNs", wantNamespace: "prodNs", wantService: "ratings"},
+		{host: "ratings.prodNs.svc", resourceNamespace: "testNs", wantNamespace: "prodNs", wantService: "ratings"},
+		{host: "ratings.prodNs.svc.cluster.local", resourceNamespace: "testNs", wantNamespace: "prodNs", wantService: "ratings"},
+		{host: "*.testNs.svc.cluster.local", resourceNamespace: "testNs", wantNamespace: "testNs", wantService: "*"},
+		{host: "", resourceNamespace: "testNs", wantNamespace: "testNs", wantService: ""},
+		{host: "httpbin.org", resourceNamespace: "testNs", wantNamespace: "org", wantService: "httpbin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			ns, svc := NormalizeHost(tt.host, tt.resourceNamespace)
+			assert.Equal(t, tt.wantNamespace, ns)
+			assert.Equal(t, tt.wantService, svc)
+		})
+	}
+}
+
+// TestNormalizeHostAlignedWithFilterByHost verifies that for every host form
+// that FilterByHost accepts, NormalizeHost produces a key that would match
+// a lookup for the target (namespace, service) pair.
+func TestNormalizeHostAlignedWithFilterByHost(t *testing.T) {
+	svcNamespace := "testNs"
+	serviceName := "ratings"
+	resourceNamespace := "testNs"
+	identityDomain := "svc.cluster.local"
+
+	hostForms := []string{
+		"ratings",
+		"ratings.testNs",
+		"ratings.testNs.svc",
+		"ratings.testNs.svc.cluster.local",
+	}
+
+	for _, host := range hostForms {
+		t.Run(host, func(t *testing.T) {
+			assert.True(t, FilterByHost(host, resourceNamespace, serviceName, svcNamespace, identityDomain),
+				"FilterByHost should accept this host form")
+
+			ns, svc := NormalizeHost(host, resourceNamespace)
+			assert.Equal(t, svcNamespace, ns, "NormalizeHost namespace must match service namespace")
+			assert.Equal(t, serviceName, svc, "NormalizeHost service must match service name")
+		})
+	}
+}
+
+// TestNormalizeHostCrossNamespace verifies that a host in "svc.otherNs" form
+// normalizes to the correct namespace (not the resource namespace).
+func TestNormalizeHostCrossNamespace(t *testing.T) {
+	resourceNamespace := "istio-system"
+	identityDomain := "svc.cluster.local"
+
+	hostForms := []string{
+		"ratings.prodNs",
+		"ratings.prodNs.svc",
+		"ratings.prodNs.svc.cluster.local",
+	}
+
+	for _, host := range hostForms {
+		t.Run(host, func(t *testing.T) {
+			assert.True(t, FilterByHost(host, resourceNamespace, "ratings", "prodNs", identityDomain))
+
+			ns, svc := NormalizeHost(host, resourceNamespace)
+			assert.Equal(t, "prodNs", ns)
+			assert.Equal(t, "ratings", svc)
+		})
+	}
+}

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -19,14 +19,14 @@ type (
 func HasDRCircuitBreaker(dr *networking_v1.DestinationRule, namespace, serviceName, version, identityDomain string) bool {
 	conf := config.Get()
 	if kubernetes.FilterByHost(dr.Spec.Host, dr.Namespace, serviceName, namespace, identityDomain) {
-		if IsCB(dr.Spec.TrafficPolicy) {
+		if isCB(dr.Spec.TrafficPolicy) {
 			return true
 		}
 		for _, subset := range dr.Spec.Subsets {
 			if subset == nil {
 				continue
 			}
-			if IsCB(subset.TrafficPolicy) {
+			if isCB(subset.TrafficPolicy) {
 				if version == "" {
 					return true
 				}
@@ -41,7 +41,7 @@ func HasDRCircuitBreaker(dr *networking_v1.DestinationRule, namespace, serviceNa
 	return false
 }
 
-func IsCB(trafficPolicy *api_networking_v1.TrafficPolicy) bool {
+func isCB(trafficPolicy *api_networking_v1.TrafficPolicy) bool {
 	if trafficPolicy == nil {
 		return false
 	}

--- a/models/destination_rule.go
+++ b/models/destination_rule.go
@@ -19,14 +19,14 @@ type (
 func HasDRCircuitBreaker(dr *networking_v1.DestinationRule, namespace, serviceName, version, identityDomain string) bool {
 	conf := config.Get()
 	if kubernetes.FilterByHost(dr.Spec.Host, dr.Namespace, serviceName, namespace, identityDomain) {
-		if isCB(dr.Spec.TrafficPolicy) {
+		if IsCB(dr.Spec.TrafficPolicy) {
 			return true
 		}
 		for _, subset := range dr.Spec.Subsets {
 			if subset == nil {
 				continue
 			}
-			if isCB(subset.TrafficPolicy) {
+			if IsCB(subset.TrafficPolicy) {
 				if version == "" {
 					return true
 				}
@@ -41,7 +41,7 @@ func HasDRCircuitBreaker(dr *networking_v1.DestinationRule, namespace, serviceNa
 	return false
 }
 
-func isCB(trafficPolicy *api_networking_v1.TrafficPolicy) bool {
+func IsCB(trafficPolicy *api_networking_v1.TrafficPolicy) bool {
 	if trafficPolicy == nil {
 		return false
 	}


### PR DESCRIPTION
The IstioAppender was a bottleneck for graph generation in large meshes due to redundant data fetching and quadratic iteration over Istio config objects.

Key changes:
- Cache workload models from populateWorkloadMap so decorateGateways filters locally instead of calling GetAllWorkloads per gateway
- Consolidate two GetIstioConfigList calls per cluster into one
- Pre-index DestinationRules and VirtualServices by normalized host for O(1) lookup instead of O(nodes × config objects) iteration
- Export IsCB from models to eliminate duplication
- Re-enable TestVS and TestVSWithRoutingBadges using current test infra
- Add NormalizeHost helper in kubernetes/filters.go

| Scenario | Metric | Before | After | Change |
|----------|--------|--------|-------|--------|
| **Geomean (all 5 scenarios)** | Time | 218ms | 44.5ms | -80% |
| | Memory | 425 MiB | 29.1 MiB | -93% |
| | Allocs | 1.47M | 152k | -90% |
| **50ns, 10 apps, 10+10 gateways** | Time | 1540ms | 221ms | -86% |
| | Memory | 3.3 GiB | 104 MiB | -97% |
| | Allocs | 10.7M | 485k | -95% |
| **50ns, 10 apps, 0 gateways** | Time | 1100ms | 209ms | -81% |
| | Memory | 2.7 GiB | 106 MiB | -96% |
| | Allocs | 8.8M | 490k | -94% |

Fixes: https://github.com/kiali/kiali/issues/8524

Generated-by: Cursor