### PR TITLE
[v1.73] Fix CVE-2026-4800: upgrade lodash-es to 4.18.1

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12021,14 +12021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.11":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
-  languageName: node
-  linkType: hard
-
-"lodash-es@npm:^4.18.0":
+"lodash-es@npm:^4.17.11, lodash-es@npm:^4.18.0":
   version: 4.18.1
   resolution: "lodash-es@npm:4.18.1"
   checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8


### PR DESCRIPTION
## Summary

Regenerates `yarn.lock` to resolve `lodash-es@^4.17.11` (from `react-resize-detector@3.4.0`) to `4.18.1` instead of stale `4.17.23`.

The `^4.17.11` semver range already includes 4.18.x — the lockfile simply had a stale resolution from before 4.18.0 existed.

## CVE Details

### CVE-2026-4800 — lodash code injection via _.template
- **Advisory**: [GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc)
- **Fix versions**: lodash/lodash-es 4.18.0+
- **Dependency chain**: `react-resize-detector@3.4.0` → `lodash-es@^4.17.11` (resolved to stale 4.17.23)
- **Resolved to**: 4.18.1

## Test plan

- [x] `yarn install` succeeds and deduplicates lodash-es to 4.18.1
- [x] No `4.17.23` remaining in lockfile


Made with [Cursor](https://cursor.com)