### PR TITLE
[Flake][Cypress] Fix Envoy config dump parsing in offline mode

### DIFF
--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -122,7 +123,7 @@ func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, erro
 	}
 
 	cd := &ConfigDump{}
-	err = json.Unmarshal(resp, cd)
+	err = json.NewDecoder(bytes.NewReader(resp)).Decode(cd)
 	if err != nil {
 		log.Errorf("Error Unmarshalling the config_dump: %v", err)
 	}

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -125,7 +125,7 @@ func (in *K8SClient) GetConfigDump(namespace, podName string) (*ConfigDump, erro
 	cd := &ConfigDump{}
 	err = json.NewDecoder(bytes.NewReader(resp)).Decode(cd)
 	if err != nil {
-		log.Errorf("Error Unmarshalling the config_dump: %v", err)
+		log.Errorf("Error decoding the config_dump: %v", err)
 	}
 
 	return cd, err

--- a/kubernetes/offline/offline.go
+++ b/kubernetes/offline/offline.go
@@ -225,18 +225,20 @@ func (c *OfflineClient) GetConfigDump(namespace, podName string) (*kialikube.Con
 // status code (e.g. "200\n") via `pilot-agent request GET /config_dump`.
 func parseConfigDump(data []byte) (*kialikube.ConfigDump, error) {
 	var configDump kialikube.ConfigDump
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&configDump); err == nil {
+	firstErr := json.NewDecoder(bytes.NewReader(data)).Decode(&configDump)
+	if firstErr == nil {
 		return &configDump, nil
 	}
 
 	idx := bytes.IndexByte(data, '{')
 	if idx <= 0 {
-		return nil, fmt.Errorf("no JSON object found in config dump data")
+		return nil, fmt.Errorf("no JSON object found in config dump data: %w", firstErr)
 	}
 
-	if err := json.NewDecoder(bytes.NewReader(data[idx:])).Decode(&configDump); err != nil {
-		return nil, fmt.Errorf("failed to parse config dump JSON starting at offset %d: %w", idx, err)
+	var fallbackDump kialikube.ConfigDump
+	if fallbackErr := json.NewDecoder(bytes.NewReader(data[idx:])).Decode(&fallbackDump); fallbackErr != nil {
+		return nil, fmt.Errorf("failed to parse config dump JSON at offset %d (%w); initial attempt: %w", idx, fallbackErr, firstErr)
 	}
 
-	return &configDump, nil
+	return &fallbackDump, nil
 }

--- a/kubernetes/offline/offline.go
+++ b/kubernetes/offline/offline.go
@@ -1,6 +1,7 @@
 package offline
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -210,7 +211,7 @@ func (c *OfflineClient) GetConfigDump(namespace, podName string) (*kialikube.Con
 	log.Debugf("Successfully read config dump file: %s", configDumpPath)
 
 	var configDump kialikube.ConfigDump
-	if err := json.Unmarshal(data, &configDump); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&configDump); err != nil {
 		log.Debugf("Failed to unmarshal config dump file %s: %s", configDumpPath, err)
 		// Return empty config dump when JSON is invalid
 		return &kialikube.ConfigDump{

--- a/kubernetes/offline/offline.go
+++ b/kubernetes/offline/offline.go
@@ -202,7 +202,6 @@ func (c *OfflineClient) GetConfigDump(namespace, podName string) (*kialikube.Con
 	data, err := os.ReadFile(configDumpPath)
 	if err != nil {
 		log.Debugf("Unable to read config dump file %s: %s", configDumpPath, err)
-		// Return empty config dump when file not found
 		return &kialikube.ConfigDump{
 			Configs: []interface{}{},
 		}, nil
@@ -210,13 +209,33 @@ func (c *OfflineClient) GetConfigDump(namespace, podName string) (*kialikube.Con
 
 	log.Debugf("Successfully read config dump file: %s", configDumpPath)
 
-	var configDump kialikube.ConfigDump
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&configDump); err != nil {
+	configDump, err := parseConfigDump(data)
+	if err != nil {
 		log.Debugf("Failed to unmarshal config dump file %s: %s", configDumpPath, err)
-		// Return empty config dump when JSON is invalid
 		return &kialikube.ConfigDump{
 			Configs: []interface{}{},
 		}, nil
+	}
+
+	return configDump, nil
+}
+
+// parseConfigDump attempts to parse Envoy config dump JSON from data that may
+// be prefixed with non-JSON content. Must-gather tools often prepend an HTTP
+// status code (e.g. "200\n") via `pilot-agent request GET /config_dump`.
+func parseConfigDump(data []byte) (*kialikube.ConfigDump, error) {
+	var configDump kialikube.ConfigDump
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&configDump); err == nil {
+		return &configDump, nil
+	}
+
+	idx := bytes.IndexByte(data, '{')
+	if idx <= 0 {
+		return nil, fmt.Errorf("no JSON object found in config dump data")
+	}
+
+	if err := json.NewDecoder(bytes.NewReader(data[idx:])).Decode(&configDump); err != nil {
+		return nil, fmt.Errorf("failed to parse config dump JSON starting at offset %d: %w", idx, err)
 	}
 
 	return &configDump, nil

--- a/kubernetes/offline/offline_test.go
+++ b/kubernetes/offline/offline_test.go
@@ -370,6 +370,61 @@ metadata:
 	}
 }
 
+func TestGetConfigDump_TrailingContent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	namespace := "test-namespace"
+	podName := "test-pod"
+
+	namespacesDir := filepath.Join(tmpDir, "namespaces")
+	mkdirAll(t, namespacesDir)
+
+	testYAML := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: ` + namespace + `
+`
+	filetest.WriteFile(t, filepath.Join(tmpDir, "test.yaml"), []byte(testYAML))
+
+	configDumpDir := filepath.Join(namespacesDir, namespace, "pods", podName)
+	mkdirAll(t, configDumpDir)
+
+	validJSONWithTrailingContent := `{
+  "configs": [
+    {
+      "@type": "type.googleapis.com/envoy.admin.v3.ClustersConfigDump",
+      "dynamic_active_clusters": [
+        {
+          "cluster": {
+            "name": "test-cluster",
+            "type": "EDS"
+          }
+        }
+      ]
+    }
+  ]
+}
+// trailing comment that must-gather may append
+/some/path/info
+`
+	configDumpFile := filepath.Join(configDumpDir, "config_dump_proxy.json")
+	filetest.WriteFile(t, configDumpFile, []byte(validJSONWithTrailingContent))
+
+	client, err := NewOfflineClient(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create offline client: %v", err)
+	}
+
+	configDump, err := client.GetConfigDump(namespace, podName)
+	if err != nil {
+		t.Fatalf("Failed to get config dump: %v", err)
+	}
+
+	if len(configDump.Configs) != 1 {
+		t.Errorf("Expected 1 config in dump (trailing content should be ignored), got %d", len(configDump.Configs))
+	}
+}
+
 func TestStreamPodLogs(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/kubernetes/offline/offline_test.go
+++ b/kubernetes/offline/offline_test.go
@@ -425,6 +425,59 @@ metadata:
 	}
 }
 
+func TestGetConfigDump_StatusCodePrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	namespace := "test-namespace"
+	podName := "test-pod"
+
+	namespacesDir := filepath.Join(tmpDir, "namespaces")
+	mkdirAll(t, namespacesDir)
+
+	testYAML := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: ` + namespace + `
+`
+	filetest.WriteFile(t, filepath.Join(tmpDir, "test.yaml"), []byte(testYAML))
+
+	configDumpDir := filepath.Join(namespacesDir, namespace, "pods", podName)
+	mkdirAll(t, configDumpDir)
+
+	jsonWithStatusCodePrefix := `200
+{
+  "configs": [
+    {
+      "@type": "type.googleapis.com/envoy.admin.v3.ClustersConfigDump",
+      "dynamic_active_clusters": [
+        {
+          "cluster": {
+            "name": "test-cluster",
+            "type": "EDS"
+          }
+        }
+      ]
+    }
+  ]
+}`
+	configDumpFile := filepath.Join(configDumpDir, "config_dump_proxy.json")
+	filetest.WriteFile(t, configDumpFile, []byte(jsonWithStatusCodePrefix))
+
+	client, err := NewOfflineClient(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create offline client: %v", err)
+	}
+
+	configDump, err := client.GetConfigDump(namespace, podName)
+	if err != nil {
+		t.Fatalf("Failed to get config dump: %v", err)
+	}
+
+	if len(configDump.Configs) != 1 {
+		t.Errorf("Expected 1 config in dump (status code prefix should be skipped), got %d", len(configDump.Configs))
+	}
+}
+
 func TestStreamPodLogs(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
### Describe the change

Fixing Cypress flake test for Offline mode.

https://github.com/kiali/kiali/actions/runs/26613612613/job/78425737945?pr=9765

**Summary**
Fix Envoy config dump parsing in offline mode to handle config_dump_proxy.json files produced by must-gather tools that prepend an HTTP status code (e.g., 200\n) before the JSON body (output of pilot-agent request GET /config_dump)
Apply the same resilient parsing to the live mode GetConfigDump in kubernetes/istio.go for robustness
**Details**
The quay.io/maistra/istio-must-gather image collects Envoy config dumps using pilot-agent request GET /config_dump, which outputs the HTTP status code on the first line followed by the JSON response body:

**200**
{"configs":[...]}
Kiali's offline reader was using json.Unmarshal which fails on this format with errors like:

invalid character '/' after top-level value
json: cannot unmarshal number into Go value of type kubernetes.ConfigDump
This caused all Envoy tabs (Clusters, Listeners, Routes, Config) to render with empty data in offline mode, producing constant Cypress test failures in the @offline suite.

The fix introduces a parseConfigDump() helper that:

First attempts to decode the data as-is (handles clean JSON files)
On failure, locates the first { in the data and decodes from that offset (skips status code prefix, and json.Decoder naturally ignores trailing content)

Test plan

- [x]  Existing TestGetConfigDump passes (clean JSON)
- [x]  Existing TestGetConfigDump_NotFound passes
- [x]  Existing TestGetConfigDump_InvalidJSON passes (truly broken JSON still returns empty config)
- [x]  New TestGetConfigDump_TrailingContent passes (JSON with trailing // comments)
- [x]  New TestGetConfigDump_StatusCodePrefix passes (200\n{...} format from must-gather)
- [x]  Offline Cypress tests pass: "See Envoy clusters/listeners/routes/bootstrap/config configuration for a workload"

