### PR TITLE
[Multicluster] Replace GetIstioConfigMap with per-cluster calls

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -247,12 +247,25 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 
 	var err error
 	var allApps []namespaceApps
+	istioConfigByCluster := map[string]*models.IstioConfigList{}
+
+	icCriteria := IstioConfigCriteria{
+		IncludeAuthorizationPolicies:  true,
+		IncludeDestinationRules:       true,
+		IncludeEnvoyFilters:           true,
+		IncludeGateways:               true,
+		IncludePeerAuthentications:    true,
+		IncludeRequestAuthentications: true,
+		IncludeSidecars:               true,
+		IncludeVirtualServices:        true,
+	}
 
 	wg := &sync.WaitGroup{}
 	type result struct {
-		cluster string
-		nsApps  namespaceApps
-		err     error
+		cluster         string
+		nsApps          namespaceApps
+		istioConfigList *models.IstioConfigList
+		err             error
 	}
 	resultsCh := make(chan result)
 
@@ -265,9 +278,17 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				nsApps, error2 := in.fetchNamespaceApps(ctx, criteria.Namespace, c, "")
 				if error2 != nil {
 					resultsCh <- result{cluster: c, nsApps: nil, err: error2}
-				} else {
-					resultsCh <- result{cluster: c, nsApps: nsApps, err: nil}
+					return
 				}
+				var icList *models.IstioConfigList
+				if criteria.IncludeIstioResources {
+					icList, error2 = in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, c, criteria.Namespace, icCriteria)
+					if error2 != nil {
+						resultsCh <- result{cluster: c, nsApps: nil, err: error2}
+						return
+					}
+				}
+				resultsCh <- result{cluster: c, nsApps: nsApps, istioConfigList: icList, err: nil}
 			}(cluster)
 		}
 		wg.Wait()
@@ -286,26 +307,8 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 			}
 		}
 		allApps = append(allApps, resultCh.nsApps)
-	}
-
-	icCriteria := IstioConfigCriteria{
-		IncludeAuthorizationPolicies:  true,
-		IncludeDestinationRules:       true,
-		IncludeEnvoyFilters:           true,
-		IncludeGateways:               true,
-		IncludePeerAuthentications:    true,
-		IncludeRequestAuthentications: true,
-		IncludeSidecars:               true,
-		IncludeVirtualServices:        true,
-	}
-	var istioConfigMap models.IstioConfigMap
-
-	// TODO: MC
-	if criteria.IncludeIstioResources {
-		istioConfigMap, err = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, criteria.Namespace, icCriteria)
-		if err != nil {
-			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
-			return models.AppList{}, err
+		if resultCh.istioConfigList != nil {
+			istioConfigByCluster[resultCh.cluster] = resultCh.istioConfigList
 		}
 	}
 
@@ -334,8 +337,8 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				Health:       models.EmptyAppHealth(),
 			}
 			istioConfigList := models.IstioConfigList{}
-			if _, ok := istioConfigMap[valueApp.cluster]; ok {
-				istioConfigList = istioConfigMap[valueApp.cluster]
+			if ic, ok := istioConfigByCluster[valueApp.cluster]; ok && ic != nil {
+				istioConfigList = *ic
 			}
 			applabels := make(map[string][]string)
 			svcReferences := make([]*models.IstioValidationKey, 0)

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -380,3 +380,47 @@ func TestJoinMap(t *testing.T) {
 	assert.Equal("val2", labels["key2"])
 	assert.Equal("al4,val4", labels["key3"])
 }
+
+// TestGetAppListSkipsClustersMissingNamespace mirrors the workloads regression
+// covered in kiali#9790 for the GetAppList code path. With ignore_home_cluster
+// topologies the home cluster does not have every namespace the user might
+// select; fetching apps for that namespace must succeed by skipping clusters
+// that do not have it instead of failing the whole list.
+func TestGetAppListSkipsClustersMissingNamespace(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "mgmt"
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	// mgmt cluster: no "default" namespace.
+	mgmt := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("istio-system"))
+
+	// member cluster: has "default" namespace and a Deployment in it.
+	memberObjs := []runtime.Object{kubetest.FakeNamespace("default")}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		o.Namespace = "default"
+		memberObjs = append(memberObjs, &o)
+	}
+	member := kubetest.NewFakeK8sClient(memberObjs...)
+	member.OpenShift = true
+	member.Token = "token"
+
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{
+		"mgmt":   mgmt,
+		"member": member,
+	})
+
+	// IncludeIstioResources=true exercises the path that used to call
+	// GetIstioConfigMap and surface the other cluster's
+	// AccessibleNamespaceError.
+	criteria := AppCriteria{Namespace: "default", IncludeIstioResources: true}
+	appList, err := svc.GetAppList(context.TODO(), criteria)
+	require.NoError(err)
+	require.NotEmpty(appList.Apps)
+	for _, a := range appList.Apps {
+		require.Equal("member", a.Cluster, "apps must come only from clusters that have the namespace")
+	}
+}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -137,35 +137,9 @@ var newSecurityConfigTypes = []schema.GroupVersionKind{
 	kubernetes.RequestAuthentications,
 }
 
-// GetIstioConfigMap returns a map of Istio config objects list per cluster
-// @TODO this method should replace GetIstioConfigList
-func (in *IstioConfigService) GetIstioConfigMap(ctx context.Context, namespace string, criteria IstioConfigCriteria) (models.IstioConfigMap, error) {
-	istioConfigMap := models.IstioConfigMap{}
-	for cluster := range in.userClients {
-		var (
-			singleClusterConfigList *models.IstioConfigList
-			err                     error
-		)
-		if namespace == meta_v1.NamespaceAll {
-			singleClusterConfigList, err = in.GetIstioConfigList(ctx, cluster, criteria)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			singleClusterConfigList, err = in.GetIstioConfigListForNamespace(ctx, cluster, namespace, criteria)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		istioConfigMap[cluster] = *singleClusterConfigList
-	}
-
-	return istioConfigMap, nil
-}
-
-// GetIstioConfigMap returns a map of Istio config objects list per cluster
-// @TODO this method should replace GetIstioConfigList
+// GetIstioConfigListForCluster returns Istio configuration objects for a single cluster.
+// When namespace is empty, the call is cluster-wide; otherwise it is scoped to the
+// given namespace.
 func (in *IstioConfigService) GetIstioConfigListForCluster(ctx context.Context, cluster, namespace string, criteria IstioConfigCriteria) (*models.IstioConfigList, error) {
 	if namespace == meta_v1.NamespaceAll {
 		return in.GetIstioConfigList(ctx, cluster, criteria)
@@ -176,13 +150,8 @@ func (in *IstioConfigService) GetIstioConfigListForCluster(ctx context.Context, 
 
 func (in *IstioConfigService) GetIstioConfigListForNamespace(ctx context.Context, cluster, namespace string, criteria IstioConfigCriteria) (*models.IstioConfigList, error) {
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
-	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
+	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces).
 	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
-		// Check if the namespace exists on the cluster in multi-cluster mode.
-		// TODO: Remove this once other business methods stop looping over all clusters.
-		if (api_errors.IsNotFound(err) || api_errors.IsForbidden(err)) && len(in.userClients) > 1 {
-			return &models.IstioConfigList{}, nil
-		}
 		return nil, err
 	}
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -335,7 +335,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		})
 	}(ctx)
 
-	var istioConfigMap models.IstioConfigMap
+	var istioConfigList *models.IstioConfigList
 
 	if criteria.IncludeIstioResources {
 		istioConfigCriteria := IstioConfigCriteria{
@@ -353,9 +353,9 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		go func(ctx context.Context) {
 			defer wg.Done()
 			var err2 error
-			istioConfigMap, err2 = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, namespace, istioConfigCriteria)
+			istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, cluster, namespace, istioConfigCriteria)
 			if err2 != nil {
-				log.Errorf("Error fetching Istio Config per namespace %s: %s", namespace, err2)
+				log.Errorf("Error fetching Istio Config for cluster [%s] per namespace [%s]: %s", cluster, namespace, err2)
 				errChan <- err2
 			}
 		}(ctx)
@@ -376,8 +376,8 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 	for _, w := range ws {
 		wItem := &models.WorkloadListItem{Health: *models.EmptyWorkloadHealth()}
 		wItem.ParseWorkload(w, in.conf)
-		if istioConfigList, ok := istioConfigMap[cluster]; ok && criteria.IncludeIstioResources {
-			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.conf, wItem.Labels, istioConfigList, cluster))
+		if istioConfigList != nil && criteria.IncludeIstioResources {
+			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.conf, wItem.Labels, *istioConfigList, cluster))
 		}
 		if criteria.IncludeHealth {
 			// Try cache first, fall back to on-demand calculation
@@ -405,7 +405,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		workloadList.Workloads = append(workloadList.Workloads, *wItem)
 	}
 
-	for _, istioConfigList := range istioConfigMap {
+	if istioConfigList != nil {
 		// @TODO multi cluster validations
 		authpolicies := istioConfigList.AuthorizationPolicies
 		allWorkloads := map[string]models.Workloads{}

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -1871,3 +1871,46 @@ func TestGetWorkloadListWithCustomKindThatMatchesCoreKind(t *testing.T) {
 	assert.Equal("custom-controller-123", workloads[0].Name)
 	assert.Equal("DaemonSet", workloads[0].WorkloadGVK.Kind)
 }
+
+// TestGetWorkloadListReturnsRequestedClusterOnly covers the regression filed as
+// kiali#9790: when one cluster does not have the requested namespace
+// (the management cluster in an ignore_home_cluster=true topology),
+// GetWorkloadList for the cluster that DOES have it must succeed without
+// surfacing the other cluster's "namespace not accessible" error.
+func TestGetWorkloadListReturnsRequestedClusterOnly(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "mgmt"
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	// mgmt cluster: no "default" namespace, mirroring discovery_selectors filtering.
+	mgmtObjs := []runtime.Object{kubetest.FakeNamespace("istio-system")}
+	mgmt := kubetest.NewFakeK8sClient(mgmtObjs...)
+
+	// member cluster: has "default" namespace and one Deployment in it.
+	memberObjs := []runtime.Object{kubetest.FakeNamespace("default")}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		o.Namespace = "default"
+		memberObjs = append(memberObjs, &o)
+	}
+	member := kubetest.NewFakeK8sClient(memberObjs...)
+
+	prom := new(prometheustest.PromClientMock)
+	prom.MockMetricsForLabels(context.Background(), []string{})
+	layer := NewLayerBuilder(t, conf).WithClients(map[string]kubernetes.UserClientInterface{
+		"mgmt":   mgmt,
+		"member": member,
+	}).WithProm(prom).Build()
+
+	// IncludeIstioResources=true is the UI default and the path that triggered
+	// the original failure via GetIstioConfigMap looping all clusters.
+	criteria := WorkloadCriteria{Cluster: "member", Namespace: "default", IncludeIstioResources: true}
+	workloadList, err := layer.Workload.GetWorkloadList(context.TODO(), criteria)
+	require.NoError(err)
+	require.NotEmpty(workloadList.Workloads)
+	for _, w := range workloadList.Workloads {
+		require.Equal("member", w.Cluster)
+	}
+}

--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -293,10 +293,12 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 				IncludeGateways:    true,
 				IncludeK8sGateways: true,
 			}
-			configMap, err := gi.Business.IstioConfig.GetIstioConfigMap(ctx, "", criteria)
-			mesh.CheckError(err)
-
-			for cluster, conf := range configMap {
+			for cluster := range clusterMap {
+				conf, err := gi.Business.IstioConfig.GetIstioConfigListForCluster(ctx, cluster, "", criteria)
+				if err != nil {
+					log.Errorf("Error fetching Istio gateway config for cluster [%s]: %s", cluster, err)
+					continue
+				}
 				gwNodes := []*mesh.Node{}
 				for _, gw := range conf.Gateways {
 					version := models.DefaultRevisionLabel


### PR DESCRIPTION
## Summary

Fixes #9790

With `clustering.ignore_home_cluster: true` on a standalone management cluster, the Workloads list page returns `Could not fetch workloads list` when the selected namespace exists on member clusters but not on the management cluster. The root cause is `GetIstioConfigMap` iterating every cluster in `userClients` even when the caller already knows which cluster it needs. The management cluster hits an `AccessibleNamespaceError` for the missing namespace and the entire request fails.

This PR:

- **Replaces** all three `GetIstioConfigMap` call sites (`GetWorkloadList`, `GetAppList`, `mesh/generator`) with direct calls to `GetIstioConfigListForCluster`, scoped to the cluster each caller is already processing.
- **Removes** `GetIstioConfigMap` and its multi-cluster error-swallowing fallback (the `IsNotFound`/`IsForbidden` check), which is no longer needed when callers target a specific cluster.
- **Adds** regression tests for both the workloads and apps code paths.

### Maintainer note

Per @hhovsepy's comment on #9790, Istio config validations also called `GetIstioConfigMap`. After this change no production code references `GetIstioConfigMap`; all paths use per-cluster calls.

## Test plan

- [x] `TestGetWorkloadListReturnsRequestedClusterOnly` — workloads for a member cluster succeed when the home cluster lacks the namespace
- [x] `TestGetAppListSkipsClustersMissingNamespace` — apps for a member cluster succeed in the same topology
- [x] `go build ./mesh/...` — mesh generator compiles with the updated call site
- [ ] Manual: select a namespace on a member cluster in the Workloads page with `ignore_home_cluster: true`