### PR TITLE
[AI] Fix mcp checker run

### DIFF
--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -142,6 +142,34 @@ jobs:
           SUMMARY_OUTPUT="$(mktemp)"
           trap 'rm -f "${SUMMARY_OUTPUT}"' EXIT
           "${MCPCHECKER}" result summary "${RESULTS_JSON}" -o json > "${SUMMARY_OUTPUT}"
+          jq 'if type == "array" then
+                def extract_total_tokens:
+                  try ((.taskOutput // "")
+                    | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n
+                    | tonumber)
+                  catch 0;
+                def assertion_count:
+                  (.assertionResults // {}) | to_entries | length;
+                def passed_assertion_count:
+                  (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length;
+                {
+                  tasksTotal: length,
+                  tasksPassed: (map(select(.taskPassed == true)) | length),
+                  assertionsTotal: (map(assertion_count) | add // 0),
+                  assertionsPassed: (map(passed_assertion_count) | add // 0),
+                  totalTokensEstimate: (map(extract_total_tokens) | add // 0),
+                  totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0),
+                  tasks: map({
+                    name: (.taskName // .taskPath // "unknown"),
+                    taskPassed: (.taskPassed // false),
+                    tokensEstimated: extract_total_tokens,
+                    mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0)
+                  })
+                }
+                | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end
+                | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end
+              else . end' "${SUMMARY_OUTPUT}" > "${SUMMARY_OUTPUT}.normalized"
+          mv "${SUMMARY_OUTPUT}.normalized" "${SUMMARY_OUTPUT}"
           TASKS_TOTAL="$(jq -r '.tasksTotal' "${SUMMARY_OUTPUT}")"
           TASKS_PASSED="$(jq -r '.tasksPassed' "${SUMMARY_OUTPUT}")"
           ASSERTIONS_TOTAL="$(jq -r '.assertionsTotal' "${SUMMARY_OUTPUT}")"
@@ -289,7 +317,9 @@ jobs:
 
         make mcp-update-token-readme
         echo "Updated baseline summary:"
-        "${MCPCHECKER}" result summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json | head -c 2000
+        "${MCPCHECKER}" result summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json \
+          | jq 'if type == "array" then def extract_total_tokens: try ((.taskOutput // "") | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n | tonumber) catch 0; def assertion_count: (.assertionResults // {}) | to_entries | length; def passed_assertion_count: (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length; { tasksTotal: length, tasksPassed: (map(select(.taskPassed == true)) | length), assertionsTotal: (map(assertion_count) | add // 0), assertionsPassed: (map(passed_assertion_count) | add // 0), totalTokensEstimate: (map(extract_total_tokens) | add // 0), totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0), tasks: map({ name: (.taskName // .taskPath // "unknown"), taskPassed: (.taskPassed // false), tokensEstimated: extract_total_tokens, mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0) }) } | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end else . end' \
+          | head -c 2000
         echo
 
     - name: Create PR with updated baseline

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -133,32 +133,31 @@ jobs:
     - name: Run mcpchecker evaluation
       id: mcpchecker
       run: |
+        MCPCHECKER="$(go env GOPATH)/bin/mcpchecker"
         MCP_EVAL_ARGS="${{ github.event.inputs.verbose == 'true' && '-v' || '' }}"
         make mcp-run-eval MCP_EVAL_ARGS="${MCP_EVAL_ARGS}"
 
         RESULTS_JSON="tests/evals/results/mcpchecker-gemini-eval-out.json"
         if [ -f "${RESULTS_JSON}" ]; then
-          TASKS_TOTAL=$(jq 'length' "${RESULTS_JSON}")
-          TASKS_PASSED=$(jq '[.[] | select(.taskPassed == true)] | length' "${RESULTS_JSON}")
-          ASSERTIONS_TOTAL=$(jq '[.[] | .assertionResults | to_entries | length] | add // 0' "${RESULTS_JSON}")
-          ASSERTIONS_PASSED=$(jq '[.[] | .assertionResults | to_entries[] | select(.value.passed == true)] | length' "${RESULTS_JSON}")
-
-          if [ "$TASKS_TOTAL" -gt 0 ]; then
-            TASK_PASS_RATE=$(awk "BEGIN {printf \"%.2f\", $TASKS_PASSED / $TASKS_TOTAL}")
-          else
-            TASK_PASS_RATE="0"
-          fi
+          SUMMARY_OUTPUT="$(mktemp)"
+          trap 'rm -f "${SUMMARY_OUTPUT}"' EXIT
+          "${MCPCHECKER}" result summary "${RESULTS_JSON}" -o json > "${SUMMARY_OUTPUT}"
+          TASKS_TOTAL="$(jq -r '.tasksTotal' "${SUMMARY_OUTPUT}")"
+          TASKS_PASSED="$(jq -r '.tasksPassed' "${SUMMARY_OUTPUT}")"
+          ASSERTIONS_TOTAL="$(jq -r '.assertionsTotal' "${SUMMARY_OUTPUT}")"
+          ASSERTIONS_PASSED="$(jq -r '.assertionsPassed' "${SUMMARY_OUTPUT}")"
+          TASK_PASS_RATE="$(jq -r '.taskPassRate // 0' "${SUMMARY_OUTPUT}")"
 
           PASSED="false"
           if awk "BEGIN {exit !($TASK_PASS_RATE >= 0.8)}"; then
             PASSED="true"
           fi
 
-          echo "tasks-passed=$TASKS_PASSED" >> $GITHUB_OUTPUT
-          echo "tasks-total=$TASKS_TOTAL" >> $GITHUB_OUTPUT
-          echo "task-pass-rate=$TASK_PASS_RATE" >> $GITHUB_OUTPUT
-          echo "assertions-passed=$ASSERTIONS_PASSED" >> $GITHUB_OUTPUT
-          echo "assertions-total=$ASSERTIONS_TOTAL" >> $GITHUB_OUTPUT
+          echo "tasks-passed=${TASKS_PASSED}" >> "$GITHUB_OUTPUT"
+          echo "tasks-total=${TASKS_TOTAL}" >> "$GITHUB_OUTPUT"
+          echo "task-pass-rate=${TASK_PASS_RATE}" >> "$GITHUB_OUTPUT"
+          echo "assertions-passed=${ASSERTIONS_PASSED}" >> "$GITHUB_OUTPUT"
+          echo "assertions-total=${ASSERTIONS_TOTAL}" >> "$GITHUB_OUTPUT"
           echo "passed=$PASSED" >> $GITHUB_OUTPUT
         fi
       env:

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -142,34 +142,6 @@ jobs:
           SUMMARY_OUTPUT="$(mktemp)"
           trap 'rm -f "${SUMMARY_OUTPUT}"' EXIT
           "${MCPCHECKER}" result summary "${RESULTS_JSON}" -o json > "${SUMMARY_OUTPUT}"
-          jq 'if type == "array" then
-                def extract_total_tokens:
-                  try ((.taskOutput // "")
-                    | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n
-                    | tonumber)
-                  catch 0;
-                def assertion_count:
-                  (.assertionResults // {}) | to_entries | length;
-                def passed_assertion_count:
-                  (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length;
-                {
-                  tasksTotal: length,
-                  tasksPassed: (map(select(.taskPassed == true)) | length),
-                  assertionsTotal: (map(assertion_count) | add // 0),
-                  assertionsPassed: (map(passed_assertion_count) | add // 0),
-                  totalTokensEstimate: (map(extract_total_tokens) | add // 0),
-                  totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0),
-                  tasks: map({
-                    name: (.taskName // .taskPath // "unknown"),
-                    taskPassed: (.taskPassed // false),
-                    tokensEstimated: extract_total_tokens,
-                    mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0)
-                  })
-                }
-                | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end
-                | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end
-              else . end' "${SUMMARY_OUTPUT}" > "${SUMMARY_OUTPUT}.normalized"
-          mv "${SUMMARY_OUTPUT}.normalized" "${SUMMARY_OUTPUT}"
           TASKS_TOTAL="$(jq -r '.tasksTotal' "${SUMMARY_OUTPUT}")"
           TASKS_PASSED="$(jq -r '.tasksPassed' "${SUMMARY_OUTPUT}")"
           ASSERTIONS_TOTAL="$(jq -r '.assertionsTotal' "${SUMMARY_OUTPUT}")"
@@ -318,7 +290,6 @@ jobs:
         make mcp-update-token-readme
         echo "Updated baseline summary:"
         "${MCPCHECKER}" result summary tests/evals/results/mcpchecker-gemini-eval-out.json -o json \
-          | jq 'if type == "array" then def extract_total_tokens: try ((.taskOutput // "") | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n | tonumber) catch 0; def assertion_count: (.assertionResults // {}) | to_entries | length; def passed_assertion_count: (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length; { tasksTotal: length, tasksPassed: (map(select(.taskPassed == true)) | length), assertionsTotal: (map(assertion_count) | add // 0), assertionsPassed: (map(passed_assertion_count) | add // 0), totalTokensEstimate: (map(extract_total_tokens) | add // 0), totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0), tasks: map({ name: (.taskName // .taskPath // "unknown"), taskPassed: (.taskPassed // false), tokensEstimated: extract_total_tokens, mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0) }) } | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end else . end' \
           | head -c 2000
         echo
 

--- a/hack/mcp/update-token-readme.sh
+++ b/hack/mcp/update-token-readme.sh
@@ -34,6 +34,34 @@ TOKEN_FILE="$(mktemp)"
 trap 'rm -f "${TOKEN_FILE}"' EXIT
 
 "${MCPCHECKER}" result summary "${EVAL_OUT}" -o json > "${TOKEN_FILE}"
+jq 'if type == "array" then
+      def extract_total_tokens:
+        try ((.taskOutput // "")
+          | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n
+          | tonumber)
+        catch 0;
+      def assertion_count:
+        (.assertionResults // {}) | to_entries | length;
+      def passed_assertion_count:
+        (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length;
+      {
+        tasksTotal: length,
+        tasksPassed: (map(select(.taskPassed == true)) | length),
+        assertionsTotal: (map(assertion_count) | add // 0),
+        assertionsPassed: (map(passed_assertion_count) | add // 0),
+        totalTokensEstimate: (map(extract_total_tokens) | add // 0),
+        totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0),
+        tasks: map({
+          name: (.taskName // .taskPath // "unknown"),
+          taskPassed: (.taskPassed // false),
+          tokensEstimated: extract_total_tokens,
+          mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0)
+        })
+      }
+      | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end
+      | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end
+    else . end' "${TOKEN_FILE}" > "${TOKEN_FILE}.normalized"
+mv "${TOKEN_FILE}.normalized" "${TOKEN_FILE}"
 
 TASKS_TOTAL=$(jq -r '.tasksTotal' "${TOKEN_FILE}")
 TASKS_PASSED=$(jq -r '.tasksPassed' "${TOKEN_FILE}")

--- a/hack/mcp/update-token-readme.sh
+++ b/hack/mcp/update-token-readme.sh
@@ -60,6 +60,11 @@ MARKDOWN+="| Task | Tokens Estimate | MCP Schema Tokens | Passed |\n"
 MARKDOWN+="|------|----------------:|------------------:|--------|\n"
 
 TASK_COUNT=$(jq '.tasks | length' "${TOKEN_FILE}")
+if (( TASK_COUNT <= 0 )); then
+  echo "Error: mcpchecker result summary returned no tasks" >&2
+  exit 1
+fi
+
 for i in $(seq 0 $((TASK_COUNT - 1))); do
   NAME=$(jq -r ".tasks[${i}].name" "${TOKEN_FILE}")
   TOKENS=$(jq -r ".tasks[${i}].tokensEstimated" "${TOKEN_FILE}")

--- a/hack/mcp/update-token-readme.sh
+++ b/hack/mcp/update-token-readme.sh
@@ -34,34 +34,6 @@ TOKEN_FILE="$(mktemp)"
 trap 'rm -f "${TOKEN_FILE}"' EXIT
 
 "${MCPCHECKER}" result summary "${EVAL_OUT}" -o json > "${TOKEN_FILE}"
-jq 'if type == "array" then
-      def extract_total_tokens:
-        try ((.taskOutput // "")
-          | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n
-          | tonumber)
-        catch 0;
-      def assertion_count:
-        (.assertionResults // {}) | to_entries | length;
-      def passed_assertion_count:
-        (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length;
-      {
-        tasksTotal: length,
-        tasksPassed: (map(select(.taskPassed == true)) | length),
-        assertionsTotal: (map(assertion_count) | add // 0),
-        assertionsPassed: (map(passed_assertion_count) | add // 0),
-        totalTokensEstimate: (map(extract_total_tokens) | add // 0),
-        totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0),
-        tasks: map({
-          name: (.taskName // .taskPath // "unknown"),
-          taskPassed: (.taskPassed // false),
-          tokensEstimated: extract_total_tokens,
-          mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0)
-        })
-      }
-      | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end
-      | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end
-    else . end' "${TOKEN_FILE}" > "${TOKEN_FILE}.normalized"
-mv "${TOKEN_FILE}.normalized" "${TOKEN_FILE}"
 
 TASKS_TOTAL=$(jq -r '.tasksTotal' "${TOKEN_FILE}")
 TASKS_PASSED=$(jq -r '.tasksPassed' "${TOKEN_FILE}")

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -122,11 +122,11 @@ mcp-eval-summary:
 
 ## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker result summary <eval.json> -o json)
 mcp-eval-summary-json:
-	@if [ ! -f ${MCP_EVAL_RESULTS} ]; then \
-		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
+	@if [ ! -f ${ROOTDIR}/${MCP_EVAL_RESULTS} ]; then \
+		echo "No results file found at ${ROOTDIR}/${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${MCPCHECKER_BIN} result summary ${MCP_EVAL_RESULTS} --output json
+	@${MCPCHECKER_BIN} result summary ${ROOTDIR}/${MCP_EVAL_RESULTS} --output json | jq 'if type == "array" then def extract_total_tokens: try ((.taskOutput // "") | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n | tonumber) catch 0; def assertion_count: (.assertionResults // {}) | to_entries | length; def passed_assertion_count: (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length; { tasksTotal: length, tasksPassed: (map(select(.taskPassed == true)) | length), assertionsTotal: (map(assertion_count) | add // 0), assertionsPassed: (map(passed_assertion_count) | add // 0), totalTokensEstimate: (map(extract_total_tokens) | add // 0), totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0), tasks: map({ name: (.taskName // .taskPath // "unknown"), taskPassed: (.taskPassed // false), tokensEstimated: extract_total_tokens, mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0) }) } | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end else . end'
 
 ## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
 mcp-eval-diff:

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -8,32 +8,35 @@ MCP_EVAL_CONFIG ?= tests/evals/gemini/eval.yaml
 MCP_EVAL_RESULTS ?= tests/evals/results/mcpchecker-gemini-eval-out.json
 KIALI_URL ?= $(shell kubectl get svc kiali -n istio-system -o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali' 2>/dev/null)
 KUBERNETES_MCP_SERVER_REPO ?=
+GO_BIN ?= $(shell go env GOPATH)/bin
+MCPCHECKER_BIN ?= ${GO_BIN}/mcpchecker
+KUBERNETES_MCP_SERVER_BIN ?= ${GO_BIN}/kubernetes-mcp-server
 
 ## mcp-install-mcpchecker: Download and install the latest mcpchecker binary
 mcp-install-mcpchecker:
 	@echo "Installing mcpchecker..."
-	@mkdir -p "${GOPATH}/bin"
+	@mkdir -p "${GO_BIN}"
 	@MCPCHECKER_URL=$$(curl -sL https://api.github.com/repos/mcpchecker/mcpchecker/releases/latest \
 		| jq -r '.assets[] | select(.name == "mcpchecker-linux-amd64.zip") | .browser_download_url'); \
 	echo "Downloading mcpchecker from: $${MCPCHECKER_URL}"; \
 	curl -sL "$${MCPCHECKER_URL}" -o /tmp/mcpchecker.zip; \
 	unzip -o /tmp/mcpchecker.zip -d /tmp/mcpchecker; \
 	chmod +x /tmp/mcpchecker/mcpchecker; \
-	mv /tmp/mcpchecker/mcpchecker "${GOPATH}/bin/"; \
+	mv /tmp/mcpchecker/mcpchecker "${MCPCHECKER_BIN}"; \
 	rm -rf /tmp/mcpchecker.zip /tmp/mcpchecker; \
-	echo "mcpchecker installed to ${GOPATH}/bin/"
+	echo "mcpchecker installed to ${GO_BIN}/"
 
 ## mcp-install-kubernetes-mcp-server: Install kubernetes-mcp-server from release or repo#branch
 mcp-install-kubernetes-mcp-server:
 	@echo "Installing kubernetes-mcp-server..."
-	@mkdir -p "${GOPATH}/bin"
+	@mkdir -p "${GO_BIN}"
 	@if [ -z "${KUBERNETES_MCP_SERVER_REPO}" ]; then \
 		RELEASE_URL=$$(curl -sL https://api.github.com/repos/containers/kubernetes-mcp-server/releases/latest \
 			| jq -r '.assets[] | select(.name | test("linux.*amd64")) | .browser_download_url'); \
 		echo "Downloading kubernetes-mcp-server from: $${RELEASE_URL}"; \
-		curl -sL "$${RELEASE_URL}" -o "${GOPATH}/bin/kubernetes-mcp-server"; \
-		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
-		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/"; \
+		curl -sL "$${RELEASE_URL}" -o "${KUBERNETES_MCP_SERVER_BIN}"; \
+		chmod +x "${KUBERNETES_MCP_SERVER_BIN}"; \
+		echo "kubernetes-mcp-server installed to ${GO_BIN}/"; \
 	else \
 		REPO_AND_BRANCH="${KUBERNETES_MCP_SERVER_REPO}"; \
 		REPO="$${REPO_AND_BRANCH%%#*}"; \
@@ -52,10 +55,10 @@ mcp-install-kubernetes-mcp-server:
 			echo "ERROR: build finished but binary '$${WORKDIR}/kubernetes-mcp-server' was not found"; \
 			exit 1; \
 		fi; \
-		mv -f "$${WORKDIR}/kubernetes-mcp-server" "${GOPATH}/bin/kubernetes-mcp-server"; \
-		chmod +x "${GOPATH}/bin/kubernetes-mcp-server"; \
+		mv -f "$${WORKDIR}/kubernetes-mcp-server" "${KUBERNETES_MCP_SERVER_BIN}"; \
+		chmod +x "${KUBERNETES_MCP_SERVER_BIN}"; \
 		rm -rf "$${WORKDIR}"; \
-		echo "kubernetes-mcp-server installed to ${GOPATH}/bin/ from source"; \
+		echo "kubernetes-mcp-server installed to ${GO_BIN}/ from source"; \
 	fi
 
 ## mcp-install-gemini-cli: Install the Gemini CLI via npm
@@ -77,7 +80,7 @@ mcp-start-server: mcp-resolve-kiali-url
 	@echo "Starting kubernetes-mcp-server on port ${MCP_SERVER_PORT}..."
 	@cat > ${MCP_SERVER_CONFIG} <<< $$'toolsets = ["kiali"]\nlog_level = 0\nport = "${MCP_SERVER_PORT}"\n[toolset_configs.kiali]\nurl = "${KIALI_URL}"\ninsecure = true'
 	@echo "MCP server config:"; cat ${MCP_SERVER_CONFIG}
-	@${GOPATH}/bin/kubernetes-mcp-server --config ${MCP_SERVER_CONFIG} & \
+	@${KUBERNETES_MCP_SERVER_BIN} --config ${MCP_SERVER_CONFIG} & \
 	MCP_PID=$$!; \
 	echo "$$MCP_PID" > /tmp/mcp-server.pid; \
 	echo "Waiting for kubernetes-mcp-server (pid $$MCP_PID) to be ready..."; \
@@ -103,7 +106,7 @@ mcp-stop-server:
 ## mcp-run-eval: Run the mcpchecker evaluation
 mcp-run-eval:
 	@echo "Running mcpchecker evaluation..."
-	${GOPATH}/bin/mcpchecker check ${MCP_EVAL_CONFIG} ${MCP_EVAL_ARGS}
+	${MCPCHECKER_BIN} check ${MCP_EVAL_CONFIG} ${MCP_EVAL_ARGS}
 	@if [ -f mcpchecker-gemini-eval-out.json ]; then \
 		mkdir -p $(dir ${MCP_EVAL_RESULTS}); \
 		mv -f mcpchecker-gemini-eval-out.json ${MCP_EVAL_RESULTS}; \
@@ -115,7 +118,7 @@ mcp-eval-summary:
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker result summary ${MCP_EVAL_RESULTS} --output text
+	@${MCPCHECKER_BIN} result summary ${MCP_EVAL_RESULTS} --output text
 
 ## mcp-eval-summary-json: Print summary JSON to stdout (same as: mcpchecker result summary <eval.json> -o json)
 mcp-eval-summary-json:
@@ -123,12 +126,12 @@ mcp-eval-summary-json:
 		echo "No results file found at ${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${GOPATH}/bin/mcpchecker result summary ${MCP_EVAL_RESULTS} --output json
+	@${MCPCHECKER_BIN} result summary ${MCP_EVAL_RESULTS} --output json
 
 ## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
 mcp-eval-diff:
 	@test -n "$${MCP_DIFF_BASE}" && test -n "$${MCP_DIFF_CURRENT}" || (echo "Usage: make mcp-eval-diff MCP_DIFF_BASE=<path> MCP_DIFF_CURRENT=<path>" >&2; exit 1)
-	@${GOPATH}/bin/mcpchecker result diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
+	@${MCPCHECKER_BIN} result diff --base "$${MCP_DIFF_BASE}" --current "$${MCP_DIFF_CURRENT}" --output markdown
 
 ## mcp-clean-eval-results: Remove local mcpchecker evaluation outputs
 mcp-clean-eval-results:

--- a/make/Makefile.mcp.mk
+++ b/make/Makefile.mcp.mk
@@ -126,7 +126,7 @@ mcp-eval-summary-json:
 		echo "No results file found at ${ROOTDIR}/${MCP_EVAL_RESULTS}. Run 'make mcp-run-eval' first."; \
 		exit 1; \
 	fi
-	@${MCPCHECKER_BIN} result summary ${ROOTDIR}/${MCP_EVAL_RESULTS} --output json | jq 'if type == "array" then def extract_total_tokens: try ((.taskOutput // "") | capture("(?s).*\"total_tokens\":(?<n>[0-9]+).*").n | tonumber) catch 0; def assertion_count: (.assertionResults // {}) | to_entries | length; def passed_assertion_count: (.assertionResults // {}) | to_entries | map(select(.value.passed == true)) | length; { tasksTotal: length, tasksPassed: (map(select(.taskPassed == true)) | length), assertionsTotal: (map(assertion_count) | add // 0), assertionsPassed: (map(passed_assertion_count) | add // 0), totalTokensEstimate: (map(extract_total_tokens) | add // 0), totalMcpSchemaTokens: (map(.tokenEstimate.mcpSchemaTokens // 0) | add // 0), tasks: map({ name: (.taskName // .taskPath // "unknown"), taskPassed: (.taskPassed // false), tokensEstimated: extract_total_tokens, mcpSchemaTokens: (.tokenEstimate.mcpSchemaTokens // 0) }) } | .taskPassRate = if .tasksTotal == 0 then 0 else (.tasksPassed / .tasksTotal) end | .assertionPassRate = if .assertionsTotal == 0 then 0 else (.assertionsPassed / .assertionsTotal) end else . end'
+	@${MCPCHECKER_BIN} result summary ${ROOTDIR}/${MCP_EVAL_RESULTS} --output json
 
 ## mcp-eval-diff: Compare two check outputs in markdown. Usage: make mcp-eval-diff MCP_DIFF_BASE=main.json MCP_DIFF_CURRENT=pr.json
 mcp-eval-diff:

--- a/tests/evals/gemini/agent.yaml
+++ b/tests/evals/gemini/agent.yaml
@@ -55,6 +55,7 @@ commands:
     trap 'cleanup $?' EXIT
 
     export HOME="${TMP_HOME}"
+    export GEMINI_CLI_TRUST_WORKSPACE=true
     cd "${TMP_HOME}"
 
     SERVER_NAME="kubernetes"
@@ -63,7 +64,8 @@ commands:
     {
       "mcpServers": {
         "${SERVER_NAME}": {
-          "httpUrl": "${MCP_URL}"
+          "httpUrl": "${MCP_URL}",
+          "trust": true
         }
       }
     }

--- a/tests/evals/gemini/agent.yaml
+++ b/tests/evals/gemini/agent.yaml
@@ -75,7 +75,7 @@ commands:
 
     GEMINI_ARGS=("--approval-mode" "yolo" "--output-format" "stream-json")
 
-    GEMINI_MODEL="${GEMINI_MODEL:-gemini-3.1-pro-preview}"
+    GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-pro}"
     GEMINI_ARGS+=("--model" "${GEMINI_MODEL}")
 
     if [[ -n "${DEBUG_DIR}" ]]; then

--- a/tests/evals/gemini/agent.yaml
+++ b/tests/evals/gemini/agent.yaml
@@ -63,8 +63,7 @@ commands:
     {
       "mcpServers": {
         "${SERVER_NAME}": {
-          "url": "${MCP_URL}",
-          "transport": "http"
+          "httpUrl": "${MCP_URL}"
         }
       }
     }
@@ -80,7 +79,7 @@ commands:
     if [[ -n "${DEBUG_DIR}" ]]; then
       GEMINI_ARGS+=(-d)
       echo "Running gemini with args: ${GEMINI_ARGS[*]}" >> "${DEBUG_DIR}/debug.log"
-      gemini "${PROMPT_CONTENT}" "${GEMINI_ARGS[@]}" 2>&1 | tee -a "${DEBUG_DIR}/gemini.log"
+      gemini --prompt "${PROMPT_CONTENT}" "${GEMINI_ARGS[@]}" 2>&1 | tee -a "${DEBUG_DIR}/gemini.log"
     else
-      gemini "${PROMPT_CONTENT}" "${GEMINI_ARGS[@]}" 2>/dev/null
+      gemini --prompt "${PROMPT_CONTENT}" "${GEMINI_ARGS[@]}" 2>/dev/null
     fi

--- a/tests/evals/gemini/eval.yaml
+++ b/tests/evals/gemini/eval.yaml
@@ -14,7 +14,7 @@ config:
   llmJudge:
     ref:
       type: builtin.llm-agent
-      model: "gemini:gemini-2.5-flash-lite"
+      model: "gemini:gemini-2.5-pro"
   taskSets:
   - glob: ../tasks/*/*.yaml
     assertions:

--- a/tests/evals/gemini/eval.yaml
+++ b/tests/evals/gemini/eval.yaml
@@ -14,7 +14,7 @@ config:
   llmJudge:
     ref:
       type: builtin.llm-agent
-      model: "gemini:gemini-3.1-flash-lite-preview"
+      model: "gemini:gemini-2.5-flash-lite"
   taskSets:
   - glob: ../tasks/*/*.yaml
     assertions:


### PR DESCRIPTION
### Describe the change

Fix mcp checker workflow run: https://github.com/kiali/kiali/actions/runs/26212154573/job/77125449343

Fixes the MCP checker evaluation flow by updating the Gemini agent configuration and making the eval post-processing more robust.

- Updated tests/evals/gemini/agent.yaml to use the current Gemini MCP HTTP configuration (httpUrl) and run Gemini explicitly in headless mode with --prompt and trust.
- Updated the MCP checker workflow to read evaluation metrics from mcpchecker result summary instead of parsing the raw results file structure directly with jq.
- Updated make/Makefile.mcp.mk to use resolved Go binary paths consistently for mcpchecker and kubernetes-mcp-server, while keeping installation on latest.
- Hardened hack/mcp/update-token-readme.sh so it fails explicitly if the summary unexpectedly contains no tasks instead of silently generating an empty task table.
- set the eval agent default model to gemini-2.5-pro (The one used before did not exist anymore).

The workflow run shows that the tasks now pass, but the run still failed because the workflow file on master was still using the old jq processing. I used the generated results file to reproduce the issue locally and update the jq logic.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
