### PR TITLE
[tests] Add istio 1.30 crds

### DIFF
--- a/tests/integration/controller/testdata/istio-crds/1.30.yaml
+++ b/tests/integration/controller/testdata/istio-crds/1.30.yaml
@@ -15,8 +15,356 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
+  name: trafficextensions.extensions.istio.io
+spec:
+  group: extensions.istio.io
+  names:
+    categories:
+      - istio-io
+      - extensions-istio-io
+    kind: TrafficExtension
+    listKind: TrafficExtensionList
+    plural: trafficextensions
+    singular: trafficextension
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Extend the functionality provided by the Istio proxy through WebAssembly or Lua filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/traffic_extension.html'
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - wasm
+                      - required:
+                          - lua
+                - required:
+                    - wasm
+                - required:
+                    - lua
+              properties:
+                lua:
+                  description: Lua filter configuration.
+                  properties:
+                    inlineCode:
+                      description: The inline Lua code to be executed.
+                      maxLength: 65536
+                      minLength: 1
+                      type: string
+                  required:
+                    - inlineCode
+                  type: object
+                match:
+                  description: Specifies the criteria to determine which traffic is passed to TrafficExtension.
+                  items:
+                    properties:
+                      mode:
+                        description: |-
+                          Criteria for selecting traffic by their direction.
+
+                          Valid Options: CLIENT, SERVER, CLIENT_AND_SERVER
+                        enum:
+                          - UNDEFINED
+                          - CLIENT
+                          - SERVER
+                          - CLIENT_AND_SERVER
+                        type: string
+                      ports:
+                        description: Criteria for selecting traffic by their destination port.
+                        items:
+                          properties:
+                            number:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                            - number
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - number
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: array
+                phase:
+                  description: |-
+                    Determines where in the filter chain this `TrafficExtension` is to be injected.
+
+                    Valid Options: AUTHN, AUTHZ, STATS
+                  enum:
+                    - UNSPECIFIED
+                    - AUTHN
+                    - AUTHZ
+                    - STATS
+                  type: string
+                priority:
+                  description: Determines ordering of `TrafficExtensions` in the same `phase`.
+                  format: int32
+                  nullable: true
+                  type: integer
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+                wasm:
+                  description: WebAssembly filter configuration.
+                  properties:
+                    failStrategy:
+                      description: |-
+                        Specifies the failure behavior for the plugin due to fatal errors.
+
+                        Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
+                      enum:
+                        - FAIL_CLOSE
+                        - FAIL_OPEN
+                        - FAIL_RELOAD
+                      type: string
+                    imagePullPolicy:
+                      description: |-
+                        The pull behaviour to be applied when fetching Wasm module by either OCI image or `http/https`.
+
+                        Valid Options: IfNotPresent, Always
+                      enum:
+                        - UNSPECIFIED_POLICY
+                        - IfNotPresent
+                        - Always
+                      type: string
+                    imagePullSecret:
+                      description: Credentials to use for OCI image pulling.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    pluginConfig:
+                      description: The configuration that will be passed on to the plugin.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    pluginName:
+                      description: The plugin name to be used in the Envoy configuration (used to be called `rootID`).
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    sha256:
+                      description: SHA256 checksum that will be used to verify Wasm module or OCI container.
+                      pattern: (^$|^[a-f0-9]{64}$)
+                      type: string
+                    type:
+                      description: |-
+                        Specifies the type of Wasm Extension to be used.
+
+                        Valid Options: HTTP, NETWORK
+                      enum:
+                        - UNSPECIFIED_PLUGIN_TYPE
+                        - HTTP
+                        - NETWORK
+                      type: string
+                    url:
+                      description: URL of a Wasm module or OCI container.
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                        - message: url must have schema one of [http, https, file, oci]
+                          rule: |-
+                            isURL(self) ? (url(self).getScheme() in ["", "http", "https", "file", "oci"]) : (isURL("http://" + self) &&
+                            url("http://" + self).getScheme() in ["", "http", "https", "file", "oci"])
+                    verificationKey:
+                      type: string
+                    vmConfig:
+                      description: Configuration for a Wasm VM.
+                      properties:
+                        env:
+                          description: Specifies environment variables to be injected to this VM.
+                          items:
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value for the environment variable.
+                                maxLength: 2048
+                                type: string
+                              valueFrom:
+                                description: |-
+                                  Source for the environment variable's value.
+
+                                  Valid Options: INLINE, HOST
+                                enum:
+                                  - INLINE
+                                  - HOST
+                                type: string
+                            required:
+                              - name
+                            type: object
+                            x-kubernetes-validations:
+                              - message: value may only be set when valueFrom is INLINE
+                                rule: '(has(self.valueFrom) ? self.valueFrom : "") != "HOST" || !has(self.value)'
+                          maxItems: 256
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                  required:
+                    - url
+                  type: object
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+                - message: exactly one of wasm or lua must be set
+                  rule: has(self.wasm) != has(self.lua)
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: base/templates/crds.yaml
+# If we are templating these CRDs, we want to wipe out the "static"/legacy
+# labels and replace them with the standard templated istio ones.
+# This allows the continued use of `kubectl apply -f crd-all.gen.yaml`
+# without any templating+the old labels, if desired.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: wasmplugins.extensions.istio.io
 spec:
   group: extensions.istio.io
@@ -46,10 +394,11 @@ spec:
                   description: |-
                     Specifies the failure behavior for the plugin due to fatal errors.
 
-                    Valid Options: FAIL_CLOSE, FAIL_OPEN
+                    Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
                   enum:
                     - FAIL_CLOSE
                     - FAIL_OPEN
+                    - FAIL_RELOAD
                   type: string
                 imagePullPolicy:
                   description: |-
@@ -362,8 +711,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: destinationrules.networking.istio.io
 spec:
   group: networking.istio.io
@@ -384,7 +733,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -558,6 +907,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -643,6 +1006,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -658,7 +1022,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -873,6 +1237,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -958,6 +1336,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -973,7 +1352,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -1109,6 +1488,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -1318,6 +1713,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -1403,6 +1812,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -1418,7 +1828,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -1633,6 +2043,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -1718,6 +2142,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -1733,7 +2158,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -1869,6 +2294,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -2025,7 +2466,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -2033,7 +2474,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -2207,6 +2648,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -2292,6 +2747,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -2307,7 +2763,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -2522,6 +2978,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -2607,6 +3077,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -2622,7 +3093,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -2758,6 +3229,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -2967,6 +3454,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -3052,6 +3553,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -3067,7 +3569,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -3282,6 +3784,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3367,6 +3883,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -3382,7 +3899,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -3518,6 +4035,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -3682,7 +4215,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -3856,6 +4389,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3941,6 +4488,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -3956,7 +4504,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -4171,6 +4719,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -4256,6 +4818,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -4271,7 +4834,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -4407,6 +4970,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -4616,6 +5195,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -4701,6 +5294,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -4716,7 +5310,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -4931,6 +5525,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -5016,6 +5624,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -5031,7 +5640,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -5167,6 +5776,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -5323,7 +5948,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -5341,8 +5966,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -5397,12 +6022,16 @@ spec:
                                     - routeConfiguration
                                 - required:
                                     - cluster
+                                - required:
+                                    - waypoint
                           - required:
                               - listener
                           - required:
                               - routeConfiguration
                           - required:
                               - cluster
+                          - required:
+                              - waypoint
                         properties:
                           cluster:
                             description: Match on envoy cluster attributes.
@@ -5426,12 +6055,13 @@ spec:
                             description: |-
                               The specific config generation context to match on.
 
-                              Valid Options: ANY, SIDECAR_INBOUND, SIDECAR_OUTBOUND, GATEWAY
+                              Valid Options: ANY, SIDECAR_INBOUND, SIDECAR_OUTBOUND, GATEWAY, WAYPOINT
                             enum:
                               - ANY
                               - SIDECAR_INBOUND
                               - SIDECAR_OUTBOUND
                               - GATEWAY
+                              - WAYPOINT
                             type: string
                           listener:
                             description: Match on envoy listener attributes.
@@ -5543,7 +6173,42 @@ spec:
                                     type: object
                                 type: object
                             type: object
+                          waypoint:
+                            properties:
+                              filter:
+                                description: The name of a specific filter to apply the patch to.
+                                properties:
+                                  name:
+                                    description: The filter name to match on.
+                                    type: string
+                                  subFilter:
+                                    description: The next level filter within this filter to match on.
+                                    properties:
+                                      name:
+                                        description: The filter name to match on.
+                                        type: string
+                                    type: object
+                                type: object
+                              portNumber:
+                                description: The service port to match on.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                                x-kubernetes-validations:
+                                  - message: port must be between 1-65535
+                                    rule: 0 < self && self <= 65535
+                              route:
+                                description: Match a specific route.
+                                properties:
+                                  name:
+                                    description: The Route objects generated by default are named as default.
+                                    type: string
+                                type: object
+                            type: object
                         type: object
+                        x-kubernetes-validations:
+                          - message: only support waypointMatch when context is WAYPOINT
+                            rule: 'has(self.context) ? ((self.context == "WAYPOINT") ? has(self.waypoint) : !has(self.waypoint)) : !has(self.waypoint)'
                       patch:
                         description: The patch to apply along with the operation.
                         properties:
@@ -5724,8 +6389,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -5796,6 +6461,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -5869,11 +6537,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5981,7 +6648,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v1alpha3
@@ -6039,6 +6706,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -6112,11 +6782,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6282,6 +6951,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -6355,11 +7027,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6467,7 +7138,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -6485,8 +7156,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: proxyconfigs.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6636,8 +7307,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: serviceentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6810,12 +7481,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -6922,7 +7594,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -7082,12 +7754,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -7354,12 +8027,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -7466,7 +8140,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -7484,8 +8158,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7775,6 +8449,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -7848,11 +8525,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -7910,6 +8586,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -8004,7 +8681,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v1alpha3
@@ -8283,6 +8960,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -8356,11 +9036,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -8418,6 +9097,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -8791,6 +9471,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -8864,11 +9547,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -8926,6 +9608,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -9020,7 +9703,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -9038,8 +9721,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: virtualservices.networking.istio.io
 spec:
   group: networking.istio.io
@@ -9194,7 +9877,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -9997,7 +10680,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -10139,7 +10822,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -11084,7 +11767,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -11887,7 +12570,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -11905,8 +12588,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: workloadentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -12064,7 +12747,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -12354,7 +13037,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -12366,12 +13049,14 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: workloadgroups.networking.istio.io
 spec:
   group: networking.istio.io
@@ -12668,7 +13353,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -13236,7 +13921,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -13254,8 +13939,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -13365,6 +14050,11 @@ spec:
                                     type: string
                                   maxItems: 16
                                   type: array
+                                notTrustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
                                 principals:
                                   description: Optional.
                                   items:
@@ -13386,6 +14076,378 @@ spec:
                                     maxLength: 320
                                     type: string
                                   maxItems: 16
+                                  type: array
+                                trustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                              x-kubernetes-validations:
+                                - message: Cannot set serviceAccounts with namespaces or principals
+                                  rule: |-
+                                    (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
+                                    !has(self.notPrincipals) && !has(self.namespaces) && !has(self.notNamespaces)) : true
+                          type: object
+                        maxItems: 512
+                        type: array
+                      to:
+                        description: Optional.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation specifies the operation of a request.
+                              properties:
+                                hosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                methods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notHosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notMethods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPaths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPorts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                paths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                ports:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      when:
+                        description: Optional.
+                        items:
+                          properties:
+                            key:
+                              description: The name of an Istio attribute.
+                              type: string
+                            notValues:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                          type: object
+                        type: array
+                    type: object
+                  maxItems: 512
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRef:
+                  properties:
+                    group:
+                      description: group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the referent.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: cross namespace referencing is not currently supported
+                          rule: self.size() == 0
+                  required:
+                    - kind
+                    - name
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The operation to take.
+          jsonPath: .spec.action
+          name: Action
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - provider
+                - required:
+                    - provider
+              properties:
+                action:
+                  description: |-
+                    Optional.
+
+                    Valid Options: ALLOW, DENY, AUDIT, CUSTOM
+                  enum:
+                    - ALLOW
+                    - DENY
+                    - AUDIT
+                    - CUSTOM
+                  type: string
+                provider:
+                  description: Specifies detailed configuration of the CUSTOM action.
+                  properties:
+                    name:
+                      description: Specifies the name of the extension provider.
+                      type: string
+                  type: object
+                rules:
+                  description: Optional.
+                  items:
+                    properties:
+                      from:
+                        description: Optional.
+                        items:
+                          properties:
+                            source:
+                              description: Source specifies the source of a request.
+                              properties:
+                                ipBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notNamespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRemoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRequestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notServiceAccounts:
+                                  description: Optional.
+                                  items:
+                                    maxLength: 320
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                notTrustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                principals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                remoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                requestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                serviceAccounts:
+                                  description: Optional.
+                                  items:
+                                    maxLength: 320
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                trustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                               x-kubernetes-validations:
@@ -13628,363 +14690,6 @@ spec:
       storage: false
       subresources:
         status: {}
-    - additionalPrinterColumns:
-        - description: The operation to take.
-          jsonPath: .spec.action
-          name: Action
-          type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-              oneOf:
-                - not:
-                    anyOf:
-                      - required:
-                          - provider
-                - required:
-                    - provider
-              properties:
-                action:
-                  description: |-
-                    Optional.
-
-                    Valid Options: ALLOW, DENY, AUDIT, CUSTOM
-                  enum:
-                    - ALLOW
-                    - DENY
-                    - AUDIT
-                    - CUSTOM
-                  type: string
-                provider:
-                  description: Specifies detailed configuration of the CUSTOM action.
-                  properties:
-                    name:
-                      description: Specifies the name of the extension provider.
-                      type: string
-                  type: object
-                rules:
-                  description: Optional.
-                  items:
-                    properties:
-                      from:
-                        description: Optional.
-                        items:
-                          properties:
-                            source:
-                              description: Source specifies the source of a request.
-                              properties:
-                                ipBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                namespaces:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notNamespaces:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notRemoteIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notRequestPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notServiceAccounts:
-                                  description: Optional.
-                                  items:
-                                    maxLength: 320
-                                    type: string
-                                  maxItems: 16
-                                  type: array
-                                principals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                remoteIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                requestPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                serviceAccounts:
-                                  description: Optional.
-                                  items:
-                                    maxLength: 320
-                                    type: string
-                                  maxItems: 16
-                                  type: array
-                              type: object
-                              x-kubernetes-validations:
-                                - message: Cannot set serviceAccounts with namespaces or principals
-                                  rule: |-
-                                    (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
-                                    !has(self.notPrincipals) && !has(self.namespaces) && !has(self.notNamespaces)) : true
-                          type: object
-                        maxItems: 512
-                        type: array
-                      to:
-                        description: Optional.
-                        items:
-                          properties:
-                            operation:
-                              description: Operation specifies the operation of a request.
-                              properties:
-                                hosts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                methods:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notHosts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notMethods:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPaths:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPorts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                paths:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                ports:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      when:
-                        description: Optional.
-                        items:
-                          properties:
-                            key:
-                              description: The name of an Istio attribute.
-                              type: string
-                            notValues:
-                              description: Optional.
-                              items:
-                                type: string
-                              type: array
-                            values:
-                              description: Optional.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                          type: object
-                        type: array
-                    type: object
-                  maxItems: 512
-                  type: array
-                selector:
-                  description: Optional.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        maxLength: 63
-                        type: string
-                        x-kubernetes-validations:
-                          - message: wildcard not allowed in label value match
-                            rule: '!self.contains("*")'
-                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
-                      maxProperties: 4096
-                      type: object
-                      x-kubernetes-validations:
-                        - message: wildcard not allowed in label key match
-                          rule: self.all(key, !key.contains("*"))
-                        - message: key must not be empty
-                          rule: self.all(key, key.size() != 0)
-                  type: object
-                targetRef:
-                  properties:
-                    group:
-                      description: group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the referent.
-                      type: string
-                      x-kubernetes-validations:
-                        - message: cross namespace referencing is not currently supported
-                          rule: self.size() == 0
-                  required:
-                    - kind
-                    - name
-                  type: object
-                targetRefs:
-                  description: Optional.
-                  items:
-                    properties:
-                      group:
-                        description: group is the group of the target resource.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        description: kind is kind of the target resource.
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: name is the name of the target resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the referent.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: cross namespace referencing is not currently supported
-                            rule: self.size() == 0
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-              type: object
-              x-kubernetes-validations:
-                - message: only one of targetRefs or selector can be set
-                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
-            status:
-              properties:
-                conditions:
-                  description: Current service state of the resource.
-                  items:
-                    properties:
-                      lastProbeTime:
-                        description: Last time we probed the condition.
-                        format: date-time
-                        type: string
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about last transition.
-                        type: string
-                      observedGeneration:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: Resource Generation to which the Condition refers.
-                        x-kubernetes-int-or-string: true
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status is the status of the condition.
-                        type: string
-                      type:
-                        description: Type is the type of the condition.
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  x-kubernetes-int-or-string: true
-                validationMessages:
-                  description: Includes any errors or warnings detected by Istio's analyzers.
-                  items:
-                    properties:
-                      documentationUrl:
-                        description: A url pointing to the Istio documentation for this specific error type.
-                        type: string
-                      level:
-                        description: |-
-                          Represents how severe a message is.
-
-                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                        enum:
-                          - UNKNOWN
-                          - ERROR
-                          - WARNING
-                          - INFO
-                        type: string
-                      type:
-                        properties:
-                          code:
-                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
-                            type: string
-                          name:
-                            description: A human-readable name for the message type.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
 ---
 # Source: base/templates/crds.yaml
 # If we are templating these CRDs, we want to wipe out the "static"/legacy
@@ -14000,8 +14705,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: peerauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -14164,7 +14869,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -14314,7 +15019,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -14332,8 +15037,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -14440,14 +15145,287 @@ spec:
                       outputPayloadToHeader:
                         description: This field specifies the header name to output a successfully verified JWT payload to the backend.
                         type: string
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
+                        items:
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        type: array
                       timeout:
                         description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
                         type: string
                         x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
+                    type: object
+                    x-kubernetes-validations:
+                      - message: only one of jwks or jwksUri can be set
+                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
+                  maxItems: 4096
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRef:
+                  properties:
+                    group:
+                      description: group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the referent.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: cross namespace referencing is not currently supported
+                          rule: self.size() == 0
+                  required:
+                    - kind
+                    - name
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
                     required:
-                      - issuer
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
+              properties:
+                jwtRules:
+                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
+                  items:
+                    properties:
+                      audiences:
+                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      forwardOriginalToken:
+                        description: If set to true, the original token will be kept for the upstream request.
+                        type: boolean
+                      fromCookies:
+                        description: List of cookie names from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      fromHeaders:
+                        description: List of header locations from which JWT is expected.
+                        items:
+                          properties:
+                            name:
+                              description: The HTTP header name.
+                              minLength: 1
+                              type: string
+                            prefix:
+                              description: The prefix that should be stripped before decoding the token.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      fromParams:
+                        description: List of query parameters from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      issuer:
+                        description: Identifies the issuer that issued the JWT.
+                        minLength: 1
+                        type: string
+                      jwks:
+                        description: JSON Web Key Set of public keys to validate signature of the JWT.
+                        type: string
+                      jwks_uri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      jwksUri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      outputClaimToHeaders:
+                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
+                        items:
+                          properties:
+                            claim:
+                              description: The name of the claim to be copied from.
+                              minLength: 1
+                              type: string
+                            header:
+                              description: The name of the header to be created.
+                              minLength: 1
+                              pattern: ^[-_A-Za-z0-9]+$
+                              type: string
+                          required:
+                            - header
+                            - claim
+                          type: object
+                        type: array
+                      outputPayloadToHeader:
+                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
+                        type: string
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
+                        items:
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        type: array
+                      timeout:
+                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                     type: object
                     x-kubernetes-validations:
                       - message: only one of jwks or jwksUri can be set
@@ -14612,269 +15590,6 @@ spec:
       storage: false
       subresources:
         status: {}
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
-              properties:
-                jwtRules:
-                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
-                  items:
-                    properties:
-                      audiences:
-                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      forwardOriginalToken:
-                        description: If set to true, the original token will be kept for the upstream request.
-                        type: boolean
-                      fromCookies:
-                        description: List of cookie names from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      fromHeaders:
-                        description: List of header locations from which JWT is expected.
-                        items:
-                          properties:
-                            name:
-                              description: The HTTP header name.
-                              minLength: 1
-                              type: string
-                            prefix:
-                              description: The prefix that should be stripped before decoding the token.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      fromParams:
-                        description: List of query parameters from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        minLength: 1
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature of the JWT.
-                        type: string
-                      jwks_uri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      jwksUri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      outputClaimToHeaders:
-                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
-                        items:
-                          properties:
-                            claim:
-                              description: The name of the claim to be copied from.
-                              minLength: 1
-                              type: string
-                            header:
-                              description: The name of the header to be created.
-                              minLength: 1
-                              pattern: ^[-_A-Za-z0-9]+$
-                              type: string
-                          required:
-                            - header
-                            - claim
-                          type: object
-                        type: array
-                      outputPayloadToHeader:
-                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
-                        type: string
-                      timeout:
-                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: must be a valid duration greater than 1ms
-                            rule: duration(self) >= duration('1ms')
-                    required:
-                      - issuer
-                    type: object
-                    x-kubernetes-validations:
-                      - message: only one of jwks or jwksUri can be set
-                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
-                  maxItems: 4096
-                  type: array
-                selector:
-                  description: Optional.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        maxLength: 63
-                        type: string
-                        x-kubernetes-validations:
-                          - message: wildcard not allowed in label value match
-                            rule: '!self.contains("*")'
-                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
-                      maxProperties: 4096
-                      type: object
-                      x-kubernetes-validations:
-                        - message: wildcard not allowed in label key match
-                          rule: self.all(key, !key.contains("*"))
-                        - message: key must not be empty
-                          rule: self.all(key, key.size() != 0)
-                  type: object
-                targetRef:
-                  properties:
-                    group:
-                      description: group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the referent.
-                      type: string
-                      x-kubernetes-validations:
-                        - message: cross namespace referencing is not currently supported
-                          rule: self.size() == 0
-                  required:
-                    - kind
-                    - name
-                  type: object
-                targetRefs:
-                  description: Optional.
-                  items:
-                    properties:
-                      group:
-                        description: group is the group of the target resource.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        description: kind is kind of the target resource.
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: name is the name of the target resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the referent.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: cross namespace referencing is not currently supported
-                            rule: self.size() == 0
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-              type: object
-              x-kubernetes-validations:
-                - message: only one of targetRefs or selector can be set
-                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
-            status:
-              properties:
-                conditions:
-                  description: Current service state of the resource.
-                  items:
-                    properties:
-                      lastProbeTime:
-                        description: Last time we probed the condition.
-                        format: date-time
-                        type: string
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about last transition.
-                        type: string
-                      observedGeneration:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: Resource Generation to which the Condition refers.
-                        x-kubernetes-int-or-string: true
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status is the status of the condition.
-                        type: string
-                      type:
-                        description: Type is the type of the condition.
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  x-kubernetes-int-or-string: true
-                validationMessages:
-                  description: Includes any errors or warnings detected by Istio's analyzers.
-                  items:
-                    properties:
-                      documentationUrl:
-                        description: A url pointing to the Istio documentation for this specific error type.
-                        type: string
-                      level:
-                        description: |-
-                          Represents how severe a message is.
-
-                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                        enum:
-                          - UNKNOWN
-                          - ERROR
-                          - WARNING
-                          - INFO
-                        type: string
-                      type:
-                        properties:
-                          code:
-                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
-                            type: string
-                          name:
-                            description: A human-readable name for the message type.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
 ---
 # Source: base/templates/crds.yaml
 # If we are templating these CRDs, we want to wipe out the "static"/legacy
@@ -14890,8 +15605,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: telemetries.telemetry.istio.io
 spec:
   group: telemetry.istio.io
@@ -15160,12 +15875,16 @@ spec:
                                       - environment
                                   - required:
                                       - header
+                                  - required:
+                                      - formatter
                             - required:
                                 - literal
                             - required:
                                 - environment
                             - required:
                                 - header
+                            - required:
+                                - formatter
                           properties:
                             environment:
                               description: Environment adds the value of an environment variable to each span.
@@ -15179,6 +15898,16 @@ spec:
                                   type: string
                               required:
                                 - name
+                              type: object
+                            formatter:
+                              description: Formatter adds the value of access logging substitution formatter.
+                              properties:
+                                value:
+                                  description: The formatter tag value to use, same formatter as HTTP access logging (e.g.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - value
                               type: object
                             header:
                               description: RequestHeader adds the value of an header from the request to each span.
@@ -15206,6 +15935,10 @@ spec:
                           type: object
                         description: Optional.
                         type: object
+                      disableContextPropagation:
+                        description: Controls whether trace context headers (e.g., `traceparent`/`tracestate` for W3C, `X-B3-*` for Zipkin) are propagated in forwarded requests.
+                        nullable: true
+                        type: boolean
                       disableSpanReporting:
                         description: Controls span reporting.
                         nullable: true
@@ -15584,12 +16317,16 @@ spec:
                                       - environment
                                   - required:
                                       - header
+                                  - required:
+                                      - formatter
                             - required:
                                 - literal
                             - required:
                                 - environment
                             - required:
                                 - header
+                            - required:
+                                - formatter
                           properties:
                             environment:
                               description: Environment adds the value of an environment variable to each span.
@@ -15603,6 +16340,16 @@ spec:
                                   type: string
                               required:
                                 - name
+                              type: object
+                            formatter:
+                              description: Formatter adds the value of access logging substitution formatter.
+                              properties:
+                                value:
+                                  description: The formatter tag value to use, same formatter as HTTP access logging (e.g.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - value
                               type: object
                             header:
                               description: RequestHeader adds the value of an header from the request to each span.
@@ -15630,6 +16377,10 @@ spec:
                           type: object
                         description: Optional.
                         type: object
+                      disableContextPropagation:
+                        description: Controls whether trace context headers (e.g., `traceparent`/`tracestate` for W3C, `X-B3-*` for Zipkin) are propagated in forwarded requests.
+                        nullable: true
+                        type: boolean
                       disableSpanReporting:
                         description: Controls span reporting.
                         nullable: true


### PR DESCRIPTION
### Describe the change

Add Istio 1.30 CRDs generated with:

`helm template --include-crds --version 1.30.0 --repo https://istio-release.storage.googleapis.com/charts base | yq ea 'select(.kind == "CustomResourceDefinition")' > 1.30.yaml;`

### Steps to test the PR

Backend integration tests should pass.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
