### PR TITLE
Pin GitHub Actions in integration-tests-frontend-core-caching

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: build
         path: frontend/build
@@ -39,7 +39,7 @@ jobs:
         CGO_ENABLED: ${{ github.base_ref && '1' }}
 
     - name: Upload go binary
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: kiali
         path: ~/go/bin/kiali

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -26,7 +26,7 @@ jobs:
       run: corepack enable
 
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
@@ -42,7 +42,7 @@ jobs:
         yarn test
 
     - name: Upload frontend build
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: build
         path: frontend/build/

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -58,7 +58,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/integration-tests-backend-mcp.yml
+++ b/.github/workflows/integration-tests-backend-mcp.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -36,7 +36,7 @@ jobs:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -45,7 +45,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -65,14 +65,14 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.intTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-rest-report-mcp-tools
         path: tests/integration/junit-rest-report-mcp-tools.xml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Upload test metadata
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: backend-test-metadata-mcp-tools
         path: test-metadata-mcp-tools/

--- a/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
+++ b/.github/workflows/integration-tests-backend-multicluster-external-controlplane.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -38,7 +38,7 @@ jobs:
         version: 'v3.18.4'
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -47,7 +47,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -66,13 +66,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload multicluster coverage artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-multicluster
         path: tests/integration/multicluster/coverage-multicluster.out

--- a/.github/workflows/integration-tests-backend.yml
+++ b/.github/workflows/integration-tests-backend.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -40,7 +40,7 @@ jobs:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -49,7 +49,7 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -72,14 +72,14 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.intTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-rest-report
         path: tests/integration/junit-rest-report.xml
@@ -93,13 +93,13 @@ jobs:
 
     - name: Upload test metadata
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: backend-test-metadata
         path: test-metadata/
 
     - name: Upload backend coverage artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-backend
         path: tests/integration/tests/coverage-backend.out

--- a/.github/workflows/integration-tests-frontend-ambient-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-ambient-multi-primary.yml
@@ -30,7 +30,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -47,14 +47,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -78,13 +78,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-ambient.yml
+++ b/.github/workflows/integration-tests-frontend-ambient.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-chat.yml
+++ b/.github/workflows/integration-tests-frontend-chat.yml
@@ -31,7 +31,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -44,14 +44,14 @@ jobs:
       run: corepack enable
 
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -68,7 +68,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-frontend-chat-report
         path: frontend/cypress/results/combined-report.xml
@@ -82,20 +82,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-1.yml
+++ b/.github/workflows/integration-tests-frontend-core-1.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-frontend-core-1-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-2.yml
+++ b/.github/workflows/integration-tests-frontend-core-2.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-frontend-core-2-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-caching.yml
+++ b/.github/workflows/integration-tests-frontend-core-caching.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v5.0.0
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       with:
         version: 'v3.18.4'
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: junit-frontend-core-caching-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-core-optional.yml
+++ b/.github/workflows/integration-tests-frontend-core-optional.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-frontend-core-optional-report
         path: frontend/cypress/results/combined-report.xml
@@ -90,20 +90,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-local-offline.yml
+++ b/.github/workflows/integration-tests-frontend-local-offline.yml
@@ -33,7 +33,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -45,14 +45,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -79,20 +79,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multi-mesh.yml
+++ b/.github/workflows/integration-tests-frontend-multi-mesh.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,20 +82,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-external-kiali.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-external-kiali.yml
@@ -29,7 +29,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -46,14 +46,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -77,13 +77,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-multi-primary.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
+++ b/.github/workflows/integration-tests-frontend-multicluster-primary-remote.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend-tempo.yml
+++ b/.github/workflows/integration-tests-frontend-tempo.yml
@@ -34,7 +34,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -51,14 +51,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -82,13 +82,13 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}

--- a/.github/workflows/integration-tests-frontend.yml
+++ b/.github/workflows/integration-tests-frontend.yml
@@ -38,7 +38,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
@@ -55,14 +55,14 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
 
     - name: Download go binary
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -86,20 +86,20 @@ jobs:
 
     - name: Upload debug info artifact
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-${{ github.job }}
         path: debug-output
 
     - name: Upload cypress screenshots when tests fail
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: cypress-screenshots-${{ github.job }}
         path: frontend/cypress/screenshots
 
     - name: Upload cypress logs from stern
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.stern_logs == true }}
       with:
         name: cypress-logs-${{ github.job }}

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -217,7 +217,7 @@ jobs:
     needs: [initialize]
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Store PR number, target branch, and Kiali version
       run: |
@@ -235,7 +235,7 @@ jobs:
     # don't have access to PR information in github.event.workflow_run.pull_requests
     # See: https://github.com/orgs/community/discussions/25220
     - name: Upload PR metadata
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: pr-metadata
         path: pr-metadata/
@@ -254,25 +254,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # -------------------------------
     # Download artifacts
     # -------------------------------
     - name: Download backend coverage
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: coverage-backend
         path: coverage
 
     - name: Download multicluster coverage
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: coverage-multicluster
         path: coverage
 
     - name: Download unit coverage
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: coverage-unit
         path: coverage
@@ -291,7 +291,7 @@ jobs:
     # Upload to Codecov
     # -------------------------------
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         fail_ci_if_error: false
         files: coverage.out

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -57,7 +57,7 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out Kiali code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ env.BUILD_BRANCH }}
 
@@ -74,13 +74,13 @@ jobs:
     # This caches the yarn deps but does not touch node_modules so it's still necessary
     # to run 'yarn install' later to link these into node_modules.
     - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
         cache-dependency-path: frontend/yarn.lock
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
@@ -88,7 +88,7 @@ jobs:
 
     - name: Download go binary
       if: github.event_name == 'workflow_call'
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: kiali
         path: ~/go/bin/
@@ -157,14 +157,14 @@ jobs:
         done
 
     - name: Check out kubernetes-mcp-server
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: containers/kubernetes-mcp-server
         path: kubernetes-mcp-server
         ref: ${{ (github.event_name == 'workflow_call' && inputs.kubernetes_mcp_server_ref) || github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
 
     - name: Set up Go for kubernetes-mcp-server
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: kubernetes-mcp-server/go.mod
         cache: true
@@ -187,7 +187,7 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.contractTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: debug-info-mcp-contract-tests
         path: debug-output

--- a/.github/workflows/mcpchecker.yml
+++ b/.github/workflows/mcpchecker.yml
@@ -93,7 +93,7 @@ jobs:
       KUBERNETES_MCP_SERVER_REPO: ${{ needs.check-trigger.outputs.kubernetes-mcp-server-repo }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ needs.check-trigger.outputs.pr-sha }}
 
@@ -103,7 +103,7 @@ jobs:
         version: "v3.18.4"
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
@@ -113,7 +113,7 @@ jobs:
       run: corepack enable
 
     - name: Set up Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: yarn
@@ -211,7 +211,7 @@ jobs:
 
     - name: Upload mcpchecker results
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: mcpchecker-results
         # Upload the directory so artifact layout matches download expectations (single-file uploads can flatten paths).
@@ -235,12 +235,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout default branch
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ env.DEFAULT_BRANCH }}
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
@@ -250,7 +250,7 @@ jobs:
       run: make mcp-install-mcpchecker
 
     - name: Download mcpchecker results
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: mcpchecker-results
         path: mcpchecker-results/

--- a/.github/workflows/molecules.yml
+++ b/.github/workflows/molecules.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
     - name: Checkout the hack script that runs the tests
       id: checkout-source
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         sparse-checkout: |
           hack/ci-kind-molecule-tests.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
       quay_tag: ${{ env.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -88,12 +88,12 @@ jobs:
       QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         # The builtin cache feature ensures that installing golangci-lint
@@ -102,13 +102,13 @@ jobs:
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: build
         path: frontend/build
 
     - name: Login to Quay.io
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       quay_tag: ${{ env.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -227,19 +227,19 @@ jobs:
     needs: [initialize, build_frontend]
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: build
         path: frontend/build
@@ -250,7 +250,7 @@ jobs:
         ./hack/build-cross-platform.sh -v -o dist
 
     - name: Upload cross-platform binaries
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cross-platform-binaries
         path: dist/kiali-*
@@ -281,7 +281,7 @@ jobs:
           #   binary_name: kiali-windows-amd64.exe
     steps:
     - name: Download cross-platform binaries
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: cross-platform-binaries
         path: dist
@@ -321,7 +321,7 @@ jobs:
       QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -335,26 +335,26 @@ jobs:
         mv frontend/package.json.tmp frontend/package.json
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
 
     - name: Download frontend build
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: build
         path: frontend/build
 
     - name: Download cross-platform binaries
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: cross-platform-binaries
         path: dist
 
     - name: Login to Quay.io
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/report-to-reportportal.yml
+++ b/.github/workflows/report-to-reportportal.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Download frontend core test reports
       continue-on-error: true
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: 'junit-frontend-core-*-report'
         path: artifacts/
@@ -26,7 +26,7 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
 
     - name: Setup Node.js for merging reports
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
 
@@ -38,7 +38,7 @@ jobs:
         jrm merged-reports/combined-report.xml "artifacts/junit-frontend-core-*-report/*.xml"
 
     - name: Upload merged report
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: merged-frontend-report
         path: merged-reports/
@@ -58,7 +58,7 @@ jobs:
       # WARNING: head_sha may be from a fork PR. workflow_run runs with base repo write permissions.
       # Do NOT execute any scripts or files from this checkout — only local action references are
       # safe, as GitHub resolves those from the base repo, not the checked-out working directory.
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
 
@@ -67,7 +67,7 @@ jobs:
     # See: https://github.com/orgs/community/discussions/25220
     - name: Download backend test results and metadata
       continue-on-error: true
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: '{junit-rest-report,backend-test-metadata,pr-metadata}'
         path: artifacts/
@@ -75,7 +75,7 @@ jobs:
         run-id: ${{ github.event.workflow_run.id }}
 
     - name: Download merged frontend report
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: merged-frontend-report
         path: frontend-core/cypress/results/

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -52,7 +52,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -73,11 +73,11 @@ jobs:
         echo "Images tag": ${{ inputs.images_tag }}
         echo "Builde mode": ${{ inputs.build_mode }}
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}
@@ -105,11 +105,11 @@ jobs:
         echo "Images tag": ${{ inputs.images_tag }}
         echo "Builde mode": ${{ inputs.build_mode }}
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/test-images-update-latest.yml
+++ b/.github/workflows/test-images-update-latest.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       build_mode: ${{ steps.determine.outputs.build_mode }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:

--- a/.github/workflows/test-istio-version.yml
+++ b/.github/workflows/test-istio-version.yml
@@ -45,7 +45,7 @@ jobs:
       sail-operator-git-ref: ${{ steps.determine-sail-operator-git-ref-to-use.outputs.sail-operator-git-ref }}
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.branch_to_test || github.ref_name }}
     - name: Determine Sail Operator git ref to use

--- a/.github/workflows/test-lint-backend.yml
+++ b/.github/workflows/test-lint-backend.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.build_branch }}
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: true
@@ -46,7 +46,7 @@ jobs:
       run: wc -l coverage-unit.out
 
     - name: Upload unit coverage artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-unit
         path: coverage-unit.out

--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: calculate versions
       id: version_info
       run: |


### PR DESCRIPTION
### Describe the change

Pin all GitHub Actions in `integration-tests-frontend-core-caching.yml` to commit SHAs, aligning with every other workflow file in the repository. Additionally, update version comments across all 33 workflow files from major-only (e.g. `# v6`) to precise minor versions (e.g. `# v6.0.2`) for better traceability.

### Steps to test the PR

- Verify CI workflow passes
- No functional changes; only SHA pinning and version comment precision

Made with [Cursor](https://cursor.com)