### PR TITLE
Remove kiosk mode restrictions from Istio Config details

### DIFF
--- a/frontend/src/components/Tab/Tabs.tsx
+++ b/frontend/src/components/Tab/Tabs.tsx
@@ -4,6 +4,7 @@ import { classes } from 'typestyle';
 
 import { location, router } from '../../app/History';
 import { PFColors } from 'components/Pf/PfColors';
+import { isKioskMode } from '../../utils/SearchParamUtils';
 import { kialiStyle } from 'styles/StyleUtils';
 
 type TabsProps = {
@@ -121,7 +122,9 @@ export class ParameterizedTabs extends React.Component<TabsProps> {
   render(): React.ReactNode {
     return (
       <div className={classes(flexTabWrapperStyle, this.props.className, tabStyle)}>
-        {this.props.actionsToolbar && <div className={actionsToolbarStyle}>{this.props.actionsToolbar}</div>}
+        {this.props.actionsToolbar && !isKioskMode() && (
+          <div className={actionsToolbarStyle}>{this.props.actionsToolbar}</div>
+        )}
 
         <Tabs
           id={this.props.id}

--- a/frontend/src/components/Tab/Tabs.tsx
+++ b/frontend/src/components/Tab/Tabs.tsx
@@ -4,7 +4,6 @@ import { classes } from 'typestyle';
 
 import { location, router } from '../../app/History';
 import { PFColors } from 'components/Pf/PfColors';
-import { isKioskMode } from '../../utils/SearchParamUtils';
 import { kialiStyle } from 'styles/StyleUtils';
 
 type TabsProps = {
@@ -122,9 +121,7 @@ export class ParameterizedTabs extends React.Component<TabsProps> {
   render(): React.ReactNode {
     return (
       <div className={classes(flexTabWrapperStyle, this.props.className, tabStyle)}>
-        {this.props.actionsToolbar && !isKioskMode() && (
-          <div className={actionsToolbarStyle}>{this.props.actionsToolbar}</div>
-        )}
+        {this.props.actionsToolbar && <div className={actionsToolbarStyle}>{this.props.actionsToolbar}</div>}
 
         <Tabs
           id={this.props.id}

--- a/frontend/src/components/Tab/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/Tab/__tests__/Tabs.test.tsx
@@ -53,4 +53,14 @@ describe('ParameterizedTabs actionsToolbar rendering', () => {
 
     expect(queryByTestId('toolbar-action')).toBeNull();
   });
+
+  it('hides actionsToolbar in kiosk mode', () => {
+    (store.getState as jest.Mock) = jest.fn(() => ({ globalState: { kiosk: 'https://parent.example.com' } }));
+
+    const { queryByTestId } = renderTabs(<span data-testid="toolbar-action">Action</span>);
+
+    expect(queryByTestId('toolbar-action')).toBeNull();
+
+    (store.getState as jest.Mock) = jest.fn(() => ({ globalState: { kiosk: '' } }));
+  });
 });

--- a/frontend/src/components/Tab/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/Tab/__tests__/Tabs.test.tsx
@@ -19,15 +19,8 @@ jest.mock('config/ServerConfig', () => ({
   serverConfig: { ambientEnabled: false }
 }));
 
-jest.mock('../../../utils/SearchParamUtils', () => ({
-  isKioskMode: jest.fn(() => false)
-}));
-
 import { store } from '../../../store/ConfigStore';
 import { ParameterizedTabs } from '../Tabs';
-import { isKioskMode } from '../../../utils/SearchParamUtils';
-
-const mockedIsKioskMode = isKioskMode as jest.Mock;
 
 const defaultProps = {
   activeTab: 'info',
@@ -48,30 +41,14 @@ const renderTabs = (actionsToolbar?: React.ReactNode): ReturnType<typeof render>
   );
 };
 
-afterEach(() => {
-  mockedIsKioskMode.mockReturnValue(false);
-});
-
-describe('ParameterizedTabs actionsToolbar visibility', () => {
-  it('renders actionsToolbar when not in kiosk mode', () => {
-    mockedIsKioskMode.mockReturnValue(false);
-
+describe('ParameterizedTabs actionsToolbar rendering', () => {
+  it('renders actionsToolbar when prop is provided', () => {
     const { container } = renderTabs(<span data-testid="toolbar-action">Action</span>);
 
     expect(container.querySelector('[data-testid="toolbar-action"]')).toBeTruthy();
   });
 
-  it('hides actionsToolbar when in kiosk mode', () => {
-    mockedIsKioskMode.mockReturnValue(true);
-
-    const { queryByTestId } = renderTabs(<span data-testid="toolbar-action">Action</span>);
-
-    expect(queryByTestId('toolbar-action')).toBeNull();
-  });
-
-  it('renders without actionsToolbar when prop is not provided', () => {
-    mockedIsKioskMode.mockReturnValue(false);
-
+  it('does not render actionsToolbar when prop is not provided', () => {
     const { queryByTestId } = renderTabs();
 
     expect(queryByTestId('toolbar-action')).toBeNull();

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -572,18 +572,15 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
                     workloadReferences={workloadReferences}
                     helpMessages={helpMessages}
                     selectedLine={this.state.selectedEditorLine}
-                    kiosk={this.props.kiosk}
                   />
                 )}
               </>
             )}
           </div>
 
-          {!isParentKiosk(this.props.kiosk) && (
-            <DrawerActions>
-              <DrawerCloseButton onClick={this.onDrawerClose} />
-            </DrawerActions>
-          )}
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onDrawerClose} />
+          </DrawerActions>
         </DrawerHead>
       </DrawerPanelContent>
     );
@@ -601,7 +598,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           width="100%"
           className={istioAceEditorStyle}
           wrapEnabled={true}
-          readOnly={!this.canUpdate() || isParentKiosk(this.props.kiosk)}
+          readOnly={!this.canUpdate()}
           setOptions={aceOptions}
           value={this.state.istioObjectDetails ? yamlSource : undefined}
           annotations={editorValidations.annotations}
@@ -633,7 +630,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
     // User won't save if file has yaml errors
     const yamlErrors = !!(this.state.yamlValidations && this.state.yamlValidations.markers.length > 0);
 
-    return !isParentKiosk(this.props.kiosk) ? (
+    return (
       <IstioActionButtons
         objectName={this.props.istioConfigId.objectName}
         readOnly={!this.canUpdate()}
@@ -645,8 +642,6 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
         overview={this.state.isExpanded}
         onOverview={this.onDrawerToggle}
       />
-    ) : (
-      ''
     );
   };
 
@@ -696,7 +691,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
 
         {this.state.error && <ErrorSection error={this.state.error} />}
 
-        {!this.state.error && !isParentKiosk(this.props.kiosk) && (
+        {!this.state.error && (
           <ParameterizedTabs
             id="basic-tabs"
             className={basicTabStyle}
@@ -715,10 +710,6 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
               <div className={classes(flexFillStyle, constrainedScrollStyle)}>{this.renderEditor()}</div>
             </Tab>
           </ParameterizedTabs>
-        )}
-
-        {!this.state.error && isParentKiosk(this.props.kiosk) && (
-          <div className={classes(flexFillStyle, constrainedScrollStyle)}>{this.renderEditor()}</div>
         )}
 
         {/* TODO Enable Prompt

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -1,4 +1,4 @@
-import { Label, Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Labels } from 'components/Label/Labels';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { LocalTime } from 'components/Time/LocalTime';
@@ -27,18 +27,13 @@ import { IstioConfigHelp } from './IstioConfigHelp';
 import { IstioConfigReferences } from './IstioConfigReferences';
 import { IstioConfigValidationReferences } from './IstioConfigValidationReferences';
 import { IstioStatusMessageList } from './IstioStatusMessageList';
-import { KioskElement } from '../../../components/Kiosk/KioskElement';
-import { PFColors } from '../../../components/Pf/PfColors';
-import { GetIstioObjectUrl } from '../../../components/Link/IstioObjectLink';
-import { homeCluster, isMultiCluster, serverConfig } from '../../../config';
-import { CLUSTER_DEFAULT } from 'types/Graph';
+import { isMultiCluster } from '../../../config';
 import { infoStyle } from 'styles/IconStyle';
 
 interface IstioConfigOverviewProps {
   helpMessages?: HelpMessage[];
   istioObjectDetails: IstioConfigDetails;
   istioValidations?: ObjectValidation;
-  kiosk: string;
   namespace: string;
   objectReferences: ObjectReference[];
   selectedLine?: string;
@@ -63,12 +58,6 @@ const resourceListStyle = kialiStyle({
       fontWeight: 700
     }
   }
-});
-
-const linkStyle = kialiStyle({
-  marginLeft: '0.25rem',
-  fontSize: '85%',
-  color: PFColors.Link
 });
 
 export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: IstioConfigOverviewProps) => {
@@ -109,24 +98,6 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
       </ul>
     </div>
   );
-
-  let urlInKiali = '';
-
-  if (istioObject !== undefined && istioObject.metadata.namespace !== undefined && istioObject.kind !== undefined) {
-    const clusterInfo = serverConfig.clusters[cluster ?? homeCluster?.name ?? CLUSTER_DEFAULT];
-    const kialiInstance = clusterInfo?.kialiInstances?.find(instance => instance.url.length !== 0);
-
-    // Set the kiali url from kialiInstance info (here a "/console" is required as external link is used)
-    const kialiUrl = `${kialiInstance?.url ?? ''}/console`;
-    urlInKiali =
-      kialiUrl +
-      GetIstioObjectUrl(
-        istioObject.metadata.name,
-        istioObject.metadata.namespace,
-        getIstioObjectGVK(istioObject.apiVersion, istioObject.kind),
-        cluster
-      );
-  }
 
   return (
     <Stack hasGutter={true}>
@@ -213,23 +184,6 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
           <IstioConfigHelp helpMessages={props.helpMessages} selectedLine={props.selectedLine}></IstioConfigHelp>
         </StackItem>
       )}
-
-      <KioskElement>
-        <StackItem>
-          <Tooltip
-            content="This is a Read only view of the YAML including Validations. It is possible to edit directly in Kiali "
-            position={TooltipPosition.top}
-          >
-            <Label color="green" isCompact>
-              Read only mode
-            </Label>
-          </Tooltip>
-
-          <a href={urlInKiali} className={linkStyle} target="_blank" rel="noreferrer">
-            Edit in Kiali
-          </a>
-        </StackItem>
-      </KioskElement>
     </Stack>
   );
 };


### PR DESCRIPTION
## Summary
- Remove kiosk mode UI-layer restrictions from IstioConfigDetailsPage, IstioConfigOverview, and ParameterizedTabs so Istio config details render identically in standalone and embedded (OSSMC) modes
- Users in kiosk/OSSMC can now edit YAML, use action buttons (save/reload/delete), close the drawer, and see the full tabbed layout — access is governed by backend RBAC permissions rather than UI-layer guards
- Clean up dead code: removed KioskElement block, "Read only mode" label, "Edit in Kiali" link, unused imports/styles, and stale isKioskMode test mock in Tabs.test.tsx

<img width="1905" height="876" alt="image" src="https://github.com/user-attachments/assets/435fc125-d0f3-407b-bb68-3e132e15eb10" />

## Test plan
- [ ] Verify Istio config details page renders correctly in standalone mode (tabs, editor, action buttons, drawer close all visible and functional)
- [ ] Verify Istio config details page renders the same in OSSMC/kiosk embed
- [ ] Verify action toolbar is visible on Service, Workload, and Namespace details pages in both standalone and kiosk modes
- [ ] Verify read-only behavior when user lacks update/delete RBAC permissions
- [ ] Run `yarn test` — all unit test suites pass

Closes https://github.com/kiali/openshift-servicemesh-plugin/issues/679

Made with [Cursor](https://cursor.com)