### PR TITLE
[v2.22] Remove healthy status test from lpinterop

### DIFF
--- a/frontend/cypress/integration/featureFiles/overview.feature
+++ b/frontend/cypress/integration/featureFiles/overview.feature
@@ -93,7 +93,6 @@ Feature: Kiali Overview page
   @error-rates-app
   @bookinfo-app
   @core-2
-  @lpinterop
   Scenario: The healthy status of a logical mesh application is reported in the overview of a namespace
     Given a healthy application in the cluster
     When I fetch the overview of the cluster

--- a/frontend/cypress/integration/featureFiles/workloads.feature
+++ b/frontend/cypress/integration/featureFiles/workloads.feature
@@ -122,7 +122,6 @@ Feature: Kiali Workloads page
   @bookinfo-app
   @core-2
   @offline
-  @lpinterop
   Scenario: The healthy status of a workload is reported in the list of workloads
     Given a healthy workload in the cluster
     When user selects the "bookinfo" namespace


### PR DESCRIPTION
Removed flaky test from lpinterop (lpinterop cluster can be unstable for a while, which causes that productpage is reported as unhealthy)

Backports: https://github.com/kiali/kiali/pull/9697 