### PR TITLE
[AI] Add configurable LLM provider support for LightSpeed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -353,7 +353,7 @@ Both services are managed by convenience scripts under `hack/`:
 ./hack/setup-mcp.sh install-mcp
 
 # 2. Install the LightSpeed service (OpenShift/CRC only)
-./hack/setup-osl.sh --openai-token sk-... install-lightspeed
+./hack/lightspeed/setup-osl.sh --openai-token sk-... install-lightspeed
 ----
 
 For full documentation, options, and deployment manifest details see:

--- a/hack/lightspeed/README.md
+++ b/hack/lightspeed/README.md
@@ -1,6 +1,6 @@
 # OpenShift LightSpeed Setup
 
-This directory contains the deployment manifests and the [`setup-osl.sh`](../setup-osl.sh) script for installing the **OpenShift LightSpeed service API** into a CRC (CodeReady Containers) or OpenShift cluster that already has an MCP server running.
+This directory contains the deployment manifests and the [`setup-osl.sh`](./setup-osl.sh) script for installing the **OpenShift LightSpeed service API** into a CRC (CodeReady Containers) or OpenShift cluster that already has an MCP server running.
 
 The LightSpeed service acts as the AI backend: it receives queries from Kiali, calls the configured LLM, and uses the MCP server for tool calling to inspect the live service mesh.
 
@@ -24,7 +24,7 @@ The LightSpeed service acts as the AI backend: it receives queries from Kiali, c
 ## Prerequisites
 
 - An **OpenShift** cluster (CRC recommended for local development):
-  - Cluster monitoring (`openshift-monitoring` pods running) is required for the operator-managed install
+  - Cluster monitoring (`openshift-monitoring` pods running) is required
   - `oc` CLI available and logged in with `cluster-admin`
 - An **MCP server** already running — install one with [`hack/setup-mcp.sh`](../setup-mcp.sh)
 - An **OpenAI or OpenAI-compatible API key**
@@ -43,7 +43,7 @@ The LightSpeed service acts as the AI backend: it receives queries from Kiali, c
 
 ## Script: setup-osl.sh
 
-**Location:** [`hack/setup-osl.sh`](../setup-osl.sh)
+**Location:** [`hack/lightspeed/setup-osl.sh`](./setup-osl.sh)
 
 The script auto-detects which MCP variant is running (`kubernetes-mcp` or `openshift-mcp`) and refuses to proceed if no healthy MCP pod is found.
 
@@ -62,7 +62,6 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
 | `-ot \| --openai-token` | *(required)* | OpenAI or OpenAI-compatible API token. Can also be set via `OPENAI_TOKEN` env var |
 | `--llm-url` | `https://api.openai.com/v1` | Base URL of the OpenAI-compatible LLM provider |
 | `--llm-model` | `gpt-5.4-nano` | Default model configured in LightSpeed |
-| `--api` | `false` | API-only mode: skip cluster monitoring and deploy the LightSpeed service directly |
 | `-n \| --namespace` | `openshift-lightspeed` | Namespace to install LightSpeed into |
 | `-i \| --image` | `quay.io/openshift-lightspeed/lightspeed-service-api:latest` | Container image to deploy |
 | `-in \| --istio-namespace` | `istio-system` | Namespace where Istio and Kiali are installed |
@@ -74,27 +73,24 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
 
 ```bash
 # Install (auto-detects running MCP)
-./hack/setup-osl.sh --openai-token sk-... install-lightspeed
+./hack/lightspeed/setup-osl.sh --openai-token sk-... install-lightspeed
 
 # Install with a custom image
-./hack/setup-osl.sh --openai-token sk-... \
+./hack/lightspeed/setup-osl.sh --openai-token sk-... \
   --image quay.io/openshift-lightspeed/lightspeed-service-api:v0.2.0 \
   install-lightspeed
 
 # Install using Gemini's OpenAI-compatible endpoint
-./hack/setup-osl.sh --openai-token <gemini-token> \
+./hack/lightspeed/setup-osl.sh --openai-token <gemini-token> \
   --llm-url https://generativelanguage.googleapis.com/v1beta/openai \
   --llm-model gemini-2.5-pro \
   install-lightspeed
 
-# Install API-only mode when openshift-monitoring is unavailable
-./hack/setup-osl.sh --openai-token <token> --api install-lightspeed
-
 # Check full status
-./hack/setup-osl.sh status-lightspeed
+./hack/lightspeed/setup-osl.sh status-lightspeed
 
 # Uninstall
-./hack/setup-osl.sh uninstall-lightspeed
+./hack/lightspeed/setup-osl.sh uninstall-lightspeed
 ```
 
 ---
@@ -109,7 +105,7 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
 4. **Create secret** `credentials` with the provider API token
 5. **Create ConfigMap / OLSConfig** with the selected provider, model, MCP endpoint, and mounted credentials
 6. **Create Deployment** `lightspeed-app-server` running the LightSpeed service API image
-7. **Create NetworkPolicy** allowing only labelled namespaces to reach the service port (`8443` for operator mode, `8080` for API-only mode)
+7. **Create NetworkPolicy** allowing only labelled namespaces to reach the service on port 8443
 8. **Label** `istio-system` with `allow-lightspeed=true` so Kiali (running there) can connect
 
 `uninstall-lightspeed` reverses all of the above and deletes the namespace.
@@ -122,9 +118,7 @@ All templates live in [`hack/lightspeed/deployment/`](deployment/) and use `${VA
 
 | File | Placeholders | Description |
 |---|---|---|
-| [`deployment_api.yaml`](deployment/deployment_api.yaml) | `${LIGHTSPEED_NAMESPACE}` `${LIGHTSPEED_IMAGE}` | `Deployment` for the LightSpeed service |
-| [`olsconfig_api.yaml`](deployment/olsconfig_api.yaml) | `${LIGHTSPEED_NAMESPACE}` `${MCP_PROVIDER}` `${LLM_PROVIDER_URL}` `${LLM_MODEL}` | `ConfigMap` with the OLS service configuration for API-only mode |
-| [`allow-policy.yaml`](deployment/allow-policy.yaml) | `${LIGHTSPEED_NAMESPACE}` `${LIGHTSPEED_PORT}` | `NetworkPolicy` restricting ingress to labelled namespaces |
+| [`allow-policy.yaml`](deployment/allow-policy.yaml) | `${LIGHTSPEED_NAMESPACE}` | `NetworkPolicy` restricting ingress to labelled namespaces |
 | [`osl_config.yaml`](deployment/osl_config.yaml) | `${MCP_PROVIDER}` `${LLM_PROVIDER_URL}` `${LLM_MODEL}` | `OLSConfig` CR for the selected OpenAI-compatible provider |
 
 ---

--- a/hack/lightspeed/README.md
+++ b/hack/lightspeed/README.md
@@ -24,10 +24,10 @@ The LightSpeed service acts as the AI backend: it receives queries from Kiali, c
 ## Prerequisites
 
 - An **OpenShift** cluster (CRC recommended for local development):
-  - Cluster monitoring (`openshift-monitoring` pods running) is required
+  - Cluster monitoring (`openshift-monitoring` pods running) is required for the operator-managed install
   - `oc` CLI available and logged in with `cluster-admin`
 - An **MCP server** already running — install one with [`hack/setup-mcp.sh`](../setup-mcp.sh)
-- An **OpenAI API key**
+- An **OpenAI or OpenAI-compatible API key**
 - `envsubst` available (part of `gettext`)
 
 ### Starting CRC with monitoring enabled
@@ -59,7 +59,10 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
 
 | Flag | Default | Description |
 |---|---|---|
-| `-ot \| --openai-token` | *(required)* | OpenAI API token. Can also be set via `OPENAI_TOKEN` env var |
+| `-ot \| --openai-token` | *(required)* | OpenAI or OpenAI-compatible API token. Can also be set via `OPENAI_TOKEN` env var |
+| `--llm-url` | `https://api.openai.com/v1` | Base URL of the OpenAI-compatible LLM provider |
+| `--llm-model` | `gpt-5.4-nano` | Default model configured in LightSpeed |
+| `--api` | `false` | API-only mode: skip cluster monitoring and deploy the LightSpeed service directly |
 | `-n \| --namespace` | `openshift-lightspeed` | Namespace to install LightSpeed into |
 | `-i \| --image` | `quay.io/openshift-lightspeed/lightspeed-service-api:latest` | Container image to deploy |
 | `-in \| --istio-namespace` | `istio-system` | Namespace where Istio and Kiali are installed |
@@ -78,6 +81,15 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
   --image quay.io/openshift-lightspeed/lightspeed-service-api:v0.2.0 \
   install-lightspeed
 
+# Install using Gemini's OpenAI-compatible endpoint
+./hack/setup-osl.sh --openai-token <gemini-token> \
+  --llm-url https://generativelanguage.googleapis.com/v1beta/openai \
+  --llm-model gemini-2.5-pro \
+  install-lightspeed
+
+# Install API-only mode when openshift-monitoring is unavailable
+./hack/setup-osl.sh --openai-token <token> --api install-lightspeed
+
 # Check full status
 ./hack/setup-osl.sh status-lightspeed
 
@@ -91,13 +103,13 @@ The script auto-detects which MCP variant is running (`kubernetes-mcp` or `opens
 
 `install-lightspeed` runs these steps in order:
 
-1. **Validate** the OpenAI token is set and not a placeholder
+1. **Validate** the API token, LLM URL, and model are set and not placeholders
 2. **Discover** the running MCP server (`kubernetes-mcp` or `openshift-mcp`)
 3. **Create namespace** `openshift-lightspeed` (idempotent)
-4. **Create secret** `credentials` with the OpenAI API token
-5. **Create ConfigMap** `olsconfig` — the OLS service config referencing the MCP endpoint and the mounted credentials
+4. **Create secret** `credentials` with the provider API token
+5. **Create ConfigMap / OLSConfig** with the selected provider, model, MCP endpoint, and mounted credentials
 6. **Create Deployment** `lightspeed-app-server` running the LightSpeed service API image
-7. **Create NetworkPolicy** allowing only labelled namespaces to reach the service on port 8443
+7. **Create NetworkPolicy** allowing only labelled namespaces to reach the service port (`8443` for operator mode, `8080` for API-only mode)
 8. **Label** `istio-system` with `allow-lightspeed=true` so Kiali (running there) can connect
 
 `uninstall-lightspeed` reverses all of the above and deletes the namespace.
@@ -111,9 +123,9 @@ All templates live in [`hack/lightspeed/deployment/`](deployment/) and use `${VA
 | File | Placeholders | Description |
 |---|---|---|
 | [`deployment_api.yaml`](deployment/deployment_api.yaml) | `${LIGHTSPEED_NAMESPACE}` `${LIGHTSPEED_IMAGE}` | `Deployment` for the LightSpeed service |
-| [`olsconfig_api.yaml`](deployment/olsconfig_api.yaml) | `${LIGHTSPEED_NAMESPACE}` `${MCP_PROVIDER}` | `ConfigMap` with the OLS service configuration |
-| [`allow-policy.yaml`](deployment/allow-policy.yaml) | `${LIGHTSPEED_NAMESPACE}` | `NetworkPolicy` restricting ingress to labelled namespaces |
-| [`osl_config.yaml`](deployment/osl_config.yaml) | `${MCP_PROVIDER}` | `OLSConfig` CR (informational reference) |
+| [`olsconfig_api.yaml`](deployment/olsconfig_api.yaml) | `${LIGHTSPEED_NAMESPACE}` `${MCP_PROVIDER}` `${LLM_PROVIDER_URL}` `${LLM_MODEL}` | `ConfigMap` with the OLS service configuration for API-only mode |
+| [`allow-policy.yaml`](deployment/allow-policy.yaml) | `${LIGHTSPEED_NAMESPACE}` `${LIGHTSPEED_PORT}` | `NetworkPolicy` restricting ingress to labelled namespaces |
+| [`osl_config.yaml`](deployment/osl_config.yaml) | `${MCP_PROVIDER}` `${LLM_PROVIDER_URL}` `${LLM_MODEL}` | `OLSConfig` CR for the selected OpenAI-compatible provider |
 
 ---
 

--- a/hack/lightspeed/deployment/allow-policy.yaml
+++ b/hack/lightspeed/deployment/allow-policy.yaml
@@ -8,12 +8,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: lightspeed-service-api
   policyTypes:
-    - Ingress
+  - Ingress
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              allow-lightspeed: "true"
-      ports:
-        - protocol: TCP
-          port: ${LIGHTSPEED_PORT}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          allow-lightspeed: "true"
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/hack/lightspeed/deployment/allow-policy.yaml
+++ b/hack/lightspeed/deployment/allow-policy.yaml
@@ -16,4 +16,4 @@ spec:
               allow-lightspeed: "true"
       ports:
         - protocol: TCP
-          port: 8443
+          port: ${LIGHTSPEED_PORT}

--- a/hack/lightspeed/deployment/osl_config.yaml
+++ b/hack/lightspeed/deployment/osl_config.yaml
@@ -7,14 +7,13 @@ spec:
   - MCPServer
   llm:
     providers:
-    - name: openAI
+    - name: openAICompatible
       type: openai
       credentialsSecretRef:
         name: credentials
-      url: https://api.openai.com/v1
+      url: ${LLM_PROVIDER_URL}
       models:
-      - name: gpt-5.4-nano
-      - name: gpt-5.4
+      - name: ${LLM_MODEL}
   mcpServers:
   - name: ${MCP_PROVIDER}-mcp    
     headers:
@@ -24,6 +23,6 @@ spec:
     url: 'http://${MCP_PROVIDER}-mcp-server.${MCP_PROVIDER}-mcp:8080/mcp'
     timeout: 30   
   ols:
-    defaultModel: gpt-5.4-nano
-    defaultProvider: openAI
+    defaultModel: ${LLM_MODEL}
+    defaultProvider: openAICompatible
     logLevel: DEBUG

--- a/hack/lightspeed/run-kiali-lightspeed.yaml
+++ b/hack/lightspeed/run-kiali-lightspeed.yaml
@@ -1,0 +1,52 @@
+auth:
+  strategy: "token"
+
+chat_ai:
+  enabled: true
+  default_provider: "LightSpeed"
+  providers:
+  - name: "LightSpeed"
+    description: "OpenShift LightSpeed"
+    type: "lightspeed"
+    endpoint: "https://lightspeed-app-server.openshift-lightspeed.svc:8443/"
+    enabled: true
+    insecure_skip_verify: true
+  store_config:
+    enabled: true
+    max_cache_memory_mb: 1024
+    reduce_threshold: 15
+    reduce_with_ai: false
+
+clustering:
+  ignore_home_cluster: false
+
+deployment:
+  cluster_wide_access: true
+
+kiali_internal:
+  url_service_version: "http://127.0.0.1:15014/version"
+
+external_services:
+  custom_dashboards:
+    enabled: false
+  grafana:
+    enabled: false
+    internal_url: ""
+    external_url: ""
+  prometheus:
+    url: "http://127.0.0.1:9091"
+  tracing:
+    enabled: false
+    provider: ""
+    internal_url: ""
+    external_url: ""
+    use_grpc: false
+
+kubernetes_config:
+  cluster_name: "Kubernetes"
+
+auth:
+  strategy: "anonymous"
+
+login_token:
+  signing_key: "0123456789abcdef"

--- a/hack/lightspeed/run-kiali-lightspeed.yaml
+++ b/hack/lightspeed/run-kiali-lightspeed.yaml
@@ -1,6 +1,3 @@
-auth:
-  strategy: "token"
-
 chat_ai:
   enabled: true
   default_provider: "LightSpeed"
@@ -46,7 +43,7 @@ kubernetes_config:
   cluster_name: "Kubernetes"
 
 auth:
-  strategy: "anonymous"
+  strategy: "token"
 
 login_token:
   signing_key: "0123456789abcdef"

--- a/hack/lightspeed/setup-osl.sh
+++ b/hack/lightspeed/setup-osl.sh
@@ -37,7 +37,6 @@ DEFAULT_TIMEOUT="300"
 DEFAULT_OPENAI_TOKEN="<OPENAI_TOKEN>"
 DEFAULT_LLM_PROVIDER_URL="https://api.openai.com/v1"
 DEFAULT_LLM_MODEL="gpt-5.4-nano"
-DEFAULT_API_ONLY_MODE="false"
 
 # Runtime variables
 _VERBOSE="false"
@@ -81,7 +80,6 @@ ensure_openshift_monitoring() {
   if ! ${CLIENT_EXE} get namespace "${monitoring_ns}" &>/dev/null; then
     errormsg "Namespace [${monitoring_ns}] not found."
     errormsg "OpenShift cluster monitoring is required for a full LightSpeed installation."
-    errormsg "If you only need the LightSpeed API (no cluster observability), pass --api."
     return 1
   fi
 
@@ -94,7 +92,6 @@ ensure_openshift_monitoring() {
   if [ "${running_pods}" -eq 0 ]; then
     errormsg "Namespace [${monitoring_ns}] exists but no Running pods were found."
     errormsg "Please ensure OpenShift cluster monitoring is healthy before proceeding."
-    errormsg "If you only need the LightSpeed API (no cluster observability), pass --api."
     return 1
   fi
 
@@ -216,8 +213,8 @@ discover_mcp() {
   errormsg "No running MCP server found."
   errormsg "LightSpeed requires a running MCP server to function."
   errormsg "Please install one first with:"
-  errormsg "  ${SCRIPT_DIR}/setup-mcp.sh install-mcp"
-  errormsg "  ${SCRIPT_DIR}/setup-mcp.sh --provider openshift install-mcp"
+  errormsg "  ${SCRIPT_DIR}/../setup-mcp.sh install-mcp"
+  errormsg "  ${SCRIPT_DIR}/../setup-mcp.sh --provider openshift install-mcp"
   return 1
 }
 
@@ -240,7 +237,7 @@ create_lightspeed_credentials() {
 
 create_lightspeed_operator_group() {
   local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/operator_lightspped_group.yaml"
+  local template="${SCRIPT_DIR}/deployment/operator_lightspped_group.yaml"
 
   if [ ! -f "${template}" ]; then
     errormsg "OperatorGroup template not found: ${template}"
@@ -263,7 +260,7 @@ create_lightspeed_operator_group() {
 
 create_lightspeed_subscription() {
   local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/subscription_lightspeed.yaml"
+  local template="${SCRIPT_DIR}/deployment/subscription_lightspeed.yaml"
 
   if [ ! -f "${template}" ]; then
     errormsg "Subscription template not found: ${template}"
@@ -287,7 +284,7 @@ create_lightspeed_subscription() {
 
 create_osl_config() {
   local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/osl_config.yaml"
+  local template="${SCRIPT_DIR}/deployment/osl_config.yaml"
 
   if [ ! -f "${template}" ]; then
     errormsg "OLSConfig template not found: ${template}"
@@ -310,68 +307,9 @@ create_osl_config() {
   infomsg "OLSConfig [cluster] created/updated in namespace [${ns}]."
 }
 
-create_olsconfig_api() {
-  local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/olsconfig_api.yaml"
-
-  if [ ! -f "${template}" ]; then
-    errormsg "OLS config API template not found: ${template}"
-    return 1
-  fi
-
-  infomsg "Creating OLS ConfigMap for API mode (mcp=${_MCP_PROVIDER}, llm=${LLM_PROVIDER_URL}, model=${LLM_MODEL}) in namespace [${ns}]..."
-
-  local tmp_cfg
-  tmp_cfg="$(mktemp /tmp/osl-api-config.XXXXXX.yaml)"
-  trap 'rm -f "${tmp_cfg}"' RETURN
-
-  export LIGHTSPEED_NAMESPACE
-  export MCP_PROVIDER="${_MCP_PROVIDER}"
-  export LLM_PROVIDER_URL
-  export LLM_MODEL
-  envsubst '${LIGHTSPEED_NAMESPACE} ${MCP_PROVIDER} ${LLM_PROVIDER_URL} ${LLM_MODEL}' < "${template}" > "${tmp_cfg}"
-
-  ${CLIENT_EXE} apply -f "${tmp_cfg}" -n "${ns}"
-
-  infomsg "ConfigMap [olsconfig] created/updated in namespace [${ns}]."
-}
-
-create_lightspeed_api_deployment() {
-  local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/deployment_api.yaml"
-
-  if [ ! -f "${template}" ]; then
-    errormsg "API deployment template not found: ${template}"
-    return 1
-  fi
-
-  infomsg "Creating LightSpeed API deployment (image=${LIGHTSPEED_IMAGE}) in namespace [${ns}]..."
-
-  local tmp_deploy
-  tmp_deploy="$(mktemp /tmp/osl-api-deployment.XXXXXX.yaml)"
-  trap 'rm -f "${tmp_deploy}"' RETURN
-
-  export LIGHTSPEED_NAMESPACE
-  export LIGHTSPEED_IMAGE
-  export LIGHTSPEED_PORT="8080"
-  envsubst '${LIGHTSPEED_NAMESPACE} ${LIGHTSPEED_IMAGE} ${LIGHTSPEED_PORT}' < "${template}" > "${tmp_deploy}"
-
-  ${CLIENT_EXE} apply -f "${tmp_deploy}" -n "${ns}"
-
-  infomsg "Deployment [lightspeed-app-server] created/updated in namespace [${ns}]."
-}
-
-wait_for_lightspeed_api_deployment() {
-  local ns="${LIGHTSPEED_NAMESPACE}"
-
-  infomsg "Waiting for API-only LightSpeed deployment to become ready..."
-  ${CLIENT_EXE} rollout status deployment/lightspeed-app-server -n "${ns}" --timeout="${TIMEOUT}s"
-  infomsg "API-only LightSpeed deployment is ready."
-}
-
 create_lightspeed_network_policy() {
   local ns="${LIGHTSPEED_NAMESPACE}"
-  local template="${SCRIPT_DIR}/lightspeed/deployment/allow-policy.yaml"
+  local template="${SCRIPT_DIR}/deployment/allow-policy.yaml"
 
   if [ ! -f "${template}" ]; then
     errormsg "NetworkPolicy template not found: ${template}"
@@ -385,11 +323,7 @@ create_lightspeed_network_policy() {
   trap 'rm -f "${tmp_np}"' RETURN
 
   export LIGHTSPEED_NAMESPACE
-  if [ "${API_ONLY_MODE}" == "true" ]; then
-    export LIGHTSPEED_PORT="8080"
-  else
-    export LIGHTSPEED_PORT="8443"
-  fi
+  export LIGHTSPEED_PORT="8443"
   envsubst '${LIGHTSPEED_NAMESPACE} ${LIGHTSPEED_PORT}' < "${template}" > "${tmp_np}"
 
   ${CLIENT_EXE} apply -f "${tmp_np}" -n "${ns}"
@@ -445,10 +379,7 @@ install_lightspeed() {
   validate_openai_token || exit 1
   validate_llm_settings || exit 1
   discover_mcp || exit 1  # MCP server discovery
-
-  if [ "${API_ONLY_MODE}" != "true" ]; then
-    ensure_openshift_monitoring || exit 1
-  fi
+  ensure_openshift_monitoring || exit 1
 
   local ns="${LIGHTSPEED_NAMESPACE}"
 
@@ -458,23 +389,16 @@ install_lightspeed() {
   infomsg "  Image      : ${LIGHTSPEED_IMAGE}"
   infomsg "  LLM URL    : ${LLM_PROVIDER_URL}"
   infomsg "  LLM Model  : ${LLM_MODEL}"
-  infomsg "  API Only   : ${API_ONLY_MODE}"
   infomsg "  MCP        : ${_MCP_PROVIDER} @ ${_MCP_ENDPOINT}"
   infomsg "========================================================"
 
   ensure_lightspeed_ns
   create_lightspeed_credentials
 
-  if [ "${API_ONLY_MODE}" == "true" ]; then
-    create_olsconfig_api
-    create_lightspeed_api_deployment
-    wait_for_lightspeed_api_deployment
-  else
-    create_lightspeed_operator_group
-    create_lightspeed_subscription
-    wait_for_lightspeed_operator
-    create_osl_config
-  fi
+  create_lightspeed_operator_group
+  create_lightspeed_subscription
+  wait_for_lightspeed_operator
+  create_osl_config
   create_lightspeed_network_policy
   label_istio_namespace
 
@@ -491,8 +415,6 @@ uninstall_lightspeed() {
   fi
 
   ${CLIENT_EXE} delete deployment lightspeed-app-server                                    -n "${ns}" --ignore-not-found
-  ${CLIENT_EXE} delete service lightspeed-app-server                                       -n "${ns}" --ignore-not-found
-  ${CLIENT_EXE} delete route lightspeed-app-server                                         -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete configmap  olsconfig                                                -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete olsconfig  cluster                                                  -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete networkpolicy allow-labeled-namespaces-to-lightspeed               -n "${ns}" --ignore-not-found
@@ -566,8 +488,6 @@ while [ "$#" -gt 0 ]; do
       LIGHTSPEED_IMAGE="$2"; shift; shift ;;
     -ot|--openai-token)
       OPENAI_TOKEN="$2"; shift; shift ;;
-    --api)
-      API_ONLY_MODE="true"; shift ;;
     --llm-url)
       LLM_PROVIDER_URL="$2"; shift; shift ;;
     --llm-model)
@@ -617,10 +537,6 @@ Valid options:
   -in|--istio-namespace <namespace>
       The namespace where Istio and Kiali are installed.
       Default: ${DEFAULT_ISTIO_NAMESPACE}
-  --api
-      Enable API-only mode. Skips the OpenShift cluster monitoring check and
-      deploys the LightSpeed service directly instead of relying on the operator.
-      Default: ${DEFAULT_API_ONLY_MODE}
   -t|--timeout <seconds>
       Timeout in seconds for waiting on resources.
       Default: ${DEFAULT_TIMEOUT}
@@ -675,7 +591,6 @@ done
 : "${OPENAI_TOKEN:=${DEFAULT_OPENAI_TOKEN}}"
 : "${LLM_PROVIDER_URL:=${DEFAULT_LLM_PROVIDER_URL}}"
 : "${LLM_MODEL:=${DEFAULT_LLM_MODEL}}"
-: "${API_ONLY_MODE:=${DEFAULT_API_ONLY_MODE}}"
 : "${TIMEOUT:=${DEFAULT_TIMEOUT}}"
 
 ##############################################################################
@@ -700,7 +615,6 @@ debug "LIGHTSPEED_VERSION=${LIGHTSPEED_VERSION}"
 debug "OPENAI_TOKEN length=${#OPENAI_TOKEN}"
 debug "LLM_PROVIDER_URL=${LLM_PROVIDER_URL}"
 debug "LLM_MODEL=${LLM_MODEL}"
-debug "API_ONLY_MODE=${API_ONLY_MODE}"
 debug "TIMEOUT=${TIMEOUT}"
 
 ##############################################################################

--- a/hack/setup-osl.sh
+++ b/hack/setup-osl.sh
@@ -35,6 +35,9 @@ DEFAULT_LIGHTSPEED_VERSION="v1.1.0"
 DEFAULT_ISTIO_NAMESPACE="istio-system"
 DEFAULT_TIMEOUT="300"
 DEFAULT_OPENAI_TOKEN="<OPENAI_TOKEN>"
+DEFAULT_LLM_PROVIDER_URL="https://api.openai.com/v1"
+DEFAULT_LLM_MODEL="gpt-5.4-nano"
+DEFAULT_API_ONLY_MODE="false"
 
 # Runtime variables
 _VERBOSE="false"
@@ -114,6 +117,28 @@ validate_openai_token() {
     return 1
   fi
   debug "OPENAI_TOKEN is set (length=${#OPENAI_TOKEN})"
+  return 0
+}
+
+validate_llm_settings() {
+  if [ -z "${LLM_PROVIDER_URL}" ]; then
+    errormsg "LLM_PROVIDER_URL is empty."
+    errormsg "Please provide a valid OpenAI-compatible base URL with:"
+    errormsg "  --llm-url <provider-base-url>"
+    errormsg "  or export LLM_PROVIDER_URL=<provider-base-url> before running this script."
+    return 1
+  fi
+
+  if [ -z "${LLM_MODEL}" ]; then
+    errormsg "LLM_MODEL is empty."
+    errormsg "Please provide a valid model name with:"
+    errormsg "  --llm-model <model-name>"
+    errormsg "  or export LLM_MODEL=<model-name> before running this script."
+    return 1
+  fi
+
+  debug "LLM_PROVIDER_URL=${LLM_PROVIDER_URL}"
+  debug "LLM_MODEL=${LLM_MODEL}"
   return 0
 }
 
@@ -269,14 +294,16 @@ create_osl_config() {
     return 1
   fi
 
-  infomsg "Creating OLSConfig (mcp=${_MCP_PROVIDER}) in namespace [${ns}]..."
+  infomsg "Creating OLSConfig (mcp=${_MCP_PROVIDER}, llm=${LLM_PROVIDER_URL}, model=${LLM_MODEL}) in namespace [${ns}]..."
 
   local tmp_cfg
   tmp_cfg="$(mktemp /tmp/osl-config.XXXXXX.yaml)"
   trap 'rm -f "${tmp_cfg}"' RETURN
 
   export MCP_PROVIDER="${_MCP_PROVIDER}"
-  envsubst '${MCP_PROVIDER}' < "${template}" > "${tmp_cfg}"
+  export LLM_PROVIDER_URL
+  export LLM_MODEL
+  envsubst '${MCP_PROVIDER} ${LLM_PROVIDER_URL} ${LLM_MODEL}' < "${template}" > "${tmp_cfg}"
 
   ${CLIENT_EXE} apply -f "${tmp_cfg}" -n "${ns}"
 
@@ -292,7 +319,7 @@ create_olsconfig_api() {
     return 1
   fi
 
-  infomsg "Creating OLS ConfigMap for API mode (mcp=${_MCP_PROVIDER}) in namespace [${ns}]..."
+  infomsg "Creating OLS ConfigMap for API mode (mcp=${_MCP_PROVIDER}, llm=${LLM_PROVIDER_URL}, model=${LLM_MODEL}) in namespace [${ns}]..."
 
   local tmp_cfg
   tmp_cfg="$(mktemp /tmp/osl-api-config.XXXXXX.yaml)"
@@ -300,7 +327,9 @@ create_olsconfig_api() {
 
   export LIGHTSPEED_NAMESPACE
   export MCP_PROVIDER="${_MCP_PROVIDER}"
-  envsubst '${LIGHTSPEED_NAMESPACE} ${MCP_PROVIDER}' < "${template}" > "${tmp_cfg}"
+  export LLM_PROVIDER_URL
+  export LLM_MODEL
+  envsubst '${LIGHTSPEED_NAMESPACE} ${MCP_PROVIDER} ${LLM_PROVIDER_URL} ${LLM_MODEL}' < "${template}" > "${tmp_cfg}"
 
   ${CLIENT_EXE} apply -f "${tmp_cfg}" -n "${ns}"
 
@@ -324,11 +353,20 @@ create_lightspeed_api_deployment() {
 
   export LIGHTSPEED_NAMESPACE
   export LIGHTSPEED_IMAGE
-  envsubst '${LIGHTSPEED_NAMESPACE} ${LIGHTSPEED_IMAGE}' < "${template}" > "${tmp_deploy}"
+  export LIGHTSPEED_PORT="8080"
+  envsubst '${LIGHTSPEED_NAMESPACE} ${LIGHTSPEED_IMAGE} ${LIGHTSPEED_PORT}' < "${template}" > "${tmp_deploy}"
 
   ${CLIENT_EXE} apply -f "${tmp_deploy}" -n "${ns}"
 
   infomsg "Deployment [lightspeed-app-server] created/updated in namespace [${ns}]."
+}
+
+wait_for_lightspeed_api_deployment() {
+  local ns="${LIGHTSPEED_NAMESPACE}"
+
+  infomsg "Waiting for API-only LightSpeed deployment to become ready..."
+  ${CLIENT_EXE} rollout status deployment/lightspeed-app-server -n "${ns}" --timeout="${TIMEOUT}s"
+  infomsg "API-only LightSpeed deployment is ready."
 }
 
 create_lightspeed_network_policy() {
@@ -347,7 +385,12 @@ create_lightspeed_network_policy() {
   trap 'rm -f "${tmp_np}"' RETURN
 
   export LIGHTSPEED_NAMESPACE
-  envsubst '${LIGHTSPEED_NAMESPACE}' < "${template}" > "${tmp_np}"
+  if [ "${API_ONLY_MODE}" == "true" ]; then
+    export LIGHTSPEED_PORT="8080"
+  else
+    export LIGHTSPEED_PORT="8443"
+  fi
+  envsubst '${LIGHTSPEED_NAMESPACE} ${LIGHTSPEED_PORT}' < "${template}" > "${tmp_np}"
 
   ${CLIENT_EXE} apply -f "${tmp_np}" -n "${ns}"
 
@@ -400,8 +443,12 @@ ensure_lightspeed_ns() {
 
 install_lightspeed() {
   validate_openai_token || exit 1
-  ensure_openshift_monitoring || exit 1  
+  validate_llm_settings || exit 1
   discover_mcp || exit 1  # MCP server discovery
+
+  if [ "${API_ONLY_MODE}" != "true" ]; then
+    ensure_openshift_monitoring || exit 1
+  fi
 
   local ns="${LIGHTSPEED_NAMESPACE}"
 
@@ -409,16 +456,25 @@ install_lightspeed() {
   infomsg "  Installing LightSpeed"
   infomsg "  Namespace  : ${ns}"
   infomsg "  Image      : ${LIGHTSPEED_IMAGE}"
+  infomsg "  LLM URL    : ${LLM_PROVIDER_URL}"
+  infomsg "  LLM Model  : ${LLM_MODEL}"
+  infomsg "  API Only   : ${API_ONLY_MODE}"
   infomsg "  MCP        : ${_MCP_PROVIDER} @ ${_MCP_ENDPOINT}"
   infomsg "========================================================"
 
   ensure_lightspeed_ns
   create_lightspeed_credentials
 
-  create_lightspeed_operator_group
-  create_lightspeed_subscription
-  wait_for_lightspeed_operator
-  create_osl_config
+  if [ "${API_ONLY_MODE}" == "true" ]; then
+    create_olsconfig_api
+    create_lightspeed_api_deployment
+    wait_for_lightspeed_api_deployment
+  else
+    create_lightspeed_operator_group
+    create_lightspeed_subscription
+    wait_for_lightspeed_operator
+    create_osl_config
+  fi
   create_lightspeed_network_policy
   label_istio_namespace
 
@@ -435,6 +491,8 @@ uninstall_lightspeed() {
   fi
 
   ${CLIENT_EXE} delete deployment lightspeed-app-server                                    -n "${ns}" --ignore-not-found
+  ${CLIENT_EXE} delete service lightspeed-app-server                                       -n "${ns}" --ignore-not-found
+  ${CLIENT_EXE} delete route lightspeed-app-server                                         -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete configmap  olsconfig                                                -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete olsconfig  cluster                                                  -n "${ns}" --ignore-not-found
   ${CLIENT_EXE} delete networkpolicy allow-labeled-namespaces-to-lightspeed               -n "${ns}" --ignore-not-found
@@ -508,6 +566,12 @@ while [ "$#" -gt 0 ]; do
       LIGHTSPEED_IMAGE="$2"; shift; shift ;;
     -ot|--openai-token)
       OPENAI_TOKEN="$2"; shift; shift ;;
+    --api)
+      API_ONLY_MODE="true"; shift ;;
+    --llm-url)
+      LLM_PROVIDER_URL="$2"; shift; shift ;;
+    --llm-model)
+      LLM_MODEL="$2"; shift; shift ;;
     -lv|--lightspeed-version)
       LIGHTSPEED_VERSION="$2"; shift; shift ;;
     -in|--istio-namespace)
@@ -541,15 +605,22 @@ Valid options:
       The OLM operator version to install (sets startingCSV in the Subscription).
       Default: ${DEFAULT_LIGHTSPEED_VERSION}
   -ot|--openai-token <token>
-      The OpenAI API token used by the LightSpeed service. Required for installation.
+      The API token used by the LightSpeed service. OpenAI and OpenAI-compatible
+      providers are supported as long as the configured URL and model are valid.
       Can also be set via the OPENAI_TOKEN environment variable.
+  --llm-url <url>
+      Base URL of the OpenAI-compatible LLM provider.
+      Default: ${DEFAULT_LLM_PROVIDER_URL}
+  --llm-model <model>
+      Default model configured in the OLSConfig.
+      Default: ${DEFAULT_LLM_MODEL}
   -in|--istio-namespace <namespace>
       The namespace where Istio and Kiali are installed.
       Default: ${DEFAULT_ISTIO_NAMESPACE}
   --api
-      Enable API-only mode. Skips the OpenShift cluster monitoring check.
-      Use this when you only need the LightSpeed API without full cluster observability.
-      Default: false
+      Enable API-only mode. Skips the OpenShift cluster monitoring check and
+      deploys the LightSpeed service directly instead of relying on the operator.
+      Default: ${DEFAULT_API_ONLY_MODE}
   -t|--timeout <seconds>
       Timeout in seconds for waiting on resources.
       Default: ${DEFAULT_TIMEOUT}
@@ -569,6 +640,12 @@ Examples:
 
   # Install using oc with a custom image
   $0 --client-exe oc --image quay.io/openshift-lightspeed/lightspeed-service-api:v0.2.0 install-lightspeed
+
+  # Install using Gemini's OpenAI-compatible endpoint
+  $0 --openai-token <token> \
+     --llm-url https://generativelanguage.googleapis.com/v1beta/openai \
+     --llm-model gemini-2.5-pro \
+     install-lightspeed
 
   # Check status
   $0 status-lightspeed
@@ -596,6 +673,9 @@ done
 : "${LIGHTSPEED_VERSION:=${DEFAULT_LIGHTSPEED_VERSION}}"
 : "${ISTIO_NAMESPACE:=${DEFAULT_ISTIO_NAMESPACE}}"
 : "${OPENAI_TOKEN:=${DEFAULT_OPENAI_TOKEN}}"
+: "${LLM_PROVIDER_URL:=${DEFAULT_LLM_PROVIDER_URL}}"
+: "${LLM_MODEL:=${DEFAULT_LLM_MODEL}}"
+: "${API_ONLY_MODE:=${DEFAULT_API_ONLY_MODE}}"
 : "${TIMEOUT:=${DEFAULT_TIMEOUT}}"
 
 ##############################################################################
@@ -618,7 +698,9 @@ debug "LIGHTSPEED_NAMESPACE=${LIGHTSPEED_NAMESPACE}"
 debug "LIGHTSPEED_IMAGE=${LIGHTSPEED_IMAGE}"
 debug "LIGHTSPEED_VERSION=${LIGHTSPEED_VERSION}"
 debug "OPENAI_TOKEN length=${#OPENAI_TOKEN}"
-
+debug "LLM_PROVIDER_URL=${LLM_PROVIDER_URL}"
+debug "LLM_MODEL=${LLM_MODEL}"
+debug "API_ONLY_MODE=${API_ONLY_MODE}"
 debug "TIMEOUT=${TIMEOUT}"
 
 ##############################################################################


### PR DESCRIPTION
### Describe the change

Add google support for lightspeed installation.

### Steps to test the PR

1. Install the Kubernetes MCP server in the cluster.

```
./hack/setup-mcp.sh --client-exe oc --provider kubernetes install-mcp
./hack/setup-mcp.sh --client-exe oc --provider kubernetes status-mcp
```

2. Export your Google API key.
`export GOOGLE_API_KEY='<your-google-api-key>'`

3. Install OpenShift LightSpeed using Google’s OpenAI-compatible Gemini endpoint.
```
./hack/lightspeed/setup-osl.sh --client-exe oc \
  --openai-token "$GOOGLE_API_KEY" \
  --llm-url https://generativelanguage.googleapis.com/v1beta/openai \
  --llm-model gemini-2.5-pro \
  install-lightspeed
```

4. Verify the installation.
```
./hack/lightspeed/setup-osl.sh status-lightspeed
oc get pods -n openshift-lightspeed
```

Check the LightSpeed pod logs.

```
oc logs -n openshift-lightspeed deploy/lightspeed-app-server -f
```
Expected result:

- the installation completes without template/path errors
- the lightspeed-app-server pod is Running
- logs do not show invalid provider/model/token configuration errors

Optional functional check:

connect Kiali to the deployed LightSpeed instance and send a simple chat request to confirm Gemini responses are working.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/pull/9754 
