### PR TITLE
Reduce graph generation memory by not retaining full workload models

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -15,7 +15,6 @@ import (
 
 func NewGlobalIstioInfo() *GlobalIstioInfo {
 	return &GlobalIstioInfo{
-		AllWorkloads:        make(map[string]models.Workloads),
 		AmbientWaypoints:    make(map[graph.NodeKey]bool),
 		AppsMap:             make(map[string]map[string]*models.AppListItem),
 		ClusterServiceLists: make(map[string]*models.ServiceList),
@@ -27,9 +26,6 @@ func NewGlobalIstioInfo() *GlobalIstioInfo {
 
 // GlobalIstioInfo contains structured information for Istio telemetry vendor
 type GlobalIstioInfo struct {
-	// AllWorkloads caches full workload models by cluster name, populated by populateWorkloadMap.
-	// Used by decorateGateways to filter locally instead of re-fetching per gateway.
-	AllWorkloads map[string]models.Workloads
 	// AmbientWaypoints maps waypoint keys to their availability status
 	AmbientWaypoints any
 	// AppsMap contains application list items keyed by cluster:namespace
@@ -42,9 +38,14 @@ type GlobalIstioInfo struct {
 	ServiceLists map[string]*models.ServiceList
 	// WorkloadLists caches workload lists by cluster:namespace key
 	WorkloadLists map[string]*models.WorkloadList
-	// WorkloadMap maps workloads to their nodes on the map. Only available to finalizers
-	// since the full graph hasn't been generated until all appenders have run.
-	WorkloadMap map[graph.NodeKey]*graph.Node
+}
+
+// gatewayWorkload holds the minimal workload info needed for gateway decoration.
+type gatewayWorkload struct {
+	Cluster   string
+	Namespace string
+	Name      string
+	Labels    map[string]string
 }
 
 type (
@@ -503,27 +504,42 @@ func getTrafficClusters(trafficMap graph.TrafficMap, namespace string, gi *Globa
 	return filteredClusterNames
 }
 
-// populateWorkloadMap populates the globalInfo.WorkloadMap with the workloads from the trafficMap.
-// It also caches the full workload models in AllWorkloads so that decorateGateways can
-// filter locally by label selector instead of re-fetching workloads per gateway.
-func populateWorkloadMap(ctx context.Context, business *business.Layer, globalInfo *GlobalInfo, trafficMap graph.TrafficMap) {
-	for _, cluster := range globalInfo.Clusters {
-		workloads, err := business.Workload.GetAllWorkloads(ctx, cluster.Name, "")
+// populateWorkloadMap fetches all workloads per cluster and returns:
+//   - a map of cluster name to lightweight gatewayWorkload slices (for gateway decoration)
+//   - a workloadMap linking known workloads to their graph nodes (nil if not in trafficMap)
+//
+// The full models.Workloads from GetAllWorkloads are not retained; only the fields
+// needed for gateway label-selector matching are extracted.
+func populateWorkloadMap(ctx context.Context, biz *business.Layer, clusters []models.KubeCluster, trafficMap graph.TrafficMap) (map[string][]gatewayWorkload, map[graph.NodeKey]*graph.Node) {
+	gwWorkloads := make(map[string][]gatewayWorkload, len(clusters))
+	workloadMap := make(map[graph.NodeKey]*graph.Node)
+
+	for _, cluster := range clusters {
+		workloads, err := biz.Workload.GetAllWorkloads(ctx, cluster.Name, "")
 		if err != nil {
 			log.FromContext(ctx).Warn().Msgf("Error fetching workloads for cluster [%s], gateway decoration may be incomplete: %s", cluster.Name, err.Error())
 			continue
 		}
 
-		globalInfo.Vendor.AllWorkloads[cluster.Name] = workloads
-
-		for _, workload := range workloads {
-			globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: workload.Cluster, Namespace: workload.Namespace, Name: workload.Name}] = nil
+		slim := make([]gatewayWorkload, 0, len(workloads))
+		for _, w := range workloads {
+			slim = append(slim, gatewayWorkload{
+				Cluster:   w.Cluster,
+				Namespace: w.Namespace,
+				Name:      w.Name,
+				Labels:    w.Labels,
+			})
+			workloadMap[graph.NodeKey{Cluster: w.Cluster, Namespace: w.Namespace, Name: w.Name}] = nil
 		}
+		gwWorkloads[cluster.Name] = slim
 	}
 
 	for _, node := range trafficMap {
-		if _, ok := globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: node.Cluster, Namespace: node.Namespace, Name: node.Workload}]; ok {
-			globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: node.Cluster, Namespace: node.Namespace, Name: node.Workload}] = node
+		key := graph.NodeKey{Cluster: node.Cluster, Namespace: node.Namespace, Name: node.Workload}
+		if _, ok := workloadMap[key]; ok {
+			workloadMap[key] = node
 		}
 	}
+
+	return gwWorkloads, workloadMap
 }

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -41,10 +41,7 @@ func (a IstioAppender) AppendGraph(ctx context.Context, trafficMap graph.Traffic
 		return
 	}
 
-	if globalInfo.Vendor.WorkloadMap == nil {
-		globalInfo.Vendor.WorkloadMap = make(map[graph.NodeKey]*graph.Node)
-		populateWorkloadMap(ctx, globalInfo.Business, globalInfo, trafficMap)
-	}
+	gwWorkloads, workloadMap := populateWorkloadMap(ctx, globalInfo.Business, globalInfo.Clusters, trafficMap)
 
 	// Fetch cluster-wide service lists once per cluster for use by addLabels.
 	for _, cluster := range globalInfo.Clusters {
@@ -73,7 +70,7 @@ func (a IstioAppender) AppendGraph(ctx context.Context, trafficMap graph.Traffic
 
 		applyCircuitBreakers(trafficMap, istioConfig.DestinationRules, identityDomain)
 		applyVirtualServices(trafficMap, istioConfig.VirtualServices, identityDomain)
-		decorateGateways(ctx, cluster.Name, globalInfo, istioConfig.Gateways, istioConfig.K8sGateways)
+		decorateGateways(ctx, gwWorkloads[cluster.Name], workloadMap, istioConfig.Gateways, istioConfig.K8sGateways)
 	}
 
 	addLabels(ctx, trafficMap, globalInfo, globalInfo.Vendor.ClusterServiceLists)
@@ -363,12 +360,9 @@ func addLabels(ctx context.Context, trafficMap graph.TrafficMap, gi *GlobalInfo,
 	}
 }
 
-// decorateGateways decorates workload nodes with gateway metadata. It uses the
-// pre-cached AllWorkloads to filter locally by label selector instead of calling
-// GetAllWorkloads/GetWorkloadList per gateway.
-func decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInfo, gateways []*networkingv1.Gateway, k8sGateways []*k8s_networking_v1.Gateway) {
-	allWorkloads := globalInfo.Vendor.AllWorkloads[cluster]
-
+// decorateGateways decorates workload nodes with gateway metadata by matching
+// gateway selectors against the lightweight workload labels.
+func decorateGateways(ctx context.Context, gwWorkloads []gatewayWorkload, workloadMap map[graph.NodeKey]*graph.Node, gateways []*networkingv1.Gateway, k8sGateways []*k8s_networking_v1.Gateway) {
 	for _, gw := range gateways {
 		selector := labels.Set(gw.Spec.Selector).AsSelector()
 
@@ -377,11 +371,12 @@ func decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInf
 			hostnames = append(hostnames, gwServer.Hosts...)
 		}
 
-		for _, w := range allWorkloads {
+		for i := range gwWorkloads {
+			w := &gwWorkloads[i]
 			if !selector.Matches(labels.Set(w.Labels)) {
 				continue
 			}
-			node := globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: w.Cluster, Namespace: w.Namespace, Name: w.Name}]
+			node := workloadMap[graph.NodeKey{Cluster: w.Cluster, Namespace: w.Namespace, Name: w.Name}]
 			if node != nil {
 				// TODO: This doesn't work for the generic gateway chart.
 				switch w.Labels["operator.istio.io/component"] {
@@ -401,10 +396,11 @@ func decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInf
 	for _, gw := range k8sGateways {
 		sel := k8sGwSelector(gw.Name)
 
-		var matched []*models.Workload
-		for _, w := range allWorkloads {
+		var matched []gatewayWorkload
+		for i := range gwWorkloads {
+			w := &gwWorkloads[i]
 			if sel.Matches(labels.Set(w.Labels)) {
-				matched = append(matched, w)
+				matched = append(matched, *w)
 			}
 		}
 
@@ -415,7 +411,7 @@ func decorateGateways(ctx context.Context, cluster string, globalInfo *GlobalInf
 		}
 
 		workload := matched[0]
-		node := globalInfo.Vendor.WorkloadMap[graph.NodeKey{Cluster: workload.Cluster, Namespace: workload.Namespace, Name: workload.Name}]
+		node := workloadMap[graph.NodeKey{Cluster: workload.Cluster, Namespace: workload.Namespace, Name: workload.Name}]
 		if node != nil {
 			var hostnames []string
 			for _, gwListener := range gw.Spec.Listeners {


### PR DESCRIPTION
## Summary

- Remove `AllWorkloads` and `WorkloadMap` from `GlobalIstioInfo` — they were only used within the `IstioAppender` finalizer and did not need to be shared with other appenders
- Replace full `models.Workloads` retention with a lightweight `gatewayWorkload` struct (cluster, namespace, name, labels) — the only fields needed for gateway label-selector matching
- Make workload data local to `IstioAppender.AppendGraph` so it is released as soon as the function returns, rather than being retained through all subsequent finalizers and graph marshaling

## Motivation

The `IstioAppender` was calling `GetAllWorkloads` and storing the entire result (including pods, services, runtimes, validations, annotations, etc.) in `globalInfo.Vendor.AllWorkloads` for the duration of graph generation. For large meshes (thousands of workloads), this could retain tens of MB per concurrent graph generation. With graph cache refresh jobs running in parallel for multiple sessions, this compounds significantly.

Relates to: #9759

## Changes

- `graph/telemetry/istio/appender/appender.go`: Add `gatewayWorkload` struct, remove `AllWorkloads`/`WorkloadMap` from `GlobalIstioInfo`, refactor `populateWorkloadMap` to return lightweight local data
- `graph/telemetry/istio/appender/istio_details.go`: Update `IstioAppender.AppendGraph` and `decorateGateways` to use local variables instead of globalInfo fields

## Test plan

- [x] All `./graph/...` tests pass
- [x] Benchmark exercising gateway decoration (`BenchmarkIstioAppender` with igw/k8sgw scenarios) passes
- [ ] CI passes


Made with [Cursor](https://cursor.com)