### PR TITLE
Fix ResizeObserver loop limit exceeded flake (#9725)

### DIFF
--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -743,14 +743,28 @@ const TopologyContent: React.FC<{
 
   return isMiniGraph ? (
     <>
-      <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={handleResize} />
+      <ReactResizeDetector
+        refreshMode="debounce"
+        refreshRate={100}
+        handleWidth={true}
+        handleHeight={true}
+        skipOnMount={true}
+        onResize={handleResize}
+      />
       <TopologyView data-test="topology-view-pf">
         <VisualizationSurface data-test="visualization-surface" state={{}} />
       </TopologyView>
     </>
   ) : (
     <>
-      <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={handleResize} />
+      <ReactResizeDetector
+        refreshMode="debounce"
+        refreshRate={100}
+        handleWidth={true}
+        handleHeight={true}
+        skipOnMount={true}
+        onResize={handleResize}
+      />
       <TopologyView
         data-test="topology-view-pf"
         controlBar={

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -477,7 +477,14 @@ const TopologyContent: React.FC<{
     </TopologyView>
   ) : (
     <>
-      <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={handleResize} />
+      <ReactResizeDetector
+        refreshMode="debounce"
+        refreshRate={100}
+        handleWidth={true}
+        handleHeight={true}
+        skipOnMount={true}
+        onResize={handleResize}
+      />
       <TopologyView
         data-test="mesh-topology-view-pf"
         controlBar={


### PR DESCRIPTION
## Summary

- Adds `refreshMode="debounce"` and `refreshRate={100}` to `ReactResizeDetector` in `Graph.tsx` (2 instances) and `Mesh.tsx` (1 instance), matching the pattern already used in `GraphHelpFind.tsx`, `TourStop.tsx`, and `MeshHelpFind.tsx`.
- This breaks the resize → layout → fit() → resize feedback loop that caused the `ResizeObserver loop limit exceeded` uncaught exception, which made the Cypress `Inbound Metrics in context menu for service node` scenario flake.
- Root cause: `react-resize-detector@9.1.x` has a [known issue](https://github.com/maslianok/react-resize-detector/issues/241) where omitting the debounce config causes the ResizeObserver callback to fire synchronously on every observation. When the callback triggers a layout change (like `fit()`), it re-triggers the observer within the same animation frame, exceeding the browser's loop limit.

Fixes #9725

## Test plan

- [ ] Cypress `graph_context_menu.feature` scenarios pass without `ResizeObserver loop limit exceeded` errors
- [ ] Graph page renders and resizes normally (no visual regressions from 100ms debounce)
- [ ] Mesh page renders and resizes normally


Made with [Cursor](https://cursor.com)