### PR TITLE
fix(cypress): Fix flaky ambient multi-primary test assertion

### DIFF
--- a/frontend/cypress/integration/common/mesh.ts
+++ b/frontend/cypress/integration/common/mesh.ts
@@ -564,7 +564,7 @@ Then('user sees ambient data planes in both clusters', () => {
         const data = cp.getData() as MeshNodeData;
         const ambient = data.infraData.filter(n => n.isAmbient);
         // Check for ambient-specific properties or labels
-        assert.exists(ambient, 'Control plane data should exist');
+        assert.isAtLeast(ambient.length, 1, 'An ambient namespace should exist in data plane');
       });
     });
 });


### PR DESCRIPTION
## Summary

Fixes first failure in #9700 - ambient multi-primary test flakiness.

Changes `assert.exists` to `assert.isAtLeast(array.length, 1)` for ambient namespace validation in dataplane nodes.

## Problem

Test assertion used `assert.exists(ambient)` where `ambient` is filtered array. Empty array `[]` passes exists check, causing false positives and flaky behavior.

Error message: "An ambient istiod node should exist: expected undefined to exist"

## Solution

Replace with `assert.isAtLeast(ambient.length, 1, 'An ambient namespace should exist in data plane')` to properly fail when no ambient namespaces present.

## Test plan

Run ambient multi-primary test 10+ times, verify no flaky behavior:
```bash
cd frontend
npm run cypress:run -- --spec "cypress/integration/featureFiles/mesh.feature" --env TAGS="@ambient-multi-primary"
```



🤖 Generated with [Claude Code](https://claude.com/claude-code)