### PR TITLE
[AI] Enable/disable tools

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -30,6 +30,7 @@ AI is configured under `chat_ai` in `config/config.go`. Key fields:
 
 - `enabled`: Enables/disables the AI assistant.
 - `default_provider`: The provider name to use by default.
+- `tools`: Optional global include/exclude filter for the default chat toolset.
 - `providers`: List of providers, each with type/config, models, and keys.
 - `store_config`: Optional conversation storage settings.
 
@@ -41,6 +42,9 @@ Example configuration:
 chat_ai:
   enabled: true
   default_provider: "openai"
+  tools:
+    exclude:
+      - "manage_istio_config"
   providers:
     - name: "openai"
       enabled: true
@@ -48,6 +52,10 @@ chat_ai:
       type: "openai"
       config: "default"
       default_model: "gemini"
+      tools:
+        include:
+          - "get_logs"
+          - "get_mesh_status"
       models:
         - name: "gemini"
           enabled: true
@@ -73,6 +81,7 @@ Reference for every configuration key under `chat_ai`, with type, allowed values
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Turns the AI assistant on or off. When `true`, `default_provider` is required. |
 | `default_provider` | string | `""` | Name of the provider to use when the UI does not specify one. Must match a provider `name` and that provider must be enabled. |
+| `tools` | object | `{}` | Optional global filter for the chat toolset. `include` restricts the exposed set to the listed tool names; `exclude` removes listed tool names from the resulting set. Empty means "use the default Kiali selection". |
 | `providers` | array | `[]` | List of provider definitions. Each entry has the keys described in [Provider keys](#provider-keys-providers). |
 | `store_config` | object | (see below) | Optional conversation storage settings. Keys are described in [Store config keys](#store-config-keys-store_config). |
 
@@ -86,6 +95,7 @@ Reference for every configuration key under `chat_ai`, with type, allowed values
 | `enabled` | boolean | no | Enable or disable this provider. Defaults to `true`. Disabled providers are ignored. |
 | `default_model` | string | yes | Name of the default model for this provider. Must match a model `name` in `models` and that model must be enabled. |
 | `description` | string | no | Human-readable description of the provider (e.g. for UI). |
+| `tools` | object | no | Optional provider-specific include/exclude filter applied after the global `chat_ai.tools` filter. It can further restrict the tools exposed to this provider, but it cannot re-enable a tool already filtered out globally or by feature availability. |
 | `key` | string | conditional | API key for all models in this provider. Inline value or `secret:<secret-name>:<key-in-secret>`. Required if no model has a `key`. |
 | `models` | array | yes | List of models. Each entry has the keys described in [Model keys](#model-keys-providersmodels). |
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -30,7 +30,7 @@ AI is configured under `chat_ai` in `config/config.go`. Key fields:
 
 - `enabled`: Enables/disables the AI assistant.
 - `default_provider`: The provider name to use by default.
-- `tools`: Optional global include/exclude filter for the default chat toolset.
+- `tools`: Optional global enable/disable filter for the default chat toolset.
 - `providers`: List of providers, each with type/config, models, and keys.
 - `store_config`: Optional conversation storage settings.
 
@@ -43,7 +43,7 @@ chat_ai:
   enabled: true
   default_provider: "openai"
   tools:
-    exclude:
+    disabled_tools:
       - "manage_istio_config"
   providers:
     - name: "openai"
@@ -53,7 +53,7 @@ chat_ai:
       config: "default"
       default_model: "gemini"
       tools:
-        include:
+        enabled_tools:
           - "get_logs"
           - "get_mesh_status"
       models:
@@ -81,7 +81,7 @@ Reference for every configuration key under `chat_ai`, with type, allowed values
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Turns the AI assistant on or off. When `true`, `default_provider` is required. |
 | `default_provider` | string | `""` | Name of the provider to use when the UI does not specify one. Must match a provider `name` and that provider must be enabled. |
-| `tools` | object | `{}` | Optional global filter for the chat toolset. `include` restricts the exposed set to the listed tool names; `exclude` removes listed tool names from the resulting set. Empty means "use the default Kiali selection". |
+| `tools` | object | `{}` | Optional global filter for the chat toolset. `enabled_tools` acts as an allowlist: when set, only the listed tool names remain available. `disabled_tools` acts as a denylist and is applied afterwards. Empty means "use the default Kiali selection". |
 | `providers` | array | `[]` | List of provider definitions. Each entry has the keys described in [Provider keys](#provider-keys-providers). |
 | `store_config` | object | (see below) | Optional conversation storage settings. Keys are described in [Store config keys](#store-config-keys-store_config). |
 
@@ -95,7 +95,7 @@ Reference for every configuration key under `chat_ai`, with type, allowed values
 | `enabled` | boolean | no | Enable or disable this provider. Defaults to `true`. Disabled providers are ignored. |
 | `default_model` | string | yes | Name of the default model for this provider. Must match a model `name` in `models` and that model must be enabled. |
 | `description` | string | no | Human-readable description of the provider (e.g. for UI). |
-| `tools` | object | no | Optional provider-specific include/exclude filter applied after the global `chat_ai.tools` filter. It can further restrict the tools exposed to this provider, but it cannot re-enable a tool already filtered out globally or by feature availability. |
+| `tools` | object | no | Optional provider-specific `enabled_tools`/`disabled_tools` filter applied after the global `chat_ai.tools` filter. It can further restrict the tools exposed to this provider, but it cannot re-enable a tool already filtered out globally or by feature availability. |
 | `key` | string | conditional | API key for all models in this provider. Inline value or `secret:<secret-name>:<key-in-secret>`. Required if no model has a `key`. |
 | `models` | array | yes | List of models. Each entry has the keys described in [Model keys](#model-keys-providersmodels). |
 

--- a/ai/providers/README.md
+++ b/ai/providers/README.md
@@ -25,6 +25,7 @@ These fields apply to all OpenAI config modes:
 - `providers[].name`: Unique provider name (also used in secrets mount names).
 - `providers[].enabled`: Enable/disable the provider.
 - `providers[].default_model`: Name of the default model for this provider.
+- `providers[].tools`: Optional include/exclude filter to further restrict which chat tools this provider can use.
 - `providers[].key`: API key for all models, unless a model overrides it.
 - `providers[].models[]`:
   - `name`: Model alias used in requests.

--- a/ai/providers/README.md
+++ b/ai/providers/README.md
@@ -25,7 +25,7 @@ These fields apply to all OpenAI config modes:
 - `providers[].name`: Unique provider name (also used in secrets mount names).
 - `providers[].enabled`: Enable/disable the provider.
 - `providers[].default_model`: Name of the default model for this provider.
-- `providers[].tools`: Optional include/exclude filter to further restrict which chat tools this provider can use.
+- `providers[].tools`: Optional `enabled_tools`/`disabled_tools` filter to further restrict which chat tools this provider can use.
 - `providers[].key`: API key for all models, unless a model overrides it.
 - `providers[].models[]`:
   - `name`: Model alias used in requests.

--- a/ai/providers/anthropic/anthropic_provider.go
+++ b/ai/providers/anthropic/anthropic_provider.go
@@ -19,9 +19,10 @@ const (
 )
 
 type AnthropicProvider struct {
-	client         anthropic.Client
-	model          string
-	tracingEnabled bool
+	client       anthropic.Client
+	conf         *config.Config
+	model        string
+	providerName string
 }
 
 type anthropicConversation struct {
@@ -39,11 +40,14 @@ func NewAnthropicProvider(conf *config.Config, provider *config.ProviderConfig, 
 		return nil, fmt.Errorf("get provider config: %w", err)
 	}
 
-	return &AnthropicProvider{
-		client:         anthropic.NewClient(opts...),
-		model:          model.Model,
-		tracingEnabled: conf.ExternalServices.Tracing.Enabled,
-	}, nil
+	p := &AnthropicProvider{
+		client:       anthropic.NewClient(opts...),
+		conf:         conf,
+		model:        model.Model,
+		providerName: provider.Name,
+	}
+	providers.LogFilteredDefaultTools(p.GetName(), conf, provider.Name)
+	return p, nil
 }
 
 func getProviderOptions(conf *config.Config, provider *config.ProviderConfig, model *config.AIModel) ([]option.RequestOption, error) {
@@ -285,12 +289,14 @@ func appendConstraintNoteToProperties(schema map[string]interface{}, fieldNames 
 }
 
 func (p *AnthropicProvider) GetToolDefinitions() interface{} {
-	tools := make([]anthropic.ToolUnionParam, 0, len(mcp.DefaultToolHandlers))
-	for _, tool := range mcp.DefaultToolHandlers {
-		if !p.tracingEnabled && mcp.IsTraceTool(tool.Name) {
-			continue
-		}
+	filtered := providers.FilteredDefaultTools(p.conf, p.providerName)
+	tools := make([]anthropic.ToolUnionParam, 0, len(filtered))
+	for _, tool := range filtered {
 		tools = append(tools, convertToolToAnthropic(tool))
 	}
 	return tools
+}
+
+func (p *AnthropicProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return providers.LookupFilteredDefaultTool(p.conf, p.providerName, toolName)
 }

--- a/ai/providers/anthropic/anthropic_test.go
+++ b/ai/providers/anthropic/anthropic_test.go
@@ -131,8 +131,8 @@ func newAnthropicTestProvider(serverURL string) *AnthropicProvider {
 			option.WithAPIKey("test-key"),
 			option.WithMaxRetries(0),
 		),
-		model:          "claude-sonnet-4-5",
-		tracingEnabled: true,
+		conf:  config.NewConfig(),
+		model: "claude-sonnet-4-5",
 	}
 }
 

--- a/ai/providers/execution.go
+++ b/ai/providers/execution.go
@@ -58,37 +58,46 @@ func ExecuteToolCallsInParallel(
 				return
 			}
 
-			handler, ok := mcp.DefaultToolHandlers[call.Name]
+			handler, ok := p.LookupToolHandler(call.Name)
 			if !ok {
+				if !kialiInterface.Conf.ExternalServices.Tracing.Enabled && mcp.IsTraceTool(call.Name) {
+					toolResult := types.StreamToolResultData{
+						Content: fmt.Errorf("tool %s is not available when tracing is disabled", call.Name).Error(),
+						ID:      call.ID,
+						Round:   1,
+						Status:  "error",
+						Type:    "tool_result",
+					}
+					results[index] = toolResult
+					SendStreamEvent(safeOnChunk, LLM_TOOL_RESULT_EVENT, toolResult)
+					return
+				}
+				if !kialiInterface.Conf.ExternalServices.Prometheus.Enabled && mcp.IsMetricTool(call.Name) {
+					toolResult := types.StreamToolResultData{
+						Content: fmt.Errorf("metrics are unavailable because Prometheus is disabled").Error(),
+						ID:      call.ID,
+						Round:   1,
+						Status:  "error",
+						Type:    "tool_result",
+					}
+					results[index] = toolResult
+					SendStreamEvent(safeOnChunk, LLM_TOOL_RESULT_EVENT, toolResult)
+					return
+				}
+				if _, exists := mcp.DefaultToolHandlers[call.Name]; exists {
+					toolResult := types.StreamToolResultData{
+						Content: fmt.Errorf("tool %s is not exposed for this AI provider", call.Name).Error(),
+						ID:      call.ID,
+						Round:   1,
+						Status:  "error",
+						Type:    "tool_result",
+					}
+					results[index] = toolResult
+					SendStreamEvent(safeOnChunk, LLM_TOOL_RESULT_EVENT, toolResult)
+					return
+				}
 				toolResult := types.StreamToolResultData{
 					Content: fmt.Errorf("tool handler not found: %s", call.Name).Error(),
-					ID:      call.ID,
-					Round:   1,
-					Status:  "error",
-					Type:    "tool_result",
-				}
-				results[index] = toolResult
-				SendStreamEvent(safeOnChunk, LLM_TOOL_RESULT_EVENT, toolResult)
-				return
-			}
-
-			if !kialiInterface.Conf.ExternalServices.Tracing.Enabled && mcp.IsTraceTool(call.Name) {
-				toolResult := types.StreamToolResultData{
-					Content: fmt.Errorf("tool %s is not available when tracing is disabled", call.Name).Error(),
-					ID:      call.ID,
-					Round:   1,
-					Status:  "error",
-					Type:    "tool_result",
-				}
-				results[index] = toolResult
-				SendStreamEvent(safeOnChunk, LLM_TOOL_RESULT_EVENT, toolResult)
-				return
-			}
-
-			// 404 mirrors the tracing gate convention above
-			if !kialiInterface.Conf.ExternalServices.Prometheus.Enabled && mcp.IsMetricTool(call.Name) {
-				toolResult := types.StreamToolResultData{
-					Content: fmt.Errorf("metrics are unavailable because Prometheus is disabled").Error(),
 					ID:      call.ID,
 					Round:   1,
 					Status:  "error",

--- a/ai/providers/execution_test.go
+++ b/ai/providers/execution_test.go
@@ -22,13 +22,19 @@ import (
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
-type dummyProvider struct{}
+type dummyProvider struct {
+	conf         *config.Config
+	providerName string
+}
 
 func (d dummyProvider) GetName() string                                              { return "dummy" }
 func (d dummyProvider) InitializeConversation(ptr *types.Conversation, query string) {}
 func (d dummyProvider) ReduceConversation(ctx context.Context, ptr *types.Conversation, reduceThreshold int) {
 }
 func (d dummyProvider) GetToolDefinitions() interface{} { return nil }
+func (d dummyProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return LookupFilteredDefaultTool(d.conf, d.providerName, toolName)
+}
 func (d dummyProvider) TransformToolCallToToolsProcessor(toolCall any) ([]types.StreamToolCallData, []string, error) {
 	return nil, nil, nil
 }
@@ -77,6 +83,27 @@ func TestExecuteToolCallsInParallel_UnknownToolHandler(t *testing.T) {
 	require.Equal(t, "error", results[0].Status)
 	assert.Contains(t, results[0].Content, "tool handler not found")
 
+}
+
+func TestExecuteToolCallsInParallel_FilteredToolIsRejected(t *testing.T) {
+	require.NoError(t, mcp.LoadTools())
+
+	ki := newTestKialiInterface(t)
+	ki.Conf.ChatAI.Providers = []config.ProviderConfig{
+		{
+			Name:  "provider-1",
+			Tools: config.ToolFilterConfig{Exclude: []string{"get_referenced_docs"}},
+		},
+	}
+	toolCalls := []types.StreamToolCallData{
+		{Name: "get_referenced_docs", Args: map[string]any{"keywords": "test"}, ID: "tc-1"},
+	}
+
+	results, _, _ := ExecuteToolCallsInParallel(dummyProvider{conf: ki.Conf, providerName: "provider-1"}, func(chunk string) {}, ki, toolCalls)
+
+	require.Len(t, results, 1)
+	require.Equal(t, "error", results[0].Status)
+	assert.Contains(t, results[0].Content, "is not exposed for this AI provider")
 }
 
 func TestExecuteToolCallsInParallel_ContextCanceledBefore(t *testing.T) {

--- a/ai/providers/execution_test.go
+++ b/ai/providers/execution_test.go
@@ -92,7 +92,7 @@ func TestExecuteToolCallsInParallel_FilteredToolIsRejected(t *testing.T) {
 	ki.Conf.ChatAI.Providers = []config.ProviderConfig{
 		{
 			Name:  "provider-1",
-			Tools: config.ToolFilterConfig{Exclude: []string{"get_referenced_docs"}},
+			Tools: config.ToolFilterConfig{DisabledTools: []string{"get_referenced_docs"}},
 		},
 	}
 	toolCalls := []types.StreamToolCallData{

--- a/ai/providers/google/google.go
+++ b/ai/providers/google/google.go
@@ -254,11 +254,9 @@ func (p *GoogleAIProvider) InitializeConversation(ptr *types.Conversation, query
 }
 
 func (p *GoogleAIProvider) GetToolDefinitions() interface{} {
-	tools := make([]*genai.FunctionDeclaration, 0, len(mcp.DefaultToolHandlers))
-	for _, tool := range mcp.DefaultToolHandlers {
-		if !p.tracingEnabled && mcp.IsTraceTool(tool.Name) {
-			continue
-		}
+	filtered := providers.FilteredDefaultTools(p.conf, p.providerName)
+	tools := make([]*genai.FunctionDeclaration, 0, len(filtered))
+	for _, tool := range filtered {
 		tools = append(tools, &genai.FunctionDeclaration{
 			Name:        tool.GetName(),
 			Description: tool.GetDescription(),
@@ -268,6 +266,10 @@ func (p *GoogleAIProvider) GetToolDefinitions() interface{} {
 	return []*genai.Tool{{
 		FunctionDeclarations: tools,
 	}}
+}
+
+func (p *GoogleAIProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return providers.LookupFilteredDefaultTool(p.conf, p.providerName, toolName)
 }
 
 func (p *GoogleAIProvider) ConversationToProvider(conversation []types.ConversationMessage) interface{} {

--- a/ai/providers/google/google_provider.go
+++ b/ai/providers/google/google_provider.go
@@ -11,10 +11,11 @@ import (
 
 // GoogleGenAIProvider implements AIProvider using google-go.
 type GoogleAIProvider struct {
-	client         *google.Client
-	config         google.ClientConfig
-	model          string
-	tracingEnabled bool
+	client       *google.Client
+	conf         *config.Config
+	config       google.ClientConfig
+	model        string
+	providerName string
 }
 
 func (p *GoogleAIProvider) GetName() string {
@@ -26,12 +27,15 @@ func NewGoogleAIProvider(conf *config.Config, provider *config.ProviderConfig, m
 	if err != nil {
 		return nil, fmt.Errorf("get provider config: %w", err)
 	}
-	return &GoogleAIProvider{
-		client:         nil,
-		config:         opts,
-		model:          model.Model,
-		tracingEnabled: conf.ExternalServices.Tracing.Enabled,
-	}, nil
+	p := &GoogleAIProvider{
+		client:       nil,
+		conf:         conf,
+		config:       opts,
+		model:        model.Model,
+		providerName: provider.Name,
+	}
+	providers.LogFilteredDefaultTools(p.GetName(), conf, provider.Name)
+	return p, nil
 }
 
 func getProviderOptions(conf *config.Config, provider *config.ProviderConfig, model *config.AIModel) (google.ClientConfig, error) {

--- a/ai/providers/google/google_test.go
+++ b/ai/providers/google/google_test.go
@@ -202,7 +202,7 @@ func TestGoogle_TransformToolCallToToolsProcessor_EmptySlice(t *testing.T) {
 func TestGoogle_GetToolDefinitions_ReturnsToolList(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
 
-	p := &GoogleAIProvider{tracingEnabled: true}
+	p := &GoogleAIProvider{conf: config.NewConfig()}
 	result := p.GetToolDefinitions()
 
 	toolList, ok := result.([]*genai.Tool)
@@ -214,8 +214,13 @@ func TestGoogle_GetToolDefinitions_ReturnsToolList(t *testing.T) {
 func TestGoogle_GetToolDefinitions_FiltersTraceToolsWhenDisabled(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
 
-	pWithTracing := &GoogleAIProvider{tracingEnabled: true}
-	pWithoutTracing := &GoogleAIProvider{tracingEnabled: false}
+	confWithTracing := config.NewConfig()
+	confWithTracing.ExternalServices.Tracing.Enabled = true
+	confWithoutTracing := config.NewConfig()
+	confWithoutTracing.ExternalServices.Tracing.Enabled = false
+
+	pWithTracing := &GoogleAIProvider{conf: confWithTracing}
+	pWithoutTracing := &GoogleAIProvider{conf: confWithoutTracing}
 
 	withTracing := pWithTracing.GetToolDefinitions().([]*genai.Tool)[0].FunctionDeclarations
 	withoutTracing := pWithoutTracing.GetToolDefinitions().([]*genai.Tool)[0].FunctionDeclarations
@@ -380,9 +385,9 @@ func TestGoogle_SendChat_TextResponse(t *testing.T) {
 	defer server.Close()
 
 	p := &GoogleAIProvider{
-		client:         newGoogleTestClientForServer(t, server.URL),
-		model:          "gemini-1.5-pro",
-		tracingEnabled: true,
+		client: newGoogleTestClientForServer(t, server.URL),
+		conf:   config.NewConfig(),
+		model:  "gemini-1.5-pro",
 	}
 	store := &googleTestStore{enabled: true}
 	ki := newGoogleTestKialiInterface("session-1")
@@ -408,9 +413,9 @@ func TestGoogle_SendChat_StoresConversation(t *testing.T) {
 	defer server.Close()
 
 	p := &GoogleAIProvider{
-		client:         newGoogleTestClientForServer(t, server.URL),
-		model:          "gemini-1.5-pro",
-		tracingEnabled: true,
+		client: newGoogleTestClientForServer(t, server.URL),
+		conf:   config.NewConfig(),
+		model:  "gemini-1.5-pro",
 	}
 	store := &googleTestStore{enabled: true}
 	ki := newGoogleTestKialiInterface("session-1")

--- a/ai/providers/helpers_test.go
+++ b/ai/providers/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kiali/kiali/ai/mcp"
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/ai/types"
 	"github.com/kiali/kiali/config"
@@ -89,6 +90,10 @@ func (f *fakeProvider) ReduceConversation(_ context.Context, ptr *types.Conversa
 
 func (f *fakeProvider) GetToolDefinitions() interface{} {
 	return nil
+}
+
+func (f *fakeProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return mcp.ToolDef{}, false
 }
 
 func (f *fakeProvider) TransformToolCallToToolsProcessor(_ any) ([]types.StreamToolCallData, []string, error) {

--- a/ai/providers/lightspeed/lightspeed_provider.go
+++ b/ai/providers/lightspeed/lightspeed_provider.go
@@ -1,6 +1,7 @@
 package lightspeed_provider
 
 import (
+	"github.com/kiali/kiali/ai/mcp"
 	"github.com/kiali/kiali/ai/providers/lightspeed/client"
 	"github.com/kiali/kiali/config"
 )
@@ -24,4 +25,8 @@ func (p *LightSpeedProvider) GetName() string {
 
 func (p *LightSpeedProvider) GetToolDefinitions() interface{} {
 	return nil
+}
+
+func (p *LightSpeedProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return mcp.ToolDef{}, false
 }

--- a/ai/providers/openai/openai_provider.go
+++ b/ai/providers/openai/openai_provider.go
@@ -16,9 +16,10 @@ import (
 
 // OpenAIProvider implements AIProvider using openai-go.
 type OpenAIProvider struct {
-	client         openai.Client
-	model          string
-	tracingEnabled bool
+	client       openai.Client
+	conf         *config.Config
+	model        string
+	providerName string
 }
 
 type BaseURL string
@@ -35,11 +36,14 @@ func NewOpenAIProvider(conf *config.Config, provider *config.ProviderConfig, mod
 		return nil, fmt.Errorf("get provider config: %w", err)
 	}
 
-	return &OpenAIProvider{
-		client:         openai.NewClient(opts...),
-		model:          model.Model,
-		tracingEnabled: conf.ExternalServices.Tracing.Enabled,
-	}, nil
+	p := &OpenAIProvider{
+		client:       openai.NewClient(opts...),
+		conf:         conf,
+		model:        model.Model,
+		providerName: provider.Name,
+	}
+	providers.LogFilteredDefaultTools(p.GetName(), conf, provider.Name)
+	return p, nil
 }
 
 func getProviderOptions(conf *config.Config, provider *config.ProviderConfig, model *config.AIModel) ([]option.RequestOption, error) {
@@ -91,14 +95,16 @@ func convertToolToOpenAI(tool mcp.ToolDef) openai.ChatCompletionToolUnionParam {
 	}
 }
 func (p *OpenAIProvider) GetToolDefinitions() interface{} {
-	tools := make([]openai.ChatCompletionToolUnionParam, 0, len(mcp.DefaultToolHandlers))
-	for _, handler := range mcp.DefaultToolHandlers {
-		if !p.tracingEnabled && mcp.IsTraceTool(handler.Name) {
-			continue
-		}
+	filtered := providers.FilteredDefaultTools(p.conf, p.providerName)
+	tools := make([]openai.ChatCompletionToolUnionParam, 0, len(filtered))
+	for _, handler := range filtered {
 		tools = append(tools, convertToolToOpenAI(handler))
 	}
 	return tools
+}
+
+func (p *OpenAIProvider) LookupToolHandler(toolName string) (mcp.ToolDef, bool) {
+	return providers.LookupFilteredDefaultTool(p.conf, p.providerName, toolName)
 }
 
 func (p *OpenAIProvider) TransformToolCallToToolsProcessor(toolCall any) ([]types.StreamToolCallData, []string, error) {

--- a/ai/providers/openai/openai_provider_test.go
+++ b/ai/providers/openai/openai_provider_test.go
@@ -210,7 +210,7 @@ func TestGetProviderOptions_AzureConfig_WithEndpoint(t *testing.T) {
 func TestGetToolDefinitions_ReturnsToolList(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
 
-	p := &OpenAIProvider{tracingEnabled: true}
+	p := &OpenAIProvider{conf: config.NewConfig()}
 	result := p.GetToolDefinitions()
 	tools, ok := result.([]openai.ChatCompletionToolUnionParam)
 	require.True(t, ok)
@@ -220,13 +220,55 @@ func TestGetToolDefinitions_ReturnsToolList(t *testing.T) {
 func TestGetToolDefinitions_FiltersTraceToolsWhenDisabled(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
 
-	pWith := &OpenAIProvider{tracingEnabled: true}
-	pWithout := &OpenAIProvider{tracingEnabled: false}
+	confWith := config.NewConfig()
+	confWith.ExternalServices.Tracing.Enabled = true
+	confWithout := config.NewConfig()
+	confWithout.ExternalServices.Tracing.Enabled = false
+
+	pWith := &OpenAIProvider{conf: confWith}
+	pWithout := &OpenAIProvider{conf: confWithout}
 
 	withTracing := pWith.GetToolDefinitions().([]openai.ChatCompletionToolUnionParam)
 	withoutTracing := pWithout.GetToolDefinitions().([]openai.ChatCompletionToolUnionParam)
 
 	assert.Less(t, len(withoutTracing), len(withTracing))
+}
+
+func TestGetToolDefinitions_FiltersMetricToolsWhenPrometheusDisabled(t *testing.T) {
+	require.NoError(t, mcp.LoadTools())
+
+	confWith := config.NewConfig()
+	confWith.ExternalServices.Prometheus.Enabled = true
+	confWithout := config.NewConfig()
+	confWithout.ExternalServices.Prometheus.Enabled = false
+
+	pWith := &OpenAIProvider{conf: confWith}
+	pWithout := &OpenAIProvider{conf: confWithout}
+
+	withMetrics := pWith.GetToolDefinitions().([]openai.ChatCompletionToolUnionParam)
+	withoutMetrics := pWithout.GetToolDefinitions().([]openai.ChatCompletionToolUnionParam)
+
+	assert.Less(t, len(withoutMetrics), len(withMetrics))
+}
+
+func TestGetToolDefinitions_AppliesGlobalAndProviderToolFilters(t *testing.T) {
+	require.NoError(t, mcp.LoadTools())
+
+	conf := config.NewConfig()
+	conf.ChatAI.Tools.Include = []string{"get_logs", "get_metrics"}
+	conf.ChatAI.Providers = []config.ProviderConfig{
+		{
+			Name:  "test-openai",
+			Tools: config.ToolFilterConfig{Exclude: []string{"get_metrics"}},
+		},
+	}
+
+	p := &OpenAIProvider{conf: conf, providerName: "test-openai"}
+	tools := p.GetToolDefinitions().([]openai.ChatCompletionToolUnionParam)
+
+	require.Len(t, tools, 1)
+	require.NotNil(t, tools[0].OfFunction)
+	assert.Equal(t, "get_logs", tools[0].OfFunction.Function.Name)
 }
 
 func TestTransformToolCallToToolsProcessor_InvalidJSON(t *testing.T) {

--- a/ai/providers/openai/openai_provider_test.go
+++ b/ai/providers/openai/openai_provider_test.go
@@ -255,11 +255,11 @@ func TestGetToolDefinitions_AppliesGlobalAndProviderToolFilters(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
 
 	conf := config.NewConfig()
-	conf.ChatAI.Tools.Include = []string{"get_logs", "get_metrics"}
+	conf.ChatAI.Tools.EnabledTools = []string{"get_logs", "get_metrics"}
 	conf.ChatAI.Providers = []config.ProviderConfig{
 		{
 			Name:  "test-openai",
-			Tools: config.ToolFilterConfig{Exclude: []string{"get_metrics"}},
+			Tools: config.ToolFilterConfig{DisabledTools: []string{"get_metrics"}},
 		},
 	}
 

--- a/ai/providers/openai/openai_test.go
+++ b/ai/providers/openai/openai_test.go
@@ -91,8 +91,8 @@ func newOpenAITestProvider(serverURL string) *OpenAIProvider {
 			option.WithBaseURL(serverURL),
 			option.WithMaxRetries(0),
 		),
-		model:          "gpt-4o",
-		tracingEnabled: true,
+		conf:  config.NewConfig(),
+		model: "gpt-4o",
 	}
 }
 

--- a/ai/providers/provider.go
+++ b/ai/providers/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/kiali/kiali/ai/mcp"
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/ai/types"
 )
@@ -14,6 +15,7 @@ type AIProvider interface {
 	InitializeConversation(ptr *types.Conversation, query string)
 	ReduceConversation(ctx context.Context, ptr *types.Conversation, reduceThreshold int)
 	GetToolDefinitions() interface{}
+	LookupToolHandler(toolName string) (mcp.ToolDef, bool)
 	TransformToolCallToToolsProcessor(toolCall any) ([]types.StreamToolCallData, []string, error)
 	ConversationToProvider(conversation []types.ConversationMessage) interface{}
 	ProviderToConversation(providerMessage interface{}) types.ConversationMessage

--- a/ai/providers/tool_filters.go
+++ b/ai/providers/tool_filters.go
@@ -86,10 +86,10 @@ func LogFilteredDefaultTools(displayName string, conf *config.Config, providerNa
 }
 
 func toolAllowedByFilter(toolName string, filter config.ToolFilterConfig) bool {
-	if len(filter.Include) > 0 {
+	if len(filter.EnabledTools) > 0 {
 		allowed := false
-		for _, included := range filter.Include {
-			if included == toolName {
+		for _, enabled := range filter.EnabledTools {
+			if enabled == toolName {
 				allowed = true
 				break
 			}
@@ -99,8 +99,8 @@ func toolAllowedByFilter(toolName string, filter config.ToolFilterConfig) bool {
 		}
 	}
 
-	for _, excluded := range filter.Exclude {
-		if excluded == toolName {
+	for _, disabled := range filter.DisabledTools {
+		if disabled == toolName {
 			return false
 		}
 	}

--- a/ai/providers/tool_filters.go
+++ b/ai/providers/tool_filters.go
@@ -1,0 +1,121 @@
+package providers
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/kiali/kiali/ai/mcp"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/log"
+)
+
+var loggedFilteredToolSets sync.Map
+
+func FilteredDefaultTools(conf *config.Config, providerName string) []mcp.ToolDef {
+	names := FilteredDefaultToolNames(conf, providerName)
+	tools := make([]mcp.ToolDef, 0, len(names))
+	for _, name := range names {
+		tools = append(tools, mcp.DefaultToolHandlers[name])
+	}
+	return tools
+}
+
+func FilteredDefaultToolNames(conf *config.Config, providerName string) []string {
+	names := make([]string, 0, len(mcp.DefaultToolHandlers))
+	for name := range mcp.DefaultToolHandlers {
+		if IsDefaultToolExposed(conf, providerName, name) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func LookupFilteredDefaultTool(conf *config.Config, providerName string, toolName string) (mcp.ToolDef, bool) {
+	tool, ok := mcp.DefaultToolHandlers[toolName]
+	if !ok {
+		return mcp.ToolDef{}, false
+	}
+	if !IsDefaultToolExposed(conf, providerName, toolName) {
+		return mcp.ToolDef{}, false
+	}
+	return tool, true
+}
+
+func IsDefaultToolExposed(conf *config.Config, providerName string, toolName string) bool {
+	if _, ok := mcp.DefaultToolHandlers[toolName]; !ok {
+		return false
+	}
+	if conf == nil {
+		return true
+	}
+
+	if !conf.ExternalServices.Tracing.Enabled && mcp.IsTraceTool(toolName) {
+		return false
+	}
+	if !conf.ExternalServices.Prometheus.Enabled && mcp.IsMetricTool(toolName) {
+		return false
+	}
+	if !toolAllowedByFilter(toolName, conf.ChatAI.Tools) {
+		return false
+	}
+
+	providerFilter, ok := providerToolFilter(conf, providerName)
+	if ok && !toolAllowedByFilter(toolName, providerFilter) {
+		return false
+	}
+
+	return true
+}
+
+func LogFilteredDefaultTools(displayName string, conf *config.Config, providerName string) {
+	names := FilteredDefaultToolNames(conf, providerName)
+	joined := strings.Join(names, ", ")
+	if joined == "" {
+		joined = "<none>"
+	}
+
+	cacheKey := displayName + "|" + providerName + "|" + joined
+	if _, loaded := loggedFilteredToolSets.LoadOrStore(cacheKey, struct{}{}); loaded {
+		return
+	}
+
+	log.Infof("[Chat AI][%s][Tools] Exposed tools after filtering (provider=%q): %d tools: %s",
+		displayName, providerName, len(names), joined)
+}
+
+func toolAllowedByFilter(toolName string, filter config.ToolFilterConfig) bool {
+	if len(filter.Include) > 0 {
+		allowed := false
+		for _, included := range filter.Include {
+			if included == toolName {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false
+		}
+	}
+
+	for _, excluded := range filter.Exclude {
+		if excluded == toolName {
+			return false
+		}
+	}
+
+	return true
+}
+
+func providerToolFilter(conf *config.Config, providerName string) (config.ToolFilterConfig, bool) {
+	if conf == nil || providerName == "" {
+		return config.ToolFilterConfig{}, false
+	}
+	for _, provider := range conf.ChatAI.Providers {
+		if provider.Name == providerName {
+			return provider.Tools, true
+		}
+	}
+	return config.ToolFilterConfig{}, false
+}

--- a/config/config.go
+++ b/config/config.go
@@ -789,8 +789,8 @@ type AIModel struct {
 }
 
 type ToolFilterConfig struct {
-	EnabledTools  []string `yaml:"enabled_tools,omitempty" json:"enabled_tools,omitempty"`
 	DisabledTools []string `yaml:"disabled_tools,omitempty" json:"disabled_tools,omitempty"`
+	EnabledTools  []string `yaml:"enabled_tools,omitempty" json:"enabled_tools,omitempty"`
 }
 
 type ProviderType string

--- a/config/config.go
+++ b/config/config.go
@@ -789,8 +789,8 @@ type AIModel struct {
 }
 
 type ToolFilterConfig struct {
-	Include []string `yaml:"include,omitempty" json:"include,omitempty"`
-	Exclude []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	EnabledTools  []string `yaml:"enabled_tools,omitempty" json:"enabled_tools,omitempty"`
+	DisabledTools []string `yaml:"disabled_tools,omitempty" json:"disabled_tools,omitempty"`
 }
 
 type ProviderType string
@@ -1479,33 +1479,30 @@ func normalizeAndValidateToolFilter(path string, filter *ToolFilterConfig) error
 		return nil
 	}
 
-	includeSet := make(map[string]struct{}, len(filter.Include))
-	for i, name := range filter.Include {
+	enabledSet := make(map[string]struct{}, len(filter.EnabledTools))
+	for i, name := range filter.EnabledTools {
 		trimmed := strings.TrimSpace(name)
 		if trimmed == "" {
-			return fmt.Errorf("%s.include[%d] must not be empty", path, i)
+			return fmt.Errorf("%s.enabled_tools[%d] must not be empty", path, i)
 		}
-		if _, exists := includeSet[trimmed]; exists {
-			return fmt.Errorf("%s.include contains duplicate name %q", path, trimmed)
+		if _, exists := enabledSet[trimmed]; exists {
+			return fmt.Errorf("%s.enabled_tools contains duplicate name %q", path, trimmed)
 		}
-		includeSet[trimmed] = struct{}{}
-		filter.Include[i] = trimmed
+		enabledSet[trimmed] = struct{}{}
+		filter.EnabledTools[i] = trimmed
 	}
 
-	excludeSet := make(map[string]struct{}, len(filter.Exclude))
-	for i, name := range filter.Exclude {
+	disabledSet := make(map[string]struct{}, len(filter.DisabledTools))
+	for i, name := range filter.DisabledTools {
 		trimmed := strings.TrimSpace(name)
 		if trimmed == "" {
-			return fmt.Errorf("%s.exclude[%d] must not be empty", path, i)
+			return fmt.Errorf("%s.disabled_tools[%d] must not be empty", path, i)
 		}
-		if _, exists := excludeSet[trimmed]; exists {
-			return fmt.Errorf("%s.exclude contains duplicate name %q", path, trimmed)
+		if _, exists := disabledSet[trimmed]; exists {
+			return fmt.Errorf("%s.disabled_tools contains duplicate name %q", path, trimmed)
 		}
-		if _, exists := includeSet[trimmed]; exists {
-			return fmt.Errorf("%s contains %q in both include and exclude", path, trimmed)
-		}
-		excludeSet[trimmed] = struct{}{}
-		filter.Exclude[i] = trimmed
+		disabledSet[trimmed] = struct{}{}
+		filter.DisabledTools[i] = trimmed
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -788,6 +788,11 @@ type AIModel struct {
 	Key         Credential `yaml:"key,omitempty" json:"key,omitempty"`
 }
 
+type ToolFilterConfig struct {
+	Include []string `yaml:"include,omitempty" json:"include,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+}
+
 type ProviderType string
 
 const (
@@ -816,6 +821,7 @@ type ProviderConfig struct {
 	DefaultModel string             `yaml:"default_model,omitempty" json:"default_model,omitempty"`
 	Models       []AIModel          `yaml:"models,omitempty" json:"models,omitempty"`
 	Key          Credential         `yaml:"key,omitempty" json:"key,omitempty"`
+	Tools        ToolFilterConfig   `yaml:"tools,omitempty" json:"tools,omitempty"`
 }
 
 // ChatAIConfig defines configuration for the ChatAI subsystem
@@ -824,6 +830,7 @@ type ChatAIConfig struct {
 	Enabled         bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Providers       []ProviderConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
 	StoreConfig     AiStoreConfig    `yaml:"store_config,omitempty" json:"store_config,omitempty"`
+	Tools           ToolFilterConfig `yaml:"tools,omitempty" json:"tools,omitempty"`
 }
 
 // Clustering defines configuration around multi-cluster functionality.
@@ -1350,6 +1357,10 @@ func (conf *Config) ValidateAI() error {
 		return nil
 	}
 
+	if err := normalizeAndValidateToolFilter("chat_ai.tools", &conf.ChatAI.Tools); err != nil {
+		return err
+	}
+
 	if conf.ChatAI.DefaultProvider == "" {
 		return fmt.Errorf("chat_ai.default_provider is required when chat_ai.enabled is true")
 	}
@@ -1368,6 +1379,9 @@ func (conf *Config) ValidateAI() error {
 		p := &conf.ChatAI.Providers[i]
 		if !p.Enabled {
 			continue
+		}
+		if err := normalizeAndValidateToolFilter(fmt.Sprintf("chat_ai.providers[%q].tools", p.Name), &p.Tools); err != nil {
+			return err
 		}
 		if _, exists := seenNames[p.Name]; exists {
 			return fmt.Errorf("chat_ai.providers contains duplicate name %q", p.Name)
@@ -1455,6 +1469,43 @@ func (conf *Config) ValidateAI() error {
 
 	if !defaultProviderFound {
 		return fmt.Errorf("chat_ai.default_provider %q not found in providers", conf.ChatAI.DefaultProvider)
+	}
+
+	return nil
+}
+
+func normalizeAndValidateToolFilter(path string, filter *ToolFilterConfig) error {
+	if filter == nil {
+		return nil
+	}
+
+	includeSet := make(map[string]struct{}, len(filter.Include))
+	for i, name := range filter.Include {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("%s.include[%d] must not be empty", path, i)
+		}
+		if _, exists := includeSet[trimmed]; exists {
+			return fmt.Errorf("%s.include contains duplicate name %q", path, trimmed)
+		}
+		includeSet[trimmed] = struct{}{}
+		filter.Include[i] = trimmed
+	}
+
+	excludeSet := make(map[string]struct{}, len(filter.Exclude))
+	for i, name := range filter.Exclude {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("%s.exclude[%d] must not be empty", path, i)
+		}
+		if _, exists := excludeSet[trimmed]; exists {
+			return fmt.Errorf("%s.exclude contains duplicate name %q", path, trimmed)
+		}
+		if _, exists := includeSet[trimmed]; exists {
+			return fmt.Errorf("%s contains %q in both include and exclude", path, trimmed)
+		}
+		excludeSet[trimmed] = struct{}{}
+		filter.Exclude[i] = trimmed
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -651,6 +651,34 @@ func TestValidateAI(t *testing.T) {
 			mutate:    nil,
 			expectErr: "",
 		},
+		"global tool filter duplicate include": {
+			mutate: func(conf *Config) {
+				conf.ChatAI.Tools.Include = []string{"get_logs", "get_logs"}
+			},
+			expectErr: "chat_ai.tools.include contains duplicate name",
+		},
+		"global tool filter include exclude overlap": {
+			mutate: func(conf *Config) {
+				conf.ChatAI.Tools.Include = []string{"get_logs"}
+				conf.ChatAI.Tools.Exclude = []string{"get_logs"}
+			},
+			expectErr: "chat_ai.tools contains \"get_logs\" in both include and exclude",
+		},
+		"provider tool filter trims whitespace": {
+			mutate: func(conf *Config) {
+				conf.ChatAI.Providers[0].Tools.Include = []string{" get_logs "}
+			},
+			expectErr: "",
+			postValidate: func(t *testing.T, conf *Config) {
+				assert.Equal(t, []string{"get_logs"}, conf.ChatAI.Providers[0].Tools.Include)
+			},
+		},
+		"provider tool filter duplicate exclude": {
+			mutate: func(conf *Config) {
+				conf.ChatAI.Providers[0].Tools.Exclude = []string{"get_logs", "get_logs"}
+			},
+			expectErr: "chat_ai.providers[\"provider-1\"].tools.exclude contains duplicate name",
+		},
 		"default provider disabled": {
 			mutate: func(conf *Config) {
 				conf.ChatAI.Providers[0].Enabled = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -657,7 +657,7 @@ func TestValidateAI(t *testing.T) {
 			},
 			expectErr: "chat_ai.tools.enabled_tools contains duplicate name",
 		},
-		"global tool filter overlap is allowed and disabled wins": {
+		"global tool filter overlap is allowed": {
 			mutate: func(conf *Config) {
 				conf.ChatAI.Tools.EnabledTools = []string{"get_logs"}
 				conf.ChatAI.Tools.DisabledTools = []string{"get_logs"}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -651,33 +651,33 @@ func TestValidateAI(t *testing.T) {
 			mutate:    nil,
 			expectErr: "",
 		},
-		"global tool filter duplicate include": {
+		"global tool filter duplicate enabled_tools": {
 			mutate: func(conf *Config) {
-				conf.ChatAI.Tools.Include = []string{"get_logs", "get_logs"}
+				conf.ChatAI.Tools.EnabledTools = []string{"get_logs", "get_logs"}
 			},
-			expectErr: "chat_ai.tools.include contains duplicate name",
+			expectErr: "chat_ai.tools.enabled_tools contains duplicate name",
 		},
-		"global tool filter include exclude overlap": {
+		"global tool filter overlap is allowed and disabled wins": {
 			mutate: func(conf *Config) {
-				conf.ChatAI.Tools.Include = []string{"get_logs"}
-				conf.ChatAI.Tools.Exclude = []string{"get_logs"}
+				conf.ChatAI.Tools.EnabledTools = []string{"get_logs"}
+				conf.ChatAI.Tools.DisabledTools = []string{"get_logs"}
 			},
-			expectErr: "chat_ai.tools contains \"get_logs\" in both include and exclude",
+			expectErr: "",
 		},
 		"provider tool filter trims whitespace": {
 			mutate: func(conf *Config) {
-				conf.ChatAI.Providers[0].Tools.Include = []string{" get_logs "}
+				conf.ChatAI.Providers[0].Tools.EnabledTools = []string{" get_logs "}
 			},
 			expectErr: "",
 			postValidate: func(t *testing.T, conf *Config) {
-				assert.Equal(t, []string{"get_logs"}, conf.ChatAI.Providers[0].Tools.Include)
+				assert.Equal(t, []string{"get_logs"}, conf.ChatAI.Providers[0].Tools.EnabledTools)
 			},
 		},
-		"provider tool filter duplicate exclude": {
+		"provider tool filter duplicate disabled_tools": {
 			mutate: func(conf *Config) {
-				conf.ChatAI.Providers[0].Tools.Exclude = []string{"get_logs", "get_logs"}
+				conf.ChatAI.Providers[0].Tools.DisabledTools = []string{"get_logs", "get_logs"}
 			},
-			expectErr: "chat_ai.providers[\"provider-1\"].tools.exclude contains duplicate name",
+			expectErr: "chat_ai.providers[\"provider-1\"].tools.disabled_tools contains duplicate name",
 		},
 		"default provider disabled": {
 			mutate: func(conf *Config) {


### PR DESCRIPTION
### Describe the change

PR Summary
This PR adds fine-grained control over which AI chat tools Kiali exposes to each provider.

Before this change, Kiali decided the available tool set internally and only filtered some tools at runtime based on feature availability, such as tracing or Prometheus. With this PR, administrators can now explicitly control individual tools using:

enabled_tools: an allowlist. If set, only these tools are exposed.
disabled_tools: a denylist applied after enabled_tools.
This works both globally under chat_ai.tools and per provider under chat_ai.providers[].tools.

Example:

```
chat_ai:
  tools:
    enabled_tools:
      - get_logs
      - get_mesh_status
      - list_traces
    disabled_tools:
      - list_traces
```
In that example, list_traces is still disabled because disabled_tools wins.

The PR also makes tool exposure consistent across the whole AI flow:

- tools are filtered before being sent to OpenAI / Google / Anthropic
- filtered tools are rejected if the model still tries to call them
- tracing and Prometheus feature gates are still respected
- Kiali now logs the final exposed tool list per provider for easier verification at runtime

```
2026-05-28T12:35:57+01:00 INF [AI]Loaded 12 MCP tools: get_action_ui, get_logs, get_mesh_status, get_mesh_traffic_graph, get_metrics, get_pod_performance, get_referenced_docs, get_trace_details, list_or_get_resources, list_traces, manage_istio_config, manage_istio_config_read
2026-05-28T12:35:57+01:00 INF [AI]Default (chatbot) toolset: 12 tools: get_action_ui, get_logs, get_mesh_status, get_mesh_traffic_graph, get_metrics, get_pod_performance, get_referenced_docs, get_trace_details, list_or_get_resources, list_traces, manage_istio_config, manage_istio_config_read
2026-05-28T12:35:57+01:00 INF [Chat AI][OpenAI][Tools] Exposed tools after filtering (provider="openai"): 2 tools: get_logs, get_mesh_status
```

### Steps to test the PR
Use a config like this:

```
chat_ai:
  enabled: true
  default_provider: "openai"
  tools:
    enabled_tools:
      - get_logs
      - get_mesh_status
      - list_traces
    disabled_tools:
      - list_traces
  providers:
    - name: "openai"
      enabled: true
      type: "openai"
      config: "default"
      default_model: "gpt-4o"
      key: "..."
      models:
        - name: "gpt-4o"
          enabled: true
          model: "gpt-4o"
```
Then restart Kiali and send a chat request.

Verify in logs: After the first chat request for that provider, look for the new log line:

`[Chat AI][OpenAI][Tools] Exposed tools after filtering (provider="openai"): ...`
list_traces should not appear there.

Important: the older startup log:

`[AI]Loaded ... MCP tools ...`
still shows the full internal registry of loaded tools, not the filtered set exposed to AI providers.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9737 
- Operator PR: https://github.com/kiali/kiali-operator/pull/1041
- Helm: https://github.com/kiali/helm-charts/pull/410 
- Docs: https://github.com/kiali/kiali.io/pull/977 
