### PR TITLE
[AI] Added LightSpeed TLS verification config

### DIFF
--- a/ai/providers/lightspeed/client/client.go
+++ b/ai/providers/lightspeed/client/client.go
@@ -37,19 +37,21 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
-// WithInsecureSkipTLS configures the client to skip TLS certificate verification (e.g. for CRC or self-signed OLS).
-func WithInsecureSkipTLS(skip bool) Option {
+// WithTLSConfig sets a pre-built TLS configuration on the client's transport.
+func WithTLSConfig(cfg *tls.Config) Option {
 	return func(c *Client) {
-		if !skip {
+		if cfg == nil {
 			return
 		}
 		transport := http.DefaultTransport.(*http.Transport).Clone()
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{}
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = true
+		transport.TLSClientConfig = cfg
 		c.httpClient = &http.Client{Transport: transport}
 	}
+}
+
+// HttpClient returns the underlying HTTP client for inspection (e.g. in tests).
+func (c *Client) HttpClient() *http.Client {
+	return c.httpClient
 }
 
 // SetAuthToken sets the Bearer token on the client (e.g. per-request token from Kiali auth).

--- a/ai/providers/lightspeed/client/client_test.go
+++ b/ai/providers/lightspeed/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,13 +49,19 @@ func TestWithHTTPClient_SetsCustomClient(t *testing.T) {
 	assert.Equal(t, custom, c.httpClient)
 }
 
-func TestWithInsecureSkipTLS_True_ReplacesTransport(t *testing.T) {
-	c := New("https://ols.example.com", WithInsecureSkipTLS(true))
+func TestWithTLSConfig_AppliesConfig(t *testing.T) {
+	cfg := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS13}
+	c := New("https://ols.example.com", WithTLSConfig(cfg))
 	assert.NotEqual(t, http.DefaultClient, c.httpClient)
+
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
 }
 
-func TestWithInsecureSkipTLS_False_KeepsDefault(t *testing.T) {
-	c := New("https://ols.example.com", WithInsecureSkipTLS(false))
+func TestWithTLSConfig_Nil_KeepsDefault(t *testing.T) {
+	c := New("https://ols.example.com", WithTLSConfig(nil))
 	assert.Equal(t, http.DefaultClient, c.httpClient)
 }
 

--- a/ai/providers/lightspeed/lightspeed_provider.go
+++ b/ai/providers/lightspeed/lightspeed_provider.go
@@ -1,6 +1,8 @@
 package lightspeed_provider
 
 import (
+	"crypto/tls"
+
 	"github.com/kiali/kiali/ai/mcp"
 	"github.com/kiali/kiali/ai/providers/lightspeed/client"
 	"github.com/kiali/kiali/config"
@@ -14,8 +16,14 @@ type LightSpeedProvider struct {
 // provider-level endpoint. LightSpeed has no models or API key; authentication
 // is handled per-request via the Kiali user's Kubernetes bearer token.
 func NewLightSpeedProvider(conf *config.Config, provider *config.ProviderConfig, model *config.AIModel) (*LightSpeedProvider, error) {
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: provider.InsecureSkipVerify,
+		RootCAs:            conf.CertPool(),
+	}
+	conf.ResolvedTLSPolicy.ApplyTo(tlsCfg)
+
 	return &LightSpeedProvider{
-		client: *client.New(provider.Endpoint, client.WithInsecureSkipTLS(true)),
+		client: *client.New(provider.Endpoint, client.WithTLSConfig(tlsCfg)),
 	}, nil
 }
 

--- a/ai/providers/lightspeed/lightspeed_provider_test.go
+++ b/ai/providers/lightspeed/lightspeed_provider_test.go
@@ -1,6 +1,8 @@
 package lightspeed_provider
 
 import (
+	"crypto/tls"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +38,61 @@ func TestNewLightSpeedProvider_NilModelIsAccepted(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, p)
+}
+
+func TestNewLightSpeedProvider_TLSVerificationEnabledByDefault(t *testing.T) {
+	conf := config.NewConfig()
+	provider := &config.ProviderConfig{
+		Name:     "LightSpeed",
+		Type:     config.LightSpeedProvider,
+		Endpoint: "https://ols.example.com",
+		Enabled:  true,
+	}
+
+	p, err := NewLightSpeedProvider(conf, provider, nil)
+
+	require.NoError(t, err)
+	transport, ok := p.client.HttpClient().Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewLightSpeedProvider_InsecureSkipVerifyFromConfig(t *testing.T) {
+	conf := config.NewConfig()
+	provider := &config.ProviderConfig{
+		Name:               "LightSpeed",
+		Type:               config.LightSpeedProvider,
+		Endpoint:           "https://ols.example.com",
+		Enabled:            true,
+		InsecureSkipVerify: true,
+	}
+
+	p, err := NewLightSpeedProvider(conf, provider, nil)
+
+	require.NoError(t, err)
+	transport, ok := p.client.HttpClient().Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewLightSpeedProvider_AppliesTLSPolicy(t *testing.T) {
+	conf := config.NewConfig()
+	conf.ResolvedTLSPolicy = config.TLSPolicy{
+		MinVersion: tls.VersionTLS13,
+	}
+	provider := &config.ProviderConfig{
+		Name:     "LightSpeed",
+		Type:     config.LightSpeedProvider,
+		Endpoint: "https://ols.example.com",
+		Enabled:  true,
+	}
+
+	p, err := NewLightSpeedProvider(conf, provider, nil)
+
+	require.NoError(t, err)
+	transport, ok := p.client.HttpClient().Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
 }
 
 func TestGetName_ReturnsLightSpeed(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -812,16 +812,17 @@ const (
 )
 
 type ProviderConfig struct {
-	Name         string             `yaml:"name" json:"name"`
-	Description  string             `yaml:"description,omitempty" json:"description,omitempty"`
-	Type         ProviderType       `yaml:"type" json:"type"`
-	Config       ProviderConfigType `yaml:"config" json:"config"`
-	Enabled      bool               `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	Endpoint     string             `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
-	DefaultModel string             `yaml:"default_model,omitempty" json:"default_model,omitempty"`
-	Models       []AIModel          `yaml:"models,omitempty" json:"models,omitempty"`
-	Key          Credential         `yaml:"key,omitempty" json:"key,omitempty"`
-	Tools        ToolFilterConfig   `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Config             ProviderConfigType `yaml:"config" json:"config"`
+	DefaultModel       string             `yaml:"default_model,omitempty" json:"default_model,omitempty"`
+	Description        string             `yaml:"description,omitempty" json:"description,omitempty"`
+	Enabled            bool               `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Endpoint           string             `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	InsecureSkipVerify bool               `yaml:"insecure_skip_verify,omitempty" json:"insecureSkipVerify,omitempty"`
+	Key                Credential         `yaml:"key,omitempty" json:"key,omitempty"`
+	Models             []AIModel          `yaml:"models,omitempty" json:"models,omitempty"`
+	Name               string             `yaml:"name" json:"name"`
+	Tools              ToolFilterConfig   `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Type               ProviderType       `yaml:"type" json:"type"`
 }
 
 // ChatAIConfig defines configuration for the ChatAI subsystem


### PR DESCRIPTION
### Describe the change
Make the LightSpeed provider's TLS certificate verification configurable via a new insecure_skip_verify field on ProviderConfig.

Previously, the LightSpeed client unconditionally skipped TLS verification (WithInsecureSkipTLS(true)), which is insecure for production deployments. Now:

TLS verification is enabled by default (secure by default)
The provider uses Kiali's global CA bundle (kiali-cabundle ConfigMap) for certificate trust
The global TLS policy (min/max TLS version) is enforced on the connection
Operators can explicitly set insecure_skip_verify: true for environments with self-signed certificates
Configuration example:

```
chat_ai:
  providers:
    - name: "lightspeed"
      type: "lightspeed"
      endpoint: "https://lightspeed-app-server.openshift-lightspeed.svc:8443"
      insecure_skip_verify: false  # default; set true only for self-signed certs
```

### Steps to test the PR

- Deploy OpenShift LightSpeed (OLS) on the cluster
- Ensure a NetworkPolicy allows traffic from Kiali's namespace to OLS
- Configure Kiali's chat_ai with a lightspeed provider pointing to the OLS endpoint
- Test with insecure_skip_verify: false (default) — works when the service-ca is in the kiali-cabundle
- Test with insecure_skip_verify: true — works regardless of certificate trust

### Automation testing
Unit tests added:

TestWithTLSConfig_AppliesConfig / TestWithTLSConfig_Nil_KeepsDefault — client option behavior
TestNewLightSpeedProvider_TLSVerificationEnabledByDefault — secure default
TestNewLightSpeedProvider_InsecureSkipVerifyFromConfig — config flag honored
TestNewLightSpeedProvider_AppliesTLSPolicy — TLS policy enforcement

### Issue reference
Fixes https://github.com/kiali/kiali/issues/9736