### PR TITLE
fix: cache OAuth2 transport in Grafana and Perses to avoid per-request token fetch

### DIFF
--- a/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources_test.go
@@ -39,8 +39,10 @@ func setupMocks(t *testing.T) *mcputil.KialiInterface {
 	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(cf.GetSAClients(), kialiCache, conf)
 	prom := &prometheustest.PromClientMock{}
-	grafanaSvc := grafana.NewService(conf, cf.GetSAHomeClusterClient())
-	persesSvc := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
+	persesSvc, err := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
 	req, _ := http.NewRequestWithContext(context.TODO(), "POST", "/", nil)
 

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -24,8 +24,11 @@ func setupService(conf *config.Config, namespace string, dashboards []dashboards
 	}
 	prom := new(pmock.PromClientMock)
 	ns := models.Namespace{Name: namespace}
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	service := NewDashboardsService(conf, grafana, prom, &ns, nil)
+	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	if err != nil {
+		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+	}
+	service := NewDashboardsService(conf, grafanaSvc, prom, &ns, nil)
 	return service, prom
 }
 
@@ -274,9 +277,12 @@ func TestBuildIstioDashboard(t *testing.T) {
 	// Setup mocks
 	conf := config.NewConfig()
 	ns := models.Namespace{Name: "my-namespace"}
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	if err != nil {
+		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+	}
 	prom := new(pmock.PromClientMock)
-	service := NewDashboardsService(conf, grafana, prom, &ns, nil)
+	service := NewDashboardsService(conf, grafanaSvc, prom, &ns, nil)
 
 	dashboard := service.BuildIstioDashboard(fakeMetrics(), "inbound")
 
@@ -370,7 +376,10 @@ func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
 	mainProm := new(pmock.PromClientMock)
 
 	ns := models.Namespace{Name: "my-namespace"}
-	grafanaSvc := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	if err != nil {
+		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+	}
 	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
 
 	expectedLabels := `{namespace="my-namespace",APP="my-app"}`
@@ -425,7 +434,10 @@ func TestCustomDashboardsPromClientFallbackOnFactoryError(t *testing.T) {
 	mainProm := new(pmock.PromClientMock)
 
 	ns := models.Namespace{Name: "my-namespace"}
-	grafanaSvc := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	if err != nil {
+		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+	}
 	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
 
 	expectedLabels := `{namespace="my-namespace",APP="my-app"}`

--- a/business/dashboards_test.go
+++ b/business/dashboards_test.go
@@ -18,16 +18,15 @@ import (
 	pmock "github.com/kiali/kiali/prometheus/prometheustest"
 )
 
-func setupService(conf *config.Config, namespace string, dashboards []dashboards.MonitoringDashboard) (*DashboardsService, *pmock.PromClientMock) {
+func setupService(t testing.TB, conf *config.Config, namespace string, dashboards []dashboards.MonitoringDashboard) (*DashboardsService, *pmock.PromClientMock) {
+	t.Helper()
 	for _, d := range dashboards {
 		conf.CustomDashboards = append(conf.CustomDashboards, d)
 	}
 	prom := new(pmock.PromClientMock)
 	ns := models.Namespace{Name: namespace}
 	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	if err != nil {
-		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
-	}
+	require.NoError(t, err)
 	service := NewDashboardsService(conf, grafanaSvc, prom, &ns, nil)
 	return service, prom
 }
@@ -36,7 +35,7 @@ func TestGetDashboard(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup mocks
-	service, prom := setupService(config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
+	service, prom := setupService(t, config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
 	service.promConfig.QueryScope = map[string]string{"mesh_id": "mesh1"}
 
 	expectedLabels := `{namespace="my-namespace",APP="my-app",mesh_id="mesh1"}`
@@ -84,7 +83,7 @@ func TestGetDashboardFromKialiNamespace(t *testing.T) {
 	kubernetes.NewTestingClientFactory(t, conf)
 
 	// Setup mocks
-	service, prom := setupService(conf, "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
+	service, prom := setupService(t, conf, "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1")})
 
 	expectedLabels := "{namespace=\"my-namespace\",APP=\"my-app\"}"
 	namespace := models.Namespace{
@@ -113,7 +112,7 @@ func TestGetComposedDashboard(t *testing.T) {
 	composed.Items = append(composed.Items, dashboards.MonitoringDashboardItem{Include: "dashboard1"})
 
 	// Setup mocks
-	service, _ := setupService(config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *composed})
+	service, _ := setupService(t, config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *composed})
 
 	d, err := service.loadAndResolveDashboardResource("dashboard2", map[string]bool{})
 	assert.Nil(err)
@@ -132,7 +131,7 @@ func TestGetComposedDashboardSingleChart(t *testing.T) {
 	composed.Items = append(composed.Items, dashboards.MonitoringDashboardItem{Include: "dashboard1$My chart 1_2"})
 
 	// Setup mocks
-	service, _ := setupService(config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *composed})
+	service, _ := setupService(t, config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *composed})
 
 	d, err := service.loadAndResolveDashboardResource("dashboard2", map[string]bool{})
 	assert.Nil(err)
@@ -150,7 +149,7 @@ func TestCircularDependency(t *testing.T) {
 	composed.Items = append(composed.Items, dashboards.MonitoringDashboardItem{Include: "dashboard2"})
 
 	// Setup mocks
-	service, _ := setupService(config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("2"), *composed})
+	service, _ := setupService(t, config.NewConfig(), "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("2"), *composed})
 
 	_, err := service.loadAndResolveDashboardResource("dashboard2", map[string]bool{})
 	assert.Contains(err.Error(), "circular dependency detected")
@@ -222,7 +221,7 @@ func TestGetCustomDashboardRefs(t *testing.T) {
 	conf.IstioLabels.VersionLabelName = "version"
 
 	// Setup mocks
-	service, prom := setupService(conf, "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *fakeDashboard("2")})
+	service, prom := setupService(t, conf, "my-namespace", []dashboards.MonitoringDashboard{*fakeDashboard("1"), *fakeDashboard("2")})
 
 	prom.MockMetricsForLabels(context.Background(), []string{"my_metric_1_1", "request_count", "tcp_received", "tcp_sent"})
 	pods := []*models.Pod{}
@@ -278,9 +277,7 @@ func TestBuildIstioDashboard(t *testing.T) {
 	conf := config.NewConfig()
 	ns := models.Namespace{Name: "my-namespace"}
 	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	if err != nil {
-		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
-	}
+	require.NoError(t, err)
 	prom := new(pmock.PromClientMock)
 	service := NewDashboardsService(conf, grafanaSvc, prom, &ns, nil)
 
@@ -377,9 +374,7 @@ func TestGetDashboardUsesCustomDashboardsPromClient(t *testing.T) {
 
 	ns := models.Namespace{Name: "my-namespace"}
 	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	if err != nil {
-		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
-	}
+	require.NoError(t, err)
 	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
 
 	expectedLabels := `{namespace="my-namespace",APP="my-app"}`
@@ -435,9 +430,7 @@ func TestCustomDashboardsPromClientFallbackOnFactoryError(t *testing.T) {
 
 	ns := models.Namespace{Name: "my-namespace"}
 	grafanaSvc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	if err != nil {
-		panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
-	}
+	require.NoError(t, err)
 	service := NewDashboardsService(conf, grafanaSvc, mainProm, &ns, nil)
 
 	expectedLabels := `{namespace="my-namespace",APP="my-app"}`

--- a/business/testing.go
+++ b/business/testing.go
@@ -6,6 +6,7 @@ package business
 */
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kiali/kiali/cache"
@@ -107,7 +108,11 @@ func (lb *layerBuilder) Build() *Layer {
 		lb.discovery = istio.NewDiscovery(lb.kialiSAClients, lb.cache, lb.conf)
 	}
 	if lb.grafana == nil {
-		lb.grafana = grafana.NewService(lb.conf, lb.userClients[lb.conf.KubernetesConfig.ClusterName])
+		grafanaSvc, err := grafana.NewService(lb.conf, lb.userClients[lb.conf.KubernetesConfig.ClusterName])
+		if err != nil {
+			panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+		}
+		lb.grafana = grafanaSvc
 	}
 	return newLayer(lb.userClients, lb.kialiSAClients, lb.prom, lb.tracingLoader(), lb.cache, lb.conf, lb.grafana, lb.discovery, lb.cpm)
 }

--- a/business/testing.go
+++ b/business/testing.go
@@ -6,7 +6,6 @@ package business
 */
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/kiali/kiali/cache"
@@ -110,7 +109,7 @@ func (lb *layerBuilder) Build() *Layer {
 	if lb.grafana == nil {
 		grafanaSvc, err := grafana.NewService(lb.conf, lb.userClients[lb.conf.KubernetesConfig.ClusterName])
 		if err != nil {
-			panic(fmt.Sprintf("test setup: failed to create Grafana service: %v", err))
+			lb.t.Fatalf("test setup: failed to create Grafana service: %v", err)
 		}
 		lb.grafana = grafanaSvc
 	}

--- a/cmd/offline.go
+++ b/cmd/offline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/frontend"
+	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
@@ -171,12 +172,18 @@ This mode allows you to analyze pre-collected data without requiring a live clus
 
 			promClient := prometheus.NewOfflineClient(offlineDataPath, &manifest)
 
+			grafanaSvc, err := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
+			if err != nil {
+				return fmt.Errorf("failed to create Grafana service: %w", err)
+			}
+
 			kialiServer, err := server.NewServer(
 				ctx,
 				nil, // controlPlaneMonitor
 				clientFactory,
 				kialiCache,
 				conf,
+				grafanaSvc,
 				promClient,    // prom
 				tracingLoader, // traceClientLoader
 				discovery,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -198,7 +198,7 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 	}
 
 	// Start listening to requests
-	server, err := server.NewServer(ctx, cpm, clientFactory, cache, conf, prom, tracingLoader, discovery, staticAssetFS)
+	server, err := server.NewServer(ctx, cpm, clientFactory, cache, conf, grafanaSvc, prom, tracingLoader, discovery, staticAssetFS)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -125,12 +125,15 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 		log.Debug("Tracing is disabled")
 	}
 
-	grafana := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
+	if err != nil {
+		log.Fatalf("Error creating Grafana service: %v", err)
+	}
 
 	// Needs to be started after the server so that the cache is started because the controllers use the cache.
 	// Passing nil here because the tracing client is not used for validations and that is all this layer is used for.
 	// Passing the `tracingClient` above would be a race condition since it gets set in a goroutine.
-	layer, err := business.NewLayerWithSAClients(conf, cache, prom, nil, cpm, grafana, discovery, clientFactory.GetSAClientsAsUserClientInterfaces())
+	layer, err := business.NewLayerWithSAClients(conf, cache, prom, nil, cpm, grafanaSvc, discovery, clientFactory.GetSAClientsAsUserClientInterfaces())
 	if err != nil {
 		log.Fatalf("Error creating business layer: %s", err)
 	}

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -356,7 +356,11 @@ func getDashboardPath(ctx context.Context, name string, conn grafanaConnectionIn
 		return "", nil
 	}
 
-	fullPath := dashPath.(string)
+	fullPath, ok := dashPath.(string)
+	if !ok {
+		zl.Warn().Msgf("URL field in Grafana dashboard is not a string for search pattern '%s'", name)
+		return "", nil
+	}
 	if fullPath != "" {
 		// Dashboard path might be an absolute URL (hence starting with cfg.URL) or a relative one, depending on grafana's "GF_SERVER_SERVE_FROM_SUB_PATH"
 		if !strings.HasPrefix(fullPath, conn.baseExternalURL) {

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -26,9 +26,12 @@ type Service struct {
 	conf                *config.Config
 	dashboardSupplier   DashboardSupplierFunc
 	homeClusterSAClient kubernetes.ClientInterface
-	httpClient          *http.Client
-	routeLock           sync.RWMutex
-	routeURL            *string
+	// httpClient is non-nil only when Grafana is enabled and auth type is OAuth2. It holds a
+	// long-lived client whose transport wraps an oauth2RoundTripper, caching the bearer token
+	// across requests. All other auth types use the per-request httputil.HttpGet path instead.
+	httpClient *http.Client
+	routeLock  sync.RWMutex
+	routeURL   *string
 }
 
 // NewService creates a new Grafana service.

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,24 +24,51 @@ import (
 // Service provides discovery and info about Grafana.
 type Service struct {
 	conf                *config.Config
+	dashboardSupplier   DashboardSupplierFunc
 	homeClusterSAClient kubernetes.ClientInterface
+	httpClient          *http.Client
 	routeLock           sync.RWMutex
 	routeURL            *string
 }
 
 // NewService creates a new Grafana service.
-func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterface) *Service {
+func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterface) (*Service, error) {
 	s := &Service{
 		conf:                conf,
 		homeClusterSAClient: homeClusterSAClient,
 	}
+
+	grafanaCfg := conf.ExternalServices.Grafana
+	if grafanaCfg.Enabled && grafanaCfg.Auth.Type == config.AuthTypeOAuth2 {
+		auth := grafanaCfg.Auth
+		roundTripper := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				KeepAlive: 30 * time.Second,
+				Timeout:   30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
+		transport, err := httputil.CreateTransport(conf, &auth, roundTripper, httputil.DefaultTimeout, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Grafana HTTP transport: %w", err)
+		}
+		s.httpClient = &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	}
+
+	s.dashboardSupplier = s.findDashboard
 
 	routeURL := s.discover(context.TODO())
 	if routeURL != "" {
 		s.routeURL = &routeURL
 	}
 
-	return s
+	return s, nil
+}
+
+// SetDashboardSupplier allows overriding the dashboard supplier function (used for test injection).
+func (s *Service) SetDashboardSupplier(supplier DashboardSupplierFunc) {
+	s.dashboardSupplier = supplier
 }
 
 func (s *Service) URL(ctx context.Context) string {
@@ -79,8 +108,6 @@ func (s *Service) discover(ctx context.Context) string {
 }
 
 type DashboardSupplierFunc func(string, string, *config.Auth) ([]byte, int, error)
-
-var DashboardSupplier = findDashboard
 
 func ParseUrl(ctx context.Context, internalURL string, homeClusterSAClient kubernetes.ClientInterface) (string, error) {
 	parsedURL, err := url.Parse(internalURL)
@@ -126,7 +153,7 @@ func discoverServiceURL(ctx context.Context, ns, service string, homeClusterSACl
 }
 
 // Info returns the Grafana URL and other info, the HTTP status code (int) and eventually an error
-func (s *Service) Info(ctx context.Context, dashboardSupplier DashboardSupplierFunc) (*models.GrafanaInfo, int, error) {
+func (s *Service) Info(ctx context.Context) (*models.GrafanaInfo, int, error) {
 	grafanaConfig := s.conf.ExternalServices.Grafana
 	if !grafanaConfig.Enabled {
 		return nil, http.StatusNoContent, nil
@@ -140,7 +167,7 @@ func (s *Service) Info(ctx context.Context, dashboardSupplier DashboardSupplierF
 	// Call Grafana REST API to get dashboard urls
 	links := []models.ExternalLink{}
 	for _, dashboardConfig := range grafanaConfig.Dashboards {
-		dashboardPath, err := getDashboardPath(ctx, dashboardConfig.Name, conn, dashboardSupplier)
+		dashboardPath, err := getDashboardPath(ctx, dashboardConfig.Name, conn, s.dashboardSupplier)
 		if err != nil {
 			return nil, http.StatusServiceUnavailable, err
 		}
@@ -187,7 +214,7 @@ func (s *Service) Links(ctx context.Context, linksSpec []dashboards.MonitoringDa
 		zl.Trace().Msgf("Skip checking Grafana links as Grafana is not configured")
 		return nil, 0, nil
 	}
-	return getGrafanaLinks(ctx, connectionInfo, linksSpec, DashboardSupplier)
+	return getGrafanaLinks(ctx, connectionInfo, linksSpec, s.dashboardSupplier)
 }
 
 // VersionURL returns the Grafana URL that can be used to obtain the Grafana build information that includes its version.
@@ -340,12 +367,27 @@ func getDashboardPath(ctx context.Context, name string, conn grafanaConnectionIn
 	return fullPath + conn.externalURLParams, nil
 }
 
-func findDashboard(url, searchPattern string, auth *config.Auth) ([]byte, int, error) {
-	urlParts := strings.Split(url, "?")
+func (s *Service) findDashboard(apiURL, searchPattern string, auth *config.Auth) ([]byte, int, error) {
+	urlParts := strings.Split(apiURL, "?")
 	query := strings.TrimSuffix(urlParts[0], "/") + "/api/search?query=" + searchPattern
 	if len(urlParts) > 1 {
 		query = query + "&" + urlParts[1]
 	}
+
+	if s.httpClient != nil {
+		req, err := http.NewRequest(http.MethodGet, query, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		return body, resp.StatusCode, err
+	}
+
 	resp, code, _, err := httputil.HttpGet(query, auth, time.Second*10, nil, nil, config.Get())
 	return resp, code, err
 }

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -66,7 +66,7 @@ func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterf
 	return s, nil
 }
 
-// SetDashboardSupplier allows overriding the dashboard supplier function (used for test injection).
+// SetDashboardSupplier exists for test injection; production code always uses the supplier set by NewService.
 func (s *Service) SetDashboardSupplier(supplier DashboardSupplierFunc) {
 	s.dashboardSupplier = supplier
 }

--- a/grafana/grafana_test.go
+++ b/grafana/grafana_test.go
@@ -3,10 +3,16 @@ package grafana_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
@@ -35,12 +41,11 @@ func TestGetGrafanaInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Grafana.Enabled = false
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/some_path"), 200, "whatever", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/some_path"), 200, "whatever", t),
-	)
+	info, code, err := svc.Info(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, code)
 	assert.Nil(t, info)
@@ -52,12 +57,11 @@ func TestGetGrafanaInfoExternal(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -73,12 +77,11 @@ func TestGetGrafanaInfoInCluster(t *testing.T) {
 	conf.ExternalServices.Grafana.InternalURL = "http://grafana.istio-system:3001"
 	conf.ExternalServices.Grafana.DatasourceUID = "PROMETHEUS"
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana.istio-system:3001", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana.istio-system:3001", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -93,12 +96,11 @@ func TestGetGrafanaInfoGetError(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(anError, 401, "http://grafana-external:3001", t))
 
-	_, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(anError, 401, "http://grafana-external:3001", t),
-	)
+	_, code, err := svc.Info(context.Background())
 
 	assert.Equal(t, "error from Grafana (401): unauthorized", err.Error())
 	assert.Equal(t, 503, code)
@@ -110,12 +112,11 @@ func TestGetGrafanaInfoInvalidDashboard(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier("unexpected response", 200, "http://grafana-external:3001", t))
 
-	_, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier("unexpected response", 200, "http://grafana-external:3001", t),
-	)
+	_, code, err := svc.Info(context.Background())
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "json: cannot unmarshal")
@@ -128,12 +129,11 @@ func TestGetGrafanaInfoWithoutLeadingSlashPath(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("some_path"), 200, "http://grafana-external:3001", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("some_path"), 200, "http://grafana-external:3001", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -147,12 +147,11 @@ func TestGetGrafanaInfoWithTrailingSlashURL(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001/"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001/", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001/", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -166,12 +165,11 @@ func TestGetGrafanaInfoWithQueryParams(t *testing.T) {
 	conf.ExternalServices.Grafana.ExternalURL = "http://grafana-external:3001/?orgId=1"
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001/?orgId=1", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/some_path"), 200, "http://grafana-external:3001/?orgId=1", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -186,12 +184,11 @@ func TestGetGrafanaInfoWithAbsoluteDashboardURL(t *testing.T) {
 	conf.ExternalServices.Grafana.Dashboards = dashboardsConfig
 	conf.ExternalServices.Grafana.InternalURL = "http://grafana.istio-system:3001"
 
-	grafana := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("/system/grafana/some_path"), 200, "http://grafana.istio-system:3001", t))
 
-	info, code, err := grafana.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("/system/grafana/some_path"), 200, "http://grafana.istio-system:3001", t),
-	)
+	info, code, err := svc.Info(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Len(t, info.ExternalLinks, 1)
@@ -204,4 +201,179 @@ func buildDashboardSupplier(jSon interface{}, code int, expectURL string, t *tes
 		bytes, err := json.Marshal(jSon)
 		return bytes, code, err
 	}
+}
+
+func TestGrafanaOAuth2_TokenCachePreservedAcrossRequests(t *testing.T) {
+	var tokenRequests int32
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenRequests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "grafana-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var backendRequests int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&backendRequests, 1)
+		assert.Equal(t, "Bearer grafana-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
+	}))
+	defer backend.Close()
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.ExternalURL = backend.URL
+	conf.ExternalServices.Grafana.InternalURL = backend.URL
+	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
+	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		TokenURL:     tokenServer.URL,
+		AuthStyle:    "params",
+	}
+	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
+
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, _, err := svc.Info(context.Background())
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests),
+		"token should be fetched only once and cached across multiple Info() calls")
+	assert.Equal(t, int32(5), atomic.LoadInt32(&backendRequests),
+		"backend should be called on each Info() invocation")
+}
+
+func TestGrafanaOAuth2_TokenRefreshedAfterExpiry(t *testing.T) {
+	var tokenRequests int32
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenRequests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("token-%d", atomic.LoadInt32(&tokenRequests)),
+			"expires_in":   1,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
+	}))
+	defer backend.Close()
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.ExternalURL = backend.URL
+	conf.ExternalServices.Grafana.InternalURL = backend.URL
+	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
+	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		TokenURL:     tokenServer.URL,
+		AuthStyle:    "params",
+	}
+	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
+
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+
+	_, _, err = svc.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests))
+
+	// Wait for token to expire (1s TTL + buffer)
+	time.Sleep(1100 * time.Millisecond)
+
+	_, _, err = svc.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&tokenRequests),
+		"token should be refreshed after expiry")
+}
+
+func TestGrafanaOAuth2_ClientSecretRotation(t *testing.T) {
+	secretFile := t.TempDir() + "/client-secret"
+	require.NoError(t, os.WriteFile(secretFile, []byte("original-secret"), 0600))
+
+	var tokenRequests int32
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenRequests, 1)
+		_ = r.ParseForm()
+		secret := r.Form.Get("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "token-for-" + secret,
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var lastAuth string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
+	}))
+	defer backend.Close()
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.ExternalURL = backend.URL
+	conf.ExternalServices.Grafana.InternalURL = backend.URL
+	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
+	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
+		ClientID:     "test-client",
+		ClientSecret: config.Credential(secretFile),
+		TokenURL:     tokenServer.URL,
+		AuthStyle:    "params",
+	}
+	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
+
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+
+	// First call uses original secret
+	_, _, err = svc.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-for-original-secret", lastAuth)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests))
+
+	// Rotate the secret file and simulate a 401 on the backend to trigger token refresh
+	require.NoError(t, os.WriteFile(secretFile, []byte("rotated-secret"), 0600))
+
+	// Simulate backend returning 401 to force token invalidation and refresh
+	backend.Close()
+	var backendCalls int32
+	backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&backendCalls, 1)
+		if call == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		lastAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
+	}))
+	defer backend.Close()
+
+	// Reconfigure the service to point to the new backend
+	conf.ExternalServices.Grafana.ExternalURL = backend.URL
+	conf.ExternalServices.Grafana.InternalURL = backend.URL
+	svc, err = grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+
+	_, _, err = svc.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-for-rotated-secret", lastAuth,
+		"after 401 retry, the rotated secret should be used for the new token")
 }

--- a/grafana/grafana_test.go
+++ b/grafana/grafana_test.go
@@ -201,8 +201,9 @@ func buildDashboardSupplier(jSon interface{}, code int, expectURL string, t *tes
 	}
 }
 
-// newOAuth2GrafanaSvc builds a Grafana service wired to the given tokenServerURL and backendURL
-// with a static client secret. Registers server cleanup with t.Cleanup.
+// newOAuth2GrafanaSvc creates a Grafana service with OAuth2 auth configured, shared by tests
+// that verify token caching and secret rotation behavior. Caller is responsible for closing
+// the token and backend servers.
 func newOAuth2GrafanaSvc(t *testing.T, tokenServerURL, backendURL string, clientSecret config.Credential) *grafana.Service {
 	t.Helper()
 	conf := config.NewConfig()
@@ -315,7 +316,8 @@ func TestGrafanaOAuth2_NewServicePicksUpCurrentSecretFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer token-for-rotated-secret", lastAuth.Load(),
 		"after 401 retry, the rotated secret should be used for the new token")
-	// New service has cold cache: fetches once, gets 401, fetches again with rotated secret = 2 token requests.
+	// New service cold-fetches a token (1), sends request, backend returns 401, round-tripper
+	// invalidates the cached token and re-fetches with the rotated secret (2).
 	assert.Equal(t, tokenRequestsBefore+2, atomic.LoadInt32(&tokenRequests),
-		"cold cache + 401 retry should have triggered exactly 2 token fetches with the rotated secret")
+		"cold cache + backend 401 should trigger exactly 2 token fetches using the rotated secret")
 }

--- a/grafana/grafana_test.go
+++ b/grafana/grafana_test.go
@@ -3,13 +3,11 @@ package grafana_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,6 +201,27 @@ func buildDashboardSupplier(jSon interface{}, code int, expectURL string, t *tes
 	}
 }
 
+// newOAuth2GrafanaSvc builds a Grafana service wired to the given tokenServerURL and backendURL
+// with a static client secret. Registers server cleanup with t.Cleanup.
+func newOAuth2GrafanaSvc(t *testing.T, tokenServerURL, backendURL string, clientSecret config.Credential) *grafana.Service {
+	t.Helper()
+	conf := config.NewConfig()
+	conf.ExternalServices.Grafana.Enabled = true
+	conf.ExternalServices.Grafana.ExternalURL = backendURL
+	conf.ExternalServices.Grafana.InternalURL = backendURL
+	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
+	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
+		ClientID:     "test-client",
+		ClientSecret: clientSecret,
+		TokenURL:     tokenServerURL,
+		AuthStyle:    "params",
+	}
+	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	return svc
+}
+
 func TestGrafanaOAuth2_TokenCachePreservedAcrossRequests(t *testing.T) {
 	var tokenRequests int32
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -225,21 +244,7 @@ func TestGrafanaOAuth2_TokenCachePreservedAcrossRequests(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	conf := config.NewConfig()
-	conf.ExternalServices.Grafana.Enabled = true
-	conf.ExternalServices.Grafana.ExternalURL = backend.URL
-	conf.ExternalServices.Grafana.InternalURL = backend.URL
-	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
-	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		TokenURL:     tokenServer.URL,
-		AuthStyle:    "params",
-	}
-	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
-
-	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	require.NoError(t, err)
+	svc := newOAuth2GrafanaSvc(t, tokenServer.URL, backend.URL, "test-secret")
 
 	for i := 0; i < 5; i++ {
 		_, _, err := svc.Info(context.Background())
@@ -252,55 +257,7 @@ func TestGrafanaOAuth2_TokenCachePreservedAcrossRequests(t *testing.T) {
 		"backend should be called on each Info() invocation")
 }
 
-func TestGrafanaOAuth2_TokenRefreshedAfterExpiry(t *testing.T) {
-	var tokenRequests int32
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&tokenRequests, 1)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token": fmt.Sprintf("token-%d", atomic.LoadInt32(&tokenRequests)),
-			"expires_in":   1,
-			"token_type":   "Bearer",
-		})
-	}))
-	defer tokenServer.Close()
-
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
-	}))
-	defer backend.Close()
-
-	conf := config.NewConfig()
-	conf.ExternalServices.Grafana.Enabled = true
-	conf.ExternalServices.Grafana.ExternalURL = backend.URL
-	conf.ExternalServices.Grafana.InternalURL = backend.URL
-	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
-	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		TokenURL:     tokenServer.URL,
-		AuthStyle:    "params",
-	}
-	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
-
-	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	require.NoError(t, err)
-
-	_, _, err = svc.Info(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests))
-
-	// Wait for token to expire (1s TTL + buffer)
-	time.Sleep(1100 * time.Millisecond)
-
-	_, _, err = svc.Info(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&tokenRequests),
-		"token should be refreshed after expiry")
-}
-
-func TestGrafanaOAuth2_ClientSecretRotation(t *testing.T) {
+func TestGrafanaOAuth2_NewServicePicksUpCurrentSecretFile(t *testing.T) {
 	secretFile := t.TempDir() + "/client-secret"
 	require.NoError(t, os.WriteFile(secretFile, []byte("original-secret"), 0600))
 
@@ -318,40 +275,25 @@ func TestGrafanaOAuth2_ClientSecretRotation(t *testing.T) {
 	}))
 	defer tokenServer.Close()
 
-	var lastAuth string
+	var lastAuth atomic.Value
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lastAuth = r.Header.Get("Authorization")
+		lastAuth.Store(r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
 	}))
 	defer backend.Close()
 
-	conf := config.NewConfig()
-	conf.ExternalServices.Grafana.Enabled = true
-	conf.ExternalServices.Grafana.ExternalURL = backend.URL
-	conf.ExternalServices.Grafana.InternalURL = backend.URL
-	conf.ExternalServices.Grafana.Auth.Type = config.AuthTypeOAuth2
-	conf.ExternalServices.Grafana.Auth.OAuth2 = config.OAuth2Config{
-		ClientID:     "test-client",
-		ClientSecret: config.Credential(secretFile),
-		TokenURL:     tokenServer.URL,
-		AuthStyle:    "params",
-	}
-	conf.ExternalServices.Grafana.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
-
-	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	require.NoError(t, err)
+	svc := newOAuth2GrafanaSvc(t, tokenServer.URL, backend.URL, config.Credential(secretFile))
 
 	// First call uses original secret
-	_, _, err = svc.Info(context.Background())
+	_, _, err := svc.Info(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "Bearer token-for-original-secret", lastAuth)
+	assert.Equal(t, "Bearer token-for-original-secret", lastAuth.Load())
 	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests))
 
-	// Rotate the secret file and simulate a 401 on the backend to trigger token refresh
+	// Rotate the secret file; next service construction will pick up the new secret
 	require.NoError(t, os.WriteFile(secretFile, []byte("rotated-secret"), 0600))
 
-	// Simulate backend returning 401 to force token invalidation and refresh
 	backend.Close()
 	var backendCalls int32
 	backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -360,20 +302,20 @@ func TestGrafanaOAuth2_ClientSecretRotation(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		lastAuth = r.Header.Get("Authorization")
+		lastAuth.Store(r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[{"url":"/d/test"}]`))
 	}))
 	defer backend.Close()
 
-	// Reconfigure the service to point to the new backend
-	conf.ExternalServices.Grafana.ExternalURL = backend.URL
-	conf.ExternalServices.Grafana.InternalURL = backend.URL
-	svc, err = grafana.NewService(conf, kubetest.NewFakeK8sClient())
-	require.NoError(t, err)
+	svc = newOAuth2GrafanaSvc(t, tokenServer.URL, backend.URL, config.Credential(secretFile))
+	tokenRequestsBefore := atomic.LoadInt32(&tokenRequests)
 
 	_, _, err = svc.Info(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "Bearer token-for-rotated-secret", lastAuth,
+	assert.Equal(t, "Bearer token-for-rotated-secret", lastAuth.Load(),
 		"after 401 retry, the rotated secret should be used for the new token")
+	// New service has cold cache: fetches once, gets 401, fetches again with rotated secret = 2 token requests.
+	assert.Equal(t, tokenRequestsBefore+2, atomic.LoadInt32(&tokenRequests),
+		"cold cache + 401 retry should have triggered exactly 2 token fetches with the rotated secret")
 }

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -41,8 +41,10 @@ func SetupChatMCPHandlerForTest(t *testing.T) (http.Handler, *config.Config) {
 	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(cf.GetSAClients(), kialiCache, conf)
 	prom := &prometheustest.PromClientMock{}
-	grafanaSvc := grafana.NewService(conf, cf.GetSAHomeClusterClient())
-	persesSvc := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
+	persesSvc, err := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := &tracingtest.TracingClientMock{}
@@ -328,8 +330,10 @@ func TestChatMCP_ResponseFormatDiffersByMCPMode(t *testing.T) {
 	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(cf.GetSAClients(), kialiCache, conf)
 	prom := &prometheustest.PromClientMock{}
-	grafanaSvc := grafana.NewService(conf, cf.GetSAHomeClusterClient())
-	persesSvc := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(err)
+	persesSvc, err := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(err)
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := &tracingtest.TracingClientMock{}
 
@@ -439,8 +443,10 @@ func setupChatAIHandlerForTest(t *testing.T, conf *config.Config) (http.Handler,
 	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(cf.GetSAClients(), kialiCache, conf)
 	prom := &prometheustest.PromClientMock{}
-	grafanaSvc := grafana.NewService(conf, cf.GetSAHomeClusterClient())
-	persesSvc := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
+	persesSvc, err := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := &tracingtest.TracingClientMock{}
@@ -544,8 +550,10 @@ func TestChatAI_AuthInfoMissingClusterName(t *testing.T) {
 	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	discovery := istio.NewDiscovery(cf.GetSAClients(), kialiCache, conf)
 	prom := &prometheustest.PromClientMock{}
-	grafanaSvc := grafana.NewService(conf, cf.GetSAHomeClusterClient())
-	persesSvc := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
+	persesSvc, err := perses.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := &tracingtest.TracingClientMock{}
 	aiStore := ai.NewAIStore(context.Background(), nil)

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -19,7 +19,7 @@ func GetGrafanaInfo(conf *config.Config, grafanaService *grafana.Service) http.H
 			return
 		}
 
-		info, code, err := grafanaService.Info(r.Context(), grafana.DashboardSupplier)
+		info, code, err := grafanaService.Info(r.Context())
 		if err != nil {
 			log.Error(err)
 			RespondWithError(w, code, err.Error())

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -349,7 +349,8 @@ func setupClustersHealthEndpoint(t *testing.T, k8s *kubetest.FakeK8sClient) (*ht
 	cpm := &business.FakeControlPlaneMonitor{}
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), kialiCache, conf)
 	traceLoader := func() tracing.ClientInterface { return nil }
-	grafanaService := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaService, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
 	handler := ClusterHealth(conf, kialiCache, cf, prom, traceLoader, discovery, cpm, grafanaService)
 	mr := mux.NewRouter()

--- a/handlers/mesh_test.go
+++ b/handlers/mesh_test.go
@@ -86,9 +86,11 @@ func TestGetMeshGraph(t *testing.T) {
 	}
 	cf := kubetest.NewFakeClientFactory(conf, clients)
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	grafana := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	grafanaSvc, err := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	require.NoError(err)
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
-	persesSvc := perses.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	persesSvc, err := perses.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	require.NoError(err)
 
 	xapi := new(prometheustest.PromAPIMock)
 	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
@@ -106,7 +108,7 @@ func TestGetMeshGraph(t *testing.T) {
 	traceLoader := func() tracing.ClientInterface { return nil }
 
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
-	handler := handlers.MeshGraph(conf, cf, cache, grafana, persesSvc, prom, traceLoader, discovery, cpm)
+	handler := handlers.MeshGraph(conf, cf, cache, grafanaSvc, persesSvc, prom, traceLoader, discovery, cpm)
 	server := httptest.NewServer(handlers.WithAuthInfo(authInfo, handler))
 	t.Cleanup(server.Close)
 
@@ -137,7 +139,8 @@ func TestControlPlanes(t *testing.T) {
 	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 	traceLoader := func() tracing.ClientInterface { return nil }
-	grafanaSvc := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	grafanaSvc, err := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	require.NoError(err)
 
 	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: "test"}}
 	handler := handlers.WithAuthInfo(authInfo, handlers.ControlPlanes(cache, cf, conf, discovery, cpm, prom, traceLoader, grafanaSvc))
@@ -179,7 +182,8 @@ func TestControlPlanesUnauthorized(t *testing.T) {
 	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
 	require.NoError(err)
 	traceLoader := func() tracing.ClientInterface { return nil }
-	grafanaSvc := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	grafanaSvc, err := grafana.NewService(conf, clients[conf.KubernetesConfig.ClusterName])
+	require.NoError(err)
 
 	handler := handlers.ControlPlanes(cache, cf, conf, discovery, cpm, prom, traceLoader, grafanaSvc)
 	r := httptest.NewRequest("GET", "/api/mesh/controlplanes", nil)

--- a/handlers/perses.go
+++ b/handlers/perses.go
@@ -19,7 +19,7 @@ func GetPersesInfo(conf *config.Config, persesService *perses.Service) http.Hand
 			return
 		}
 
-		info, code, err := persesService.Info(r.Context(), perses.DashboardSupplier)
+		info, code, err := persesService.Info(r.Context())
 		if err != nil {
 			log.Error(err)
 			RespondWithError(w, code, err.Error())

--- a/handlers/proxy_logging_test.go
+++ b/handlers/proxy_logging_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,9 +36,10 @@ func setupTestLoggingServer(t *testing.T, namespace, pod string) *httptest.Serve
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), cache, conf)
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := func() tracing.ClientInterface { return nil }
-	grafana := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
-	handler := handlers.WithFakeAuthInfo(conf, handlers.LoggingUpdate(conf, cache, cf, cpm, prom, traceLoader, grafana, discovery))
+	handler := handlers.WithFakeAuthInfo(conf, handlers.LoggingUpdate(conf, cache, cf, cpm, prom, traceLoader, grafanaSvc, discovery))
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/namespaces/{namespace}/pods/{pod}/logging", handler)
 

--- a/handlers/workloads_test.go
+++ b/handlers/workloads_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kiali/kiali/business"
@@ -28,9 +29,10 @@ func setupWorkloadList(t *testing.T, k8s *kubetest.FakeK8sClient, conf *config.C
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(cf.Clients), cache, conf)
 	cpm := &business.FakeControlPlaneMonitor{}
 	traceLoader := func() tracing.ClientInterface { return nil }
-	grafana := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, cf.GetSAHomeClusterClient())
+	require.NoError(t, err)
 
-	handler := WithFakeAuthInfo(conf, ClusterWorkloads(conf, cache, cf, cpm, prom, traceLoader, grafana, discovery))
+	handler := WithFakeAuthInfo(conf, ClusterWorkloads(conf, cache, cf, cpm, prom, traceLoader, grafanaSvc, discovery))
 	mr := mux.NewRouter()
 	mr.HandleFunc("/api/clusters/workloads", handler)
 

--- a/mesh/api/api_test.go
+++ b/mesh/api/api_test.go
@@ -228,7 +228,8 @@ V/InYncUvcXt0M4JJSUJi/u6VBKSYYDIHt3mk9Le2qlMQuHkOQ1ZcuEOM2CU/KtO
 	cache := cache.NewTestingCacheWithClients(t, kubernetes.ConvertFromUserClients(clients), *conf)
 	discovery := istio.NewDiscovery(kubernetes.ConvertFromUserClients(clients), cache, conf)
 	layer := business.NewLayerBuilder(t, conf).WithClients(clients).WithCache(cache).WithDiscovery(discovery).Build()
-	persesSvc := perses.NewService(conf, primaryClient)
+	persesSvc, err := perses.NewService(conf, primaryClient)
+	require.NoError(err)
 
 	meshDef, err := discovery.Mesh(context.TODO())
 	require.NoError(err)

--- a/perses/perses.go
+++ b/perses/perses.go
@@ -178,7 +178,7 @@ func (s *Service) getToken(ctx context.Context) (token string, err error) {
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Failed to read response: %v", err)
+		log.Errorf("Failed to read response: status %d", resp.StatusCode)
 		return "", fmt.Errorf("failed to read response: %d", resp.StatusCode)
 	}
 

--- a/perses/perses.go
+++ b/perses/perses.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -25,7 +26,9 @@ import (
 // Service provides discovery and info about Perses.
 type Service struct {
 	conf                *config.Config
+	dashboardSupplier   DashboardSupplierFunc
 	homeClusterSAClient kubernetes.ClientInterface
+	httpClient          *http.Client
 	routeLock           sync.RWMutex
 	routeURL            *string
 	sessionData         *sessionData
@@ -43,18 +46,43 @@ type sessionData struct {
 }
 
 // NewService creates a new Perses service.
-func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterface) *Service {
+func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterface) (*Service, error) {
 	s := &Service{
 		conf:                conf,
 		homeClusterSAClient: homeClusterSAClient,
 	}
+
+	auth := conf.ExternalServices.Perses.Auth
+	if auth.Type == config.AuthTypeOAuth2 {
+		roundTripper := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				KeepAlive: 30 * time.Second,
+				Timeout:   30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
+		transport, err := httputil.CreateTransport(conf, &auth, roundTripper, httputil.DefaultTimeout, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Perses HTTP transport: %w", err)
+		}
+		s.httpClient = &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	}
+
+	s.dashboardSupplier = s.checkDashboard
 
 	routeURL := s.discover(context.TODO())
 	if routeURL != "" {
 		s.routeURL = &routeURL
 	}
 
-	return s
+	return s, nil
+}
+
+// SetDashboardSupplier allows overriding the dashboard supplier function (used for test injection).
+// Note: this only overrides the non-OpenShift path. The OpenShift branch always uses checkDashboardOpenShift.
+func (s *Service) SetDashboardSupplier(supplier DashboardSupplierFunc) {
+	s.dashboardSupplier = supplier
 }
 
 func (s *Service) URL(ctx context.Context) string {
@@ -240,10 +268,8 @@ func (s *Service) GetAuth(ctx context.Context) *config.Auth {
 
 type DashboardSupplierFunc func(PersesConnectionInfo, string, string, *config.Auth) ([]byte, int, string, error)
 
-var DashboardSupplier = checkDashboard
-
 // Info returns the Perses URL and other info, the HTTP status code (int) and eventually an error
-func (s *Service) Info(ctx context.Context, dashboardSupplier DashboardSupplierFunc) (*models.PersesInfo, int, error) {
+func (s *Service) Info(ctx context.Context) (*models.PersesInfo, int, error) {
 	persesConfig := s.conf.ExternalServices.Perses
 	if !persesConfig.Enabled {
 		return nil, http.StatusNoContent, nil
@@ -262,9 +288,9 @@ func (s *Service) Info(ctx context.Context, dashboardSupplier DashboardSupplierF
 	// Select the appropriate dashboard supplier based on url_format
 	var supplier DashboardSupplierFunc
 	if persesConfig.URLFormat == "openshift" {
-		supplier = checkDashboardOpenShift
+		supplier = s.checkDashboardOpenShift
 	} else {
-		supplier = dashboardSupplier
+		supplier = s.dashboardSupplier
 	}
 
 	for _, dashboardConfig := range persesConfig.Dashboards {
@@ -322,9 +348,9 @@ func (s *Service) Links(ctx context.Context, linksSpec []dashboards.MonitoringDa
 	// Select the appropriate dashboard supplier based on url_format
 	var supplier DashboardSupplierFunc
 	if persesConfig.URLFormat == "openshift" {
-		supplier = checkDashboardOpenShift
+		supplier = s.checkDashboardOpenShift
 	} else {
-		supplier = DashboardSupplier
+		supplier = s.dashboardSupplier
 	}
 
 	return getPersesLinks(ctx, connectionInfo, persesConfig.Project, linksSpec, supplier)
@@ -466,7 +492,7 @@ func getDashboardPath(ctx context.Context, project, name string, conn PersesConn
 // checkDashboard uses the internal and external URL from the Perses connection data
 // Kiali will use the internal URL to check for the dashboard, but the external URL to be returned (And used as an external link)
 // This is because, contrary to Grafana, the external URL from the dashboard is not returned in the API response
-func checkDashboard(conn PersesConnectionInfo, project, searchPattern string, auth *config.Auth) ([]byte, int, string, error) {
+func (s *Service) checkDashboard(conn PersesConnectionInfo, project, searchPattern string, auth *config.Auth) ([]byte, int, string, error) {
 	url := conn.BaseExternalURL
 	if conn.InternalURL != "" {
 		url = conn.InternalURL
@@ -476,7 +502,29 @@ func checkDashboard(conn PersesConnectionInfo, project, searchPattern string, au
 	if len(urlParts) > 1 {
 		query = query + "&" + urlParts[1]
 	}
-	resp, code, _, err := httputil.HttpGet(query, auth, time.Second*10, nil, nil, config.Get())
+
+	var resp []byte
+	var code int
+	var err error
+
+	if s.httpClient != nil {
+		req, reqErr := http.NewRequest(http.MethodGet, query, nil)
+		if reqErr != nil {
+			return nil, 0, "", reqErr
+		}
+		httpResp, doErr := s.httpClient.Do(req)
+		if doErr != nil {
+			return nil, 0, "", doErr
+		}
+		defer httpResp.Body.Close()
+		resp, err = io.ReadAll(httpResp.Body)
+		if err != nil {
+			return nil, 0, "", err
+		}
+		code = httpResp.StatusCode
+	} else {
+		resp, code, _, err = httputil.HttpGet(query, auth, time.Second*10, nil, nil, config.Get())
+	}
 
 	useURL := conn.BaseExternalURL
 	if useURL == "" {
@@ -491,7 +539,7 @@ func checkDashboard(conn PersesConnectionInfo, project, searchPattern string, au
 
 // checkDashboardOpenShift uses the OpenShift monitoring format for dashboard URLs
 // Format: https://external_url/monitoring/v2/dashboards?project=istio-system&dashboard=istio-control-plane&start=30m&refresh=0s
-func checkDashboardOpenShift(conn PersesConnectionInfo, project, searchPattern string, auth *config.Auth) ([]byte, int, string, error) {
+func (s *Service) checkDashboardOpenShift(conn PersesConnectionInfo, project, searchPattern string, auth *config.Auth) ([]byte, int, string, error) {
 	// For internal cluster access, use the internal URL directly
 	// For external access, use the console proxy
 	var query string
@@ -503,7 +551,24 @@ func checkDashboardOpenShift(conn PersesConnectionInfo, project, searchPattern s
 		// Internal cluster access - use direct Perses API
 		query = fmt.Sprintf("%s/api/v1/projects/%s/dashboards/%s", conn.InternalURL, project, searchPattern)
 		log.Debugf("[Perses] Openshift Dashboard supplier (internal) checking: %s", query)
-		resp, code, _, err = httputil.HttpGet(query, auth, time.Second*10, nil, nil, config.Get())
+		if s.httpClient != nil {
+			req, reqErr := http.NewRequest(http.MethodGet, query, nil)
+			if reqErr != nil {
+				return nil, 0, "", reqErr
+			}
+			httpResp, doErr := s.httpClient.Do(req)
+			if doErr != nil {
+				return nil, 0, "", doErr
+			}
+			defer httpResp.Body.Close()
+			resp, err = io.ReadAll(httpResp.Body)
+			if err != nil {
+				return nil, 0, "", err
+			}
+			code = httpResp.StatusCode
+		} else {
+			resp, code, _, err = httputil.HttpGet(query, auth, time.Second*10, nil, nil, config.Get())
+		}
 	} else {
 		// External access - use console proxy might not be accessible - skip
 		resp = []byte(`{"status": "skip"}`)

--- a/perses/perses.go
+++ b/perses/perses.go
@@ -53,7 +53,7 @@ func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterf
 	}
 
 	auth := conf.ExternalServices.Perses.Auth
-	if auth.Type == config.AuthTypeOAuth2 {
+	if conf.ExternalServices.Perses.Enabled && auth.Type == config.AuthTypeOAuth2 {
 		roundTripper := &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
@@ -79,7 +79,7 @@ func NewService(conf *config.Config, homeClusterSAClient kubernetes.ClientInterf
 	return s, nil
 }
 
-// SetDashboardSupplier allows overriding the dashboard supplier function (used for test injection).
+// SetDashboardSupplier exists for test injection; production code always uses the supplier set by NewService.
 // Note: this only overrides the non-OpenShift path. The OpenShift branch always uses checkDashboardOpenShift.
 func (s *Service) SetDashboardSupplier(supplier DashboardSupplierFunc) {
 	s.dashboardSupplier = supplier

--- a/perses/perses.go
+++ b/perses/perses.go
@@ -28,10 +28,13 @@ type Service struct {
 	conf                *config.Config
 	dashboardSupplier   DashboardSupplierFunc
 	homeClusterSAClient kubernetes.ClientInterface
-	httpClient          *http.Client
-	routeLock           sync.RWMutex
-	routeURL            *string
-	sessionData         *sessionData
+	// httpClient is non-nil only when Perses is enabled and auth type is OAuth2. It holds a
+	// long-lived client whose transport wraps an oauth2RoundTripper, caching the bearer token
+	// across requests. All other auth types use the per-request httputil.HttpGet path instead.
+	httpClient  *http.Client
+	routeLock   sync.RWMutex
+	routeURL    *string
+	sessionData *sessionData
 }
 
 type loginRequest struct {

--- a/perses/perses_test.go
+++ b/perses/perses_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -250,6 +252,70 @@ func TestGetAuthUseKialiTokenNilClientConfig(t *testing.T) {
 
 	assert.Equal(t, config.Credential("static-snapshot-token"), auth.Token,
 		"Should fall back to GetToken() when ClientConfig is nil")
+}
+
+// TestPersesOAuth2_TokenCachePreservedAcrossRequests verifies that the cached http.Client
+// created by NewService when OAuth2 auth is configured reuses the same token across multiple
+// Info() calls rather than fetching a new token on every request.
+//
+// What this test covers:
+//   - The s.httpClient != nil branch in checkDashboard is reached when OAuth2 is configured.
+//   - The oauth2RoundTripper inside that client caches the token and does not call the token
+//     endpoint more than once for a long-lived token (expires_in=3600).
+//
+// What this test does NOT cover (already covered at the oauth2RoundTripper unit level in
+// util/httputil/oauth2_roundtripper_test.go):
+//   - Token refresh after expiry.
+//   - Token invalidation and re-fetch after a 401 from the backend.
+//   - Client secret rotation (reading an updated credential file).
+func TestPersesOAuth2_TokenCachePreservedAcrossRequests(t *testing.T) {
+	var tokenRequests int32
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenRequests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "perses-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var backendRequests int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&backendRequests, 1)
+		assert.Equal(t, "Bearer perses-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(genDashboard("test-project"))
+	}))
+	defer backend.Close()
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Perses.Enabled = true
+	conf.ExternalServices.Perses.ExternalURL = backend.URL
+	conf.ExternalServices.Perses.InternalURL = backend.URL
+	conf.ExternalServices.Perses.Project = "test-project"
+	conf.ExternalServices.Perses.Auth.Type = config.AuthTypeOAuth2
+	conf.ExternalServices.Perses.Auth.OAuth2 = config.OAuth2Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		TokenURL:     tokenServer.URL,
+		AuthStyle:    "params",
+	}
+	conf.ExternalServices.Perses.Dashboards = []config.GrafanaDashboardConfig{{Name: "test"}}
+
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, _, err := svc.Info(context.Background())
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenRequests),
+		"token should be fetched only once and cached across multiple Info() calls")
+	assert.Equal(t, int32(5), atomic.LoadInt32(&backendRequests),
+		"backend should be called on each Info() invocation")
 }
 
 func buildDashboardSupplier(jsonData interface{}, code int, expectURL string, t *testing.T) perses.DashboardSupplierFunc {

--- a/perses/perses_test.go
+++ b/perses/perses_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 
 	"github.com/kiali/kiali/config"
@@ -50,12 +51,11 @@ func TestGetPersesInfoDisabled(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ExternalServices.Perses.Enabled = false
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("istio"), 200, "whatever", t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("istio"), 200, "whatever", t),
-	)
+	info, code, err := svc.Info(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, code)
 	assert.Nil(t, info)
@@ -68,12 +68,11 @@ func TestGetPersesInfoExternal(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = PERSES_URL
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("istio"), 200, PERSES_URL, t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("istio"), 200, PERSES_URL, t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -89,12 +88,11 @@ func TestGetPersesInfoGetError(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = PERSES_URL
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(anError, 401, PERSES_URL, t))
 
-	_, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(anError, 401, PERSES_URL, t),
-	)
+	_, code, err := svc.Info(context.Background())
 
 	assert.Equal(t, "error from Perses (401): unauthorized", err.Error())
 	assert.Equal(t, 503, code)
@@ -107,12 +105,11 @@ func TestGetPersesInfoInvalidDashboard(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = PERSES_URL
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier("unexpected response", 200, PERSES_URL, t))
 
-	_, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier("unexpected response", 200, PERSES_URL, t),
-	)
+	_, code, err := svc.Info(context.Background())
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "json: cannot unmarshal")
@@ -126,12 +123,11 @@ func TestGetPersesInfoWithoutLeadingSlashPath(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = PERSES_URL
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("some_path"), 200, PERSES_URL, t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("some_path"), 200, PERSES_URL, t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -146,12 +142,11 @@ func TestGetPersesInfoWithTrailingSlashURL(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = "http://perses-external:4001"
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("istio"), 200, "http://perses-external:4001", t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("istio"), 200, "http://perses-external:4001", t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -167,12 +162,11 @@ func TestGetPersesInfoWithQueryParams(t *testing.T) {
 	conf.ExternalServices.Perses.ExternalURL = fmt.Sprintf("%s/?orgId=1", PERSES_URL)
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("istio"), 200, fmt.Sprintf("%s/?orgId=1", PERSES_URL), t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("istio"), 200, fmt.Sprintf("%s/?orgId=1", PERSES_URL), t),
-	)
+	info, code, err := svc.Info(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
@@ -188,12 +182,11 @@ func TestGetPersesInfoWithAbsoluteDashboardURL(t *testing.T) {
 	conf.ExternalServices.Perses.Dashboards = dashboardsConfig
 	conf.ExternalServices.Perses.InternalURL = PERSES_URL
 
-	perses := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	svc, err := perses.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	svc.SetDashboardSupplier(buildDashboardSupplier(genDashboard("istio"), 200, "/system/perses/", t))
 
-	info, code, err := perses.Info(
-		context.Background(),
-		buildDashboardSupplier(genDashboard("istio"), 200, "/system/perses/", t),
-	)
+	info, code, err := svc.Info(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Len(t, info.ExternalLinks, 1)
@@ -213,7 +206,8 @@ func TestGetAuthUseKialiTokenPrefersTokenFile(t *testing.T) {
 	conf.ExternalServices.Perses.Auth.Type = config.AuthTypeBearer
 	conf.ExternalServices.Perses.Auth.UseKialiToken = true
 
-	svc := perses.NewService(conf, fakeClient)
+	svc, err := perses.NewService(conf, fakeClient)
+	require.NoError(t, err)
 	auth := svc.GetAuth(context.Background())
 
 	assert.Equal(t, config.Credential(tokenFile), auth.Token,
@@ -232,7 +226,8 @@ func TestGetAuthUseKialiTokenFallsBackToStaticToken(t *testing.T) {
 	conf.ExternalServices.Perses.Auth.Type = config.AuthTypeBearer
 	conf.ExternalServices.Perses.Auth.UseKialiToken = true
 
-	svc := perses.NewService(conf, fakeClient)
+	svc, err := perses.NewService(conf, fakeClient)
+	require.NoError(t, err)
 	auth := svc.GetAuth(context.Background())
 
 	assert.Equal(t, config.Credential("static-snapshot-token"), auth.Token,
@@ -249,7 +244,8 @@ func TestGetAuthUseKialiTokenNilClientConfig(t *testing.T) {
 	conf.ExternalServices.Perses.Auth.Type = config.AuthTypeBearer
 	conf.ExternalServices.Perses.Auth.UseKialiToken = true
 
-	svc := perses.NewService(conf, fakeClient)
+	svc, err := perses.NewService(conf, fakeClient)
+	require.NoError(t, err)
 	auth := svc.GetAuth(context.Background())
 
 	assert.Equal(t, config.Credential("static-snapshot-token"), auth.Token,

--- a/server/server.go
+++ b/server/server.go
@@ -41,15 +41,12 @@ func NewServer(ctx context.Context,
 	clientFactory kubernetes.ClientFactory,
 	cache cache.KialiCache,
 	conf *config.Config,
+	grafanaSvc *grafana.Service,
 	prom prometheus.ClientInterface,
 	traceClientLoader func() tracing.ClientInterface,
 	discovery *istio.Discovery,
 	staticAssetFS fs.FS,
 ) (*Server, error) {
-	grafanaSvc, err := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Grafana service: %w", err)
-	}
 	persesSvc, err := perses.NewService(conf, clientFactory.GetSAHomeClusterClient())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Perses service: %w", err)

--- a/server/server.go
+++ b/server/server.go
@@ -46,10 +46,16 @@ func NewServer(ctx context.Context,
 	discovery *istio.Discovery,
 	staticAssetFS fs.FS,
 ) (*Server, error) {
-	grafana := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
-	perses := perses.NewService(conf, clientFactory.GetSAHomeClusterClient())
+	grafanaSvc, err := grafana.NewService(conf, clientFactory.GetSAHomeClusterClient())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Grafana service: %w", err)
+	}
+	persesSvc, err := perses.NewService(conf, clientFactory.GetSAHomeClusterClient())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Perses service: %w", err)
+	}
 	// create a router that will route all incoming API server requests to different handlers
-	router, err := routing.NewRouter(ctx, conf, cache, clientFactory, prom, traceClientLoader, controlPlaneMonitor, grafana, perses, discovery, staticAssetFS)
+	router, err := routing.NewRouter(ctx, conf, cache, clientFactory, prom, traceClientLoader, controlPlaneMonitor, grafanaSvc, persesSvc, discovery, staticAssetFS)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,12 +26,20 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/config/security"
+	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/prometheus/prometheustest"
 	"github.com/kiali/kiali/util"
 	"github.com/kiali/kiali/util/filetest"
 )
+
+func newTestGrafanaService(t *testing.T, conf *config.Config) *grafana.Service {
+	t.Helper()
+	svc, err := grafana.NewService(conf, kubetest.NewFakeK8sClient())
+	require.NoError(t, err)
+	return svc
+}
 
 const (
 	testHostname = "127.0.0.1"
@@ -62,7 +70,7 @@ func TestRootContextPath(t *testing.T) {
 	cf := kubernetes.NewTestingClientFactory(t, conf)
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
-	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, nil, nil, nil, filetest.StaticAssetDir(t))
+	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, newTestGrafanaService(t, conf), nil, nil, nil, filetest.StaticAssetDir(t))
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -126,7 +134,7 @@ func TestAnonymousMode(t *testing.T) {
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	prom := prometheustest.FakeClient{}
 
-	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, &prom, nil, nil, filetest.StaticAssetDir(t))
+	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, newTestGrafanaService(t, conf), &prom, nil, nil, filetest.StaticAssetDir(t))
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
@@ -219,7 +227,7 @@ func TestSecureComm(t *testing.T) {
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	prom := prometheustest.FakeClient{}
-	server, err := NewServer(t.Context(), cpm, cf, cache, conf, &prom, nil, nil, filetest.StaticAssetDir(t))
+	server, err := NewServer(t.Context(), cpm, cf, cache, conf, newTestGrafanaService(t, conf), &prom, nil, nil, filetest.StaticAssetDir(t))
 	require.NoError(err)
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
@@ -333,7 +341,7 @@ func TestTracingConfigured(t *testing.T) {
 	cpm := &business.FakeControlPlaneMonitor{}
 	cache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 	prom := prometheustest.FakeClient{}
-	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, &prom, nil, nil, filetest.StaticAssetDir(t))
+	server, _ := NewServer(t.Context(), cpm, cf, cache, conf, newTestGrafanaService(t, conf), &prom, nil, nil, filetest.StaticAssetDir(t))
 	server.Start()
 	t.Logf("Started test http server: %v", serverURL)
 	defer func() {


### PR DESCRIPTION
The oauth2RoundTripper's token cache was being discarded on every Grafana and Perses API request because HttpGet() calls CreateTransport() each time, creating a new oauth2RoundTripper with an empty cache. This caused a fresh token to be fetched from the identity provider on every single request, adding latency and risking IDP rate-limiting.

The fix stores a long-lived http.Client (with its oauth2RoundTripper and token cache) on the Grafana and Perses Service structs — the same pattern Prometheus already uses. The cached client is only built when auth type is OAuth2 and the service is enabled; non-OAuth2 auth types continue using the per-request httputil.HttpGet path since they have no expensive token fetch.

TLS certificate rotation is unaffected because the existing architecture already handles it dynamically via VerifyConnection and GetClientCertificate callbacks that read fresh values on each TLS handshake.

Additional refactoring:
- NewService now returns (*Service, error) for both packages
- DashboardSupplier package-level var removed; replaced by unexported field with exported SetDashboardSupplier setter for test injection
- Info() no longer takes a DashboardSupplierFunc parameter
- findDashboard/checkDashboard/checkDashboardOpenShift converted from package-level functions to methods on Service

Closes #9767

Generated-by: Cursor and Claude