### PR TITLE
Improve traffic animation performance

### DIFF
--- a/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
+++ b/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
@@ -42,6 +42,7 @@ export function getMoveAnimation(edge: Edge, percentVisible: number): string {
     moveAnimation['0%'] = { opacity: 1, translate: '0' };
     moveAnimation[`${bend}%`] = { opacity: 1, translate: `${moveBendX}px ${moveBendY}px` };
     moveAnimation[`${percentVisible}%`] = {
+      opacity: 1,
       translate: `${moveEndX}px ${moveEndY}px`
     };
     if (percentVisible < 100) {

--- a/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
+++ b/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
@@ -26,10 +26,9 @@ export function getMoveAnimation(edge: Edge, percentVisible: number): string {
       opacity: 1,
       translate: `${moveX}px ${moveY}px`
     };
-    // this acts like a delay at the end, the animation continues but nothing is visible
     if (percentVisible < 100) {
-      moveAnimation[`${percentVisible}.1%`] = { display: 'none' };
-      moveAnimation['100%'] = { display: 'none' };
+      moveAnimation[`${percentVisible}.1%`] = { opacity: 0 };
+      moveAnimation['100%'] = { opacity: 0 };
     }
   } else {
     // a kiali edge can have at most 1 bendpoint, in the middle. see extendedBaseEdge.ts
@@ -45,10 +44,9 @@ export function getMoveAnimation(edge: Edge, percentVisible: number): string {
     moveAnimation[`${percentVisible}%`] = {
       translate: `${moveEndX}px ${moveEndY}px`
     };
-    // this acts like a delay at the end, the animation continues but nothing is visible
     if (percentVisible < 100) {
-      moveAnimation[`${percentVisible}.1%`] = { display: 'none' };
-      moveAnimation['100%'] = { display: 'none' };
+      moveAnimation[`${percentVisible}.1%`] = { opacity: 0 };
+      moveAnimation['100%'] = { opacity: 0 };
     }
   }
   return keyframes(moveAnimation);

--- a/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
+++ b/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
@@ -6,12 +6,13 @@ import { Edge } from '@patternfly/react-topology';
 export abstract class TrafficPointRenderer {
   abstract render(
     edge: Edge,
+    moveAnimation: string,
     animationDelay: string,
     onAnimationEnd?: React.AnimationEventHandler
   ): React.SVGProps<SVGElement>;
 }
 
-function getMoveAnimation(edge: Edge, percentVisible: number): string {
+export function getMoveAnimation(edge: Edge, percentVisible: number): string {
   const startPoint = edge.getStartPoint();
   const endPoint = edge.getEndPoint();
   const moveAnimation = {};
@@ -93,11 +94,11 @@ export class TrafficPointCircleRenderer extends TrafficPointRenderer {
 
   render(
     edge: Edge,
+    moveAnimation: string,
     animationDelay: string,
     onAnimationEnd?: React.AnimationEventHandler
   ): React.SVGProps<SVGCircleElement> {
     const startPoint = edge.getStartPoint();
-    const moveAnimation = getMoveAnimation(edge, this.percentVisible);
     // If requested, calculate offsets. The offset must be small to avoid more serious
     // calculation that would ensure perpendicular distance from the edge. Instead, we
     // just apply a [-2.5, 2.5] offset to both 'x' and 'y'
@@ -162,11 +163,11 @@ export class TrafficPointDiamondRenderer extends TrafficPointRenderer {
 
   render(
     edge: Edge,
+    moveAnimation: string,
     animationDelay: string,
     onAnimationEnd?: React.AnimationEventHandler
   ): React.SVGProps<SVGRectElement> {
     const startPoint = edge.getStartPoint();
-    const moveAnimation = getMoveAnimation(edge, this.percentVisible);
 
     // use random # to ensure the key is not repeated, or it can be ignored by the render
     const key = `point-rect-${Math.random()}}`;

--- a/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
+++ b/frontend/src/pages/Graph/TrafficAnimation/TrafficPointRenderer.tsx
@@ -61,6 +61,8 @@ export class TrafficPointCircleRenderer extends TrafficPointRenderer {
   readonly percentVisible: number;
   readonly radius: number;
   readonly withOffsets: boolean;
+  private cachedStyleClass: string | undefined;
+  private cachedMoveAnimation: string | undefined;
 
   constructor(
     animationDuration: string,
@@ -80,7 +82,11 @@ export class TrafficPointCircleRenderer extends TrafficPointRenderer {
   }
 
   private getStyle(moveAnimation: string): string {
-    return kialiStyle({
+    if (this.cachedMoveAnimation === moveAnimation && this.cachedStyleClass) {
+      return this.cachedStyleClass;
+    }
+    this.cachedMoveAnimation = moveAnimation;
+    this.cachedStyleClass = kialiStyle({
       animationDuration: this.animationDuration,
       animationFillMode: 'forwards',
       animationIterationCount: 'infinite',
@@ -90,6 +96,7 @@ export class TrafficPointCircleRenderer extends TrafficPointRenderer {
       opacity: 0,
       stroke: this.borderColor
     });
+    return this.cachedStyleClass;
   }
 
   render(
@@ -128,6 +135,8 @@ export class TrafficPointDiamondRenderer extends TrafficPointRenderer {
   readonly borderColor: string;
   readonly percentVisible: number;
   readonly radius: number;
+  private cachedStyleClass: string | undefined;
+  private cachedMoveAnimation: string | undefined;
 
   constructor(
     animationDuration: string,
@@ -145,7 +154,11 @@ export class TrafficPointDiamondRenderer extends TrafficPointRenderer {
   }
 
   private getStyle(moveAnimation: string): string {
-    return kialiStyle({
+    if (this.cachedMoveAnimation === moveAnimation && this.cachedStyleClass) {
+      return this.cachedStyleClass;
+    }
+    this.cachedMoveAnimation = moveAnimation;
+    this.cachedStyleClass = kialiStyle({
       animationDuration: this.animationDuration,
       animationFillMode: 'forwards',
       animationIterationCount: 'infinite',
@@ -159,6 +172,7 @@ export class TrafficPointDiamondRenderer extends TrafficPointRenderer {
       transformBox: 'fill-box',
       transformOrigin: 'center'
     });
+    return this.cachedStyleClass;
   }
 
   render(

--- a/frontend/src/pages/Graph/TrafficAnimation/TrafficRenderer.tsx
+++ b/frontend/src/pages/Graph/TrafficAnimation/TrafficRenderer.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { Point, clamp, distance } from '../../../utils/MathUtils';
-import { TrafficPointCircleRenderer, TrafficPointDiamondRenderer, TrafficPointRenderer } from './TrafficPointRenderer';
+import {
+  getMoveAnimation,
+  TrafficPointCircleRenderer,
+  TrafficPointDiamondRenderer,
+  TrafficPointRenderer
+} from './TrafficPointRenderer';
 import { Protocol } from '../../../types/Graph';
 import { timerConfig, tcpTimerConfig } from './AnimationTimerConfig';
 import { Controller, Edge, EdgeAnimationSpeed, EdgeStyle } from '@patternfly/react-topology';
@@ -152,10 +157,11 @@ export class TrafficPointGenerator {
           : getTrafficPointRendererForRpsSuccess(edge, animationDurationSeconds, percentVisible);
 
       const delayInterval = animationDuration / renderedPointsOnEdge;
+      const moveAnimation = getMoveAnimation(edge, percentVisible);
 
       for (let i = 0; i < pointsOnEdge; ++i) {
         const animationDelay = `${i * delayInterval + initialDelay}ms`;
-        const point = renderer.render(edge, animationDelay, undefined);
+        const point = renderer.render(edge, moveAnimation, animationDelay, undefined);
         points.unshift(point);
       }
     } else {
@@ -181,6 +187,7 @@ export class TrafficPointGenerator {
       const errorRenderer = getTrafficPointRendererForRpsError(edge, animationDurationSeconds, percentVisible);
 
       const delayInterval = animationDuration / renderedPointsOnEdge;
+      const moveAnimation = getMoveAnimation(edge, percentVisible);
 
       for (let i = 0, injectedError = false; i < renderedPointsOnEdge; ++i) {
         const animationDelay = `${i * delayInterval + initialDelay}ms`;
@@ -189,8 +196,8 @@ export class TrafficPointGenerator {
         injectedError = injectedError || isErrorPoint;
 
         const point = isErrorPoint
-          ? errorRenderer.render(edge, animationDelay, undefined)
-          : renderer.render(edge, animationDelay, undefined);
+          ? errorRenderer.render(edge, moveAnimation, animationDelay, undefined)
+          : renderer.render(edge, moveAnimation, animationDelay, undefined);
 
         points.unshift(point);
       }


### PR DESCRIPTION
Closes #9701

I investigates ways to improve the animation rendering without changing the animation itself. End users seem happy with what we show with the "point" animation, and I didn't want them to really notice anything different other than, hopefully, a snappier experience. The main change does a good job of reducing long tasks, and therefore freeing up the main thread to better handle things like node dragging by the user.

Using the Chrome Perf tab with 15s recordings, here is a rough before and after when animating the following:

<img width="698" height="677" alt="image" src="https://github.com/user-attachments/assets/fa4f5e64-f6bb-4264-9a17-f8a9c2cc6a13" />

**before:**
<img width="1920" height="1080" alt="before-animation-15s" src="https://github.com/user-attachments/assets/8444d6e6-543c-4106-8365-b48413deed8e" />

**after:**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d12b8566-cf92-4e10-b838-3dbc77a46e53" />

The AI summary below...

## Summary

- Compute keyframe animation once per edge instead of per point, making the data flow clearer (the keyframe is an edge-level concept, not a per-point concept)
- Cache kialiStyle CSS class per renderer instance, avoiding redundant style registration calls
- Replace `display:none` with `opacity:0` in animation keyframes, eliminating main-thread layout recalculations caused by display toggling on every animation cycle

The first two changes are primarily code quality improvements — the underlying typestyle/free-style library already deduplicates identical styles via content hashing, so the measurable impact is minimal.

The `display:none` to `opacity:0` change is the significant performance win. `display` toggling removes/re-adds elements from the render tree, forcing layout recalculation on the main thread every animation cycle. `opacity` changes are handled entirely by the browser compositor thread, freeing the main thread for interactive operations (node dragging, panning, side panels). Testing shows:

- ~8% reduction in rendering time
- Significant reduction in scripting time
- Elimination of long-task warnings (red triangles in Chrome DevTools)
- Animation work moved from main thread to compositor thread (visible as increased System time, decreased Scripting/Rendering time)

No visual changes to the animation behavior.

## Test plan

- [ ] Enable traffic animation on the graph page (Display menu)
- [ ] Verify animation looks identical to master (circles for success, diamonds for errors, TCP offset)
- [ ] Verify animation works with edges that have bendpoints
- [ ] Verify animation with mixed error rates
- [ ] Verify graph refresh properly resets animation
- [ ] Verify node dragging responsiveness with animation enabled on a larger graph


Made with [Cursor](https://cursor.com)