### PR TITLE
Post-merge cleanup for IstioLabels refactoring (#9690)

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -14,7 +14,6 @@ const (
 	IstiodClusterIDEnvKey          = "CLUSTER_ID"
 	IstiodExternalEnvKey           = "EXTERNAL_ISTIOD"
 	IstiodScopeGatewayEnvKey       = "PILOT_SCOPE_GATEWAY_TO_NAMESPACE"
-	IstioInjectionLabel            = "istio-injection"
 	IstioControlPlaneClustersLabel = "topology.istio.io/controlPlaneClusters"
 )
 

--- a/business/tls.go
+++ b/business/tls.go
@@ -81,7 +81,7 @@ func (in *TLSService) MeshWidemTLSStatus(ctx context.Context, cluster string, re
 
 	// Look for enabled if rev label isn't set: https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
 	namespacesForRevision := sliceutil.Filter(namespaces, func(ns models.Namespace) bool {
-		return ns.Labels[config.IstioRevisionLabel] == revision || ns.Labels[models.IstioInjectionLabel] == "enabled"
+		return ns.Labels[config.IstioRevisionLabel] == revision || ns.Labels[config.IstioInjectionLabelName] == "enabled"
 	})
 	namespaceNames := sliceutil.Map(namespacesForRevision, func(ns models.Namespace) string {
 		return ns.Name

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -36,7 +36,7 @@ func nonDefaultTrustDomainMeshConfig() *models.MeshConfig {
 }
 
 var (
-	injectionEnabledLabel          = map[string]string{IstioInjectionLabel: "enabled"}
+	injectionEnabledLabel          = map[string]string{config.IstioInjectionLabelName: "enabled"}
 	meshConfigWithAutomTLSDisabled = meshConfig(false)
 	meshConfigWithAutomTLSEnabled  = meshConfig(true)
 )

--- a/business/tls_test.go
+++ b/business/tls_test.go
@@ -36,7 +36,7 @@ func nonDefaultTrustDomainMeshConfig() *models.MeshConfig {
 }
 
 var (
-	injectionEnabledLabel          = map[string]string{config.IstioInjectionLabelName: "enabled"}
+	injectionEnabledLabel          = map[string]string{config.IstioInjectionLabelName: models.IstioInjectionEnabledLabelValue}
 	meshConfigWithAutomTLSDisabled = meshConfig(false)
 	meshConfigWithAutomTLSEnabled  = meshConfig(true)
 )

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,7 @@ const (
 	IstioSidecarAnnotation          = "sidecar.istio.io/status" // the standard annotation for sidecar status
 	IstioVersionLabel               = "version"                 // we can assume istio components are labeled with "version", if versioned
 	KubernetesAppLabel              = "app.kubernetes.io/name"
+	KubernetesVersionLabel          = "app.kubernetes.io/version"
 	SpireComponentLabel             = "app.kubernetes.io/instance"
 	SpireManagedIdentityLabel       = "spiffe.io/spire-managed-identity" // SPIRE label indicating workload is managed by SPIRE
 	SpireManagedIdentityValue       = "true"                             // Value for SPIRE managed identity label

--- a/frontend/cypress/integration/common/namespaces.ts
+++ b/frontend/cypress/integration/common/namespaces.ts
@@ -84,6 +84,7 @@ When('user unchecks column {string} in manage columns', (columnTitle: string) =>
 
 When('user saves manage columns', () => {
   cy.get('[data-ouia-component-id="ColumnManagementModal-save-button"]').click();
+  cy.get('[data-ouia-component-id="ColumnManagementModal"]').should('not.exist');
 });
 
 When('user resets columns to default on namespaces page', () => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "https://kiali-istio-system.apps-crc.testing/",
   "name": "@kiali/kiali-ui",
   "version": "2.27.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,4 @@
 {
-  "proxy": "https://kiali-istio-system.apps-crc.testing/",
   "name": "@kiali/kiali-ui",
   "version": "2.27.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -530,8 +530,6 @@ export const getNamespaceRevision = (ns: NamespaceInfo): string | undefined => {
   if (ns.labels) {
     if (ns.labels[INJECTION_LABEL_REV]) {
       revision = ns.labels[INJECTION_LABEL_REV];
-    } else if (ns.labels['istio.io/rev']) {
-      revision = ns.labels['istio.io/rev'];
     }
   }
   if (!revision || revision === '') {
@@ -619,7 +617,7 @@ export const nsHealth: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
 
 export const nsTls: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
   const isControlPlane = !!ns.isControlPlane;
-    const isDataPlane =
+  const isDataPlane =
     !isControlPlane &&
     !!ns.labels &&
     (ns.labels[INJECTION_LABEL_NAME] === 'enabled' ||

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -10,12 +10,10 @@ export type ComputedServerConfig = ServerConfig & {
 };
 
 // Exported default label name candidates and key constants
-
+// note: these constants are also declared server-side in config/config.go
 export const AMBIENT_NAMESPACE_LABEL = 'istio.io/dataplane-mode';
 export const AMBIENT_NAMESPACE_LABEL_VALUE = 'ambient';
 export const AMBIENT_WAYPOINT_GATEWAY_LABEL = 'gateway.networking.k8s.io/gateway-name';
-export const AMBIENT_WAYPOINT_LABEL = 'gateway.istio.io/managed';
-export const AMBIENT_WAYPOINT_LABEL_VALUE = 'istio.io-mesh-controller';
 export const INJECTION_LABEL_NAME = 'istio-injection';
 export const INJECTION_LABEL_REV = 'istio.io/rev';
 

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -46,7 +46,7 @@ import { panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { isRemoteCluster } from './TargetPanelControlPlane';
 import { BoxTarget, ControlPlane, NamespaceNodeData } from 'types/Mesh';
 import { MeshInfraType } from 'types/Mesh';
-import { isIstioNamespace } from 'config/ServerConfig';
+import { INJECTION_LABEL_REV, isIstioNamespace } from 'config/ServerConfig';
 import { getNamespaceDetailUrl } from 'utils/NamespaceUtils';
 
 type TargetPanelNamespaceProps = TargetPanelCommonProps & {
@@ -376,7 +376,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     return (
       <>
         {isControlPlane && !ns.isControlPlane && (
-          <ControlPlaneVersionBadge version={ns.labels ? ns.labels['istio.io/rev'] : ''} />
+          <ControlPlaneVersionBadge version={ns.labels ? ns.labels[INJECTION_LABEL_REV] : ''} />
         )}
 
         {isControlPlane && <IstioAPIDisabledBadge />}

--- a/frontend/src/pages/NamespaceDetails/namespaceDetailActions.ts
+++ b/frontend/src/pages/NamespaceDetails/namespaceDetailActions.ts
@@ -42,7 +42,7 @@ export const buildNamespaceRowActions = (p: NamespaceRowActionsParams): Namespac
       !(
         serverConfig.ambientEnabled &&
         nsInfo.labels &&
-           nsInfo.labels[AMBIENT_NAMESPACE_LABEL] === AMBIENT_NAMESPACE_LABEL_VALUE
+        nsInfo.labels[AMBIENT_NAMESPACE_LABEL] === AMBIENT_NAMESPACE_LABEL_VALUE
       ) &&
       serverConfig.kialiFeatureFlags.istioInjectionAction &&
       !serverConfig.kialiFeatureFlags.istioUpgradeAction
@@ -94,17 +94,17 @@ export const buildNamespaceRowActions = (p: NamespaceRowActionsParams): Namespac
           })
       };
 
-        if (
-          nsInfo.labels &&
-          ((nsInfo.labels[INJECTION_LABEL_NAME] && nsInfo.labels[INJECTION_LABEL_NAME] === 'enabled') ||
-           nsInfo.labels[INJECTION_LABEL_REV])
-        ) {
+      if (
+        nsInfo.labels &&
+        ((nsInfo.labels[INJECTION_LABEL_NAME] && nsInfo.labels[INJECTION_LABEL_NAME] === 'enabled') ||
+          nsInfo.labels[INJECTION_LABEL_REV])
+      ) {
         namespaceActions.push(disableAction);
         namespaceActions.push(removeAction);
       } else if (
         nsInfo.labels &&
-       nsInfo.labels[INJECTION_LABEL_NAME] &&
-       nsInfo.labels[INJECTION_LABEL_NAME] === 'disabled'
+        nsInfo.labels[INJECTION_LABEL_NAME] &&
+        nsInfo.labels[INJECTION_LABEL_NAME] === 'disabled'
       ) {
         namespaceActions.push(enableAction);
         namespaceActions.push(removeAction);
@@ -159,11 +159,7 @@ export const buildNamespaceRowActions = (p: NamespaceRowActionsParams): Namespac
           })
       };
 
-      if (
-        nsInfo.labels &&
-        !nsInfo.labels[INJECTION_LABEL_NAME] &&
-        !nsInfo.labels[INJECTION_LABEL_REV]
-      ) {
+      if (nsInfo.labels && !nsInfo.labels[INJECTION_LABEL_NAME] && !nsInfo.labels[INJECTION_LABEL_REV]) {
         if (nsInfo.isAmbient) {
           pushSeparator(namespaceActions);
           namespaceActions.push(disableAmbientAction);

--- a/frontend/src/utils/NamespaceUtils.ts
+++ b/frontend/src/utils/NamespaceUtils.ts
@@ -23,11 +23,7 @@ export const getNamespaceMode = (ns: NamespaceLike): NamespaceMode => {
 
   const labels = ns.labels;
   const injectionEnabled = !!(labels && labels[INJECTION_LABEL_NAME] === 'enabled');
-  const revisionSet = !!(
-    labels &&
-    labels[INJECTION_LABEL_REV] !== undefined &&
-    labels[INJECTION_LABEL_REV] !== ''
-  )
+  const revisionSet = !!(labels && labels[INJECTION_LABEL_REV] !== undefined && labels[INJECTION_LABEL_REV] !== '');
 
   if (ns.isControlPlane || injectionEnabled || revisionSet) {
     return 'sidecar';

--- a/istio/constants.go
+++ b/istio/constants.go
@@ -1,13 +1,5 @@
 package istio
 
-// These are used across files in this package and elsewhere.
-
-const (
-	AmbientDataplaneModeLabelValue = "ambient"
-	IstioDataplaneModeLabelKey     = "istio.io/dataplane-mode"
-	KubeVersionLabel               = "app.kubernetes.io/version"
-)
-
 const (
 	istioControlPlaneClustersLabel        = "topology.istio.io/controlPlaneClusters"
 	istiodAppLabelValue                   = "istiod"

--- a/istio/discovery.go
+++ b/istio/discovery.go
@@ -275,13 +275,13 @@ func NewDiscovery(clients map[string]kubernetes.ClientInterface, cache cache.Kia
 	if conf.RunMode == config.RunModeOffline {
 		// Offline mode function that reads version from controlPlane labels
 		getVersion = func(ctx context.Context, conf *config.Config, client kubernetes.ClientInterface, kubeCache ctrlclient.Reader, controlPlane models.ControlPlane) (*models.ExternalServiceInfo, error) {
-			if version, exists := controlPlane.Labels[KubeVersionLabel]; exists && version != "" {
+			if version, exists := controlPlane.Labels[config.KubernetesVersionLabel]; exists && version != "" {
 				return &models.ExternalServiceInfo{
 					Name:    "Istio",
 					Version: version,
 				}, nil
 			}
-			return nil, fmt.Errorf("version label %s not found or empty in controlPlane labels", KubeVersionLabel)
+			return nil, fmt.Errorf("version label %s not found or empty in controlPlane labels", config.KubernetesVersionLabel)
 		}
 	} else {
 		// Use the actual GetVersion function for non-offline modes

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -127,8 +127,8 @@ func TestGetClustersResolvesTheKialiCluster(t *testing.T) {
 					"kiali.io/external-url":         "http://kiali.url.local",
 				},
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of": "kiali",
-					"app.kubernetes.io/version": "v1.25",
+					"app.kubernetes.io/part-of":   "kiali",
+					config.KubernetesVersionLabel: "v1.25",
 				},
 				Name:      "kiali-service",
 				Namespace: "foo",
@@ -193,8 +193,8 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 				"operator-sdk/primary-resource": "kiali-operator/myKialiCR",
 			},
 			Labels: map[string]string{
-				"app.kubernetes.io/version": "v1.25",
-				"app.kubernetes.io/part-of": "kiali",
+				config.KubernetesVersionLabel: "v1.25",
+				"app.kubernetes.io/part-of":   "kiali",
 			},
 			Name:      "kiali-service",
 			Namespace: config.IstioNamespaceDefault,
@@ -299,8 +299,8 @@ func TestResolveKialiControlPlaneClusterIsCached(t *testing.T) {
 				"operator-sdk/primary-resource": "kiali-operator/myKialiCR",
 			},
 			Labels: map[string]string{
-				"app.kubernetes.io/version": "v1.25",
-				"app.kubernetes.io/part-of": "kiali",
+				config.KubernetesVersionLabel: "v1.25",
+				"app.kubernetes.io/part-of":   "kiali",
 			},
 			Name:      "kiali-service",
 			Namespace: "foo",
@@ -1761,7 +1761,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioInjectionLabelName: "enabled"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioInjectionLabelName: models.IstioInjectionEnabledLabelValue}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -2331,7 +2331,7 @@ func TestDiscoverWithMaistra(t *testing.T) {
 	maistraIstiod := defaultIstiod.DeepCopy()
 	maistraIstiod.Name = "istiod-basic"
 	maistraIstiod.Labels["maistra.io/owner"] = "basic"
-	maistraIstiod.Labels["istio.io/rev"] = "basic"
+	maistraIstiod.Labels[config.IstioRevisionLabel] = "basic"
 
 	cases := map[string]struct {
 		BookinfoLabels            map[string]string
@@ -2339,18 +2339,18 @@ func TestDiscoverWithMaistra(t *testing.T) {
 		ExpectedIstioNamespaces   []string
 	}{
 		"maistra manages bookinfo": {
-			BookinfoLabels:            map[string]string{"maistra.io/member-of": "istio-system", "istio.io/rev": "default"},
+			BookinfoLabels:            map[string]string{"maistra.io/member-of": "istio-system", config.IstioRevisionLabel: "default"},
 			ExpectedMaistraNamespaces: []string{"bookinfo"},
 		},
 		"istiod manages bookinfo": {
-			BookinfoLabels:          map[string]string{"istio.io/rev": "default"},
+			BookinfoLabels:          map[string]string{config.IstioRevisionLabel: "default"},
 			ExpectedIstioNamespaces: []string{"bookinfo"},
 		},
 		"maistra ignore label - istiod manages bookinfo": {
 			BookinfoLabels: map[string]string{
 				"maistra.io/member-of":        "istio-system",
 				"maistra.io/ignore-namespace": "true",
-				"istio.io/rev":                "default",
+				config.IstioRevisionLabel:     "default",
 			},
 			ExpectedIstioNamespaces: []string{"bookinfo"},
 		},

--- a/istio/discovery_test.go
+++ b/istio/discovery_test.go
@@ -1727,7 +1727,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{istio.IstioDataplaneModeLabelKey: istio.AmbientDataplaneModeLabelValue}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
@@ -1761,7 +1761,7 @@ func TestDiscoverWithTags(t *testing.T) {
 			setup: func() map[string][]runtime.Object {
 				return map[string][]runtime.Object{
 					conf.KubernetesConfig.ClusterName: {
-						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{models.IstioInjectionLabel: "enabled"}}},
+						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "bookinfo", Labels: map[string]string{config.IstioInjectionLabelName: "enabled"}}},
 						defaultWebhook,
 						defaultIstiod,
 						&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},

--- a/istio/kubernetes.go
+++ b/istio/kubernetes.go
@@ -94,7 +94,7 @@ func GetRevision(namespace models.Namespace) string {
 		}
 	}
 	rev, hasRevLabel := namespace.Labels[config.IstioRevisionLabel]
-	injectionEnabled := namespace.Labels[models.IstioInjectionLabel] == models.IstioInjectionEnabledLabelValue
+	injectionEnabled := namespace.Labels[config.IstioInjectionLabelName] == models.IstioInjectionEnabledLabelValue
 	// Injection label takes precedence over revision label.
 	// Or if there's no rev label and ambient is enabled then set to default.
 	// TODO: Factor in exclude namespaces for cni for ambient.

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -191,7 +191,7 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 		},
 	}
 
-	defaultInjection := map[string]string{models.IstioInjectionLabel: models.IstioInjectionEnabledLabelValue}
+	defaultInjection := map[string]string{config.IstioInjectionLabelName: models.IstioInjectionEnabledLabelValue}
 	revLabel := map[string]string{config.IstioRevisionLabel: "default"}
 	primaryClient := kubetest.NewFakeK8sClient(
 		kubetest.FakeNamespace("istio-system"),

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/graph"
-	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/mesh"
@@ -230,7 +229,7 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 							continue
 						}
 						// Revision/tag matches; use app.kubernetes.io/version as tie-breaker
-						ztunnelVersion := ztunnel.Labels[istio.KubeVersionLabel]
+						ztunnelVersion := ztunnel.Labels[config.KubernetesVersionLabel]
 						if ztunnelVersion != "" && cp.Version != nil && cp.Version.Version != "" && ztunnelVersion != cp.Version.Version {
 							continue
 						}

--- a/models/mesh.go
+++ b/models/mesh.go
@@ -17,8 +17,6 @@ const (
 	IstioTagLabel = "istio.io/tag"
 	// DefaultRevisionLabel is the value for the default revision.
 	DefaultRevisionLabel = "default"
-	// IstioInjectionLabel is the key for the istio injection label on a namespace.
-	IstioInjectionLabel = "istio-injection"
 	// IstioInjectionDisabledLabelValue is the value for the istio injection label when it is disabled.
 	IstioInjectionDisabledLabelValue = "disabled"
 	// IstioInjectionEnabledLabelValue is the value for the istio injection label when it is enabled.

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -81,7 +81,7 @@ func CastNamespace(ns core_v1.Namespace, cluster string) Namespace {
 	if ns.Labels != nil {
 		// Injection label takes precedence.
 		// See rules at: https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
-		if injectionLabel := ns.Labels[IstioInjectionLabel]; injectionLabel == IstioInjectionDisabledLabelValue {
+		if injectionLabel := ns.Labels[config.IstioInjectionLabelName]; injectionLabel == IstioInjectionDisabledLabelValue {
 			namespace.Revision = ""
 		} else if injectionLabel == IstioInjectionEnabledLabelValue {
 			namespace.Revision = DefaultRevisionLabel


### PR DESCRIPTION
## Summary

- Consolidates duplicate Istio/Kubernetes label constants that were scattered across `models`, `business`, and `istio` packages into the canonical `config` package (e.g. `IstioInjectionLabelName`, `IstioAmbientNamespaceLabel`, `KubernetesVersionLabel`)
- Removes dead code and fixes minor style issues in frontend files left over from the IstioLabels refactoring in #9690
- Renames `KubeVersionLabel` to `KubernetesVersionLabel` and co-locates it with `KubernetesAppLabel` in `config/config.go`

## Details

After #9690 was merged, several cleanup items remained:

**Go backend:**
- Removed `IstioInjectionLabel` from `models/mesh.go` and `business/mesh.go`; all usages now reference `config.IstioInjectionLabelName`
- Removed `IstioDataplaneModeLabelKey` and `AmbientDataplaneModeLabelValue` from `istio/constants.go`; usages now reference `config.IstioAmbientNamespaceLabel` and `config.IstioAmbientNamespaceLabelValue`
- Migrated `KubeVersionLabel` from `istio/constants.go` to `config/config.go` as `KubernetesVersionLabel`
- Updated `istio/discovery.go`, `istio/discovery_test.go`, `istio/kubernetes.go`, `business/tls.go`, `models/namespace.go`, and `mesh/generator/generator.go` to use the consolidated constants

**Frontend:**
- Removed unused `AMBIENT_WAYPOINT_LABEL` and `AMBIENT_WAYPOINT_LABEL_VALUE` exports from `ServerConfig.ts`
- Removed dead duplicate branch in `Renderers.tsx`
- Fixed indentation/formatting in `namespaceDetailActions.ts` and `NamespaceUtils.ts`

## Test plan
- [x] `go build ./...` passes
- [ ] `make test` passes (backend unit tests)
- [ ] CI green


Made with [Cursor](https://cursor.com)