### PR TITLE
[v2.17] Upgrade shell-quote to 1.8.4 to fix CVE-2026-9277

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15766,9 +15766,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.7.3":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Backport of #9745 to v2.17
- Upgrades transitive dependency `shell-quote` from 1.8.1 to 1.8.4 to fix CVE-2026-9277 (CVSS 8.1 High)

## Test plan

- [ ] CI passes


Made with [Cursor](https://cursor.com)