### PR TITLE
Added 2 new validations of SE host-port combination

### DIFF
--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -19,13 +19,21 @@ type ServiceEntryChecker struct {
 func (s ServiceEntryChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	weMap := serviceentries.GroupWorkloadEntriesByLabels(s.WorkloadEntries)
+	validations.MergeValidations(s.runGroupChecks())
 
+	weMap := serviceentries.GroupWorkloadEntriesByLabels(s.WorkloadEntries)
 	for _, se := range s.ServiceEntries {
 		validations.MergeValidations(s.runSingleChecks(se, weMap))
 	}
 
 	return validations
+}
+
+func (s ServiceEntryChecker) runGroupChecks() models.IstioValidations {
+	return serviceentries.MultiMatchChecker{
+		Cluster:        s.Cluster,
+		ServiceEntries: s.ServiceEntries,
+	}.Check()
 }
 
 func (s ServiceEntryChecker) runSingleChecks(se *networking_v1.ServiceEntry, workloadEntriesMap map[string][]string) models.IstioValidations {

--- a/business/checkers/serviceentries/multi_match_checker.go
+++ b/business/checkers/serviceentries/multi_match_checker.go
@@ -23,8 +23,8 @@ type hostPortKey struct {
 type sePortEntry struct {
 	Name      string
 	Namespace string
-	Protocol  string
 	PortIndex int
+	Protocol  string
 }
 
 func (m MultiMatchChecker) Check() models.IstioValidations {

--- a/business/checkers/serviceentries/multi_match_checker.go
+++ b/business/checkers/serviceentries/multi_match_checker.go
@@ -39,7 +39,7 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 			}
 			protocol := strings.ToUpper(port.Protocol)
 			for _, host := range se.Spec.Hosts {
-				key := hostPortKey{Host: host, PortNumber: port.Number}
+				key := hostPortKey{Host: strings.ToLower(host), PortNumber: port.Number}
 				index[key] = append(index[key], sePortEntry{
 					Name:      se.Name,
 					Namespace: se.Namespace,

--- a/business/checkers/serviceentries/multi_match_checker.go
+++ b/business/checkers/serviceentries/multi_match_checker.go
@@ -1,0 +1,112 @@
+package serviceentries
+
+import (
+	"fmt"
+	"strings"
+
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+type MultiMatchChecker struct {
+	Cluster        string
+	ServiceEntries []*networking_v1.ServiceEntry
+}
+
+type hostPortKey struct {
+	Host       string
+	PortNumber uint32
+}
+
+type sePortEntry struct {
+	Name      string
+	Namespace string
+	Protocol  string
+	PortIndex int
+}
+
+func (m MultiMatchChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	index := make(map[hostPortKey][]sePortEntry)
+
+	for _, se := range m.ServiceEntries {
+		for portIndex, port := range se.Spec.Ports {
+			if port == nil {
+				continue
+			}
+			protocol := strings.ToUpper(port.Protocol)
+			for _, host := range se.Spec.Hosts {
+				key := hostPortKey{Host: host, PortNumber: port.Number}
+				index[key] = append(index[key], sePortEntry{
+					Name:      se.Name,
+					Namespace: se.Namespace,
+					Protocol:  protocol,
+					PortIndex: portIndex,
+				})
+			}
+		}
+	}
+
+	for _, entries := range index {
+		if len(entries) < 2 {
+			continue
+		}
+		checkID := "serviceentries.multimatch"
+		if hasProtocolConflict(entries) {
+			checkID = "serviceentries.port.protocol.conflict"
+		}
+		m.addValidations(validations, entries, checkID)
+	}
+
+	return validations
+}
+
+func hasProtocolConflict(entries []sePortEntry) bool {
+	first := entries[0].Protocol
+	for _, e := range entries[1:] {
+		if e.Protocol != first {
+			return true
+		}
+	}
+	return false
+}
+
+func (m MultiMatchChecker) addValidations(validations models.IstioValidations, entries []sePortEntry, checkID string) {
+	keys := make([]models.IstioValidationKey, 0, len(entries))
+	vals := make([]*models.IstioValidation, 0, len(entries))
+
+	for _, entry := range entries {
+		key := models.IstioValidationKey{
+			Name:      entry.Name,
+			Namespace: entry.Namespace,
+			ObjectGVK: kubernetes.ServiceEntries,
+			Cluster:   m.Cluster,
+		}
+		check := models.Build(checkID,
+			fmt.Sprintf("spec/ports[%d]", entry.PortIndex))
+		val := &models.IstioValidation{
+			Cluster:    m.Cluster,
+			Name:       entry.Name,
+			Namespace:  entry.Namespace,
+			ObjectGVK:  kubernetes.ServiceEntries,
+			Valid:      true,
+			Checks:     []*models.IstioCheck{&check},
+			References: make([]models.IstioValidationKey, 0),
+		}
+		keys = append(keys, key)
+		vals = append(vals, val)
+	}
+
+	for i := range vals {
+		for j := range keys {
+			if i == j {
+				continue
+			}
+			vals[i].References = append(vals[i].References, keys[j])
+		}
+		validations.MergeValidations(models.IstioValidations{keys[i]: vals[i]})
+	}
+}

--- a/business/checkers/serviceentries/multi_match_checker_test.go
+++ b/business/checkers/serviceentries/multi_match_checker_test.go
@@ -1,0 +1,382 @@
+package serviceentries
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+	"github.com/kiali/kiali/tests/testutils/validations"
+)
+
+func TestSameHostPortSameProtocolMultiMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	assertMultiMatchValidation(assert, vals, "se1", "test", []string{"se2"})
+	assertMultiMatchValidation(assert, vals, "se2", "test", []string{"se1"})
+}
+
+func TestDifferentPortNumbersNoConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(80, "http", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+	assert.Empty(vals)
+}
+
+func TestDifferentHostsNoConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "http-13835", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"other.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+	assert.Empty(vals)
+}
+
+func TestConflictingProtocols(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "http-13835", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	assertProtocolConflictValidation(assert, vals, "se1", "test", []string{"se2"})
+	assertProtocolConflictValidation(assert, vals, "se2", "test", []string{"se1"})
+}
+
+func TestThreeSEsTwoConflicting(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "http-13835", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se3", "test", []string{"other.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	assertProtocolConflictValidation(assert, vals, "se1", "test", []string{"se2"})
+	assertProtocolConflictValidation(assert, vals, "se2", "test", []string{"se1"})
+
+	_, ok := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "test", Name: "se3"}]
+	assert.False(ok)
+}
+
+func TestMultipleHostsConflictOnOne(t *testing.T) {
+	assert := assert.New(t)
+
+	se1 := data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com", "other.com"})
+	data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"), se1)
+
+	se2 := data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"})
+	data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyServicePortDefinition(443, "http", "HTTP"), se2)
+
+	serviceEntries := []*networking_v1.ServiceEntry{se1, se2}
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	assertProtocolConflictValidation(assert, vals, "se1", "test", []string{"se2"})
+	assertProtocolConflictValidation(assert, vals, "se2", "test", []string{"se1"})
+}
+
+func TestMultiplePortsConflictOnOne(t *testing.T) {
+	assert := assert.New(t)
+
+	se1 := data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"})
+	data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyServicePortDefinition(80, "http", "HTTP"), se1)
+	data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"), se1)
+
+	se2 := data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"})
+	data.AddPortDefinitionToServiceEntry(
+		data.CreateEmptyServicePortDefinition(443, "tls", "TLS"), se2)
+
+	serviceEntries := []*networking_v1.ServiceEntry{se1, se2}
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	v1 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "test", Name: "se1"}]
+	assert.NotNil(v1)
+	assert.Equal("spec/ports[1]", v1.Checks[0].Path)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.port.protocol.conflict", v1.Checks[0]))
+
+	v2 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "test", Name: "se2"}]
+	assert.NotNil(v2)
+	assert.Equal("spec/ports[0]", v2.Checks[0].Path)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.port.protocol.conflict", v2.Checks[0]))
+}
+
+func TestProtocolCaseInsensitiveMultiMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(80, "http", "http"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(80, "http2", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+	assertMultiMatchValidation(assert, vals, "se1", "test", []string{"se2"})
+	assertMultiMatchValidation(assert, vals, "se2", "test", []string{"se1"})
+}
+
+func TestCrossNamespaceConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "https-13835", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "ns1", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(13835, "http-13835", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "ns2", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	v1 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns1", Name: "se1"}]
+	assert.NotNil(v1)
+	assert.True(v1.Valid)
+	assert.NotEmpty(v1.Checks)
+	assert.Equal(models.WarningSeverity, v1.Checks[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.port.protocol.conflict", v1.Checks[0]))
+	assert.Contains(v1.References, models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns2", Name: "se2"})
+
+	v2 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns2", Name: "se2"}]
+	assert.NotNil(v2)
+	assert.Contains(v2.References, models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns1", Name: "se1"})
+}
+
+func TestCrossNamespaceMultiMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "ns1", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "ns2", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+
+	v1 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns1", Name: "se1"}]
+	assert.NotNil(v1)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.multimatch", v1.Checks[0]))
+	assert.Contains(v1.References, models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns2", Name: "se2"})
+
+	v2 := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns2", Name: "se2"}]
+	assert.NotNil(v2)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.multimatch", v2.Checks[0]))
+	assert.Contains(v2.References, models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "ns1", Name: "se1"})
+}
+
+func TestNoPortsNoConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+	assert.Empty(vals)
+}
+
+func TestSingleServiceEntryNoConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(80, "http", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+	assert.Empty(vals)
+}
+
+func TestMultiMatchNotProtocolConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https-alt", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https-backup", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se3", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(3, len(vals))
+
+	assertMultiMatchValidation(assert, vals, "se1", "test", []string{"se2", "se3"})
+	assertMultiMatchValidation(assert, vals, "se2", "test", []string{"se1", "se3"})
+	assertMultiMatchValidation(assert, vals, "se3", "test", []string{"se1", "se2"})
+}
+
+func TestThreeSEsMixedProtocolConflict(t *testing.T) {
+	assert := assert.New(t)
+
+	serviceEntries := []*networking_v1.ServiceEntry{
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se1", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "https-alt", "HTTPS"),
+			data.CreateEmptyMeshExternalServiceEntry("se2", "test", []string{"example.com"}),
+		),
+		data.AddPortDefinitionToServiceEntry(
+			data.CreateEmptyServicePortDefinition(443, "http", "HTTP"),
+			data.CreateEmptyMeshExternalServiceEntry("se3", "test", []string{"example.com"}),
+		),
+	}
+
+	vals := MultiMatchChecker{ServiceEntries: serviceEntries}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(3, len(vals))
+
+	for _, seName := range []string{"se1", "se2", "se3"} {
+		v := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: "test", Name: seName}]
+		assert.NotNil(v)
+		assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.port.protocol.conflict", v.Checks[0]))
+	}
+}
+
+func assertMultiMatchValidation(assert *assert.Assertions, vals models.IstioValidations, seName, seNamespace string, refNames []string) {
+	validation, ok := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: seNamespace, Name: seName}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.multimatch", validation.Checks[0]))
+
+	assert.NotEmpty(validation.References)
+	for _, refName := range refNames {
+		assert.Contains(validation.References,
+			models.IstioValidationKey{
+				ObjectGVK: kubernetes.ServiceEntries,
+				Namespace: seNamespace,
+				Name:      refName,
+			},
+		)
+	}
+}
+
+func assertProtocolConflictValidation(assert *assert.Assertions, vals models.IstioValidations, seName, seNamespace string, refNames []string) {
+	validation, ok := vals[models.IstioValidationKey{ObjectGVK: kubernetes.ServiceEntries, Namespace: seNamespace, Name: seName}]
+	assert.True(ok)
+	assert.True(validation.Valid)
+	assert.NotEmpty(validation.Checks)
+	assert.Equal(models.WarningSeverity, validation.Checks[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("serviceentries.port.protocol.conflict", validation.Checks[0]))
+
+	assert.NotEmpty(validation.References)
+	for _, refName := range refNames {
+		assert.Contains(validation.References,
+			models.IstioValidationKey{
+				ObjectGVK: kubernetes.ServiceEntries,
+				Namespace: seNamespace,
+				Name:      refName,
+			},
+		)
+	}
+}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -298,6 +298,16 @@ var checkDescriptors = map[string]IstioCheck{
 		Message:  "Deployment exposing same port as Service not found",
 		Severity: WarningSeverity,
 	},
+	"serviceentries.multimatch": {
+		Code:     "KIA1202",
+		Message:  "More than one ServiceEntry for the same host and port",
+		Severity: WarningSeverity,
+	},
+	"serviceentries.port.protocol.conflict": {
+		Code:     "KIA1203",
+		Message:  "ServiceEntries have conflicting protocols for the same host and port",
+		Severity: WarningSeverity,
+	},
 	"serviceentries.workloadentries.addressmatch": {
 		Code:     "KIA1201",
 		Message:  "Missing one or more addresses from matching WorkloadEntries",


### PR DESCRIPTION
### Summary
Adds two new Kiali validations for ServiceEntry resources that detect conflicting or duplicate host+port definitions across multiple ServiceEntries. This addresses a known Istio limitation where multiple ServiceEntries for the same host cause broken Envoy configuration, leading to blackholed traffic or NoClusterFound errors.

1. KIA1202 (serviceentries.multimatch) -- Warning when multiple ServiceEntries define the same host and port number with the same protocol (duplicate configuration)

1. KIA1203 (serviceentries.port.protocol.conflict) -- Warning when multiple ServiceEntries define the same host and port number with different protocols (conflicting configuration)

Only one warning is shown per host+port combination: KIA1203 (protocol conflict) takes precedence over KIA1202 (duplicate) when protocols differ.

Fixes https://github.com/kiali/kiali/issues/9800

### Background
Istio merges multiple ServiceEntries with the same hostname into a single internal service keyed by namespace + hostname. This merge is fundamentally broken in multiple scenarios:

1. Same host + same port + different protocol ([istio#51466](https://github.com/istio/istio/issues/51466)): Traffic is blackholed due to conflicting Envoy cluster config.

1. Same host + different ports ([istio#54988](https://github.com/istio/istio/issues/54988)): Only one SE's port gets a cluster; the other fails with NC (NoClusterFound). Still open and affects versions 1.22 through 1.26+.

1. Same host + same port + same protocol ([istio PR#57782](https://github.com/istio/istio/pull/57782)): Deduplicated by creation timestamp, but deleting the "winning" SE can leave the original unrecoverable until istiod restarts.

Istio's istioctl analyze does not currently have a check for overlapping ServiceEntries. The recommended workaround from Istio maintainers is to consolidate all ports into a single ServiceEntry per host.

### Steps to Reproduce
**Scenario 1:** Protocol conflict (KIA1203)
Apply two ServiceEntries with the same host (example.com) and port (13835) but different protocols:
```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: sentry1
spec:
  hosts:
  - example.com
  ports:
  - name: https-13835
    number: 13835
    protocol: HTTPS
---
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: sentry2
spec:
  hosts:
  - example.com
  ports:
  - name: http-13835
    number: 13835
    protocol: HTTP
```
Expected: Both sentry1 and sentry2 show KIA1203 warning: "ServiceEntries have conflicting protocols for the same host and port", with bidirectional references linking each to the other.

**Scenario 2:** Duplicate host+port (KIA1202)
Apply two ServiceEntries with the same host (example.com2) and port (13836) and same protocol:
```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: sentry3
spec:
  hosts:
  - example.com2
  ports:
  - name: grpc-13836
    number: 13836
    protocol: GRPC
---
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: sentry4
spec:
  hosts:
  - example.com2
  ports:
  - name: grpc-13836
    number: 13836
    protocol: GRPC
 ```
Expected: Both sentry3 and sentry4 show KIA1202 warning: "More than one ServiceEntry for the same host and port", with bidirectional references.

**No false positives**

- [ ] Two SEs with the same host but different port numbers produce no warning.
- [ ] Two SEs with different hosts but same port and different protocols produce no warning.
- [ ] A single SE with multiple ports produces no warning.

### Test plan

 14 unit tests covering both validation codes, cross-namespace, multi-host, multi-port, case insensitivity, and mutual exclusivity

- [ ]  All existing ServiceEntry checker tests pass (business/checkers/serviceentries/)
- [ ] All checker packages pass (business/checkers/...)
- [ ]  Models package passes (models/...)
- [ ] Manual validation with example YAML above on a cluster with Kiali