### PR TITLE
[v2.26] Retry Prometheus connection at startup instead of degrading to noop

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"os"
 	"slices"
-	"time"
 
 	"github.com/go-logr/zerologr"
 	"github.com/rs/zerolog"
@@ -49,7 +48,6 @@ import (
 	"github.com/kiali/kiali/server"
 	"github.com/kiali/kiali/tlspolicy"
 	"github.com/kiali/kiali/tracing"
-	"github.com/kiali/kiali/util/httputil"
 )
 
 func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFactory kubernetes.ClientFactory) <-chan struct{} {
@@ -94,40 +92,14 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 	business.SetKialiSAToken(kialiToken)
 
 	// Create shared prometheus client shared by all prometheus requests in the business layer.
-	// If enabled=true but the URL is empty, unreachable, or the transport fails to initialize,
-	// Kiali injects a NoopClient and records a DisabledReason but keeps Enabled=true so that
-	// addon status checks and the mesh page still probe Prometheus and report the error.
+	// config.Validate() ensures that if Prometheus is enabled, a URL is always present,
+	// so the only two cases here are disabled (NoopClient) or enabled with a URL (LazyClient).
 	var prom prometheus.ClientInterface
-	if conf.ExternalServices.Prometheus.Enabled {
-		var disabledReason string
-		if conf.ExternalServices.Prometheus.URL == "" {
-			disabledReason = "Prometheus URL is empty; metrics features are unavailable"
-		} else {
-			client, err := prometheus.NewClient(*conf, kialiToken)
-			if err != nil {
-				disabledReason = fmt.Sprintf("Prometheus client init failed: %s", err)
-			} else {
-				healthURL := conf.ExternalServices.Prometheus.HealthCheckUrl
-				if healthURL == "" {
-					healthURL = conf.ExternalServices.Prometheus.URL + "/-/healthy"
-				}
-				_, statusCode, _, probeErr := httputil.HttpGet(healthURL, &conf.ExternalServices.Prometheus.Auth, 10*time.Second, nil, nil, conf)
-				if probeErr != nil || statusCode > 399 {
-					disabledReason = fmt.Sprintf("Prometheus unreachable at [%s] (status [%d])", healthURL, statusCode)
-				} else {
-					prom = client
-				}
-			}
-		}
-		if disabledReason != "" {
-			log.Warningf("%s", disabledReason)
-			conf.ExternalServices.Prometheus.DisabledReason = disabledReason
-			config.Set(conf)
-			prom = prometheus.NewNoopClient()
-		}
-	} else {
+	if !conf.ExternalServices.Prometheus.Enabled {
 		log.Info("Prometheus is disabled")
 		prom = prometheus.NewNoopClient()
+	} else {
+		prom = prometheus.NewLazyClient(ctx, *conf, kialiToken)
 	}
 
 	// Create shared tracing client shared by all tracing requests in the business layer.

--- a/config/config.go
+++ b/config/config.go
@@ -339,20 +339,12 @@ type PrometheusConfig struct {
 	CacheEnabled    bool              `yaml:"cache_enabled,omitempty" json:"cacheEnabled,omitempty"`       // Enable cache for Prometheus queries
 	CacheExpiration int               `yaml:"cache_expiration,omitempty" json:"cacheExpiration,omitempty"` // Global cache expiration expressed in seconds
 	CustomHeaders   map[string]string `yaml:"custom_headers,omitempty" json:"customHeaders,omitempty"`
-	// DisabledReason is set at startup when Prometheus is enabled but unavailable (empty URL, transport
-	// failure, or unreachable endpoint). Enabled remains true so that addon status checks and the mesh
-	// page still probe Prometheus and report errors. The handlers layer surfaces DisabledReason to the
-	// frontend via the /api/config endpoint so the UI can warn the user and hide metrics features.
-	// When Enabled is true and DisabledReason is empty, Prometheus is fully operational.
-	// When Enabled is true and DisabledReason is non-empty, Prometheus was requested but is unavailable.
-	// When Enabled is false, the user explicitly disabled Prometheus.
-	DisabledReason string            `yaml:"-" json:"-"`             // in-memory only; never serialized to config files
-	Enabled        bool              `yaml:"enabled" json:"enabled"` // no omitempty: false must be serialized to the frontend
-	HealthCheckUrl string            `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
-	IsCore         bool              `yaml:"is_core,omitempty" json:"isCore,omitempty"`
-	QueryScope     map[string]string `yaml:"query_scope,omitempty" json:"queryScope,omitempty"`
-	ThanosProxy    ThanosProxy       `yaml:"thanos_proxy,omitempty" json:"thanosProxy,omitempty"`
-	URL            string            `yaml:"url,omitempty" json:"url,omitempty"`
+	Enabled         bool              `yaml:"enabled" json:"enabled"` // no omitempty: false must be serialized to the frontend
+	HealthCheckUrl  string            `yaml:"health_check_url,omitempty" json:"healthCheckUrl,omitempty"`
+	IsCore          bool              `yaml:"is_core,omitempty" json:"isCore,omitempty"`
+	QueryScope      map[string]string `yaml:"query_scope,omitempty" json:"queryScope,omitempty"`
+	ThanosProxy     ThanosProxy       `yaml:"thanos_proxy,omitempty" json:"thanosProxy,omitempty"`
+	URL             string            `yaml:"url,omitempty" json:"url,omitempty"`
 }
 
 // CustomDashboardsConfig describes configuration specific to Custom Dashboards
@@ -2063,6 +2055,10 @@ func Validate(conf *Config) error {
 	// log a warning if the user is ignoring some validations
 	if len(conf.KialiFeatureFlags.Validations.Ignore) > 0 {
 		log.Infof("Some validation errors will be ignored [%v]. If these errors do occur, they will still be logged. If you think the validation errors you see are incorrect, please report them to the Kiali team if you have not done so already and provide the details of your scenario. This will keep Kiali validations strong for the whole community.", conf.KialiFeatureFlags.Validations.Ignore)
+	}
+
+	if conf.ExternalServices.Prometheus.Enabled && conf.ExternalServices.Prometheus.URL == "" {
+		return fmt.Errorf("external_services.prometheus.url must be set when prometheus is enabled")
 	}
 
 	// log a info message if the user is disabling some features

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1438,3 +1438,23 @@ func TestDefaultIdentityDomainIsEmpty(t *testing.T) {
 	assert.Empty(t, conf.ExternalServices.Istio.IstioIdentityDomain,
 		"default should be empty to enable auto-detection")
 }
+
+func TestValidatePrometheusURL(t *testing.T) {
+	conf := NewConfig()
+	conf.LoginToken.SigningKey = Credential("signingkey12345!")
+
+	// enabled with a URL is valid (default)
+	conf.ExternalServices.Prometheus.Enabled = true
+	conf.ExternalServices.Prometheus.URL = "http://prometheus:9090"
+	assert.NoError(t, Validate(conf), "enabled with URL should be valid")
+
+	// disabled with empty URL is valid
+	conf.ExternalServices.Prometheus.Enabled = false
+	conf.ExternalServices.Prometheus.URL = ""
+	assert.NoError(t, Validate(conf), "disabled with empty URL should be valid")
+
+	// enabled with empty URL is a misconfiguration and must fail
+	conf.ExternalServices.Prometheus.Enabled = true
+	conf.ExternalServices.Prometheus.URL = ""
+	assert.Error(t, Validate(conf), "enabled with empty URL should fail validation")
+}

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -215,13 +215,17 @@ type PrometheusPartialConfig struct {
 }
 
 func getPrometheusConfig(conf *config.Config, client prometheus.ClientInterface, logger *zerolog.Logger) PrometheusConfig {
+	var disabledReason string
+	if drp, ok := client.(prometheus.DisabledReasonProvider); ok {
+		disabledReason = drp.DisabledReason()
+	}
 	promConfig := PrometheusConfig{
-		DisabledReason:       conf.ExternalServices.Prometheus.DisabledReason,
+		DisabledReason:       disabledReason,
 		Enabled:              conf.ExternalServices.Prometheus.Enabled,
 		GlobalScrapeInterval: defaultPrometheusGlobalScrapeInterval,
 		StorageTsdbRetention: defaultPrometheusGlobalStorageTSDBRetention,
 	}
-	if !conf.ExternalServices.Prometheus.Enabled || conf.ExternalServices.Prometheus.DisabledReason != "" || conf.RunMode == config.RunModeOffline {
+	if !conf.ExternalServices.Prometheus.Enabled || disabledReason != "" || conf.RunMode == config.RunModeOffline {
 		return promConfig
 	}
 	// Check if thanosProxy

--- a/handlers/config_test.go
+++ b/handlers/config_test.go
@@ -35,6 +35,17 @@ func (fpc *fakePromClient) GetRuntimeinfo(ctx context.Context) (prom_v1.Runtimei
 	return prom_v1.RuntimeinfoResult{}, nil
 }
 
+// fakeDisabledPromClient extends fakePromClient with a DisabledReason,
+// simulating a LazyClient that hasn't yet connected to Prometheus.
+type fakeDisabledPromClient struct {
+	fakePromClient
+	reason string
+}
+
+func (f *fakeDisabledPromClient) DisabledReason() string {
+	return f.reason
+}
+
 func TestConfigHandler(t *testing.T) {
 	require := require.New(t)
 
@@ -111,13 +122,19 @@ func TestConfigHandlerPrometheusEnabledButUnreachable(t *testing.T) {
 
 	conf := config.NewConfig()
 	conf.ExternalServices.Prometheus.Enabled = true
-	conf.ExternalServices.Prometheus.DisabledReason = "Prometheus unreachable at [http://prometheus:9090/-/healthy] (status [0])"
+	expectedReason := "Prometheus unreachable at [http://prometheus:9090/-/healthy] (status [0])"
+
 	k8s := kubetest.NewFakeK8sClient()
 	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := &istiotest.FakeDiscovery{}
 
-	prom := &fakePromClient{PromClientMock: prometheustest.PromClientMock{}}
+	// Use a client that implements DisabledReasonProvider to simulate the LazyClient
+	// reporting a disabled reason to the config handler.
+	prom := &fakeDisabledPromClient{
+		fakePromClient: fakePromClient{PromClientMock: prometheustest.PromClientMock{}},
+		reason:         expectedReason,
+	}
 
 	handler := handlers.WithFakeAuthInfo(conf, handlers.Config(conf, cache, discovery, cf, prom))
 	mr := mux.NewRouter()
@@ -140,7 +157,7 @@ func TestConfigHandlerPrometheusEnabledButUnreachable(t *testing.T) {
 
 	require.True(confResp.Prometheus.Enabled, "Prometheus should still be enabled (user's intent)")
 	require.NotEmpty(confResp.Prometheus.DisabledReason, "DisabledReason should be set when Prometheus is unreachable")
-	require.Equal(conf.ExternalServices.Prometheus.DisabledReason, confResp.Prometheus.DisabledReason)
+	require.Equal(expectedReason, confResp.Prometheus.DisabledReason)
 }
 
 func TestConfigHandlerResolvesIdentityDomainFromMeshTrustDomain(t *testing.T) {

--- a/prometheus/lazy_client.go
+++ b/prometheus/lazy_client.go
@@ -1,0 +1,164 @@
+package prometheus
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+	"github.com/kiali/kiali/util/httputil"
+)
+
+var _ ClientInterface = (*LazyClient)(nil)
+
+const defaultLazyClientRetryInterval = 30 * time.Second
+
+// DisabledReasonProvider is implemented by clients that can report why Prometheus
+// features are currently unavailable. Handlers use this interface via a type
+// assertion rather than adding the method to ClientInterface, keeping the core
+// interface free of lifecycle concerns.
+type DisabledReasonProvider interface {
+	DisabledReason() string
+}
+
+// LazyClient implements ClientInterface with deferred Prometheus connectivity.
+// It starts serving immediately with a NoopClient and spawns a background
+// goroutine that retries NewClient + a health probe until Prometheus is
+// reachable, then atomically swaps in the real client. All business-layer
+// consumers hold a pointer to the same LazyClient, so the swap transparently
+// upgrades every caller with no locking on reads.
+type LazyClient struct {
+	ptr            atomic.Pointer[ClientInterface]
+	disabledReason atomic.Value // stores string; empty means fully operational
+}
+
+func NewLazyClient(ctx context.Context, conf config.Config, kialiSAToken string) *LazyClient {
+	return newLazyClient(ctx, conf, kialiSAToken, defaultLazyClientRetryInterval)
+}
+
+func newLazyClient(ctx context.Context, conf config.Config, kialiSAToken string, retryInterval time.Duration) *LazyClient {
+	lc := &LazyClient{}
+	var noop ClientInterface = NewNoopClient()
+	lc.ptr.Store(&noop)
+	lc.disabledReason.Store("Connecting to Prometheus, metrics features are temporarily unavailable")
+
+	go lc.connect(ctx, conf, kialiSAToken, retryInterval)
+	return lc
+}
+
+// DisabledReason returns the human-readable message explaining why Prometheus
+// features are currently unavailable, or an empty string when fully operational.
+func (lc *LazyClient) DisabledReason() string {
+	if v := lc.disabledReason.Load(); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+func (lc *LazyClient) connect(ctx context.Context, conf config.Config, kialiSAToken string, retryInterval time.Duration) {
+	healthURL := conf.ExternalServices.Prometheus.HealthCheckUrl
+	if healthURL == "" {
+		healthURL = conf.ExternalServices.Prometheus.URL + "/-/healthy"
+	}
+
+	var client *Client
+	retryErr := wait.PollUntilContextCancel(ctx, retryInterval, true, func(ctx context.Context) (bool, error) {
+		c, err := NewClient(conf, kialiSAToken)
+		if err != nil {
+			log.Warningf("Prometheus client init failed: %v. Retrying in %s", err, retryInterval)
+			return false, nil
+		}
+		_, statusCode, _, probeErr := httputil.HttpGet(healthURL, &conf.ExternalServices.Prometheus.Auth, 10*time.Second, nil, nil, &conf)
+		if probeErr != nil || statusCode > 399 {
+			log.Warningf("Prometheus unreachable at [%s] (status %d): %v. Retrying in %s", healthURL, statusCode, probeErr, retryInterval)
+			return false, nil
+		}
+		client = c
+		return true, nil
+	})
+	if retryErr != nil {
+		log.Warningf("Prometheus client initialization cancelled (context done): %s", retryErr)
+		return
+	}
+
+	lc.set(client)
+	lc.disabledReason.Store("")
+	log.Info("Prometheus connected -- metrics features restored")
+}
+
+func (lc *LazyClient) set(c ClientInterface) {
+	lc.ptr.Store(&c)
+}
+
+func (lc *LazyClient) get() ClientInterface {
+	return *lc.ptr.Load()
+}
+
+func (lc *LazyClient) API() prom_v1.API {
+	return lc.get().API()
+}
+
+func (lc *LazyClient) FetchDelta(ctx context.Context, metricName, labels, grouping string, queryTime time.Time, duration time.Duration) Metric {
+	return lc.get().FetchDelta(ctx, metricName, labels, grouping, queryTime, duration)
+}
+
+func (lc *LazyClient) FetchHistogramRange(ctx context.Context, metricName, labels, grouping string, q *RangeQuery) Histogram {
+	return lc.get().FetchHistogramRange(ctx, metricName, labels, grouping, q)
+}
+
+func (lc *LazyClient) FetchHistogramValues(ctx context.Context, metricName, labels, grouping, rateInterval string, avg bool, quantiles []string, queryTime time.Time) (map[string]model.Vector, error) {
+	return lc.get().FetchHistogramValues(ctx, metricName, labels, grouping, rateInterval, avg, quantiles, queryTime)
+}
+
+func (lc *LazyClient) FetchRange(ctx context.Context, metricName, labels, grouping, aggregator string, q *RangeQuery) Metric {
+	return lc.get().FetchRange(ctx, metricName, labels, grouping, aggregator, q)
+}
+
+func (lc *LazyClient) FetchRateRange(ctx context.Context, metricName string, labels []string, grouping string, q *RangeQuery) Metric {
+	return lc.get().FetchRateRange(ctx, metricName, labels, grouping, q)
+}
+
+func (lc *LazyClient) GetAllRequestRates(ctx context.Context, namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return lc.get().GetAllRequestRates(ctx, namespace, cluster, ratesInterval, queryTime)
+}
+
+func (lc *LazyClient) GetAppRequestRates(ctx context.Context, namespace, cluster, app, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
+	return lc.get().GetAppRequestRates(ctx, namespace, cluster, app, ratesInterval, queryTime)
+}
+
+func (lc *LazyClient) GetBuildInfo(ctx context.Context) (*prom_v1.BuildinfoResult, error) {
+	return lc.get().GetBuildInfo(ctx)
+}
+
+func (lc *LazyClient) GetConfiguration(ctx context.Context) (prom_v1.ConfigResult, error) {
+	return lc.get().GetConfiguration(ctx)
+}
+
+func (lc *LazyClient) GetExistingMetricNames(ctx context.Context, metricNames []string) ([]string, error) {
+	return lc.get().GetExistingMetricNames(ctx, metricNames)
+}
+
+func (lc *LazyClient) GetMetricsForLabels(ctx context.Context, metricNames []string, labels string) ([]string, error) {
+	return lc.get().GetMetricsForLabels(ctx, metricNames, labels)
+}
+
+func (lc *LazyClient) GetNamespaceServicesRequestRates(ctx context.Context, namespace, cluster, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return lc.get().GetNamespaceServicesRequestRates(ctx, namespace, cluster, ratesInterval, queryTime)
+}
+
+func (lc *LazyClient) GetRuntimeinfo(ctx context.Context) (prom_v1.RuntimeinfoResult, error) {
+	return lc.get().GetRuntimeinfo(ctx)
+}
+
+func (lc *LazyClient) GetServiceRequestRates(ctx context.Context, namespace, cluster, service, ratesInterval string, queryTime time.Time) (model.Vector, error) {
+	return lc.get().GetServiceRequestRates(ctx, namespace, cluster, service, ratesInterval, queryTime)
+}
+
+func (lc *LazyClient) GetWorkloadRequestRates(ctx context.Context, namespace, cluster, workload, ratesInterval string, queryTime time.Time) (model.Vector, model.Vector, error) {
+	return lc.get().GetWorkloadRequestRates(ctx, namespace, cluster, workload, ratesInterval, queryTime)
+}

--- a/prometheus/lazy_client_test.go
+++ b/prometheus/lazy_client_test.go
@@ -1,0 +1,174 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/config"
+)
+
+const shortRetry = 5 * time.Millisecond
+
+func newTestConf(t *testing.T, serverURL string) config.Config {
+	t.Helper()
+	conf := config.NewConfig()
+	var err error
+	conf.Credentials, err = config.NewCredentialManager(nil)
+	require.NoError(t, err)
+	t.Cleanup(conf.Close)
+	conf.ExternalServices.Prometheus.URL = serverURL
+	return *conf
+}
+
+func TestLazyClientStartsWithNoopClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(ctx, conf, "", shortRetry)
+
+	_, err := lc.GetBuildInfo(t.Context())
+	assert.ErrorIs(t, err, ErrPrometheusDisabled, "should delegate to NoopClient before connect succeeds")
+}
+
+func TestLazyClientUpgradesOnConnect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(t.Context(), conf, "", shortRetry)
+
+	require.Eventually(t, func() bool {
+		_, err := lc.GetBuildInfo(t.Context())
+		return err == nil || err != ErrPrometheusDisabled
+	}, 2*time.Second, 10*time.Millisecond, "LazyClient should upgrade from NoopClient after connect")
+
+	_, err := lc.GetBuildInfo(t.Context())
+	assert.NotErrorIs(t, err, ErrPrometheusDisabled, "should no longer return ErrPrometheusDisabled")
+}
+
+func TestLazyClientRetriesUntilHealthy(t *testing.T) {
+	var probeCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if probeCount.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(t.Context(), conf, "", shortRetry)
+
+	require.Eventually(t, func() bool {
+		_, err := lc.GetBuildInfo(t.Context())
+		return err == nil || err != ErrPrometheusDisabled
+	}, 2*time.Second, 10*time.Millisecond, "LazyClient should eventually connect after retries")
+
+	assert.GreaterOrEqual(t, probeCount.Load(), int32(3), "expected at least 3 probe attempts")
+}
+
+func TestLazyClientContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(ctx, conf, "", shortRetry)
+
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	_, err := lc.GetBuildInfo(t.Context())
+	assert.ErrorIs(t, err, ErrPrometheusDisabled, "should remain as NoopClient when context is cancelled")
+}
+
+func TestLazyClientCustomHealthCheckURL(t *testing.T) {
+	var customHit, defaultHit atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/custom/health" {
+			customHit.Store(true)
+		}
+		if r.URL.Path == "/-/healthy" {
+			defaultHit.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	conf.ExternalServices.Prometheus.HealthCheckUrl = server.URL + "/custom/health"
+
+	lc := newLazyClient(t.Context(), conf, "", shortRetry)
+
+	require.Eventually(t, func() bool {
+		_, err := lc.GetBuildInfo(t.Context())
+		return err == nil || err != ErrPrometheusDisabled
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.True(t, customHit.Load(), "custom health check URL should have been probed")
+	assert.False(t, defaultHit.Load(), "default /-/healthy should not have been probed when HealthCheckUrl is set")
+}
+
+func TestLazyClientConstructionFailure(t *testing.T) {
+	conf := newTestConf(t, "http://\x00invalid")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	lc := newLazyClient(ctx, conf, "", shortRetry)
+
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	_, err := lc.GetBuildInfo(t.Context())
+	assert.ErrorIs(t, err, ErrPrometheusDisabled, "should remain as NoopClient when construction always fails")
+}
+
+func TestLazyClientAPINotNil(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(ctx, conf, "", shortRetry)
+	require.NotNil(t, lc.API())
+}
+
+func TestLazyClientAtomicVisibility(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conf := newTestConf(t, server.URL)
+	lc := newLazyClient(t.Context(), conf, "", shortRetry)
+
+	require.Eventually(t, func() bool {
+		_, err := lc.GetBuildInfo(t.Context())
+		return err == nil || err != ErrPrometheusDisabled
+	}, 2*time.Second, 10*time.Millisecond, "atomic swap must be visible across goroutines")
+}

--- a/tests/integration/controller/testdata/istio-crds/1.30.yaml
+++ b/tests/integration/controller/testdata/istio-crds/1.30.yaml
@@ -15,8 +15,356 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
+  name: trafficextensions.extensions.istio.io
+spec:
+  group: extensions.istio.io
+  names:
+    categories:
+      - istio-io
+      - extensions-istio-io
+    kind: TrafficExtension
+    listKind: TrafficExtensionList
+    plural: trafficextensions
+    singular: trafficextension
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Extend the functionality provided by the Istio proxy through WebAssembly or Lua filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/traffic_extension.html'
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - wasm
+                      - required:
+                          - lua
+                - required:
+                    - wasm
+                - required:
+                    - lua
+              properties:
+                lua:
+                  description: Lua filter configuration.
+                  properties:
+                    inlineCode:
+                      description: The inline Lua code to be executed.
+                      maxLength: 65536
+                      minLength: 1
+                      type: string
+                  required:
+                    - inlineCode
+                  type: object
+                match:
+                  description: Specifies the criteria to determine which traffic is passed to TrafficExtension.
+                  items:
+                    properties:
+                      mode:
+                        description: |-
+                          Criteria for selecting traffic by their direction.
+
+                          Valid Options: CLIENT, SERVER, CLIENT_AND_SERVER
+                        enum:
+                          - UNDEFINED
+                          - CLIENT
+                          - SERVER
+                          - CLIENT_AND_SERVER
+                        type: string
+                      ports:
+                        description: Criteria for selecting traffic by their destination port.
+                        items:
+                          properties:
+                            number:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                            - number
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - number
+                        x-kubernetes-list-type: map
+                    type: object
+                  type: array
+                phase:
+                  description: |-
+                    Determines where in the filter chain this `TrafficExtension` is to be injected.
+
+                    Valid Options: AUTHN, AUTHZ, STATS
+                  enum:
+                    - UNSPECIFIED
+                    - AUTHN
+                    - AUTHZ
+                    - STATS
+                  type: string
+                priority:
+                  description: Determines ordering of `TrafficExtensions` in the same `phase`.
+                  format: int32
+                  nullable: true
+                  type: integer
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+                wasm:
+                  description: WebAssembly filter configuration.
+                  properties:
+                    failStrategy:
+                      description: |-
+                        Specifies the failure behavior for the plugin due to fatal errors.
+
+                        Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
+                      enum:
+                        - FAIL_CLOSE
+                        - FAIL_OPEN
+                        - FAIL_RELOAD
+                      type: string
+                    imagePullPolicy:
+                      description: |-
+                        The pull behaviour to be applied when fetching Wasm module by either OCI image or `http/https`.
+
+                        Valid Options: IfNotPresent, Always
+                      enum:
+                        - UNSPECIFIED_POLICY
+                        - IfNotPresent
+                        - Always
+                      type: string
+                    imagePullSecret:
+                      description: Credentials to use for OCI image pulling.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    pluginConfig:
+                      description: The configuration that will be passed on to the plugin.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    pluginName:
+                      description: The plugin name to be used in the Envoy configuration (used to be called `rootID`).
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    sha256:
+                      description: SHA256 checksum that will be used to verify Wasm module or OCI container.
+                      pattern: (^$|^[a-f0-9]{64}$)
+                      type: string
+                    type:
+                      description: |-
+                        Specifies the type of Wasm Extension to be used.
+
+                        Valid Options: HTTP, NETWORK
+                      enum:
+                        - UNSPECIFIED_PLUGIN_TYPE
+                        - HTTP
+                        - NETWORK
+                      type: string
+                    url:
+                      description: URL of a Wasm module or OCI container.
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                        - message: url must have schema one of [http, https, file, oci]
+                          rule: |-
+                            isURL(self) ? (url(self).getScheme() in ["", "http", "https", "file", "oci"]) : (isURL("http://" + self) &&
+                            url("http://" + self).getScheme() in ["", "http", "https", "file", "oci"])
+                    verificationKey:
+                      type: string
+                    vmConfig:
+                      description: Configuration for a Wasm VM.
+                      properties:
+                        env:
+                          description: Specifies environment variables to be injected to this VM.
+                          items:
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value for the environment variable.
+                                maxLength: 2048
+                                type: string
+                              valueFrom:
+                                description: |-
+                                  Source for the environment variable's value.
+
+                                  Valid Options: INLINE, HOST
+                                enum:
+                                  - INLINE
+                                  - HOST
+                                type: string
+                            required:
+                              - name
+                            type: object
+                            x-kubernetes-validations:
+                              - message: value may only be set when valueFrom is INLINE
+                                rule: '(has(self.valueFrom) ? self.valueFrom : "") != "HOST" || !has(self.value)'
+                          maxItems: 256
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                  required:
+                    - url
+                  type: object
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+                - message: exactly one of wasm or lua must be set
+                  rule: has(self.wasm) != has(self.lua)
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: base/templates/crds.yaml
+# If we are templating these CRDs, we want to wipe out the "static"/legacy
+# labels and replace them with the standard templated istio ones.
+# This allows the continued use of `kubectl apply -f crd-all.gen.yaml`
+# without any templating+the old labels, if desired.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: wasmplugins.extensions.istio.io
 spec:
   group: extensions.istio.io
@@ -46,10 +394,11 @@ spec:
                   description: |-
                     Specifies the failure behavior for the plugin due to fatal errors.
 
-                    Valid Options: FAIL_CLOSE, FAIL_OPEN
+                    Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
                   enum:
                     - FAIL_CLOSE
                     - FAIL_OPEN
+                    - FAIL_RELOAD
                   type: string
                 imagePullPolicy:
                   description: |-
@@ -362,8 +711,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: destinationrules.networking.istio.io
 spec:
   group: networking.istio.io
@@ -384,7 +733,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -558,6 +907,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -643,6 +1006,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -658,7 +1022,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -873,6 +1237,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -958,6 +1336,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -973,7 +1352,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -1109,6 +1488,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -1318,6 +1713,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -1403,6 +1812,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -1418,7 +1828,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -1633,6 +2043,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -1718,6 +2142,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -1733,7 +2158,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -1869,6 +2294,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -2025,7 +2466,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -2033,7 +2474,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -2207,6 +2648,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -2292,6 +2747,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -2307,7 +2763,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -2522,6 +2978,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -2607,6 +3077,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -2622,7 +3093,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -2758,6 +3229,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -2967,6 +3454,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -3052,6 +3553,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -3067,7 +3569,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -3282,6 +3784,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3367,6 +3883,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -3382,7 +3899,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -3518,6 +4035,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -3682,7 +4215,7 @@ spec:
           jsonPath: .spec.host
           name: Host
           type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -3856,6 +4389,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3941,6 +4488,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -3956,7 +4504,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -4171,6 +4719,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -4256,6 +4818,7 @@ spec:
                                     simple:
                                       description: |2-
 
+
                                         Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                       enum:
                                         - UNSPECIFIED
@@ -4271,7 +4834,7 @@ spec:
                                         aggression:
                                           description: This parameter controls the speed of traffic increase over the warmup duration.
                                           format: double
-                                          minimum: 1
+                                          minimum: 0
                                           nullable: true
                                           type: number
                                         duration:
@@ -4407,6 +4970,22 @@ spec:
                                   - V1
                                   - V2
                                 type: string
+                            type: object
+                          retryBudget:
+                            description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                            properties:
+                              minRetryConcurrency:
+                                description: Specifies the minimum retry concurrency allowed for the retry budget.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              percent:
+                                description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                                format: double
+                                maximum: 100
+                                minimum: 0
+                                nullable: true
+                                type: number
                             type: object
                           tls:
                             description: TLS related settings for connections to the upstream service.
@@ -4616,6 +5195,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -4701,6 +5294,7 @@ spec:
                         simple:
                           description: |2-
 
+
                             Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                           enum:
                             - UNSPECIFIED
@@ -4716,7 +5310,7 @@ spec:
                             aggression:
                               description: This parameter controls the speed of traffic increase over the warmup duration.
                               format: double
-                              minimum: 1
+                              minimum: 0
                               nullable: true
                               type: number
                             duration:
@@ -4931,6 +5525,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -5016,6 +5624,7 @@ spec:
                               simple:
                                 description: |2-
 
+
                                   Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                 enum:
                                   - UNSPECIFIED
@@ -5031,7 +5640,7 @@ spec:
                                   aggression:
                                     description: This parameter controls the speed of traffic increase over the warmup duration.
                                     format: double
-                                    minimum: 1
+                                    minimum: 0
                                     nullable: true
                                     type: number
                                   duration:
@@ -5167,6 +5776,22 @@ spec:
                             - V1
                             - V2
                           type: string
+                      type: object
+                    retryBudget:
+                      description: Specifies a limit on concurrent retries in relation to the number of active requests.
+                      properties:
+                        minRetryConcurrency:
+                          description: Specifies the minimum retry concurrency allowed for the retry budget.
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        percent:
+                          description: Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests.
+                          format: double
+                          maximum: 100
+                          minimum: 0
+                          nullable: true
+                          type: number
                       type: object
                     tls:
                       description: TLS related settings for connections to the upstream service.
@@ -5323,7 +5948,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -5341,8 +5966,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -5397,12 +6022,16 @@ spec:
                                     - routeConfiguration
                                 - required:
                                     - cluster
+                                - required:
+                                    - waypoint
                           - required:
                               - listener
                           - required:
                               - routeConfiguration
                           - required:
                               - cluster
+                          - required:
+                              - waypoint
                         properties:
                           cluster:
                             description: Match on envoy cluster attributes.
@@ -5426,12 +6055,13 @@ spec:
                             description: |-
                               The specific config generation context to match on.
 
-                              Valid Options: ANY, SIDECAR_INBOUND, SIDECAR_OUTBOUND, GATEWAY
+                              Valid Options: ANY, SIDECAR_INBOUND, SIDECAR_OUTBOUND, GATEWAY, WAYPOINT
                             enum:
                               - ANY
                               - SIDECAR_INBOUND
                               - SIDECAR_OUTBOUND
                               - GATEWAY
+                              - WAYPOINT
                             type: string
                           listener:
                             description: Match on envoy listener attributes.
@@ -5543,7 +6173,42 @@ spec:
                                     type: object
                                 type: object
                             type: object
+                          waypoint:
+                            properties:
+                              filter:
+                                description: The name of a specific filter to apply the patch to.
+                                properties:
+                                  name:
+                                    description: The filter name to match on.
+                                    type: string
+                                  subFilter:
+                                    description: The next level filter within this filter to match on.
+                                    properties:
+                                      name:
+                                        description: The filter name to match on.
+                                        type: string
+                                    type: object
+                                type: object
+                              portNumber:
+                                description: The service port to match on.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                                x-kubernetes-validations:
+                                  - message: port must be between 1-65535
+                                    rule: 0 < self && self <= 65535
+                              route:
+                                description: Match a specific route.
+                                properties:
+                                  name:
+                                    description: The Route objects generated by default are named as default.
+                                    type: string
+                                type: object
+                            type: object
                         type: object
+                        x-kubernetes-validations:
+                          - message: only support waypointMatch when context is WAYPOINT
+                            rule: 'has(self.context) ? ((self.context == "WAYPOINT") ? has(self.waypoint) : !has(self.waypoint)) : !has(self.waypoint)'
                       patch:
                         description: The patch to apply along with the operation.
                         properties:
@@ -5724,8 +6389,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -5796,6 +6461,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -5869,11 +6537,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5981,7 +6648,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v1alpha3
@@ -6039,6 +6706,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -6112,11 +6782,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6282,6 +6951,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -6355,11 +7027,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6467,7 +7138,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -6485,8 +7156,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: proxyconfigs.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6636,8 +7307,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: serviceentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6810,12 +7481,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -6922,7 +7594,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -7082,12 +7754,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -7354,12 +8027,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -7466,7 +8140,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -7484,8 +8158,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7775,6 +8449,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -7848,11 +8525,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -7910,6 +8586,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -8004,7 +8681,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v1alpha3
@@ -8283,6 +8960,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -8356,11 +9036,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -8418,6 +9097,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -8791,6 +9471,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -8864,11 +9547,10 @@ spec:
                               type: string
                             type: array
                           tlsCertificates:
-                            description: Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
+                            description: Only one of `server_certificate`, `private_key` or `credential_name` or `credential_names` or `tls_certificates` should be specified.
                             items:
                               properties:
                                 caCertificates:
-                                  description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                   type: string
                                 privateKey:
                                   description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -8926,6 +9608,7 @@ spec:
                       type: object
                     mode:
                       description: |2-
+
 
                         Valid Options: REGISTRY_ONLY, ALLOW_ANY
                       enum:
@@ -9020,7 +9703,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -9038,8 +9721,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: virtualservices.networking.istio.io
 spec:
   group: networking.istio.io
@@ -9194,7 +9877,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -9997,7 +10680,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -10139,7 +10822,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -11084,7 +11767,7 @@ spec:
                             properties:
                               bytes:
                                 description: response body as base64 encoded bytes.
-                                format: binary
+                                format: byte
                                 type: string
                               string:
                                 type: string
@@ -11887,7 +12570,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -11905,8 +12588,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: workloadentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -12064,7 +12747,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -12354,7 +13037,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -12366,12 +13049,14 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: workloadgroups.networking.istio.io
 spec:
   group: networking.istio.io
@@ -12668,7 +13353,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -13236,7 +13921,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -13254,8 +13939,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -13365,6 +14050,11 @@ spec:
                                     type: string
                                   maxItems: 16
                                   type: array
+                                notTrustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
                                 principals:
                                   description: Optional.
                                   items:
@@ -13386,6 +14076,378 @@ spec:
                                     maxLength: 320
                                     type: string
                                   maxItems: 16
+                                  type: array
+                                trustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                              x-kubernetes-validations:
+                                - message: Cannot set serviceAccounts with namespaces or principals
+                                  rule: |-
+                                    (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
+                                    !has(self.notPrincipals) && !has(self.namespaces) && !has(self.notNamespaces)) : true
+                          type: object
+                        maxItems: 512
+                        type: array
+                      to:
+                        description: Optional.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation specifies the operation of a request.
+                              properties:
+                                hosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                methods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notHosts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notMethods:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPaths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPorts:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                paths:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                ports:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      when:
+                        description: Optional.
+                        items:
+                          properties:
+                            key:
+                              description: The name of an Istio attribute.
+                              type: string
+                            notValues:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Optional.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                          type: object
+                        type: array
+                    type: object
+                  maxItems: 512
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRef:
+                  properties:
+                    group:
+                      description: group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the referent.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: cross namespace referencing is not currently supported
+                          rule: self.size() == 0
+                  required:
+                    - kind
+                    - name
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The operation to take.
+          jsonPath: .spec.action
+          name: Action
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+              oneOf:
+                - not:
+                    anyOf:
+                      - required:
+                          - provider
+                - required:
+                    - provider
+              properties:
+                action:
+                  description: |-
+                    Optional.
+
+                    Valid Options: ALLOW, DENY, AUDIT, CUSTOM
+                  enum:
+                    - ALLOW
+                    - DENY
+                    - AUDIT
+                    - CUSTOM
+                  type: string
+                provider:
+                  description: Specifies detailed configuration of the CUSTOM action.
+                  properties:
+                    name:
+                      description: Specifies the name of the extension provider.
+                      type: string
+                  type: object
+                rules:
+                  description: Optional.
+                  items:
+                    properties:
+                      from:
+                        description: Optional.
+                        items:
+                          properties:
+                            source:
+                              description: Source specifies the source of a request.
+                              properties:
+                                ipBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notNamespaces:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRemoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notRequestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                notServiceAccounts:
+                                  description: Optional.
+                                  items:
+                                    maxLength: 320
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                notTrustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                principals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                remoteIpBlocks:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                requestPrincipals:
+                                  description: Optional.
+                                  items:
+                                    type: string
+                                  type: array
+                                serviceAccounts:
+                                  description: Optional.
+                                  items:
+                                    maxLength: 320
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                trustDomains:
+                                  description: Optional.
+                                  items:
+                                    type: string
                                   type: array
                               type: object
                               x-kubernetes-validations:
@@ -13628,363 +14690,6 @@ spec:
       storage: false
       subresources:
         status: {}
-    - additionalPrinterColumns:
-        - description: The operation to take.
-          jsonPath: .spec.action
-          name: Action
-          type: string
-        - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-              oneOf:
-                - not:
-                    anyOf:
-                      - required:
-                          - provider
-                - required:
-                    - provider
-              properties:
-                action:
-                  description: |-
-                    Optional.
-
-                    Valid Options: ALLOW, DENY, AUDIT, CUSTOM
-                  enum:
-                    - ALLOW
-                    - DENY
-                    - AUDIT
-                    - CUSTOM
-                  type: string
-                provider:
-                  description: Specifies detailed configuration of the CUSTOM action.
-                  properties:
-                    name:
-                      description: Specifies the name of the extension provider.
-                      type: string
-                  type: object
-                rules:
-                  description: Optional.
-                  items:
-                    properties:
-                      from:
-                        description: Optional.
-                        items:
-                          properties:
-                            source:
-                              description: Source specifies the source of a request.
-                              properties:
-                                ipBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                namespaces:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notNamespaces:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notRemoteIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notRequestPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notServiceAccounts:
-                                  description: Optional.
-                                  items:
-                                    maxLength: 320
-                                    type: string
-                                  maxItems: 16
-                                  type: array
-                                principals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                remoteIpBlocks:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                requestPrincipals:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                serviceAccounts:
-                                  description: Optional.
-                                  items:
-                                    maxLength: 320
-                                    type: string
-                                  maxItems: 16
-                                  type: array
-                              type: object
-                              x-kubernetes-validations:
-                                - message: Cannot set serviceAccounts with namespaces or principals
-                                  rule: |-
-                                    (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
-                                    !has(self.notPrincipals) && !has(self.namespaces) && !has(self.notNamespaces)) : true
-                          type: object
-                        maxItems: 512
-                        type: array
-                      to:
-                        description: Optional.
-                        items:
-                          properties:
-                            operation:
-                              description: Operation specifies the operation of a request.
-                              properties:
-                                hosts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                methods:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notHosts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notMethods:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPaths:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                notPorts:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                paths:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                                ports:
-                                  description: Optional.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      when:
-                        description: Optional.
-                        items:
-                          properties:
-                            key:
-                              description: The name of an Istio attribute.
-                              type: string
-                            notValues:
-                              description: Optional.
-                              items:
-                                type: string
-                              type: array
-                            values:
-                              description: Optional.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                          type: object
-                        type: array
-                    type: object
-                  maxItems: 512
-                  type: array
-                selector:
-                  description: Optional.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        maxLength: 63
-                        type: string
-                        x-kubernetes-validations:
-                          - message: wildcard not allowed in label value match
-                            rule: '!self.contains("*")'
-                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
-                      maxProperties: 4096
-                      type: object
-                      x-kubernetes-validations:
-                        - message: wildcard not allowed in label key match
-                          rule: self.all(key, !key.contains("*"))
-                        - message: key must not be empty
-                          rule: self.all(key, key.size() != 0)
-                  type: object
-                targetRef:
-                  properties:
-                    group:
-                      description: group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the referent.
-                      type: string
-                      x-kubernetes-validations:
-                        - message: cross namespace referencing is not currently supported
-                          rule: self.size() == 0
-                  required:
-                    - kind
-                    - name
-                  type: object
-                targetRefs:
-                  description: Optional.
-                  items:
-                    properties:
-                      group:
-                        description: group is the group of the target resource.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        description: kind is kind of the target resource.
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: name is the name of the target resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the referent.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: cross namespace referencing is not currently supported
-                            rule: self.size() == 0
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-              type: object
-              x-kubernetes-validations:
-                - message: only one of targetRefs or selector can be set
-                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
-            status:
-              properties:
-                conditions:
-                  description: Current service state of the resource.
-                  items:
-                    properties:
-                      lastProbeTime:
-                        description: Last time we probed the condition.
-                        format: date-time
-                        type: string
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about last transition.
-                        type: string
-                      observedGeneration:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: Resource Generation to which the Condition refers.
-                        x-kubernetes-int-or-string: true
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status is the status of the condition.
-                        type: string
-                      type:
-                        description: Type is the type of the condition.
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  x-kubernetes-int-or-string: true
-                validationMessages:
-                  description: Includes any errors or warnings detected by Istio's analyzers.
-                  items:
-                    properties:
-                      documentationUrl:
-                        description: A url pointing to the Istio documentation for this specific error type.
-                        type: string
-                      level:
-                        description: |-
-                          Represents how severe a message is.
-
-                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                        enum:
-                          - UNKNOWN
-                          - ERROR
-                          - WARNING
-                          - INFO
-                        type: string
-                      type:
-                        properties:
-                          code:
-                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
-                            type: string
-                          name:
-                            description: A human-readable name for the message type.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
 ---
 # Source: base/templates/crds.yaml
 # If we are templating these CRDs, we want to wipe out the "static"/legacy
@@ -14000,8 +14705,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: peerauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -14164,7 +14869,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -14314,7 +15019,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 ---
@@ -14332,8 +15037,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -14440,14 +15145,287 @@ spec:
                       outputPayloadToHeader:
                         description: This field specifies the header name to output a successfully verified JWT payload to the backend.
                         type: string
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
+                        items:
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        type: array
                       timeout:
                         description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
                         type: string
                         x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
+                    type: object
+                    x-kubernetes-validations:
+                      - message: only one of jwks or jwksUri can be set
+                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
+                  maxItems: 4096
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRef:
+                  properties:
+                    group:
+                      description: group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the referent.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: cross namespace referencing is not currently supported
+                          rule: self.size() == 0
+                  required:
+                    - kind
+                    - name
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
                     required:
-                      - issuer
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
+              properties:
+                jwtRules:
+                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
+                  items:
+                    properties:
+                      audiences:
+                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      forwardOriginalToken:
+                        description: If set to true, the original token will be kept for the upstream request.
+                        type: boolean
+                      fromCookies:
+                        description: List of cookie names from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      fromHeaders:
+                        description: List of header locations from which JWT is expected.
+                        items:
+                          properties:
+                            name:
+                              description: The HTTP header name.
+                              minLength: 1
+                              type: string
+                            prefix:
+                              description: The prefix that should be stripped before decoding the token.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      fromParams:
+                        description: List of query parameters from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      issuer:
+                        description: Identifies the issuer that issued the JWT.
+                        minLength: 1
+                        type: string
+                      jwks:
+                        description: JSON Web Key Set of public keys to validate signature of the JWT.
+                        type: string
+                      jwks_uri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      jwksUri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      outputClaimToHeaders:
+                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
+                        items:
+                          properties:
+                            claim:
+                              description: The name of the claim to be copied from.
+                              minLength: 1
+                              type: string
+                            header:
+                              description: The name of the header to be created.
+                              minLength: 1
+                              pattern: ^[-_A-Za-z0-9]+$
+                              type: string
+                          required:
+                            - header
+                            - claim
+                          type: object
+                        type: array
+                      outputPayloadToHeader:
+                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
+                        type: string
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
+                        items:
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        type: array
+                      timeout:
+                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                     type: object
                     x-kubernetes-validations:
                       - message: only one of jwks or jwksUri can be set
@@ -14612,269 +15590,6 @@ spec:
       storage: false
       subresources:
         status: {}
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
-              properties:
-                jwtRules:
-                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
-                  items:
-                    properties:
-                      audiences:
-                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      forwardOriginalToken:
-                        description: If set to true, the original token will be kept for the upstream request.
-                        type: boolean
-                      fromCookies:
-                        description: List of cookie names from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      fromHeaders:
-                        description: List of header locations from which JWT is expected.
-                        items:
-                          properties:
-                            name:
-                              description: The HTTP header name.
-                              minLength: 1
-                              type: string
-                            prefix:
-                              description: The prefix that should be stripped before decoding the token.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      fromParams:
-                        description: List of query parameters from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        minLength: 1
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature of the JWT.
-                        type: string
-                      jwks_uri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      jwksUri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      outputClaimToHeaders:
-                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
-                        items:
-                          properties:
-                            claim:
-                              description: The name of the claim to be copied from.
-                              minLength: 1
-                              type: string
-                            header:
-                              description: The name of the header to be created.
-                              minLength: 1
-                              pattern: ^[-_A-Za-z0-9]+$
-                              type: string
-                          required:
-                            - header
-                            - claim
-                          type: object
-                        type: array
-                      outputPayloadToHeader:
-                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
-                        type: string
-                      timeout:
-                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: must be a valid duration greater than 1ms
-                            rule: duration(self) >= duration('1ms')
-                    required:
-                      - issuer
-                    type: object
-                    x-kubernetes-validations:
-                      - message: only one of jwks or jwksUri can be set
-                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
-                  maxItems: 4096
-                  type: array
-                selector:
-                  description: Optional.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        maxLength: 63
-                        type: string
-                        x-kubernetes-validations:
-                          - message: wildcard not allowed in label value match
-                            rule: '!self.contains("*")'
-                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
-                      maxProperties: 4096
-                      type: object
-                      x-kubernetes-validations:
-                        - message: wildcard not allowed in label key match
-                          rule: self.all(key, !key.contains("*"))
-                        - message: key must not be empty
-                          rule: self.all(key, key.size() != 0)
-                  type: object
-                targetRef:
-                  properties:
-                    group:
-                      description: group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the referent.
-                      type: string
-                      x-kubernetes-validations:
-                        - message: cross namespace referencing is not currently supported
-                          rule: self.size() == 0
-                  required:
-                    - kind
-                    - name
-                  type: object
-                targetRefs:
-                  description: Optional.
-                  items:
-                    properties:
-                      group:
-                        description: group is the group of the target resource.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        description: kind is kind of the target resource.
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: name is the name of the target resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the referent.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: cross namespace referencing is not currently supported
-                            rule: self.size() == 0
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-              type: object
-              x-kubernetes-validations:
-                - message: only one of targetRefs or selector can be set
-                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
-            status:
-              properties:
-                conditions:
-                  description: Current service state of the resource.
-                  items:
-                    properties:
-                      lastProbeTime:
-                        description: Last time we probed the condition.
-                        format: date-time
-                        type: string
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about last transition.
-                        type: string
-                      observedGeneration:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: Resource Generation to which the Condition refers.
-                        x-kubernetes-int-or-string: true
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status is the status of the condition.
-                        type: string
-                      type:
-                        description: Type is the type of the condition.
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  x-kubernetes-int-or-string: true
-                validationMessages:
-                  description: Includes any errors or warnings detected by Istio's analyzers.
-                  items:
-                    properties:
-                      documentationUrl:
-                        description: A url pointing to the Istio documentation for this specific error type.
-                        type: string
-                      level:
-                        description: |-
-                          Represents how severe a message is.
-
-                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                        enum:
-                          - UNKNOWN
-                          - ERROR
-                          - WARNING
-                          - INFO
-                        type: string
-                      type:
-                        properties:
-                          code:
-                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
-                            type: string
-                          name:
-                            description: A human-readable name for the message type.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
 ---
 # Source: base/templates/crds.yaml
 # If we are templating these CRDs, we want to wipe out the "static"/legacy
@@ -14890,8 +15605,8 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26.0
-    helm.sh/chart: base-1.26.0
+    app.kubernetes.io/version: 1.30.0
+    helm.sh/chart: base-1.30.0
   name: telemetries.telemetry.istio.io
 spec:
   group: telemetry.istio.io
@@ -15160,12 +15875,16 @@ spec:
                                       - environment
                                   - required:
                                       - header
+                                  - required:
+                                      - formatter
                             - required:
                                 - literal
                             - required:
                                 - environment
                             - required:
                                 - header
+                            - required:
+                                - formatter
                           properties:
                             environment:
                               description: Environment adds the value of an environment variable to each span.
@@ -15179,6 +15898,16 @@ spec:
                                   type: string
                               required:
                                 - name
+                              type: object
+                            formatter:
+                              description: Formatter adds the value of access logging substitution formatter.
+                              properties:
+                                value:
+                                  description: The formatter tag value to use, same formatter as HTTP access logging (e.g.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - value
                               type: object
                             header:
                               description: RequestHeader adds the value of an header from the request to each span.
@@ -15206,6 +15935,10 @@ spec:
                           type: object
                         description: Optional.
                         type: object
+                      disableContextPropagation:
+                        description: Controls whether trace context headers (e.g., `traceparent`/`tracestate` for W3C, `X-B3-*` for Zipkin) are propagated in forwarded requests.
+                        nullable: true
+                        type: boolean
                       disableSpanReporting:
                         description: Controls span reporting.
                         nullable: true
@@ -15584,12 +16317,16 @@ spec:
                                       - environment
                                   - required:
                                       - header
+                                  - required:
+                                      - formatter
                             - required:
                                 - literal
                             - required:
                                 - environment
                             - required:
                                 - header
+                            - required:
+                                - formatter
                           properties:
                             environment:
                               description: Environment adds the value of an environment variable to each span.
@@ -15603,6 +16340,16 @@ spec:
                                   type: string
                               required:
                                 - name
+                              type: object
+                            formatter:
+                              description: Formatter adds the value of access logging substitution formatter.
+                              properties:
+                                value:
+                                  description: The formatter tag value to use, same formatter as HTTP access logging (e.g.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - value
                               type: object
                             header:
                               description: RequestHeader adds the value of an header from the request to each span.
@@ -15630,6 +16377,10 @@ spec:
                           type: object
                         description: Optional.
                         type: object
+                      disableContextPropagation:
+                        description: Controls whether trace context headers (e.g., `traceparent`/`tracestate` for W3C, `X-B3-*` for Zipkin) are propagated in forwarded requests.
+                        nullable: true
+                        type: boolean
                       disableSpanReporting:
                         description: Controls span reporting.
                         nullable: true

--- a/util/httputil/http_util.go
+++ b/util/httputil/http_util.go
@@ -36,7 +36,11 @@ func HttpGet(url string, auth *config.Auth, timeout time.Duration, customHeaders
 		req.AddCookie(c)
 	}
 
-	transport, err := CreateTransport(conf, auth, &http.Transport{}, timeout, customHeaders)
+	// DisableKeepAlives ensures the connection is closed immediately after the
+	// response is read rather than being pooled. HttpGet is one-shot — a fresh
+	// transport is created per call and never reused, so keep-alive pooling
+	// only leaks sockets until GC runs.
+	transport, err := CreateTransport(conf, auth, &http.Transport{DisableKeepAlives: true}, timeout, customHeaders)
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -59,7 +63,10 @@ func HttpPost(url string, auth *config.Auth, body io.Reader, timeout time.Durati
 		return nil, 0, nil, err
 	}
 
-	transport, err := CreateTransport(conf, auth, &http.Transport{}, timeout, customHeaders)
+	// Same one-shot transport pattern as HttpGet — DisableKeepAlives ensures
+	// the connection is closed immediately after the response rather than being
+	// pooled for a transport that is never reused.
+	transport, err := CreateTransport(conf, auth, &http.Transport{DisableKeepAlives: true}, timeout, customHeaders)
 	if err != nil {
 		return nil, 0, nil, err
 	}


### PR DESCRIPTION
* Retry Prometheus connection at startup instead of degrading to noop

Previously, if Prometheus was unreachable at startup Kiali immediately fell back to a NoopClient and recorded a DisabledReason, causing metrics features to be unavailable for the entire lifetime of the pod unless it was restarted after Prometheus came up.

This change makes Kiali retry the Prometheus connection in a background goroutine (mirroring how tracing connectivity is established), so startup is non-blocking and metrics features become available automatically once Prometheus is reachable without requiring a Kiali restart.

cherry-pick of https://github.com/kiali/kiali/pull/9720