### PR TITLE
Optimized loading Istio Configs for App and Workloads

### DIFF
--- a/business/apps.go
+++ b/business/apps.go
@@ -298,11 +298,11 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 		IncludeSidecars:               true,
 		IncludeVirtualServices:        true,
 	}
-	var istioConfigMap models.IstioConfigMap
+	istioConfigList := &models.IstioConfigList{}
 
 	// TODO: MC
 	if criteria.IncludeIstioResources {
-		istioConfigMap, err = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, criteria.Namespace, icCriteria)
+		istioConfigList, err = in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, criteria.Cluster, criteria.Namespace, icCriteria)
 		if err != nil {
 			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
 			return models.AppList{}, err
@@ -333,10 +333,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				IstioSidecar: true,
 				Health:       models.EmptyAppHealth(),
 			}
-			istioConfigList := models.IstioConfigList{}
-			if _, ok := istioConfigMap[valueApp.cluster]; ok {
-				istioConfigList = istioConfigMap[valueApp.cluster]
-			}
+
 			applabels := make(map[string][]string)
 			svcReferences := make([]*models.IstioValidationKey, 0)
 			for _, srv := range valueApp.Services {
@@ -366,7 +363,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 			for _, wrk := range valueApp.Workloads {
 				joinMap(applabels, wrk.Labels)
 				if criteria.IncludeIstioResources {
-					wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, istioConfigList, criteria.Cluster)...)
+					wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, *istioConfigList, criteria.Cluster)...)
 				}
 			}
 			appItem.Labels = buildFinalLabels(applabels)

--- a/business/apps.go
+++ b/business/apps.go
@@ -248,44 +248,54 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 	var err error
 	var allApps []namespaceApps
 
-	wg := &sync.WaitGroup{}
-	type result struct {
-		cluster string
-		nsApps  namespaceApps
-		err     error
-	}
-	resultsCh := make(chan result)
-
-	// TODO: Use a context to define a timeout. The context should be passed to the k8s client
-	go func() {
-		for cluster := range in.userClients {
-			wg.Add(1)
-			go func(c string) {
-				defer wg.Done()
-				nsApps, error2 := in.fetchNamespaceApps(ctx, criteria.Namespace, c, "")
-				if error2 != nil {
-					resultsCh <- result{cluster: c, nsApps: nil, err: error2}
-				} else {
-					resultsCh <- result{cluster: c, nsApps: nsApps, err: nil}
-				}
-			}(cluster)
+	// Avoid cross-cluster fan-out and redundant Istio config fetches when the caller
+	// already knows which cluster it wants.
+	if criteria.Cluster != "" {
+		if _, ok := in.userClients[criteria.Cluster]; !ok {
+			return *appList, fmt.Errorf("Cluster [%s] is not found or is not accessible for Kiali", criteria.Cluster)
 		}
-		wg.Wait()
-		close(resultsCh)
-	}()
+		nsApps, err2 := in.fetchNamespaceApps(ctx, criteria.Namespace, criteria.Cluster, "")
+		if err2 != nil {
+			return models.AppList{}, err2
+		}
+		allApps = append(allApps, nsApps)
+	} else {
+		wg := &sync.WaitGroup{}
+		type result struct {
+			cluster string
+			nsApps  namespaceApps
+			err     error
+		}
+		resultsCh := make(chan result)
 
-	// Combine namespace data
-	for resultCh := range resultsCh {
-		if resultCh.err != nil {
-			// Return failure if we are in single cluster
-			if resultCh.cluster == in.conf.KubernetesConfig.ClusterName && len(in.userClients) == 1 {
-				log.Errorf("Error fetching Applications for local cluster [%s]: %s", resultCh.cluster, resultCh.err)
-				return models.AppList{}, resultCh.err
-			} else {
-				log.Infof("Error fetching Applications for cluster [%s]: %s", resultCh.cluster, resultCh.err)
+		go func() {
+			for cluster := range in.userClients {
+				wg.Add(1)
+				go func(c string) {
+					defer wg.Done()
+					nsApps, error2 := in.fetchNamespaceApps(ctx, criteria.Namespace, c, "")
+					if error2 != nil {
+						resultsCh <- result{cluster: c, nsApps: nil, err: error2}
+					} else {
+						resultsCh <- result{cluster: c, nsApps: nsApps, err: nil}
+					}
+				}(cluster)
 			}
+			wg.Wait()
+			close(resultsCh)
+		}()
+
+		for resultCh := range resultsCh {
+			if resultCh.err != nil {
+				if resultCh.cluster == in.conf.KubernetesConfig.ClusterName && len(in.userClients) == 1 {
+					log.Errorf("Error fetching Applications for local cluster [%s]: %s", resultCh.cluster, resultCh.err)
+					return models.AppList{}, resultCh.err
+				} else {
+					log.Infof("Error fetching Applications for cluster [%s]: %s", resultCh.cluster, resultCh.err)
+				}
+			}
+			allApps = append(allApps, resultCh.nsApps)
 		}
-		allApps = append(allApps, resultCh.nsApps)
 	}
 
 	icCriteria := IstioConfigCriteria{
@@ -297,15 +307,26 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 		IncludeRequestAuthentications: true,
 		IncludeSidecars:               true,
 		IncludeVirtualServices:        true,
+		IncludeWorkloadGroups:         true,
 	}
-	istioConfigList := &models.IstioConfigList{}
 
-	// TODO: MC
+	var istioConfigMap models.IstioConfigMap
 	if criteria.IncludeIstioResources {
-		istioConfigList, err = in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, criteria.Cluster, criteria.Namespace, icCriteria)
-		if err != nil {
-			log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
-			return models.AppList{}, err
+		if criteria.Cluster != "" {
+			icl, err2 := in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, criteria.Cluster, criteria.Namespace, icCriteria)
+			if err2 != nil {
+				log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err2)
+				return models.AppList{}, err2
+			}
+			istioConfigMap = models.IstioConfigMap{criteria.Cluster: *icl}
+		} else {
+			// TODO: MC - when multi-cluster validations are implemented, this path
+			// should also scope Istio config per-cluster for validation purposes.
+			istioConfigMap, err = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, criteria.Namespace, icCriteria)
+			if err != nil {
+				log.Errorf("Error fetching Istio Config per namespace %s: %s", criteria.Namespace, err)
+				return models.AppList{}, err
+			}
 		}
 	}
 
@@ -334,6 +355,13 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				Health:       models.EmptyAppHealth(),
 			}
 
+			istioConfigList := models.IstioConfigList{}
+			if criteria.IncludeIstioResources {
+				if icl, ok := istioConfigMap[valueApp.cluster]; ok {
+					istioConfigList = icl
+				}
+			}
+
 			applabels := make(map[string][]string)
 			svcReferences := make([]*models.IstioValidationKey, 0)
 			for _, srv := range valueApp.Services {
@@ -341,17 +369,17 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 				if criteria.IncludeIstioResources {
 					vsFiltered := kubernetes.FilterVirtualServicesByService(istioConfigList.VirtualServices, srv.Namespace, srv.Name, clusterIdentityDomain)
 					for _, v := range vsFiltered {
-						ref := models.BuildKey(kubernetes.VirtualServices, v.Name, v.Namespace, criteria.Cluster)
+						ref := models.BuildKey(kubernetes.VirtualServices, v.Name, v.Namespace, valueApp.cluster)
 						svcReferences = append(svcReferences, &ref)
 					}
 					drFiltered := kubernetes.FilterDestinationRulesByService(istioConfigList.DestinationRules, srv.Namespace, srv.Name, clusterIdentityDomain)
 					for _, d := range drFiltered {
-						ref := models.BuildKey(kubernetes.DestinationRules, d.Name, d.Namespace, criteria.Cluster)
+						ref := models.BuildKey(kubernetes.DestinationRules, d.Name, d.Namespace, valueApp.cluster)
 						svcReferences = append(svcReferences, &ref)
 					}
 					gwFiltered := kubernetes.FilterGatewaysByVirtualServices(istioConfigList.Gateways, istioConfigList.VirtualServices)
 					for _, g := range gwFiltered {
-						ref := models.BuildKey(kubernetes.Gateways, g.Name, g.Namespace, criteria.Cluster)
+						ref := models.BuildKey(kubernetes.Gateways, g.Name, g.Namespace, valueApp.cluster)
 						svcReferences = append(svcReferences, &ref)
 					}
 
@@ -363,7 +391,7 @@ func (in *AppService) GetAppList(ctx context.Context, criteria AppCriteria) (mod
 			for _, wrk := range valueApp.Workloads {
 				joinMap(applabels, wrk.Labels)
 				if criteria.IncludeIstioResources {
-					wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, *istioConfigList, criteria.Cluster)...)
+					wkdReferences = append(wkdReferences, FilterWorkloadReferences(in.conf, wrk.Labels, istioConfigList, valueApp.cluster)...)
 				}
 			}
 			appItem.Labels = buildFinalLabels(applabels)

--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -105,6 +105,37 @@ func TestGetAppListFromWorkloadGroups(t *testing.T) {
 	}
 }
 
+func TestGetAppListWithClusterAndIstioResources(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	objects := []runtime.Object{
+		kubetest.FakeNamespace("Namespace"),
+	}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		objects = append(objects, &o)
+	}
+
+	k8s := kubetest.NewFakeK8sClient(objects...)
+	k8s.OpenShift = true
+	k8s.Token = "token"
+
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+
+	criteria := AppCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: true, IncludeHealth: false}
+	appList, err := svc.GetAppList(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal(1, len(appList.Apps))
+	assert.Equal("httpbin", appList.Apps[0].Name)
+	assert.Equal("Namespace", appList.Apps[0].Namespace)
+}
+
 func TestGetAppFromDeployments(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -229,6 +260,113 @@ func TestGetAppFromWorkloadGroups(t *testing.T) {
 	assert.Equal(1, len(appDetails.Workloads))
 	assert.Equal("ratings-vm", appDetails.Workloads[0].WorkloadName)
 	assert.Equal(0, len(appDetails.ServiceNames))
+}
+
+func TestGetAppListWithoutClusterFromDeployments(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	objects := []runtime.Object{
+		kubetest.FakeNamespace("Namespace"),
+	}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		objects = append(objects, &o)
+	}
+
+	k8s := kubetest.NewFakeK8sClient(objects...)
+	k8s.OpenShift = true
+	k8s.Token = "token"
+
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+
+	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	appList, err := svc.GetAppList(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal(1, len(appList.Apps))
+	assert.Equal("httpbin", appList.Apps[0].Name)
+	assert.Equal("Namespace", appList.Apps[0].Namespace)
+}
+
+func TestGetAppListWithoutClusterMultiCluster(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	homeObjects := []runtime.Object{
+		kubetest.FakeNamespace("Namespace"),
+	}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		homeObjects = append(homeObjects, &o)
+	}
+	homeClient := kubetest.NewFakeK8sClient(homeObjects...)
+	homeClient.OpenShift = true
+	homeClient.Token = "token"
+
+	remoteObjects := []runtime.Object{
+		kubetest.FakeNamespace("Namespace"),
+	}
+	for _, obj := range FakeReplicaSets(*conf) {
+		o := obj
+		remoteObjects = append(remoteObjects, &o)
+	}
+	remoteClient := kubetest.NewFakeK8sClient(remoteObjects...)
+	remoteClient.OpenShift = true
+	remoteClient.Token = "token"
+
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{
+		conf.KubernetesConfig.ClusterName: homeClient,
+		"west":                            remoteClient,
+	})
+
+	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	appList, err := svc.GetAppList(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal(2, len(appList.Apps))
+	appNames := []string{appList.Apps[0].Name, appList.Apps[1].Name}
+	assert.Contains(appNames, "httpbin")
+	assert.Equal(2, len(appNames))
+}
+
+func TestGetAppListWithoutClusterWithIstioResources(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	objects := []runtime.Object{
+		kubetest.FakeNamespace("Namespace"),
+	}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		objects = append(objects, &o)
+	}
+
+	k8s := kubetest.NewFakeK8sClient(objects...)
+	k8s.OpenShift = true
+	k8s.Token = "token"
+
+	svc := setupAppService(t, map[string]kubernetes.UserClientInterface{conf.KubernetesConfig.ClusterName: k8s})
+
+	criteria := AppCriteria{Namespace: "Namespace", IncludeIstioResources: true, IncludeHealth: false}
+	appList, err := svc.GetAppList(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal(1, len(appList.Apps))
+	assert.Equal("httpbin", appList.Apps[0].Name)
+	assert.Equal("Namespace", appList.Apps[0].Namespace)
 }
 
 func TestGetAppListFromReplicaSets(t *testing.T) {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -335,7 +335,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		})
 	}(ctx)
 
-	var istioConfigMap models.IstioConfigMap
+	istioConfigList := &models.IstioConfigList{}
 
 	if criteria.IncludeIstioResources {
 		istioConfigCriteria := IstioConfigCriteria{
@@ -353,7 +353,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		go func(ctx context.Context) {
 			defer wg.Done()
 			var err2 error
-			istioConfigMap, err2 = in.businessLayer.IstioConfig.GetIstioConfigMap(ctx, namespace, istioConfigCriteria)
+			istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigListForCluster(ctx, cluster, namespace, istioConfigCriteria)
 			if err2 != nil {
 				log.Errorf("Error fetching Istio Config per namespace %s: %s", namespace, err2)
 				errChan <- err2
@@ -376,8 +376,8 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 	for _, w := range ws {
 		wItem := &models.WorkloadListItem{Health: *models.EmptyWorkloadHealth()}
 		wItem.ParseWorkload(w, in.conf)
-		if istioConfigList, ok := istioConfigMap[cluster]; ok && criteria.IncludeIstioResources {
-			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.conf, wItem.Labels, istioConfigList, cluster))
+		if criteria.IncludeIstioResources {
+			wItem.IstioReferences = FilterUniqueIstioReferences(FilterWorkloadReferences(in.conf, wItem.Labels, *istioConfigList, cluster))
 		}
 		if criteria.IncludeHealth {
 			// Try cache first, fall back to on-demand calculation
@@ -405,15 +405,13 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		workloadList.Workloads = append(workloadList.Workloads, *wItem)
 	}
 
-	for _, istioConfigList := range istioConfigMap {
-		// @TODO multi cluster validations
-		authpolicies := istioConfigList.AuthorizationPolicies
-		allWorkloads := map[string]models.Workloads{}
-		allWorkloads[namespace] = ws
-		validations := in.getWorkloadValidations(ctx, authpolicies, allWorkloads, cluster)
-		validations.StripIgnoredChecks(in.conf)
-		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
-	}
+	// @TODO multi cluster validations
+	authpolicies := istioConfigList.AuthorizationPolicies
+	allWorkloads := map[string]models.Workloads{}
+	allWorkloads[namespace] = ws
+	validations := in.getWorkloadValidations(ctx, authpolicies, allWorkloads, cluster)
+	validations.StripIgnoredChecks(in.conf)
+	workloadList.Validations = workloadList.Validations.MergeValidations(validations)
 
 	return *workloadList, nil
 }

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -405,13 +405,15 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		workloadList.Workloads = append(workloadList.Workloads, *wItem)
 	}
 
-	// @TODO multi cluster validations
-	authpolicies := istioConfigList.AuthorizationPolicies
-	allWorkloads := map[string]models.Workloads{}
-	allWorkloads[namespace] = ws
-	validations := in.getWorkloadValidations(ctx, authpolicies, allWorkloads, cluster)
-	validations.StripIgnoredChecks(in.conf)
-	workloadList.Validations = workloadList.Validations.MergeValidations(validations)
+	if criteria.IncludeIstioResources {
+		// @TODO multi cluster validations
+		authPolicies := istioConfigList.AuthorizationPolicies
+		allWorkloads := map[string]models.Workloads{}
+		allWorkloads[namespace] = ws
+		validations := in.getWorkloadValidations(ctx, authPolicies, allWorkloads, cluster)
+		validations.StripIgnoredChecks(in.conf)
+		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
+	}
 
 	return *workloadList, nil
 }

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -131,6 +131,36 @@ func TestGetWorkloadListFromDeploymentsNoAppVerLabelNames(t *testing.T) {
 	assert.Equal("Deployment", workloads[2].WorkloadGVK.Kind)
 }
 
+func TestGetWorkloadListFromDeploymentsWithIstioResources(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	kubeObjs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Namespace"}},
+	}
+	for _, obj := range FakeDeployments(*conf) {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
+	k8s.OpenShift = true
+	svc := setupWorkloadService(t, k8s, conf)
+
+	criteria := WorkloadCriteria{Cluster: conf.KubernetesConfig.ClusterName, Namespace: "Namespace", IncludeIstioResources: true, IncludeHealth: false}
+	workloadList, err := svc.GetWorkloadList(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal("Namespace", workloadList.Namespace)
+	require.Equal(3, len(workloadList.Workloads))
+	assert.Equal("httpbin-v1", workloadList.Workloads[0].Name)
+	assert.Equal("Deployment", workloadList.Workloads[0].WorkloadGVK.Kind)
+}
+
 func TestGetWorkloadListFromWorkloadGroups(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
### Describe the change

In Applications and Workloads List/Details pages it was calling a `GetIstioConfigMap` however there was clear defined `cluster` param in these methods, so instead of that `GetIstioConfigMap` the more specific and optimal method `GetIstioConfigListForCluster` is called now.
The @TODO Multi-cluster validations are still not touched and are a part of a separate epic.

### Steps to test the PR

Regression testing of Applications/Workloads list and details pages.
Including checking `clustering.ignore_home_cluster: true/false` both ways.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
https://github.com/kiali/kiali/issues/9790
