### PR TITLE
Remove default: [] from array swagger parameter annotations

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -386,7 +386,6 @@ type ByLabelsParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"byLabels[]"`
 }
 
@@ -416,7 +415,6 @@ type FiltersParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"filters[]"`
 }
 
@@ -436,7 +434,6 @@ type QuantilesParam struct {
 	//
 	// in: query
 	// required: false
-	// default: []
 	Name []string `json:"quantiles[]"`
 }
 


### PR DESCRIPTION
## Summary

* Remove `// default: []` annotation from `ByLabelsParam`, `FiltersParam`, and `QuantilesParam` structs in `doc.go`
* ZAP's OpenAPI validator rejects array parameters that have `"default": []` in the generated swagger spec

## Problem

ZAP reports the following validation error when scanning the generated swagger spec:

```
attribute paths...parameters.[byLabels[]].schemas.default is not of type `array`
```

This occurs for `byLabels[]`, `filters[]`, and `quantiles[]` parameters. Removing the `default` annotation from the swagger comments prevents the empty array default from appearing in the generated spec.

## Test plan

- Verified `swagger generate spec` succeeds
- Verified generated spec no longer contains `"default": []` for array parameters

Made with Cursor

Made with [Cursor](https://cursor.com)