### PR TITLE
[AI] Added functionality to delate previous chat conversation when starting a new one.

### DIFF
--- a/ai/providers/anthropic/anthropic_test.go
+++ b/ai/providers/anthropic/anthropic_test.go
@@ -32,6 +32,10 @@ func (s *anthropicTestStore) GenerateConversationID() string {
 	return "test-id"
 }
 
+func (s *anthropicTestStore) DeleteConversations(_ string, _ []string) error {
+	return nil
+}
+
 func (s *anthropicTestStore) Enabled() bool {
 	return s.enabled
 }

--- a/ai/providers/google/google_test.go
+++ b/ai/providers/google/google_test.go
@@ -26,10 +26,11 @@ type googleTestStore struct {
 	conversations map[string]*types.Conversation
 }
 
-func (s *googleTestStore) GenerateConversationID() string { return "test-conv-id" }
-func (s *googleTestStore) Enabled() bool                  { return s.enabled }
-func (s *googleTestStore) ReduceWithAI() bool             { return false }
-func (s *googleTestStore) ReduceThreshold() int           { return 0 }
+func (s *googleTestStore) GenerateConversationID() string                 { return "test-conv-id" }
+func (s *googleTestStore) DeleteConversations(_ string, _ []string) error { return nil }
+func (s *googleTestStore) Enabled() bool                                  { return s.enabled }
+func (s *googleTestStore) ReduceWithAI() bool                             { return false }
+func (s *googleTestStore) ReduceThreshold() int                           { return 0 }
 
 func (s *googleTestStore) GetConversation(sessionID, conversationID string) (*types.Conversation, bool) {
 	if s.conversations == nil {

--- a/ai/providers/helpers_test.go
+++ b/ai/providers/helpers_test.go
@@ -26,6 +26,10 @@ type fakeStore struct {
 	conversations map[string]*types.Conversation
 }
 
+func (f *fakeStore) DeleteConversations(_ string, _ []string) error {
+	return nil
+}
+
 func (f *fakeStore) Enabled() bool {
 	return f.enabled
 }

--- a/ai/providers/openai/openai_test.go
+++ b/ai/providers/openai/openai_test.go
@@ -27,10 +27,11 @@ type openaiTestStore struct {
 	conversations map[string]*types.Conversation
 }
 
-func (s *openaiTestStore) GenerateConversationID() string { return "test-conv-id" }
-func (s *openaiTestStore) Enabled() bool                  { return s.enabled }
-func (s *openaiTestStore) ReduceWithAI() bool             { return false }
-func (s *openaiTestStore) ReduceThreshold() int           { return 0 }
+func (s *openaiTestStore) GenerateConversationID() string                 { return "test-conv-id" }
+func (s *openaiTestStore) DeleteConversations(_ string, _ []string) error { return nil }
+func (s *openaiTestStore) Enabled() bool                                  { return s.enabled }
+func (s *openaiTestStore) ReduceWithAI() bool                             { return false }
+func (s *openaiTestStore) ReduceThreshold() int                           { return 0 }
 
 func (s *openaiTestStore) GetConversation(sessionID, conversationID string) (*types.Conversation, bool) {
 	if s.conversations == nil {

--- a/ai/store.go
+++ b/ai/store.go
@@ -79,6 +79,28 @@ func (s *AIStoreImpl) Enabled() bool {
 	return s.config.Enabled
 }
 
+// DeleteConversations removes the given conversations from a session but
+// preserves the session's UsageMetrics so token accounting is not lost.
+func (s *AIStoreImpl) DeleteConversations(sessionID string, conversationIDs []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sessionConversation, exists := s.conversations[sessionID]
+	if !exists {
+		return nil
+	}
+
+	sessionConversation.mu.Lock()
+	defer sessionConversation.mu.Unlock()
+
+	for _, id := range conversationIDs {
+		delete(sessionConversation.Conversation, id)
+	}
+
+	internalmetrics.SetAIStoreConversationsTotal(s.totalConversationsLocked())
+	return nil
+}
+
 // GetConversation retrieves a conversation by sessionID
 func (s *AIStoreImpl) GetConversation(sessionID string, conversationID string) (*types.Conversation, bool) {
 	s.mu.RLock()

--- a/ai/types/store.go
+++ b/ai/types/store.go
@@ -2,12 +2,13 @@ package types
 
 // AIStore defines the interface for storing AI conversations
 type AIStore interface {
+	DeleteConversations(sessionID string, conversationIDs []string) error
 	Enabled() bool
-	ReduceWithAI() bool
-	ReduceThreshold() int
 	GenerateConversationID() string
 	GetConversation(sessionID string, conversationID string) (*Conversation, bool)
-	SetConversation(sessionID string, conversationID string, conversation *Conversation) error
-	RecordUsage(sessionID string, provider string, model string, usage TokenUsage) error
 	GetUsageMetrics(sessionID string) []UsageMetric
+	RecordUsage(sessionID string, provider string, model string, usage TokenUsage) error
+	ReduceThreshold() int
+	ReduceWithAI() bool
+	SetConversation(sessionID string, conversationID string, conversation *Conversation) error
 }

--- a/frontend/src/components/ChatBot/ChatBot.tsx
+++ b/frontend/src/components/ChatBot/ChatBot.tsx
@@ -16,6 +16,7 @@ import { ReactComponent as KialiIconLight } from '../../assets/img/kiali/icon-li
 import { ReactComponent as KialiIconDark } from '../../assets/img/kiali/icon-darkbkg.svg';
 import { defer } from 'lodash-es';
 import { ChatAIActions } from 'actions/ChatAIActions';
+import * as API from 'services/Api';
 
 const conversationList: { [key: string]: Conversation[] } = {};
 conversationList[CHAT_HISTORY_HEADER] = [];
@@ -114,9 +115,14 @@ export const ChatBot: React.FC = () => {
   };
 
   const clearChat = React.useCallback(() => {
+    if (conversationID !== '') {
+      // Fire-and-forget: the result is irrelevant because the UI has already
+      // moved to a fresh conversation and there is nowhere to surface the error.
+      API.deleteChatConversations(conversationID).catch(() => {});
+    }
     dispatch(ChatAIActions.setConversationID({ id: undefined }));
     dispatch(ChatAIActions.setChatHistoryClear());
-  }, [dispatch]);
+  }, [dispatch, conversationID]);
 
   const onConfirm = React.useCallback(() => {
     if (newProvider !== '') {

--- a/frontend/src/config/Config.ts
+++ b/frontend/src/config/Config.ts
@@ -125,6 +125,7 @@ const conf = {
       authenticate: 'api/authenticate',
       authInfo: 'api/auth/info',
       chatAI: (provider: string, model: string) => `api/chat/${provider}/${model}/ai`,
+      chatDeleteConversations: 'api/chat/conversations',
       chatSessionUsage: `api/chat/session/usage`,
       clustersApps: () => `api/clusters/apps`,
       clustersHealth: () => `api/clusters/health`,

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1566,6 +1566,10 @@ export const postChatAI = (
   });
 };
 
+export const deleteChatConversations = (conversationIDs: string): Promise<ApiResponse<Record<string, string>>> => {
+  return newRequest<Record<string, string>>(HTTP_VERBS.DELETE, urls.chatDeleteConversations, { conversationIDs }, {});
+};
+
 export const getChatSessionUsage = (): Promise<ApiResponse<ChatSessionUsageMetric[]>> => {
   return newRequest<ChatSessionUsageMetric[]>(HTTP_VERBS.GET, urls.chatSessionUsage, { _ts: Date.now() }, {});
 };

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -286,5 +287,40 @@ func ChatSessionUsage(
 		}
 
 		RespondWithJSON(w, http.StatusOK, aiStore.GetUsageMetrics(userID))
+	}
+}
+
+func DeleteConversations(conf *config.Config, aiStore aiTypes.AIStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if aiStore == nil || !aiStore.Enabled() {
+			RespondWithJSON(w, http.StatusOK, map[string]string{"message": "AI store is not enabled"})
+			return
+		}
+
+		idsParam := r.URL.Query().Get("conversationIDs")
+		if idsParam == "" {
+			RespondWithError(w, http.StatusBadRequest, "Missing required query parameter: conversationIDs")
+			return
+		}
+
+		var ids []string
+		for _, id := range strings.Split(idsParam, ",") {
+			trimmed := strings.TrimSpace(id)
+			if trimmed != "" {
+				ids = append(ids, trimmed)
+			}
+		}
+		if len(ids) == 0 {
+			RespondWithError(w, http.StatusBadRequest, "No valid conversation IDs provided")
+			return
+		}
+
+		sessionID := authentication.GetSessionIDContext(r.Context())
+		if err := aiStore.DeleteConversations(sessionID, ids); err != nil {
+			RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to delete conversations: %v", err))
+			return
+		}
+
+		RespondWithJSON(w, http.StatusOK, map[string]string{"message": "Conversations deleted"})
 	}
 }

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/authentication"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/perses"
@@ -849,4 +850,238 @@ func TestChatAI_StreamingNotSupported(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.code)
 	assert.Contains(t, w.body.String(), "Streaming unsupported")
+}
+
+// ========================================================================
+// DeleteConversations handler tests
+// ========================================================================
+
+func withSessionID(sessionID string, hf http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := authentication.SetSessionIDContext(r.Context(), sessionID)
+		hf(w, r.WithContext(ctx))
+	}
+}
+
+func TestDeleteConversations_Success(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	conv := &aiTypes.Conversation{
+		Conversation: []aiTypes.ConversationMessage{{Role: "user", Content: "hello"}},
+	}
+	require.NoError(t, aiStore.SetConversation("test-session", "conv-1", conv))
+
+	_, found := aiStore.GetConversation("test-session", "conv-1")
+	require.True(t, found, "conversation should exist before delete")
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, found = aiStore.GetConversation("test-session", "conv-1")
+	assert.False(t, found, "conversation should be deleted")
+}
+
+func TestDeleteConversations_MultipleIDs(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	for _, id := range []string{"conv-1", "conv-2", "conv-3"} {
+		conv := &aiTypes.Conversation{
+			Conversation: []aiTypes.ConversationMessage{{Role: "user", Content: id}},
+		}
+		require.NoError(t, aiStore.SetConversation("test-session", id, conv))
+	}
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1,conv-3", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, found := aiStore.GetConversation("test-session", "conv-1")
+	assert.False(t, found, "conv-1 should be deleted")
+
+	_, found = aiStore.GetConversation("test-session", "conv-2")
+	assert.True(t, found, "conv-2 should remain")
+
+	_, found = aiStore.GetConversation("test-session", "conv-3")
+	assert.False(t, found, "conv-3 should be deleted")
+}
+
+func TestDeleteConversations_MissingParam(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestDeleteConversations_StoreDisabled(t *testing.T) {
+	conf := config.NewConfig()
+	aiStore := ai.NewAIStore(context.Background(), &ai.AiStoreConfig{Enabled: false})
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "disabled store should return 200 (no-op)")
+}
+
+func TestDeleteConversations_NilStore(t *testing.T) {
+	conf := config.NewConfig()
+
+	handler := withSessionID("test-session", DeleteConversations(conf, nil))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "nil store should return 200 (no-op)")
+}
+
+func TestDeleteConversations_NonexistentID(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=nonexistent", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "deleting nonexistent ID should succeed (idempotent)")
+}
+
+func TestDeleteConversations_PreservesTokenUsage(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	conv := &aiTypes.Conversation{
+		Conversation: []aiTypes.ConversationMessage{{Role: "user", Content: "hello"}},
+	}
+	require.NoError(t, aiStore.SetConversation("test-session", "conv-1", conv))
+	require.NoError(t, aiStore.RecordUsage("test-session", "openai", "gpt-4o", aiTypes.NewTokenUsage(10, 20, 30)))
+
+	metricsBefore := aiStore.GetUsageMetrics("test-session")
+	require.Len(t, metricsBefore, 1, "should have usage metrics before deletion")
+	assert.Equal(t, int64(30), metricsBefore[0].TotalTokens)
+
+	handler := withSessionID("test-session", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, found := aiStore.GetConversation("test-session", "conv-1")
+	assert.False(t, found, "conversation should be deleted")
+
+	metricsAfter := aiStore.GetUsageMetrics("test-session")
+	require.Len(t, metricsAfter, 1, "token usage metrics must be preserved after conversation deletion")
+	assert.Equal(t, int64(30), metricsAfter[0].TotalTokens, "token counts must remain unchanged")
+	assert.Equal(t, "openai", metricsAfter[0].Provider)
+	assert.Equal(t, "gpt-4o", metricsAfter[0].Model)
+}
+
+func TestDeleteConversations_SessionScoping(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ChatAI.Enabled = true
+	aiStore := ai.NewAIStore(context.Background(), nil)
+
+	conv := &aiTypes.Conversation{
+		Conversation: []aiTypes.ConversationMessage{{Role: "user", Content: "hello"}},
+	}
+	require.NoError(t, aiStore.SetConversation("session-A", "conv-1", conv))
+	require.NoError(t, aiStore.SetConversation("session-B", "conv-1", conv))
+
+	handler := withSessionID("session-A", DeleteConversations(conf, aiStore))
+
+	mr := mux.NewRouter()
+	mr.Handle("/api/chat/conversations", handler).Methods("DELETE")
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/chat/conversations?conversationIDs=conv-1", nil)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, found := aiStore.GetConversation("session-A", "conv-1")
+	assert.False(t, found, "session-A conv-1 should be deleted")
+
+	_, found = aiStore.GetConversation("session-B", "conv-1")
+	assert.True(t, found, "session-B conv-1 should NOT be affected")
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1882,6 +1882,28 @@ func NewRoutes(
 			handlers.ChatMCP(conf, kialiCache, aiStore, clientFactory, prom, cpm, traceClientLoader, grafana, perses, discovery),
 			true,
 		},
+		// swagger:route DELETE /chat/conversations ChatConversations
+		// ---
+		// Endpoint to delete AI chat conversations
+		//
+		//     Produces:
+		//     - application/json
+		//
+		//     Schemes: http, https
+		//
+		// responses:
+		//      500: internalError
+		//      400: badRequestError
+		//      200: noContent
+		//
+		{
+			"DeleteConversations",
+			log.ChatAILogName,
+			"DELETE",
+			"/api/chat/conversations",
+			handlers.DeleteConversations(conf, aiStore),
+			true,
+		},
 		// swagger:route GET /chat/session/usage chat aiChatSessionUsage
 		// ---
 		// Endpoint to get token usage statistics for the current user session


### PR DESCRIPTION
### Describe the change

"New Chat" button deletes the previous conversation to free up a space.
The response from backend is ignored as unnecessary and as already a new chat is created.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

https://github.com/kiali/kiali/issues/9738
