### PR TITLE
[v2.27] Add missing swagger path parameter declarations for chat routes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -51,6 +51,33 @@ type AppVersionParam struct {
 	Name string `json:"version"`
 }
 
+// swagger:parameters aiChatAI
+type ChatProviderParam struct {
+	// The AI provider name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"provider"`
+}
+
+// swagger:parameters aiChatAI
+type ChatModelParam struct {
+	// The AI model name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"model"`
+}
+
+// swagger:parameters MCPTools
+type ChatToolNameParam struct {
+	// The MCP tool name.
+	//
+	// in: path
+	// required: true
+	Name string `json:"tool_name"`
+}
+
 // swagger:parameters graphAggregate graphAggregateByService graphApp graphAppVersion graphService graphWorkload
 type ClusterParam struct {
 	// The cluster name. If not supplied queries/results will not be constrained by cluster.


### PR DESCRIPTION
## Summary

* Add `swagger:parameters` declarations for chat route path variables (`{provider}`, `{model}`, `{tool_name}`)
* Without these, the generated swagger spec has paths with undeclared parameters, causing ZAP to report: "Declared path parameter needs to be defined as a path parameter"

## Problem

The `POST /chat/{provider}/{model}/ai` and `POST /chat/mcp/{tool_name}` routes use path parameters but lack corresponding `swagger:parameters` struct declarations in `doc.go`. This means `swagger generate spec` produces a spec where path parameters are not formally declared, which ZAP rejects during OpenAPI validation.

## Test plan

- Verified `swagger generate spec` succeeds
- Verified generated spec includes `provider`, `model`, and `tool_name` as path parameters with `in: "path"` and `required: true`

Made with Cursor

Made with [Cursor](https://cursor.com)