### PR TITLE
[AI] Add coderabbit config file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,7 @@ knowledge_base:
     - "AI_POLICY.md"
     - "CONTRIBUTING.md"
     - "STYLE_GUIDE.adoc"
+tone_instructions: "Be concise and pragmatic. Prioritize feedback related to scalability and long-term maintainability."
 reviews:
   high_level_summary: false
   review_status: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Keep CodeRabbit aligned with the repository's shared AI guidance files
+# without duplicating those instructions here.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+    - "AI_POLICY.md"
+    - "CONTRIBUTING.md"
+    - "STYLE_GUIDE.adoc"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,3 +9,16 @@ knowledge_base:
     - "AI_POLICY.md"
     - "CONTRIBUTING.md"
     - "STYLE_GUIDE.adoc"
+reviews:
+  review_status: false
+  poem: false
+  auto_review:
+    enabled: false
+  path_instructions:
+  - path: "frontend/public/locales/**/translation.json"
+    instructions: |
+      These files contain localization resources.
+      Do not comment on missing translations, untranslated strings,
+      missing locale parity, or missing i18n keys in this path.
+      Only flag malformed JSON, broken structure, duplicate keys,
+      or clearly invalid translation entries.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,7 @@ knowledge_base:
     - "CONTRIBUTING.md"
     - "STYLE_GUIDE.adoc"
 reviews:
+  high_level_summary: false
   review_status: false
   poem: false
   auto_review:
@@ -18,7 +19,6 @@ reviews:
   - path: "frontend/public/locales/**/translation.json"
     instructions: |
       These files contain localization resources.
-      Do not comment on missing translations, untranslated strings,
-      missing locale parity, or missing i18n keys in this path.
+      Do not comment on untranslated strings in this path.
       Only flag malformed JSON, broken structure, duplicate keys,
       or clearly invalid translation entries.


### PR DESCRIPTION
### Describe the change

Added a minimal .coderabbit.yaml to make CodeRabbit explicitly use AI_POLICY.md, CONTRIBUTING.md, and STYLE_GUIDE.adoc as review guidelines.

CodeRabbit already auto-detects standard AI instruction files such as Cursor and Claude guidance (.cursor/rules, .cursorrules, CLAUDE.md, and AGENTS.md), so this change does not duplicate those rules. It only extends the review context with Kiali-specific project documentation.

### Steps to test the PR

The effective configuration can be checked with `@coderabbitai configuration`

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
