### PR TITLE
Fix KIA0106 false positives for custom trust domains in AuthorizationPolicy principals

### DIFF
--- a/business/checkers/authorization/principals_checker.go
+++ b/business/checkers/authorization/principals_checker.go
@@ -14,6 +14,7 @@ import (
 type PrincipalsChecker struct {
 	AuthorizationPolicy *security_v1.AuthorizationPolicy
 	Cluster             string
+	KnownTrustDomains   []string
 	ServiceAccounts     map[string][]string
 }
 
@@ -63,6 +64,9 @@ func (pc PrincipalsChecker) validateFromField(ruleIdx int, from []*api_security_
 				if pc.hasMatchingRemoteServiceAccount(p) {
 					validation := models.Build("authorizationpolicy.source.principalremote", path)
 					checks = append(checks, &validation)
+				} else if pc.hasForeignTrustDomain(p) {
+					validation := models.Build("authorizationpolicy.source.principalforeign", path)
+					checks = append(checks, &validation)
 				} else {
 					validation := models.Build("authorizationpolicy.source.principalnotfound", path)
 					checks = append(checks, &validation)
@@ -102,6 +106,28 @@ func (pc PrincipalsChecker) hasMatchingRemoteServiceAccount(principal string) bo
 		}
 	}
 	return false
+}
+
+// hasForeignTrustDomain returns true when the principal's trust domain (the
+// part before "/ns/") is not in the set of trust domains known to Kiali.
+// Principals with foreign trust domains cannot be validated because Kiali has
+// no visibility into the cluster that owns them. Wildcard principals are
+// skipped because a reliable trust domain cannot be extracted from them.
+func (pc PrincipalsChecker) hasForeignTrustDomain(principal string) bool {
+	if strings.Contains(principal, wildCardMatch) {
+		return false
+	}
+	idx := strings.Index(principal, "/ns/")
+	if idx <= 0 {
+		return false
+	}
+	td := principal[:idx]
+	for _, known := range pc.KnownTrustDomains {
+		if td == known {
+			return false
+		}
+	}
+	return true
 }
 
 func regexpFromPrincipal(principal string) *regexp.Regexp {

--- a/business/checkers/authorization/principals_checker_test.go
+++ b/business/checkers/authorization/principals_checker_test.go
@@ -21,10 +21,10 @@ func TestPresentServiceAccount(t *testing.T) {
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}),
 		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
-	// Well configured object
 	assert.True(valid)
 	assert.Empty(validations)
 }
@@ -35,10 +35,10 @@ func TestRegexPrincipalFound(t *testing.T) {
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"*local/ns/bookinfo/sa/default*", "*.local/ns/bookinfo/sa/test*"}),
 		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"}},
 	}.Check()
 
-	// regex matches
 	assert.True(valid)
 	assert.Empty(validations)
 }
@@ -49,6 +49,7 @@ func TestRegexPrincipalNotFound(t *testing.T) {
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"*wronglocal/ns/bookinfo/sa/default*", "*.local/ns/bookinfo/sa/test1*"}),
 		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default-a", "cluster.local/ns/bookinfo/sa/test-1"}},
 	}.Check()
 
@@ -69,10 +70,10 @@ func TestEmptyPrincipals(t *testing.T) {
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{}),
 		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
-	// Well configured object
 	assert.True(valid)
 	assert.Empty(validations)
 }
@@ -87,7 +88,6 @@ func TestNotPresentServiceAccount(t *testing.T) {
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
-	// Wrong host is not present
 	assert.False(valid)
 	assert.NotEmpty(vals)
 	assert.Len(vals, 2)
@@ -105,14 +105,14 @@ func TestRemoteClusterServiceAccount(t *testing.T) {
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}),
 		Cluster:             "east",
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{"west": {"cluster.local/ns/bookinfo/sa/default"}, "east": {"cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
-	// service account is on remote cluster
 	assert.False(valid)
 	assert.NotEmpty(vals)
 	assert.Len(vals, 1)
-	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.Equal(models.Unknown, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalremote", vals[0]))
 	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
 }
@@ -126,7 +126,6 @@ func TestEmptyServiceAccount(t *testing.T) {
 		ServiceAccounts:     map[string][]string{},
 	}.Check()
 
-	// Wrong host is not present
 	assert.False(valid)
 	assert.NotEmpty(vals)
 	assert.Len(vals, 1)
@@ -135,17 +134,30 @@ func TestEmptyServiceAccount(t *testing.T) {
 	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
 }
 
+func TestWildcardPrincipal(t *testing.T) {
+	assert := assert.New(t)
+
+	validations, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"*"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
+		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default"}},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
 func TestPrincipalWithTrustDomainAlias(t *testing.T) {
 	assert := assert.New(t)
 
-	// SA list includes entries for both the primary trust domain and an alias,
-	// simulating what getServiceAccounts produces when trustDomainAliases are set.
 	validations, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{
 			"central.example.com/ns/pokemon-trainers/sa/ash",
 			"north.example.com/ns/pokemon-trainers/sa/red",
 		}),
-		Cluster: config.DefaultClusterID,
+		Cluster:           config.DefaultClusterID,
+		KnownTrustDomains: []string{"central.example.com", "north.example.com"},
 		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
 			"central.example.com/ns/pokemon-trainers/sa/ash",
 			"north.example.com/ns/pokemon-trainers/sa/ash",
@@ -175,6 +187,7 @@ func TestPrincipalWithForeignTrustDomain(t *testing.T) {
 	assert.Len(vals, 1)
 	assert.Equal(models.WarningSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
 }
 
 func TestPrincipalWithKnownDomainButMissingSA(t *testing.T) {
@@ -193,6 +206,228 @@ func TestPrincipalWithKnownDomainButMissingSA(t *testing.T) {
 	assert.Len(vals, 1)
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
+}
+
+// TestMultiPrimaryFederation simulates the full multi-primary scenario from
+// the OSSM-13864 reproduction: east cluster (trustDomain: east.example.com,
+// aliases: south.example.com, cluster.local) and west cluster (trustDomain:
+// west.example.com, aliases: north.example.com, cluster.remote).
+func TestMultiPrimaryFederation(t *testing.T) {
+	assert := assert.New(t)
+
+	eastSAs := []string{
+		"east.example.com/ns/bookinfo/sa/bookinfo-productpage",
+		"south.example.com/ns/bookinfo/sa/bookinfo-productpage",
+		"cluster.local/ns/bookinfo/sa/bookinfo-productpage",
+		"east.example.com/ns/bookinfo/sa/bookinfo-reviews",
+		"south.example.com/ns/bookinfo/sa/bookinfo-reviews",
+		"cluster.local/ns/bookinfo/sa/bookinfo-reviews",
+	}
+	westSAs := []string{
+		"west.example.com/ns/bookinfo/sa/bookinfo-reviews",
+		"north.example.com/ns/bookinfo/sa/bookinfo-reviews",
+		"cluster.remote/ns/bookinfo/sa/bookinfo-reviews",
+		"west.example.com/ns/bookinfo/sa/bookinfo-productpage",
+		"north.example.com/ns/bookinfo/sa/bookinfo-productpage",
+		"cluster.remote/ns/bookinfo/sa/bookinfo-productpage",
+	}
+	knownDomains := []string{
+		"east.example.com", "south.example.com", "cluster.local",
+		"west.example.com", "north.example.com", "cluster.remote",
+	}
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{
+			"east.example.com/ns/bookinfo/sa/bookinfo-productpage",  // local match
+			"cluster.local/ns/bookinfo/sa/bookinfo-productpage",     // alias match
+			"south.example.com/ns/bookinfo/sa/bookinfo-productpage", // alias match
+			"wrong.example.com/ns/bookinfo/sa/bookinfo-productpage", // foreign domain -> KIA0108
+			"west.example.com/ns/bookinfo/sa/bookinfo-reviews",      // remote match -> KIA0107
+			"cluster.remote/ns/bookinfo/sa/bookinfo-reviews",        // remote alias match -> KIA0107
+			"north.example.com/ns/bookinfo/sa/bookinfo-reviews",     // remote alias match -> KIA0107
+			"west.example.com/ns/bookinfo/sa/bookinfo-wrong",        // known domain, missing SA -> KIA0106
+			"wrong", // no trust domain format -> KIA0106
+		}),
+		Cluster:           "east",
+		KnownTrustDomains: knownDomains,
+		ServiceAccounts:   map[string][]string{"east": eastSAs, "west": westSAs},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 6)
+
+	// wrong.example.com -> KIA0108 (foreign trust domain)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[3]", vals[0].Path)
+
+	// west.example.com/ns/bookinfo/sa/bookinfo-reviews -> KIA0107 (remote)
+	assert.Equal(models.Unknown, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalremote", vals[1]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[4]", vals[1].Path)
+
+	// cluster.remote/ns/bookinfo/sa/bookinfo-reviews -> KIA0107 (remote)
+	assert.Equal(models.Unknown, vals[2].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalremote", vals[2]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[5]", vals[2].Path)
+
+	// north.example.com/ns/bookinfo/sa/bookinfo-reviews -> KIA0107 (remote)
+	assert.Equal(models.Unknown, vals[3].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalremote", vals[3]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[6]", vals[3].Path)
+
+	// west.example.com/ns/bookinfo/sa/bookinfo-wrong -> KIA0106 (known domain, SA missing)
+	assert.Equal(models.ErrorSeverity, vals[4].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[4]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[7]", vals[4].Path)
+
+	// "wrong" -> KIA0106 (no trust domain format, not found)
+	assert.Equal(models.ErrorSeverity, vals[5].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[5]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[8]", vals[5].Path)
+}
+
+// TestMultipleForeignDomains validates that multiple principals with different
+// unknown trust domains each produce KIA0108 warnings.
+func TestMultipleForeignDomains(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{
+			"alpha.unknown.org/ns/default/sa/svc1",
+			"beta.unknown.org/ns/default/sa/svc2",
+		}),
+		Cluster:           config.DefaultClusterID,
+		KnownTrustDomains: []string{"cluster.local"},
+		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
+			"cluster.local/ns/default/sa/default",
+		}},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 2)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+	assert.Equal(models.WarningSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[1]))
+}
+
+// TestForeignDomainWithEmptyKnownDomains verifies that when KnownTrustDomains
+// is empty (e.g., mesh not available), any structured principal is classified
+// as foreign (KIA0108) rather than missing (KIA0106).
+func TestForeignDomainWithEmptyKnownDomains(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/default"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{},
+		ServiceAccounts:     map[string][]string{},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+}
+
+// TestForeignDomainWithNilKnownDomains verifies that nil KnownTrustDomains
+// behaves the same as empty — all structured principals are foreign.
+func TestForeignDomainWithNilKnownDomains(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"some.domain/ns/ns1/sa/sa1"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   nil,
+		ServiceAccounts:     map[string][]string{},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+}
+
+// TestPrincipalWithNoNamespaceSegment verifies that principals without the
+// "/ns/" pattern (e.g., plain strings or malformed) are not classified as
+// foreign but fall through to KIA0106 (not found).
+func TestPrincipalWithNoNamespaceSegment(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"just-a-string", "another/one"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
+		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
+			"cluster.local/ns/bookinfo/sa/default",
+		}},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 2)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[0]))
+	assert.Equal(models.ErrorSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[1]))
+}
+
+// TestMixedValidationsInSinglePolicy verifies correct classification when
+// a single policy contains principals that trigger all three outcomes:
+// KIA0106, KIA0107, and KIA0108.
+func TestMixedValidationsInSinglePolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{
+			"cluster.local/ns/bookinfo/sa/valid",           // match -> no issue
+			"cluster.local/ns/bookinfo/sa/typo",            // known domain, missing SA -> KIA0106
+			"foreign.example.com/ns/bookinfo/sa/something", // foreign -> KIA0108
+		}),
+		Cluster:           "east",
+		KnownTrustDomains: []string{"cluster.local"},
+		ServiceAccounts: map[string][]string{
+			"east": {"cluster.local/ns/bookinfo/sa/valid"},
+			"west": {"cluster.local/ns/bookinfo/sa/other"},
+		},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 2)
+
+	// cluster.local/ns/bookinfo/sa/typo -> KIA0106
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[0]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[1]", vals[0].Path)
+
+	// foreign.example.com -> KIA0108
+	assert.Equal(models.WarningSeverity, vals[1].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[1]))
+	assert.Equal("spec/rules[0]/from[0]/source/principals[2]", vals[1].Path)
+}
+
+// TestRemoteClusterWithAlias verifies that a principal using a trust domain
+// alias of a remote cluster is correctly identified as KIA0107.
+func TestRemoteClusterWithAlias(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{
+			"north.example.com/ns/bookinfo/sa/reviews",
+		}),
+		Cluster:           "east",
+		KnownTrustDomains: []string{"east.example.com", "west.example.com", "north.example.com"},
+		ServiceAccounts: map[string][]string{
+			"east": {"east.example.com/ns/bookinfo/sa/productpage"},
+			"west": {"west.example.com/ns/bookinfo/sa/reviews", "north.example.com/ns/bookinfo/sa/reviews"},
+		},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.Unknown, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalremote", vals[0]))
 }
 
 func authPolicyWithPrincipals(principalsList []string) *security_v1.AuthorizationPolicy {

--- a/business/checkers/authorization/principals_checker_test.go
+++ b/business/checkers/authorization/principals_checker_test.go
@@ -83,6 +83,7 @@ func TestNotPresentServiceAccount(t *testing.T) {
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong", "test"}),
 		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{config.DefaultClusterID: {"cluster.local/ns/bookinfo/sa/default", "cluster.local/ns/bookinfo/sa/test"}},
 	}.Check()
 
@@ -121,6 +122,7 @@ func TestEmptyServiceAccount(t *testing.T) {
 
 	vals, valid := PrincipalsChecker{
 		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/wrong"}),
+		KnownTrustDomains:   []string{"cluster.local"},
 		ServiceAccounts:     map[string][]string{},
 	}.Check()
 
@@ -131,6 +133,66 @@ func TestEmptyServiceAccount(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[0]))
 	assert.Equal("spec/rules[0]/from[0]/source/principals[0]", vals[0].Path)
+}
+
+func TestPrincipalWithTrustDomainAlias(t *testing.T) {
+	assert := assert.New(t)
+
+	// SA list includes entries for both the primary trust domain and an alias,
+	// simulating what getServiceAccounts produces when trustDomainAliases are set.
+	validations, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{
+			"central.example.com/ns/pokemon-trainers/sa/ash",
+			"north.example.com/ns/pokemon-trainers/sa/red",
+		}),
+		Cluster: config.DefaultClusterID,
+		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
+			"central.example.com/ns/pokemon-trainers/sa/ash",
+			"north.example.com/ns/pokemon-trainers/sa/ash",
+			"central.example.com/ns/pokemon-trainers/sa/red",
+			"north.example.com/ns/pokemon-trainers/sa/red",
+		}},
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(validations)
+}
+
+func TestPrincipalWithForeignTrustDomain(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"unknown.example.com/ns/bookinfo/sa/default"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local", "central.example.com"},
+		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
+			"cluster.local/ns/bookinfo/sa/default",
+			"central.example.com/ns/bookinfo/sa/default",
+		}},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalforeign", vals[0]))
+}
+
+func TestPrincipalWithKnownDomainButMissingSA(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := PrincipalsChecker{
+		AuthorizationPolicy: authPolicyWithPrincipals([]string{"cluster.local/ns/bookinfo/sa/nonexistent"}),
+		Cluster:             config.DefaultClusterID,
+		KnownTrustDomains:   []string{"cluster.local", "central.example.com"},
+		ServiceAccounts: map[string][]string{config.DefaultClusterID: {
+			"cluster.local/ns/bookinfo/sa/default",
+		}},
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.source.principalnotfound", vals[0]))
 }
 
 func authPolicyWithPrincipals(principalsList []string) *security_v1.AuthorizationPolicy {

--- a/business/checkers/authorization_policies_checker.go
+++ b/business/checkers/authorization_policies_checker.go
@@ -17,6 +17,7 @@ type AuthorizationPolicyChecker struct {
 	Cluster               string
 	Conf                  *config.Config
 	IdentityDomain        string
+	KnownTrustDomains     []string
 	KubeServiceHosts      kubernetes.KubeServiceHosts
 	MtlsDetails           kubernetes.MTLSDetails
 	Namespaces            []string
@@ -63,7 +64,7 @@ func (a AuthorizationPolicyChecker) runChecks(authPolicy *security_v1.Authorizat
 		authorization.NamespaceMethodChecker{AuthorizationPolicy: authPolicy, Namespaces: a.Namespaces},
 		authorization.NoHostChecker{AuthorizationPolicy: authPolicy, IdentityDomain: a.IdentityDomain, KubeServiceHosts: a.KubeServiceHosts,
 			Namespaces: a.Namespaces, PolicyAllowAny: a.PolicyAllowAny, ServiceEntries: serviceHosts, VirtualServices: a.VirtualServices},
-		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, Cluster: a.Cluster, ServiceAccounts: a.ServiceAccounts},
+		authorization.PrincipalsChecker{AuthorizationPolicy: authPolicy, Cluster: a.Cluster, KnownTrustDomains: a.KnownTrustDomains, ServiceAccounts: a.ServiceAccounts},
 	}
 
 	for _, checker := range enabledCheckers {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -163,12 +163,13 @@ func (in ValidationChangeMap) update(key, value string, report bool) bool {
 // may otherwise need to be recalculated.
 type validationInfo struct {
 	// cross-cluster information
-	clusters []string                               // all clusters being validated
-	conf     *config.Config                         // kiali config
-	mesh     *models.Mesh                           // control plane info
-	nsMap    map[string][]models.Namespace          // cluster => namespaces
-	saMap    map[string][]string                    // cluster => serviceAccounts
-	wlMap    map[string]map[string]models.Workloads // cluster => namespace => Workloads, all workloads
+	clusters          []string                               // all clusters being validated
+	conf              *config.Config                         // kiali config
+	knownTrustDomains []string                               // all trust domains + aliases across clusters
+	mesh              *models.Mesh                           // control plane info
+	nsMap             map[string][]models.Namespace          // cluster => namespaces
+	saMap             map[string][]string                    // cluster => serviceAccounts
+	wlMap             map[string]map[string]models.Workloads // cluster => namespace => Workloads, all workloads
 
 	// clusterInfo is reset for each cluster being validated
 	clusterInfo *validationClusterInfo
@@ -230,8 +231,12 @@ func (in *IstioValidationsService) NewValidationInfo(ctx context.Context, cluste
 		}
 		vInfo.wlMap[cluster] = toWorkloadMap(workloads)
 
-		vInfo.saMap[cluster] = in.getServiceAccounts(namespaces, vInfo.wlMap[cluster], ResolveClusterIdentityDomain(mesh, cluster, in.conf.ExternalServices.Istio.IstioIdentityDomain))
+		identityDomain := ResolveClusterIdentityDomain(mesh, cluster, in.conf.ExternalServices.Istio.IstioIdentityDomain)
+		aliases := ResolveClusterTrustDomainAliases(mesh, cluster)
+		vInfo.saMap[cluster] = in.getServiceAccounts(namespaces, vInfo.wlMap[cluster], identityDomain, aliases)
 	}
+
+	vInfo.knownTrustDomains = collectKnownTrustDomains(mesh, clusters, in.conf.ExternalServices.Istio.IstioIdentityDomain)
 
 	// if changeDetection is enabled then loop through the namespaces and workloads, looking for a change
 	if changeMap != nil {
@@ -535,7 +540,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) (
 	identityDomain := vInfo.clusterInfo.identityDomain
 
 	return []checkers.ObjectChecker{
-		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, KubeServiceHosts: kubeServiceHosts, MtlsDetails: *mtlsDetails, Namespaces: nsNames, PolicyAllowAny: policyAllowAny, ServiceAccounts: vInfo.saMap, ServiceEntries: istioConfigList.ServiceEntries, Services: services, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace},
+		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, KnownTrustDomains: vInfo.knownTrustDomains, KubeServiceHosts: kubeServiceHosts, MtlsDetails: *mtlsDetails, Namespaces: nsNames, PolicyAllowAny: policyAllowAny, ServiceAccounts: vInfo.saMap, ServiceEntries: istioConfigList.ServiceEntries, Services: services, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.DestinationRulesChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, MTLSDetails: *mtlsDetails, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries},
 		checkers.GatewayChecker{Cluster: cluster, Conf: conf, Gateways: istioConfigList.Gateways, IsGatewayToNamespace: gatewayToNamespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.K8sGatewayChecker{Cluster: cluster, GatewayClasses: in.kialiCache.GatewayAPIClasses(cluster), K8sGateways: istioConfigList.K8sGateways},
@@ -710,11 +715,20 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		referenceChecker = references.SidecarReferences{Conf: conf, IdentityDomain: identityDomain, KubeServiceHosts: kubeServiceHosts, Namespace: namespace, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, Sidecars: istioConfigList.Sidecars, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.AuthorizationPolicies:
 		authPoliciesChecker := checkers.AuthorizationPolicyChecker{
+			AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
+			Cluster:               cluster,
 			Conf:                  conf,
 			IdentityDomain:        identityDomain,
-			AuthorizationPolicies: rbacDetails.AuthorizationPolicies,
-			Cluster:               cluster, Namespaces: nsNames, ServiceEntries: istioConfigList.ServiceEntries, ServiceAccounts: vInfo.saMap,
-			WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: *mtlsDetails, VirtualServices: istioConfigList.VirtualServices, KubeServiceHosts: kubeServiceHosts, Services: services, PolicyAllowAny: policyAllowAny,
+			KnownTrustDomains:     vInfo.knownTrustDomains,
+			KubeServiceHosts:      kubeServiceHosts,
+			MtlsDetails:           *mtlsDetails,
+			Namespaces:            nsNames,
+			PolicyAllowAny:        policyAllowAny,
+			ServiceAccounts:       vInfo.saMap,
+			ServiceEntries:        istioConfigList.ServiceEntries,
+			Services:              services,
+			VirtualServices:       istioConfigList.VirtualServices,
+			WorkloadsPerNamespace: workloadsPerNamespace,
 		}
 		objectCheckers = []checkers.ObjectChecker{authPoliciesChecker}
 		referenceChecker = references.NewAuthorizationPolicyReferences(rbacDetails.AuthorizationPolicies, conf, identityDomain, cluster, rootNamespaces, namespace, nsNames, istioConfigList.ServiceEntries, istioConfigList.VirtualServices, kubeServiceHosts, workloadsPerNamespace)
@@ -826,22 +840,52 @@ func runObjectReferenceChecker(ctx context.Context, conf *config.Config, referen
 	return referenceChecker.References()
 }
 
+// collectKnownTrustDomains gathers all trust domains and aliases across every
+// cluster so that the principals checker can distinguish between principals
+// referencing a known-but-missing SA (KIA0106) and those referencing a
+// completely foreign trust domain that Kiali cannot validate (KIA0108).
+func collectKnownTrustDomains(mesh *models.Mesh, clusters []string, configuredIdentityDomain string) []string {
+	seen := map[string]struct{}{}
+	for _, cluster := range clusters {
+		idDomain := ResolveClusterIdentityDomain(mesh, cluster, configuredIdentityDomain)
+		td := strings.TrimPrefix(idDomain, "svc.")
+		seen[td] = struct{}{}
+		for _, alias := range ResolveClusterTrustDomainAliases(mesh, cluster) {
+			seen[alias] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(seen))
+}
+
 // getServiceAccounts gets SA information given the namespaces and workloads for a given cluster.
+// trustDomainAliases are additional trust domains (from MeshConfig.TrustDomainAliases) that
+// Istio treats as equivalent to the primary trust domain. Entries are generated for both the
+// primary domain and each alias so that AuthorizationPolicy principals referencing any of them
+// are validated correctly.
 func (in *IstioValidationsService) getServiceAccounts(
 	namespaces []models.Namespace,
 	workloadsMap map[string]models.Workloads,
 	identityDomain string,
+	trustDomainAliases []string,
 ) []string {
 	serviceAccounts := map[string]bool{}
 	istioDomain := strings.TrimPrefix(identityDomain, "svc.")
 
+	domains := []string{istioDomain}
+	for _, alias := range trustDomainAliases {
+		if alias != istioDomain {
+			domains = append(domains, alias)
+		}
+	}
+
 	for _, ns := range namespaces {
-		saFullNameNs := fmt.Sprintf("%s/ns/%s/sa/", istioDomain, ns.Name)
 		workloads := workloadsMap[ns.Name]
 		for _, w := range workloads {
 			for _, sAccountName := range w.ServiceAccountNames {
-				saFullName := saFullNameNs + sAccountName
-				serviceAccounts[saFullName] = true
+				for _, domain := range domains {
+					saFullName := fmt.Sprintf("%s/ns/%s/sa/%s", domain, ns.Name, sAccountName)
+					serviceAccounts[saFullName] = true
+				}
 			}
 		}
 	}

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -108,3 +108,19 @@ func ResolveClusterIdentityDomain(mesh *models.Mesh, cluster, configured string)
 	}
 	return config.ResolveIdentityDomain(configured, trustDomain)
 }
+
+// ResolveClusterTrustDomainAliases extracts the trustDomainAliases for a
+// specific cluster from the mesh. Returns nil when the mesh, cluster, or
+// MeshConfig is not available or when no aliases are configured.
+func ResolveClusterTrustDomainAliases(mesh *models.Mesh, cluster string) []string {
+	if mesh == nil {
+		return nil
+	}
+	for i := range mesh.ControlPlanes {
+		cp := &mesh.ControlPlanes[i]
+		if cp.Cluster != nil && cp.Cluster.Name == cluster && cp.MeshConfig != nil {
+			return cp.MeshConfig.TrustDomainAliases
+		}
+	}
+	return nil
+}

--- a/business/mesh_internal_test.go
+++ b/business/mesh_internal_test.go
@@ -87,3 +87,77 @@ func TestResolveClusterIdentityDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveClusterTrustDomainAliases(t *testing.T) {
+	cases := map[string]struct {
+		mesh     *models.Mesh
+		cluster  string
+		expected []string
+	}{
+		"nil mesh returns nil": {
+			mesh:     nil,
+			cluster:  "mycluster",
+			expected: nil,
+		},
+		"no matching cluster returns nil": {
+			mesh: &models.Mesh{
+				ControlPlanes: []models.ControlPlane{{
+					Cluster: &models.KubeCluster{Name: "other"},
+					MeshConfig: &models.MeshConfig{
+						MeshConfig: &istiov1alpha1.MeshConfig{
+							TrustDomainAliases: []string{"alias.example.com"},
+						},
+					},
+				}},
+			},
+			cluster:  "mycluster",
+			expected: nil,
+		},
+		"matching cluster with nil MeshConfig returns nil": {
+			mesh: &models.Mesh{
+				ControlPlanes: []models.ControlPlane{{
+					Cluster:    &models.KubeCluster{Name: "mycluster"},
+					MeshConfig: nil,
+				}},
+			},
+			cluster:  "mycluster",
+			expected: nil,
+		},
+		"matching cluster with no aliases returns nil": {
+			mesh: &models.Mesh{
+				ControlPlanes: []models.ControlPlane{{
+					Cluster: &models.KubeCluster{Name: "mycluster"},
+					MeshConfig: &models.MeshConfig{
+						MeshConfig: &istiov1alpha1.MeshConfig{
+							TrustDomain: "central.example.com",
+						},
+					},
+				}},
+			},
+			cluster:  "mycluster",
+			expected: nil,
+		},
+		"matching cluster returns aliases": {
+			mesh: &models.Mesh{
+				ControlPlanes: []models.ControlPlane{{
+					Cluster: &models.KubeCluster{Name: "mycluster"},
+					MeshConfig: &models.MeshConfig{
+						MeshConfig: &istiov1alpha1.MeshConfig{
+							TrustDomain:        "central.example.com",
+							TrustDomainAliases: []string{"north.example.com", "south.example.com"},
+						},
+					},
+				}},
+			},
+			cluster:  "mycluster",
+			expected: []string{"north.example.com", "south.example.com"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ResolveClusterTrustDomainAliases(tc.mesh, tc.cluster)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -131,6 +131,11 @@ var checkDescriptors = map[string]IstioCheck{
 	"authorizationpolicy.source.principalremote": {
 		Code:     "KIA0107",
 		Message:  "Service Account for this principal is on remote cluster",
+		Severity: Unknown,
+	},
+	"authorizationpolicy.source.principalforeign": {
+		Code:     "KIA0108",
+		Message:  "Unable to verify principal, trust domain is not known to Kiali",
 		Severity: WarningSeverity,
 	},
 	"authorizationpolicy.to.wrongmethod": {


### PR DESCRIPTION
### Describe the change

Introduces KIA0108 ("Unable to verify principal, trust domain is not known
to Kiali") as a warning for principals referencing trust domains that Kiali
has no visibility into. This addresses false-positive KIA0106 errors in
multi-primary federation setups where clusters use different trust domains
(e.g., central.example.com, north.example.com) and Kiali does not manage
all federated clusters.

Additionally:
- Expand SA validation to consider trustDomainAliases from MeshConfig
- Downgrade KIA0107 severity from Warning to Informative (Unknown)
- Collect all known trust domains (primary + aliases) across clusters to
  distinguish foreign domains (KIA0108) from genuine missing SAs (KIA0106)

Validation behavior after this change:
- No issue: principal matches local SA (including trust domain aliases)
- KIA0107 (info): SA found on a remote cluster Kiali can access
- KIA0108 (warning): trust domain is foreign, Kiali cannot verify
- KIA0106 (error): SA does not exist (typo)

### Steps to test the PR

1. Setup multi-primary clusters:
   hack/run-integration-tests.sh \
     --test-suite frontend-multi-primary \
     --ambient true --waypoint true --sail false

2. Patch east cluster Istio MeshConfig:
   trustDomain: east.example.com
   trustDomainAliases:
   - south.example.com
   - cluster.local

3. Patch west cluster Istio MeshConfig:
   trustDomain: west.example.com
   trustDomainAliases:
   - north.example.com
   - cluster.remote

4. Apply AuthorizationPolicy on east cluster:
   apiVersion: security.istio.io/v1
   kind: AuthorizationPolicy
   metadata:
     name: auth-service-test
     namespace: bookinfo
   spec:
     action: ALLOW
     selector:
       matchLabels:
         app: details
     rules:
     - from:
       - source:
           principals:
           - east.example.com/ns/bookinfo/sa/bookinfo-productpage
           - cluster.local/ns/bookinfo/sa/bookinfo-productpage
           - south.example.com/ns/bookinfo/sa/bookinfo-productpage
           - wrong.example.com/ns/bookinfo/sa/bookinfo-productpage
           - west.example.com/ns/bookinfo/sa/bookinfo-reviews
           - cluster.remote/ns/bookinfo/sa/bookinfo-reviews
           - north.example.com/ns/bookinfo/sa/bookinfo-reviews
           - west.example.com/ns/bookinfo/sa/bookinfo-wrong
           - wrong
       to:
       - operation:
           methods:
           - GET

Verify that correct Validations are done on 'auth-service-test'.
<img width="1622" height="861" alt="Screenshot From 2026-05-18 15-50-42" src="https://github.com/user-attachments/assets/1ac433f8-e8a3-4419-acbf-12a56e3a7ad0" />

   - Lines 1-3: no validation issue (local SA with aliases)
   - Line 4: KIA0108 warning (foreign trust domain)
   - Lines 5-7: KIA0107 info (SA on remote cluster)
   - Line 8: KIA0106 error (known domain, SA missing)
   - Line 9: KIA0106 error (no trust domain format)

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
OSSM-13864
