### PR TITLE
Remove healthy status test from lpinterop

### DIFF
--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -122,7 +122,6 @@ Feature: Kiali Workloads page
   @bookinfo-app
   @core-2
   @offline
-  @lpinterop
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
     When user selects the "bookinfo" namespace


### PR DESCRIPTION
Removed flaky test from lpinterop (lpinterop cluster can be unstable for a while, which causes that productpage is reported as unhealthy)
