### PR TITLE
Fix SE-backed services incorrectly appearing in workload/app Related cards

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -277,9 +277,13 @@ func (in *SvcService) buildServiceList(ctx context.Context, cluster string, name
 		services[i].Cluster = cluster
 	}
 
-	// Add ServiceEntry-backed services that have no corresponding K8s Service
-	seServices := in.buildServiceEntryOverviews(ctx, istioConfigList.ServiceEntries, svcs, namespace, istioConfigList, cluster)
-	services = append(services, seServices...)
+	// Add ServiceEntry-backed services that have no corresponding K8s Service.
+	// Skip when a ServiceSelector is set because SE-backed services have no
+	// pod selector and should not appear as "related" to a specific workload.
+	if criteria.ServiceSelector == "" {
+		seServices := in.buildServiceEntryOverviews(ctx, istioConfigList.ServiceEntries, svcs, namespace, istioConfigList, cluster)
+		services = append(services, seServices...)
+	}
 	return &models.ServiceList{Namespace: namespace, Services: services, Validations: validations}
 }
 

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -507,6 +507,58 @@ func TestServiceListIncludesServiceEntryServices(t *testing.T) {
 	assert.True(foundSERef, "ServiceEntry reference not found in IstioReferences")
 }
 
+func TestServiceListSEExcludedWhenServiceSelectorSet(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	se := &networking_v1.ServiceEntry{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "external-api",
+			Namespace: "bookinfo",
+		},
+		Spec: api_networking_v1.ServiceEntry{
+			Hosts: []string{"external-api.example.com"},
+		},
+	}
+
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("bookinfo"),
+		&core_v1.Service{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "reviews",
+				Namespace: "bookinfo",
+				Labels:    map[string]string{"app": "reviews"},
+			},
+			Spec: core_v1.ServiceSpec{
+				Selector: map[string]string{"app": "reviews"},
+			},
+		},
+		se,
+	)
+	svc := NewLayerBuilder(t, conf).WithClient(k8s).Build().Svc
+
+	// Without ServiceSelector: both k8s service and SE-backed service appear
+	criteria := ServiceCriteria{
+		Namespace:              "bookinfo",
+		IncludeHealth:          false,
+		IncludeOnlyDefinitions: true,
+	}
+	serviceList, err := svc.GetServiceList(context.TODO(), criteria)
+	require.NoError(err)
+	assert.Len(serviceList.Services, 2, "without selector, both k8s and SE services should appear")
+
+	// With ServiceSelector: only the matching k8s service appears
+	criteria.ServiceSelector = "app=reviews"
+	serviceList, err = svc.GetServiceList(context.TODO(), criteria)
+	require.NoError(err)
+	require.Len(serviceList.Services, 1, "with selector, only the matching k8s service should appear")
+	assert.Equal("reviews", serviceList.Services[0].Name)
+	assert.Equal("Kubernetes", serviceList.Services[0].ServiceRegistry)
+}
+
 func TestServiceListSEMultipleHosts(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/9718

## Summary
- ServiceEntry-backed services have no pod selector, so they should never be returned when `GetServiceList` is called with a `ServiceSelector` (used to find services related to a specific workload)
- Previously, `buildServiceEntryOverviews` was unconditionally appended to every service list result, causing external service hosts to appear in workload detail, app detail, and waypoint capture queries
- The fix skips `buildServiceEntryOverviews` when `ServiceSelector` is set, since SE-backed services can never match a workload's label selector

Note that because this is a server-side change, it similarly benefits OSSMC, MCP, etc.

## Test plan
- [x] All existing `business/` Go tests pass
- [x] Verify workload detail "Related" card no longer shows SE-backed service hosts
- [x] Verify app detail "Related" card no longer shows SE-backed service hosts
- [x] Verify the services list page still shows SE-backed services as expected
- [x] Verify waypoint capture logic is unaffected


Made with [Cursor](https://cursor.com)