### PR TITLE
Show "No related resources" message in empty Related card

### DIFF
--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -449,6 +449,7 @@
   "No namespaces found": "No se encontraron espacios de nombres",
   "No notifications found": "No se encontraron notificaciones",
   "No Operations Defined": "No se definieron operaciones",
+  "No related resources": "No related resources",
   "No results found": "No se encontraron resultados",
   "No results match the filter criteria. Clear all filters and try again.": "Ningún resultado coincide con los criterios del filtro. Limpie todos los filtros e inténtelo de nuevo.",
   "No Route Rules defined": "No se definieron reglas de enrutamiento",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -431,6 +431,7 @@
   "No namespaces found": "No namespaces found",
   "No notifications found": "No notifications found",
   "No Operations Defined": "No Operations Defined",
+  "No related resources": "No related resources",
   "No results found": "没有结果找到",
   "No results match the filter criteria. Clear all filters and try again.": "No results match the filter criteria. Clear all filters and try again.",
   "No Route Rules defined": "未定义路由规则",

--- a/frontend/src/components/DetailDescription/DetailDescription.tsx
+++ b/frontend/src/components/DetailDescription/DetailDescription.tsx
@@ -38,6 +38,11 @@ const flowStyle = kialiStyle({
   listStyleType: 'none'
 });
 
+const emptyStyle = kialiStyle({
+  color: 'var(--pf-t--global--text--color--subtle)',
+  fontStyle: 'italic'
+});
+
 const itemStyle = kialiStyle({
   display: 'inline-flex',
   alignItems: 'center',
@@ -180,7 +185,7 @@ const DetailDescriptionComponent: React.FC<Props> = (props: Props) => {
   }
 
   if (items.length === 0) {
-    return null;
+    return <span className={emptyStyle}>{t('No related resources')}</span>;
   }
 
   return <ul className={flowStyle}>{items}</ul>;

--- a/frontend/src/components/DetailDescription/__tests__/DetailDescription.test.tsx
+++ b/frontend/src/components/DetailDescription/__tests__/DetailDescription.test.tsx
@@ -49,6 +49,32 @@ const makeWorkload = (name: string, kind: string): AppWorkload => ({
   workloadName: name
 });
 
+describe('DetailDescription empty state', () => {
+  it('shows "No related resources" when no apps, services, or workloads are provided', () => {
+    const { getByText } = render(
+      <Provider store={store as any}>
+        <MemoryRouter>
+          <DetailDescription namespace="bookinfo" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(getByText('No related resources')).toBeTruthy();
+  });
+
+  it('shows "No related resources" when all arrays are empty', () => {
+    const { getByText } = render(
+      <Provider store={store as any}>
+        <MemoryRouter>
+          <DetailDescription namespace="bookinfo" apps={[]} services={[]} workloads={[]} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(getByText('No related resources')).toBeTruthy();
+  });
+});
+
 describe('DetailDescription workload kioskParams', () => {
   beforeEach(() => {
     mockKioskValue = 'https://console.example.com';

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -253,7 +253,7 @@ export type AccessLog = {
   // mixer_status: string;
   // OriginalMessage is the original raw log line.
   // original_message: string;
-  // ParseError provides a string value if a parse error occured.
+  // ParseError provides a string value if a parse error occurred.
   // parse_error: string;
 };
 


### PR DESCRIPTION
## Summary

- Display an italic, subtle-colored **"No related resources"** message in the Related card when there are no apps, services, or workloads to show
- Styled consistently with the existing "No labels" and "No annotations" empty states (subtle text color + italic)
- Applies to all three detail pages (Service, Workload, App) since they share the `DetailDescription` component

<img width="1591" height="792" alt="image" src="https://github.com/user-attachments/assets/f9f50bcb-bfeb-430b-b174-2c6c148bdbd2" />

Fixes #9691

## Test plan

- [x] Unit tests pass (`DetailDescription.test.tsx` — two new empty-state tests)
- [ ] Navigate to a service detail page with no related resources (e.g., an external ServiceEntry) and verify the Related card shows "No related resources" in italic subtle text
- [ ] Verify services/workloads/apps with related resources still render normally


Made with [Cursor](https://cursor.com)