### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: build
         path: frontend/build
@@ -39,7 +39,7 @@ jobs:
         CGO_ENABLED: ${{ github.base_ref && '1' }}
 
     - name: Upload go binary
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: kiali
         path: ~/go/bin/kiali

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -26,7 +26,7 @@ jobs:
       run: corepack enable
 
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
@@ -42,7 +42,7 @@ jobs:
         yarn test
 
     - name: Upload frontend build
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: build
         path: frontend/build/

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -52,7 +52,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -15,8 +15,12 @@ on:
         required: true
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -43,6 +47,8 @@ jobs:
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
   bump_version:
+    permissions:
+      contents: write
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integration-tests-backend-mcp.yml
+++ b/.github/workflows/integration-tests-backend-mcp.yml
@@ -26,17 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -45,7 +45,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -65,14 +65,14 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.intTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-rest-report-mcp-tools
         path: tests/integration/junit-rest-report-mcp-tools.xml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Upload test metadata
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: backend-test-metadata-mcp-tools
         path: test-metadata-mcp-tools/

--- a/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+++ b/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -47,7 +47,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -66,13 +66,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload multicluster coverage artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: coverage-multicluster
         path: tests/integration/multicluster/coverage-multicluster.out

--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -49,7 +49,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -72,14 +72,14 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.intTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-rest-report
         path: tests/integration/junit-rest-report.xml
@@ -93,13 +93,13 @@ jobs:
 
     - name: Upload test metadata
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: backend-test-metadata
         path: test-metadata/
 
     - name: Upload backend coverage artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: coverage-backend
         path: tests/integration/tests/coverage-backend.out

--- a/.github/workflows/integration-tests-frontend-ambient-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-ambient-multi-primary.yml
@@ -30,12 +30,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -47,14 +47,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -78,13 +78,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-ambient.yml
+++ b/.github/workflows/integration-tests-frontend-ambient.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-chat.yml
+++ b/.github/workflows/integration-tests-frontend-chat.yml
@@ -31,12 +31,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -44,14 +44,14 @@ jobs:
       run: corepack enable
 
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -68,7 +68,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-frontend-chat-report
         path: frontend/cypress/results/combined-report.xml
@@ -82,20 +82,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-1.yml
+++ b/.github/workflows/integration-tests-frontend-core-1.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-frontend-core-1-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-2.yml
+++ b/.github/workflows/integration-tests-frontend-core-2.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-frontend-core-2-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-optional.yml
+++ b/.github/workflows/integration-tests-frontend-core-optional.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: junit-frontend-core-optional-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-local-offline.yml
+++ b/.github/workflows/integration-tests-frontend-local-offline.yml
@@ -33,7 +33,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -45,14 +45,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -79,20 +79,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multi-mesh.yml
+++ b/.github/workflows/integration-tests-frontend-multi-mesh.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,20 +82,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-external-kiali.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-external-kiali.yml
@@ -29,12 +29,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -46,14 +46,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -77,13 +77,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-tempo.yml
+++ b/.github/workflows/integration-tests-frontend-tempo.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -38,12 +38,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -55,14 +55,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -86,20 +86,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -203,7 +203,7 @@ jobs:
     needs: [initialize]
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Store PR number, target branch, and Kiali version
       run: |
@@ -221,7 +221,7 @@ jobs:
     # don't have access to PR information in github.event.workflow_run.pull_requests
     # See: https://github.com/orgs/community/discussions/25220
     - name: Upload PR metadata
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: pr-metadata
         path: pr-metadata/
@@ -240,25 +240,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # -------------------------------
     # Download artifacts
     # -------------------------------
     - name: Download backend coverage
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: coverage-backend
         path: coverage
 
     - name: Download multicluster coverage
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: coverage-multicluster
         path: coverage
 
     - name: Download unit coverage
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: coverage-unit
         path: coverage
@@ -277,7 +277,7 @@ jobs:
     # Upload to Codecov
     # -------------------------------
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
         fail_ci_if_error: false
         files: coverage.out

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -16,8 +16,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -198,6 +202,8 @@ jobs:
       istio_version: ""
 
   store_pr_metadata:
+    permissions:
+      contents: read
     name: Store PR metadata
     runs-on: ubuntu-latest
     needs: [initialize]

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -53,12 +53,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out Kiali code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ env.BUILD_BRANCH }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -70,13 +70,13 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
@@ -84,7 +84,7 @@ jobs:
 
     - name: Download go binary
       if: github.event_name == 'workflow_call'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: kiali
         path: ~/go/bin/
@@ -153,14 +153,14 @@ jobs:
         done
 
     - name: Check out kubernetes-mcp-server
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: containers/kubernetes-mcp-server
         path: kubernetes-mcp-server
         ref: ${{ (github.event_name == 'workflow_call' && inputs.kubernetes_mcp_server_ref) || github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
 
     - name: Set up Go for kubernetes-mcp-server
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: kubernetes-mcp-server/go.mod
         cache: true
@@ -183,7 +183,7 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.contractTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-mcp-contract-tests
         path: debug-output

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -44,8 +44,12 @@ env:
   TARGET_BRANCH: ${{ inputs.target_branch || github.base_ref || github.ref_name }}
   BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch || github.ref }}
 
+permissions: read-all
+
 jobs:
   mcp_contract_tests:
+    permissions:
+      contents: read
     name: MCP Contract Tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -11,10 +11,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.ref }}
@@ -31,6 +28,8 @@ jobs:
   check-trigger:
     name: Check if evaluation should run
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
@@ -66,7 +65,7 @@ jobs:
 
             K8S_MCP_SERVER_REPO=""
             if [[ "$COMMENT_BODY" =~ (^|[[:space:]])KUBERNETES_MCP_SERVER_REPO=([^[:space:]]+) ]]; then
-              K8S_MCP_SERVER_REPO="${BASH_REMATCH[2]}"
+              K8S_MCP_SERVER_REPO="${BASH_REMATCH[2]//[$'\n\r']/}"
               echo "Using KUBERNETES_MCP_SERVER_REPO=${K8S_MCP_SERVER_REPO}"
             fi
             echo "kubernetes_mcp_server_repo=${K8S_MCP_SERVER_REPO}" >> $GITHUB_OUTPUT
@@ -85,23 +84,26 @@ jobs:
     needs: check-trigger
     if: needs.check-trigger.outputs.should-run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TARGET_BRANCH: ${{ github.base_ref || github.event.repository.default_branch || 'master' }}
       BUILD_BRANCH: ${{ needs.check-trigger.outputs.pr-sha }}
       KUBERNETES_MCP_SERVER_REPO: ${{ needs.check-trigger.outputs.kubernetes-mcp-server-repo }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ needs.check-trigger.outputs.pr-sha }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
@@ -111,7 +113,7 @@ jobs:
       run: corepack enable
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: yarn
@@ -209,7 +211,7 @@ jobs:
 
     - name: Upload mcpchecker results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: mcpchecker-results
         # Upload the directory so artifact layout matches download expectations (single-file uploads can flatten paths).
@@ -223,6 +225,9 @@ jobs:
   update-baseline:
     name: Update Token Baseline
     needs: [check-trigger, run-evaluation]
+    permissions:
+      contents: write
+      pull-requests: write
     if: |
       always() &&
       needs.run-evaluation.result == 'success' &&
@@ -230,12 +235,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout default branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ env.DEFAULT_BRANCH }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
@@ -245,7 +250,7 @@ jobs:
       run: make mcp-install-mcpchecker
 
     - name: Download mcpchecker results
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: mcpchecker-results
         path: mcpchecker-results/

--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -38,8 +38,12 @@ on:
         required: false
         type: number
         default: 0
+permissions: read-all
+
 jobs:
   molecules:
+    permissions:
+      contents: read
     name: Molecule tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - name: Checkout the hack script that runs the tests
       id: checkout-source
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         sparse-checkout: |
           hack/ci-kind-molecule-tests.sh
@@ -57,7 +57,7 @@ jobs:
           hack/ory-hydra/manifests/postgresql.yaml
           hack/ory-hydra/manifests/hydra-ui-simple.yaml
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
     - name: Free Disk Space

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       quay_tag: ${{ env.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -82,12 +82,12 @@ jobs:
       QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -96,7 +96,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: build
         path: frontend/build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,8 +17,12 @@ on:
         default: quay.io/kiali/kiali
         required: true
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -33,7 +37,7 @@ jobs:
     - name: Determine Quay tag
       id: quay_tag
       run: |
-        if [ -z ${{ github.event.inputs.quay_repository }} ];
+        if [ -z "${{ github.event.inputs.quay_repository }}" ];
         then
           QUAY_REPO="quay.io/kiali/kiali"
         else
@@ -73,6 +77,8 @@ jobs:
       build_branch: ${{ github.event.inputs.release_branch || github.ref_name }}
 
   push:
+    permissions:
+      contents: read
     name: Push latest
     # Avoid schedule workflows from forks to push images
     if: ${{ (github.event_name == 'schedule' && github.repository == 'kiali/kiali') || github.event_name != 'schedule' }}
@@ -101,11 +107,15 @@ jobs:
         name: build
         path: frontend/build
 
-    - name: Build and push image
-      run: |
-        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+    - name: Login to Quay.io
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
 
-        make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
+    - name: Build and push image
+      run: make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
 
   integration_tests_frontend:
     name: Run frontend integration tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,12 @@ on:
         default: quay.io/kiali/kiali
         required: true
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -85,7 +89,7 @@ jobs:
     - name: Determine release type
       id: release_type
       run: |
-        if [ -z ${{ github.event.inputs.release_type }} ];
+        if [ -z "${{ github.event.inputs.release_type }}" ];
         then
           DO_RELEASE=$(python minor.py)
           if [[ $DO_RELEASE == "True" ]]
@@ -156,7 +160,7 @@ jobs:
         BRANCH_VERSION: ${{ env.branch_version }}
       id: quay_tag
       run: |
-        if [ -z ${{ github.event.inputs.quay_repository }} ];
+        if [ -z "${{ github.event.inputs.quay_repository }}" ];
         then
           QUAY_REPO="quay.io/kiali/kiali"
         else
@@ -210,6 +214,8 @@ jobs:
       istio_minor_version_offset: 0
 
   build_cross_platform_binaries:
+    permissions:
+      contents: read
     name: Build cross-platform binaries
     if: ${{ needs.initialize.outputs.release_type != 'skip' }}
     runs-on: ubuntu-latest
@@ -246,6 +252,8 @@ jobs:
         retention-days: 30
 
   test_cross_platform_binaries:
+    permissions:
+      contents: read
     name: Test cross-platform binaries
     if: ${{ needs.initialize.outputs.release_type != 'skip' }}
     runs-on: ${{ matrix.os }}
@@ -293,6 +301,9 @@ jobs:
         echo "✓ ${{ matrix.binary_name }} works correctly on ${{ matrix.os }}"
 
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Release
     if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/kiali') || github.event_name != 'schedule') }}
     runs-on: ubuntu-latest
@@ -337,11 +348,15 @@ jobs:
         name: cross-platform-binaries
         path: dist
 
-    - name: Build and push image
-      run: |
-        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+    - name: Login to Quay.io
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
 
-        make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
+    - name: Build and push image
+      run: make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
 
     - name: Configure git
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       quay_tag: ${{ env.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -216,19 +216,19 @@ jobs:
     needs: [initialize, build_frontend]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: build
         path: frontend/build
@@ -239,7 +239,7 @@ jobs:
         ./hack/build-cross-platform.sh -v -o dist
 
     - name: Upload cross-platform binaries
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: cross-platform-binaries
         path: dist/kiali-*
@@ -268,7 +268,7 @@ jobs:
           #   binary_name: kiali-windows-amd64.exe
     steps:
     - name: Download cross-platform binaries
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: cross-platform-binaries
         path: dist
@@ -305,7 +305,7 @@ jobs:
       QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -319,20 +319,20 @@ jobs:
         mv frontend/package.json.tmp frontend/package.json
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: build
         path: frontend/build
 
     - name: Download cross-platform binaries
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: cross-platform-binaries
         path: dist

--- a/.github/workflows/report-to-reportportal.yml
+++ b/.github/workflows/report-to-reportportal.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Download frontend core test reports
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: 'junit-frontend-core-*-report'
         path: artifacts/
@@ -22,7 +22,7 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
 
     - name: Setup Node.js for merging reports
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
 
@@ -34,7 +34,7 @@ jobs:
         jrm merged-reports/combined-report.xml "artifacts/junit-frontend-core-*-report/*.xml"
 
     - name: Upload merged report
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: merged-frontend-report
         path: merged-reports/
@@ -49,7 +49,10 @@ jobs:
       image: quay.io/dno/droute:latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      # WARNING: head_sha may be from a fork PR. workflow_run runs with base repo write permissions.
+      # Do NOT execute any scripts or files from this checkout — only local action references are
+      # safe, as GitHub resolves those from the base repo, not the checked-out working directory.
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -58,7 +61,7 @@ jobs:
     # See: https://github.com/orgs/community/discussions/25220
     - name: Download backend test results and metadata
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: '{junit-rest-report,backend-test-metadata,pr-metadata}'
         path: artifacts/
@@ -66,7 +69,7 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
 
     - name: Download merged frontend report
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: merged-frontend-report
         path: frontend-core/cypress/results/

--- a/.github/workflows/report-to-reportportal.yml
+++ b/.github/workflows/report-to-reportportal.yml
@@ -6,8 +6,12 @@ on:
     types:
     - completed
 
+permissions: read-all
+
 jobs:
   merge-reports:
+    permissions:
+      contents: read
     name: Merge frontend test reports
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
@@ -41,6 +45,8 @@ jobs:
         retention-days: 1
 
   report-tests:
+    permissions:
+      contents: read
     name: Report tests to ReportPortal
     runs-on: ubuntu-latest
     needs: [merge-reports]

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -9,8 +9,12 @@ on:
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -37,6 +41,8 @@ jobs:
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
   release_tag:
+    permissions:
+      contents: write
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -46,7 +46,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -71,11 +71,11 @@ jobs:
         echo "Images tag": ${{ inputs.images_tag }}
         echo "Builde mode": ${{ inputs.build_mode }}
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}
@@ -101,11 +101,11 @@ jobs:
         echo "Images tag": ${{ inputs.images_tag }}
         echo "Builde mode": ${{ inputs.build_mode }}
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -53,6 +53,8 @@ on:
         required: true
 
 
+permissions: read-all
+
 jobs:
   build_and_push_integration_tests:
     name: Generate and push integration test docker images
@@ -85,6 +87,8 @@ jobs:
         make container-build-int-tests container-push-int-tests-quay
 
   build_and_push_cypress_tests:
+    permissions:
+      contents: read
     name: Generate and push cypress test docker images
     if: ${{ inputs.build_mode == 'cypress' || inputs.build_mode == 'both' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-images-update-latest.yml
+++ b/.github/workflows/test-images-update-latest.yml
@@ -19,8 +19,8 @@ jobs:
     outputs:
       build_mode: ${{ steps.determine.outputs.build_mode }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v4.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/test-images-update-latest.yml
+++ b/.github/workflows/test-images-update-latest.yml
@@ -12,6 +12,8 @@ on:
     - 'deploy/docker/Dockerfile-cypress'
     - 'tests/integration/**'
 
+permissions: read-all
+
 jobs:
   determine_change:
     name: Determine which images are affected by the change

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -30,8 +30,12 @@ on:
         default: ""
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -41,7 +41,7 @@ jobs:
       sail-operator-git-ref: ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.branch_to_test || github.ref_name }}
     - name: Determine Sail Operator git ref to use

--- a/.github/workflows/test-lint-backend.yml
+++ b/.github/workflows/test-lint-backend.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache: true
@@ -46,7 +46,7 @@ jobs:
       run: wc -l coverage-unit.out
 
     - name: Upload unit coverage artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: coverage-unit
         path: coverage-unit.out

--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -12,6 +12,8 @@ on:
     paths:
     - 'frontend/package.json'
     - 'Makefile'
+permissions: read-all
+
 jobs:
   version:
     name: Check version

--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: calculate versions
       id: version_info
       run: |

--- a/hack/hooks/pre-commit.sh
+++ b/hack/hooks/pre-commit.sh
@@ -83,7 +83,7 @@ if [ "${#yaml_files[@]}" -gt 0 ]; then
   if [ "${#yaml_files[@]}" -gt 0 ]; then
     yaml_unformatted=()
     while IFS= read -r f; do
-      yaml_unformatted+=("$f")
+      [[ -n "$f" ]] && yaml_unformatted+=("$f")
     done < <(yamlfmt -dry -quiet "${yaml_files[@]}" 2>&1 | sed 's/^.*://')
   fi
 fi


### PR DESCRIPTION
This PR hardens the GitHub Actions workflows against several known vulnerability classes.

**Supply chain risk (unpinned actions):** All third-party actions across every workflow were using floating version tags (e.g. `@v4`, `@v6`). These tags are mutable — a compromised action maintainer account can silently retag them to point to malicious code, which would then execute in CI with full access to repository secrets. All action references have been pinned to their full immutable commit SHA, with the version tag retained as a comment for readability.

**Credential exposure via `docker login -p`:** The nightly and release workflows were passing Quay credentials directly as a `-p` CLI argument to `docker login`. This exposes the password in the process list (`ps aux`) for the duration of the call. Both have been replaced with `docker/login-action`, which passes credentials securely via stdin.

**Unquoted shell variable expansion:** Several `[ -z ${{ }} ]` expressions in the nightly and release workflows were missing quotes around the interpolated value. An empty or whitespace-containing input would cause the test expression to fail unpredictably. These have been quoted.

**Missing `permissions:` blocks:** None of the directly-triggered workflows declared explicit token permissions, meaning they inherited the repository default (typically broad write access). All workflows now declare `permissions: read-all` at the top level, with `contents: write` and/or `pull-requests: write` granted only to the specific jobs that actually need them (release, tag creation, PR creation). Reusable `workflow_call`-only workflows are intentionally left without a top-level permissions block, as they inherit from their caller.

**Overly broad permissions on `issue_comment` trigger (`mcpchecker.yml`):** The MCP checker workflow was declaring `contents: write` and `pull-requests: write` at the top level while being triggered by `issue_comment`, which fires for any comment from any contributor. The token is minted with those privileges before any runtime permission check runs. Permissions are now scoped per-job.

**`GITHUB_OUTPUT` injection (`mcpchecker.yml`):** A value extracted from a PR comment body via regex was written directly to `$GITHUB_OUTPUT` without stripping newlines, enabling a collaborator to inject additional output entries. Newline stripping has been added.

**Pre-commit hook bug fix:** The `hack/hooks/pre-commit.sh` yamlfmt parsing loop was incorrectly populating the unformatted-files array with empty strings when yamlfmt reported no files needed formatting, causing false-positive hook failures. Fixed by skipping empty entries.

Generated-by: Claude