### PR TITLE
Update mcp checker commands

### DIFF
--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -199,7 +199,7 @@ jobs:
           echo "**Commit:** \`${PR_SHA:0:7}\` — [View full workflow run](${RUN_URL})"
           echo ""
           if [[ -n "${BASE_TMP}" && -s "${BASE_TMP}" && -f "${PR_RAW}" ]]; then
-            "${MCPCHECKER}" diff --base "${BASE_TMP}" --current "${PR_RAW}" --output markdown || \
+            "${MCPCHECKER}" result diff --base "${BASE_TMP}" --current "${PR_RAW}" --output markdown || \
                echo "⚠ Diff comparison not available. See [workflow run](${RUN_URL}) for evaluation results."
           else
             echo "⚠️ Could not compare runs: baseline on ${DEFAULT_BRANCH} or PR results is missing."
@@ -283,14 +283,14 @@ jobs:
         cp "${ARTIFACT_JSON}" tests/evals/results/mcpchecker-gemini-eval-out.json
 
         if [[ "${PREVIOUS_EXISTS}" -eq 1 ]]; then
-          "${MCPCHECKER}" diff --base "${PREVIOUS}" --current tests/evals/results/mcpchecker-gemini-eval-out.json --output markdown > baseline-pr-diff.md
+          "${MCPCHECKER}" result diff --base "${PREVIOUS}" --current tests/evals/results/mcpchecker-gemini-eval-out.json --output markdown > baseline-pr-diff.md
         else
           echo "_No previous committed baseline on \`${DEFAULT_BRANCH}\` at this path — first update or new file._" > baseline-pr-diff.md
         fi
 
         make mcp-update-token-readme
         echo "Updated baseline summary:"
-        "${MCPCHECKER}" summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json | head -c 2000
+        "${MCPCHECKER}" result summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json | head -c 2000
         echo
 
     - name: Create PR with updated baseline

--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -467,5 +467,5 @@ The repository runs [mcpchecker](https://github.com/mcpchecker/mcpchecker) in Gi
 
 ### Token baseline
 
-Successful runs that are **not** tied to a PR comment trigger (for example a manual run on `master`) can update the committed eval baseline via the **Update Token Baseline** job: it refreshes `tests/evals/results/mcpchecker-gemini-eval-out.json` and the [Token Consumption](#token-consumption) section below (through `hack/mcp/update-token-readme.sh`, which runs `mcpchecker summary` on that file) and may open an automated PR.
+Successful runs that are **not** tied to a PR comment trigger (for example a manual run on `master`) can update the committed eval baseline via the **Update Token Baseline** job: it refreshes `tests/evals/results/mcpchecker-gemini-eval-out.json` and the [Token Consumption](#token-consumption) section below (through `hack/mcp/update-token-readme.sh`, which runs `mcpchecker result summary` on that file) and may open an automated PR.
 

--- a/hack/mcp/update-token-readme.sh
+++ b/hack/mcp/update-token-readme.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Updates the token consumption section in ai/mcp/README.md from a summary of
-# tests/evals/results/mcpchecker-gemini-eval-out.json (mcpchecker summary -o json).
+# tests/evals/results/mcpchecker-gemini-eval-out.json (mcpchecker result summary -o json).
 #
 set -euo pipefail
 
@@ -33,7 +33,7 @@ fi
 TOKEN_FILE="$(mktemp)"
 trap 'rm -f "${TOKEN_FILE}"' EXIT
 
-"${MCPCHECKER}" summary "${EVAL_OUT}" -o json > "${TOKEN_FILE}"
+"${MCPCHECKER}" result summary "${EVAL_OUT}" -o json > "${TOKEN_FILE}"
 
 TASKS_TOTAL=$(jq -r '.tasksTotal' "${TOKEN_FILE}")
 TASKS_PASSED=$(jq -r '.tasksPassed' "${TOKEN_FILE}")

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -117,18 +117,18 @@ mcp-eval-summary:
 	fi
 	@${GOPATH}/bin/mcpchecker result summary ${MCP_EVAL_RESULTS} --output text
 
-## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker summary <eval.json> -o json)
+## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker result summary <eval.json> -o json)
 mcp-eval-summary-json:
 	@if [ ! -f ${MCP_EVAL_RESULTS} ]; then \
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker summary ${MCP_EVAL_RESULTS} --output json
+	@${GOPATH}/bin/mcpchecker result summary ${MCP_EVAL_RESULTS} --output json
 
 ## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
 mcp-eval-diff:
 	@test -n "$${MCP_DIFF_BASE}" && test -n "$${MCP_DIFF_CURRENT}" || (echo "Usage: make mcp-eval-diff MCP_DIFF_BASE=<path> MCP_DIFF_CURRENT=<path>" >&2; exit 1)
-	@${GOPATH}/bin/mcpchecker diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
+	@${GOPATH}/bin/mcpchecker result diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
 
 ## mcp-clean-eval-results: Remove local mcpchecker evaluation outputs
 mcp-clean-eval-results:
@@ -136,6 +136,6 @@ mcp-clean-eval-results:
 	@rm -f mcpchecker-gemini-eval-out.json
 	@rm -f tests/evals/results/mcpchecker-gemini-eval-out.json
 
-## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from mcpchecker summary of MCP_EVAL_RESULTS
+## mcp-update-token-readme: Update the token consumption section in ai/mcp/README.md from mcpchecker result summary of MCP_EVAL_RESULTS
 mcp-update-token-readme:
 	@${ROOTDIR}/hack/mcp/update-token-readme.sh


### PR DESCRIPTION
### Describe the change

This PR updates the MCP evaluation integration to work with the current mcpchecker CLI by replacing deprecated top-level commands such as mcpchecker summary and mcpchecker diff with the new mcpchecker result summary and mcpchecker result diff syntax. The change is applied across the Make targets, the GitHub Actions workflow that generates summaries and compares results, and the script that refreshes the token consumption section in the README, while also aligning the related documentation so CI does not fail when installing the latest mcpchecker release.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
