### PR TITLE
[v2.22] Fix duplicate swagger operation IDs for chat routes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -51,6 +51,33 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
+// swagger:parameters aiChatAI
+type ChatProviderParam struct {
+	// The AI provider name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"provider"`
+}
+
+// swagger:parameters aiChatAI
+type ChatModelParam struct {
+	// The AI model name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"model"`
+}
+
+// swagger:parameters MCPTools
+type ChatToolNameParam struct {
+	// The MCP tool name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"tool_name"`
+}
+
 // swagger:parameters graphAggregate graphAggregateByService graphApp graphAppVersion graphService graphWorkload
 type ClusterParam struct {
 	// The cluster name. If not supplied queries/results will not be constrained by cluster.
@@ -386,7 +413,6 @@ type ByLabelsParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"byLabels[]"`
 }
 
@@ -416,7 +442,6 @@ type FiltersParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"filters[]"`
 }
 
@@ -436,7 +461,6 @@ type QuantilesParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"quantiles[]"`
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1798,7 +1798,7 @@ func NewRoutes(
 			handlers.ChatMCP(conf, kialiCache, aiStore, clientFactory, prom, cpm, traceClientLoader, grafana, perses, discovery),
 			true,
 		},
-		// swagger:route GET /chat/conversations chat aiChatAI
+		// swagger:route GET /chat/conversations chat aiChatGetConversations
 		// ---
 		// Endpoint to get the list of conversations for the user
 		//
@@ -1821,7 +1821,7 @@ func NewRoutes(
 			handlers.ChatConversations(conf, aiStore),
 			true,
 		},
-		// swagger:route DELETE /chat/conversations chat aiChatAI
+		// swagger:route DELETE /chat/conversations chat aiChatDeleteConversations
 		// ---
 		// Endpoint to delete conversations for the user
 		//
@@ -1830,12 +1830,6 @@ func NewRoutes(
 		//
 		//     Schemes: http, https
 		//
-		//     Parameters:
-		//       - name: conversationIDs
-		//         in: query
-		//         description: Comma-separated list of conversation IDs to delete
-		//         required: true
-		//         type: string
 		//
 		// responses:
 		//      500: internalError


### PR DESCRIPTION
## Summary

* Fix `swagger generate spec` failure caused by duplicate operation IDs in chat routes
* The GET and DELETE `/chat/conversations` routes both used `aiChatAI` as the operation ID, now each has a unique one: `aiChatGetConversations` and `aiChatDeleteConversations`
* Remove unsupported inline `Parameters` block from the DELETE route annotation
* Add missing path parameter declarations for chat routes (`{provider}`, `{model}`, `{tool_name}`)
* Remove `default: []` from array query parameters (`byLabels[]`, `filters[]`, `quantiles[]`) which is rejected by ZAP's OpenAPI validator

## Problem

Running `swagger generate spec` fails on v2.22 with:

```
operation (aiChatAI): invalid route/operation schema provided
```

This is because three routes share the same operation ID `aiChatAI`:
- `POST /chat/{provider}/{model}/ai`
- `GET /chat/conversations`
- `DELETE /chat/conversations`

Additionally, when ZAP processes the generated swagger spec it reports:
- `"Declared path parameter needs to be defined as a path parameter"` for chat routes missing `{provider}`, `{model}`, `{tool_name}` path parameter definitions
- `"attribute paths...parameters.[].schemas.default is not of type array"` for `byLabels[]`, `filters[]`, and `quantiles[]` parameters with `default: []`

## Test plan

- Verified `swagger generate spec` succeeds after the fix
- Verified all three chat operation IDs appear in generated spec: `aiChatAI`, `aiChatGetConversations`, `aiChatDeleteConversations`
- Verified generated spec includes path parameters for `provider`, `model`, and `tool_name`
- Verified no array parameters contain `default: []`