### PR TITLE
[v2.22] Backport health cache improvements (#9478, #9487, #9500, #9516)

### DIFF
--- a/business/health.go
+++ b/business/health.go
@@ -321,10 +321,10 @@ func (in *HealthService) GetNamespaceAppHealth(ctx context.Context, criteria Nam
 		return nil, err
 	}
 
-	return in.getNamespaceAppHealth(appEntities, criteria)
+	return in.getNamespaceAppHealth(ctx, appEntities, criteria)
 }
 
-func (in *HealthService) getNamespaceAppHealth(appEntities namespaceApps, criteria NamespaceHealthCriteria) (models.NamespaceAppHealth, error) {
+func (in *HealthService) getNamespaceAppHealth(ctx context.Context, appEntities namespaceApps, criteria NamespaceHealthCriteria) (models.NamespaceAppHealth, error) {
 	namespace := criteria.Namespace
 	queryTime := criteria.QueryTime
 	rateInterval := criteria.RateInterval
@@ -355,7 +355,7 @@ func (in *HealthService) getNamespaceAppHealth(appEntities namespaceApps, criter
 
 	if hasHTTPTraffic && criteria.IncludeMetrics {
 		// Fetch services requests rates
-		rates, err := in.prom.GetAllRequestRates(context.Background(), namespace, cluster, rateInterval, queryTime)
+		rates, err := in.prom.GetAllRequestRates(ctx, namespace, cluster, rateInterval, queryTime)
 		if err != nil {
 			return allHealth, errors.NewServiceUnavailable(err.Error())
 		}
@@ -371,6 +371,50 @@ func (in *HealthService) getNamespaceAppHealth(appEntities namespaceApps, criter
 	}
 
 	return allHealth, nil
+}
+
+// GetNamespaceAppHealthFromWorkloads computes app health from pre-fetched workloads.
+// This avoids the per-namespace full-cluster listing that GetNamespaceAppHealth performs,
+// making it suitable for batch health computation across many namespaces.
+func (in *HealthService) GetNamespaceAppHealthFromWorkloads(ctx context.Context, criteria NamespaceHealthCriteria, workloads models.Workloads) (models.NamespaceAppHealth, error) {
+	var end observability.EndFunc
+	ctx, end = observability.StartSpan(ctx, "GetNamespaceAppHealthFromWorkloads",
+		observability.Attribute("package", "business"),
+		observability.Attribute(observability.TracingClusterTag, criteria.Cluster),
+		observability.Attribute("namespace", criteria.Namespace),
+	)
+	defer end()
+
+	appEntities := make(namespaceApps)
+	for _, w := range workloads {
+		if w.IsInfra() {
+			continue
+		}
+		appLabelName, found := in.conf.GetAppLabelName(w.Labels)
+		if !found || appLabelName == "" {
+			continue
+		}
+		appName := w.Labels[appLabelName]
+		if appName == "" {
+			continue
+		}
+		if _, ok := appEntities[appName]; !ok {
+			appEntities[appName] = &appDetails{
+				app:     appName,
+				cluster: criteria.Cluster,
+			}
+		}
+		appEntities[appName].Workloads = append(appEntities[appName].Workloads, w)
+	}
+
+	return in.getNamespaceAppHealth(ctx, appEntities, criteria)
+}
+
+// GetNamespaceWorkloadHealthFromWorkloads computes workload health from pre-fetched workloads.
+// This avoids the per-namespace full-cluster listing that GetNamespaceWorkloadHealth performs,
+// making it suitable for batch health computation across many namespaces.
+func (in *HealthService) GetNamespaceWorkloadHealthFromWorkloads(ctx context.Context, criteria NamespaceHealthCriteria, workloads models.Workloads) (models.NamespaceWorkloadHealth, error) {
+	return in.getNamespaceWorkloadHealth(ctx, workloads, criteria)
 }
 
 // GetNamespaceServiceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)

--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -3,6 +3,7 @@ package business
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -71,12 +72,20 @@ func (m *healthMonitor) Start(ctx context.Context) {
 	timeout := m.conf.HealthConfig.Compute.Timeout
 	m.logger.Info().Msgf("Starting health monitor with refresh interval: %s, timeout: %s", interval, timeout)
 
-	// Prime the cache with an initial refresh (with timeout)
-	refreshCtx, cancel := context.WithTimeout(ctx, timeout)
-	if err := m.RefreshHealth(refreshCtx); err != nil {
-		m.logger.Error().Err(err).Msg("Initial health refresh failed")
-	}
-	cancel()
+	// Prime the cache with an initial refresh (with timeout).
+	// Recover from panics so that a failure here does not crash the entire process.
+	func() {
+		refreshCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				m.logger.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic during initial health refresh")
+			}
+		}()
+		if err := m.RefreshHealth(refreshCtx); err != nil {
+			m.logger.Error().Err(err).Msg("Initial health refresh failed")
+		}
+	}()
 
 	go func() {
 		for {
@@ -85,11 +94,18 @@ func (m *healthMonitor) Start(ctx context.Context) {
 				m.logger.Info().Msg("Stopping health monitor")
 				return
 			case <-time.After(interval):
-				refreshCtx, cancel := context.WithTimeout(ctx, timeout)
-				if err := m.RefreshHealth(refreshCtx); err != nil {
-					m.logger.Error().Err(err).Msg("Health refresh failed")
-				}
-				cancel()
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							m.logger.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic during health refresh")
+						}
+					}()
+					refreshCtx, cancel := context.WithTimeout(ctx, timeout)
+					defer cancel()
+					if err := m.RefreshHealth(refreshCtx); err != nil {
+						m.logger.Error().Err(err).Msg("Health refresh failed")
+					}
+				}()
 			}
 		}
 	}()

--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -23,6 +23,7 @@ import (
 // This is an interface for testing purposes.
 type HealthMonitor interface {
 	// Start starts the background health refresh job.
+	// The initial refresh and all subsequent refreshes run in a background goroutine
 	Start(ctx context.Context)
 	// RefreshHealth performs a single refresh of the health cache.
 	RefreshHealth(ctx context.Context) error
@@ -67,33 +68,40 @@ type healthMonitor struct {
 }
 
 // Start starts the background health refresh loop.
+// The initial refresh and all subsequent refreshes run in a background goroutine
+// so that Start returns immediately, allowing the HTTP server to begin accepting
+// requests (and passing startup/liveness probes) without waiting for the first
+// health computation to finish.
 func (m *healthMonitor) Start(ctx context.Context) {
 	interval := m.conf.HealthConfig.Compute.RefreshInterval
 	timeout := m.conf.HealthConfig.Compute.Timeout
 	m.logger.Info().Msgf("Starting health monitor with refresh interval: %s, timeout: %s", interval, timeout)
 
-	// Prime the cache with an initial refresh (with timeout).
-	// Recover from panics so that a failure here does not crash the entire process.
-	func() {
-		refreshCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-		defer func() {
-			if r := recover(); r != nil {
-				m.logger.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic during initial health refresh")
+	go func() {
+		// Prime the cache with an initial refresh (non-blocking to caller).
+		// Recover from panics so that a failure here does not crash the entire process.
+		func() {
+			refreshCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			defer func() {
+				if r := recover(); r != nil {
+					m.logger.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic during initial health refresh")
+				}
+			}()
+			if err := m.RefreshHealth(refreshCtx); err != nil {
+				m.logger.Error().Err(err).Msg("Initial health refresh failed")
 			}
 		}()
-		if err := m.RefreshHealth(refreshCtx); err != nil {
-			m.logger.Error().Err(err).Msg("Initial health refresh failed")
-		}
-	}()
 
-	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				m.logger.Info().Msg("Stopping health monitor")
 				return
-			case <-time.After(interval):
+			case <-ticker.C:
 				func() {
 					defer func() {
 						if r := recover(); r != nil {

--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -221,6 +221,21 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 		return 0, 1
 	}
 
+	// Pre-fetch ALL workloads for the cluster once to avoid having each namespace's health
+	// computation independently list all cluster-wide resources (pods, deployments,
+	// replicasets, etc.) and filters to its namespace.
+	allWorkloads, err := layer.Workload.GetAllWorkloads(ctx, cluster, "")
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to pre-fetch workloads for cluster")
+		return 0, 1
+	}
+
+	// Create a map and then use it to pass down per-namespace workloads.
+	workloadsByNamespace := make(map[string]models.Workloads, len(namespaces))
+	for _, w := range allWorkloads {
+		workloadsByNamespace[w.Namespace] = append(workloadsByNamespace[w.Namespace], w)
+	}
+
 	visitedNamespaces := make(map[string]bool, len(namespaces))
 	errorCount := 0
 	for _, ns := range namespaces {
@@ -230,7 +245,7 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 			return len(namespaces), errorCount
 		}
 
-		if err := m.refreshNamespaceHealth(ctx, layer, cluster, ns.Name, duration); err != nil {
+		if err := m.refreshNamespaceHealth(ctx, layer, cluster, ns.Name, duration, workloadsByNamespace[ns.Name]); err != nil {
 			log.Warn().Err(err).Str("namespace", ns.Name).Msg("Failed to refresh health for namespace")
 			errorCount++
 			continue
@@ -249,7 +264,8 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 }
 
 // refreshNamespaceHealth computes and caches health for a single namespace.
-func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer, cluster, namespace, duration string) error {
+// workloads contains pre-fetched workloads for this namespace (may be nil if none exist).
+func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer, cluster, namespace, duration string, workloads models.Workloads) error {
 	log := m.logger.With().
 		Str("cluster", cluster).
 		Str("namespace", namespace).
@@ -266,10 +282,11 @@ func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer
 		RateInterval:   duration,
 	}
 
-	// Compute health for apps, services, and workloads
-	appHealth, appErr := layer.Health.GetNamespaceAppHealth(ctx, criteria)
+	// Use pre-fetched workloads for app and workload health.
+	// Service health still fetches per-namespace since services are already listed namespace-scoped.
+	appHealth, appErr := layer.Health.GetNamespaceAppHealthFromWorkloads(ctx, criteria, workloads)
 	serviceHealth, svcErr := layer.Health.GetNamespaceServiceHealth(ctx, criteria)
-	workloadHealth, wkErr := layer.Health.GetNamespaceWorkloadHealth(ctx, criteria)
+	workloadHealth, wkErr := layer.Health.GetNamespaceWorkloadHealthFromWorkloads(ctx, criteria, workloads)
 
 	// If all failed, return error (no cache write or metrics export; refreshClusterHealth will not
 	// mark this namespace visited so dropped-namespace reconciliation can age stale gauges).

--- a/business/health_cache_test.go
+++ b/business/health_cache_test.go
@@ -1,12 +1,17 @@
 package business
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+	"github.com/kiali/kiali/log"
 )
 
 func TestCalculateDuration_FirstRun(t *testing.T) {
@@ -115,4 +120,37 @@ func parseNumber(s string, result *int) (bool, error) {
 	}
 	*result = n
 	return true, nil
+}
+
+func TestRefreshClusterHealth_GetAllWorkloadsError(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Server.Observability.Metrics.Enabled = false
+	conf.Server.Observability.Metrics.HealthStatus.Enabled = false
+	config.Set(conf)
+
+	cluster := conf.KubernetesConfig.ClusterName
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+
+	layer := NewLayerBuilder(t, conf).WithClient(k8s).Build()
+
+	// Remove the cluster's SA client from the WorkloadService so GetAllWorkloads
+	// fails with "Cluster [...] is not found", while the NamespaceService (which
+	// has its own copy of the SA clients) still succeeds for GetClusterNamespaces.
+	delete(layer.Workload.kialiSAClients, cluster)
+
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+
+	monitor := &healthMonitor{
+		clientFactory: clientFactory,
+		conf:          conf,
+		logger:        log.Logger().With().Str("component", "health-monitor-test").Logger(),
+	}
+
+	nsCount, errCount := monitor.refreshClusterHealth(context.Background(), layer, cluster, "5m")
+
+	assert.Equal(t, 0, nsCount, "expected 0 namespaces processed when GetAllWorkloads fails")
+	assert.Equal(t, 1, errCount, "expected 1 error when GetAllWorkloads fails")
 }

--- a/business/health_test.go
+++ b/business/health_test.go
@@ -554,6 +554,282 @@ var (
 	}
 )
 
+func TestGetNamespaceAppHealthFromWorkloads(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
+	prom.MockAllRequestRates(context.Background(), "ns", conf.KubernetesConfig.ClusterName, "1m", queryTime, otherRatesIn)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: true,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+			DesiredReplicas:   3,
+			AvailableReplicas: 2,
+		},
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v2",
+				Namespace:    "ns",
+				IstioSidecar: true,
+				Labels:       map[string]string{"app": "reviews", "version": "v2"},
+			},
+			DesiredReplicas:   2,
+			AvailableReplicas: 1,
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      queryTime,
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceAppHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	assert.Nil(err)
+	assert.Len(health, 1)
+	assert.Contains(health, "reviews")
+	assert.Len(health["reviews"].WorkloadStatuses, 2)
+	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 1)
+}
+
+func TestGetNamespaceAppHealthFromWorkloadsWithoutIstio(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: false,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC),
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceAppHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	require.NoError(err)
+	require.Len(health, 1)
+	require.Contains(health, "reviews")
+	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 0)
+}
+
+func TestGetNamespaceAppHealthFromWorkloadsFiltersInfra(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: false,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+		},
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:       "waypoint-proxy",
+				Namespace:  "ns",
+				IsWaypoint: true,
+				Labels:     map[string]string{"app": "waypoint-proxy", "gateway.networking.k8s.io/gateway-name": "waypoint"},
+			},
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC),
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceAppHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	require.NoError(err)
+	require.Len(health, 1)
+	require.Contains(health, "reviews")
+	require.NotContains(health, "waypoint-proxy")
+}
+
+func TestGetNamespaceAppHealthFromWorkloadsSkipsNoAppLabel(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:      "unlabeled-workload",
+				Namespace: "ns",
+				Labels:    map[string]string{"version": "v1"},
+			},
+		},
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:      "empty-app-label",
+				Namespace: "ns",
+				Labels:    map[string]string{"app": "", "version": "v1"},
+			},
+		},
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: false,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC),
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceAppHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	require.NoError(err)
+	require.Len(health, 1)
+	require.Contains(health, "reviews")
+}
+
+func TestGetNamespaceWorkloadHealthFromWorkloads(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	queryTime := time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC)
+	prom.MockAllRequestRates(context.Background(), "ns", conf.KubernetesConfig.ClusterName, "1m", queryTime, otherRatesIn)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: true,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+			DesiredReplicas:   3,
+			AvailableReplicas: 2,
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      queryTime,
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceWorkloadHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	assert.Nil(err)
+	assert.Len(health, 1)
+	assert.Contains(health, "reviews-v1")
+	assert.Equal(int32(3), health["reviews-v1"].WorkloadStatus.DesiredReplicas)
+	assert.Equal(int32(2), health["reviews-v1"].WorkloadStatus.AvailableReplicas)
+	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 1)
+}
+
+func TestGetNamespaceWorkloadHealthFromWorkloadsWithoutIstio(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns"}},
+	)
+	prom := new(prometheustest.PromClientMock)
+
+	hs := NewLayerBuilder(t, conf).WithClient(k8s).WithProm(prom).Build().Health
+
+	workloads := models.Workloads{
+		&models.Workload{
+			WorkloadListItem: models.WorkloadListItem{
+				Name:         "reviews-v1",
+				Namespace:    "ns",
+				IstioSidecar: false,
+				Labels:       map[string]string{"app": "reviews", "version": "v1"},
+			},
+			DesiredReplicas:   2,
+			AvailableReplicas: 2,
+		},
+	}
+
+	criteria := NamespaceHealthCriteria{
+		Cluster:        conf.KubernetesConfig.ClusterName,
+		Namespace:      "ns",
+		RateInterval:   "1m",
+		QueryTime:      time.Date(2017, 1, 15, 0, 0, 0, 0, time.UTC),
+		IncludeMetrics: true,
+	}
+	health, err := hs.GetNamespaceWorkloadHealthFromWorkloads(context.TODO(), criteria, workloads)
+
+	require.NoError(err)
+	require.Len(health, 1)
+	require.Contains(health, "reviews-v1")
+	require.Equal(emptyResult, health["reviews-v1"].Requests.Inbound)
+	require.Equal(emptyResult, health["reviews-v1"].Requests.Outbound)
+	prom.AssertNumberOfCalls(t, "GetAllRequestRates", 0)
+}
+
 func fakePodsHealthReview() []core_v1.Pod {
 	return []core_v1.Pod{
 		{

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -991,6 +991,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 	pods = sliceutil.Filter(podList.Items, func(pod core_v1.Pod) bool {
 		return slices.Contains(namespaces, pod.Namespace)
 	})
+	podList = nil
 
 	depList := &apps_v1.DeploymentList{}
 	if err := kubeCache.List(ctx, depList); err != nil {
@@ -999,6 +1000,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 	dep = sliceutil.Filter(depList.Items, func(dep apps_v1.Deployment) bool {
 		return slices.Contains(namespaces, dep.Namespace)
 	})
+	depList = nil
 
 	repList := &apps_v1.ReplicaSetList{}
 	if err := kubeCache.List(ctx, repList); err != nil {
@@ -1007,6 +1009,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 	repset = sliceutil.Filter(repList.Items, func(rs apps_v1.ReplicaSet) bool {
 		return slices.Contains(namespaces, rs.Namespace)
 	})
+	repList = nil
 
 	// ReplicaControllers are fetched only when included
 	wg.Add(1)
@@ -1055,6 +1058,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 		fulset = sliceutil.Filter(setList.Items, func(ss apps_v1.StatefulSet) bool {
 			return slices.Contains(namespaces, ss.Namespace)
 		})
+		setList = nil
 	}
 
 	// CronJobs are fetched only when included
@@ -1104,6 +1108,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 		daeset = sliceutil.Filter(daeList.Items, func(ds apps_v1.DaemonSet) bool {
 			return slices.Contains(namespaces, ds.Namespace)
 		})
+		daeList = nil
 	}
 
 	// WorkloadGroups are fetched only when included
@@ -1115,6 +1120,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 		wgroups = sliceutil.Filter(wgroupList.Items, func(wg *networking_v1.WorkloadGroup) bool {
 			return slices.Contains(namespaces, wg.Namespace)
 		})
+		wgroupList = nil
 	}
 
 	// WorkloadEntries are fetched only when included
@@ -1126,6 +1132,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 		wentries = sliceutil.Filter(wentryList.Items, func(we *networking_v1.WorkloadEntry) bool {
 			return slices.Contains(namespaces, we.Namespace)
 		})
+		wentryList = nil
 	}
 
 	// Sidecars are fetched only when included
@@ -1137,6 +1144,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 		sidecars = sliceutil.Filter(sidecarList.Items, func(sc *networking_v1.Sidecar) bool {
 			return slices.Contains(namespaces, sc.Namespace)
 		})
+		sidecarList = nil
 	}
 
 	wg.Wait()

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -149,8 +149,12 @@ type kialiCacheImpl struct {
 	// Cache gateways to speed up access for these specific workloads. The only key is kialiCacheGatewaysKey
 	gatewayStore store.Store[string, models.Workloads]
 
-	// Cache pre-computed health data per cluster:namespace
-	healthStore store.Store[string, *models.CachedHealthData]
+	// Cache pre-computed health data per cluster:namespace.
+	// Readers get a snapshot pointer via GetHealth; writers use copy-on-write
+	// under healthUpdateMutex so that concurrent readers never observe a
+	// partially-mutated map (which would be a fatal runtime.throw).
+	healthStore       store.Store[string, *models.CachedHealthData]
+	healthUpdateMutex sync.Mutex
 
 	// There's only ever one IstioStatus but we want to reuse the store machinery
 	// so using a store here but the only key should be kialiCacheIstioStatusKey.
@@ -456,8 +460,13 @@ func (c *kialiCacheImpl) GetHealth(cluster, namespace string, healthType interna
 	return data, found
 }
 
-// SetHealth stores health data in cache
+// SetHealth stores health data in cache.
+// Acquires healthUpdateMutex so that a concurrent Update*Health call cannot
+// read a stale snapshot and then overwrite this fresh data.
 func (c *kialiCacheImpl) SetHealth(cluster, namespace string, data *models.CachedHealthData) {
+	c.healthUpdateMutex.Lock()
+	defer c.healthUpdateMutex.Unlock()
+
 	key := models.HealthCacheKey(cluster, namespace)
 	c.zl.Trace().
 		Str("cluster", cluster).
@@ -469,7 +478,11 @@ func (c *kialiCacheImpl) SetHealth(cluster, namespace string, data *models.Cache
 }
 
 // UpdateAppHealth updates a single app's health in the cached namespace data.
+// Uses copy-on-write: existing readers holding the old pointer are unaffected.
 func (c *kialiCacheImpl) UpdateAppHealth(cluster, namespace, appName string, health *models.AppHealth) {
+	c.healthUpdateMutex.Lock()
+	defer c.healthUpdateMutex.Unlock()
+
 	key := models.HealthCacheKey(cluster, namespace)
 	cached, found := c.healthStore.Get(key)
 	if !found {
@@ -481,13 +494,21 @@ func (c *kialiCacheImpl) UpdateAppHealth(cluster, namespace, appName string, hea
 		return
 	}
 
-	// Update the specific app health entry
-	if cached.AppHealth == nil {
-		cached.AppHealth = models.NamespaceAppHealth{}
+	newMap := make(models.NamespaceAppHealth, len(cached.AppHealth)+1)
+	for k, v := range cached.AppHealth {
+		newMap[k] = v
 	}
-	cached.AppHealth[appName] = health
-	cached.ComputedAt = time.Now()
-	c.healthStore.Set(key, cached)
+	newMap[appName] = health
+
+	c.healthStore.Set(key, &models.CachedHealthData{
+		AppHealth:      newMap,
+		Cluster:        cached.Cluster,
+		ComputedAt:     time.Now(),
+		Duration:       cached.Duration,
+		Namespace:      cached.Namespace,
+		ServiceHealth:  cached.ServiceHealth,
+		WorkloadHealth: cached.WorkloadHealth,
+	})
 
 	c.zl.Debug().
 		Str("cluster", cluster).
@@ -497,7 +518,11 @@ func (c *kialiCacheImpl) UpdateAppHealth(cluster, namespace, appName string, hea
 }
 
 // UpdateServiceHealth updates a single service's health in the cached namespace data.
+// Uses copy-on-write: existing readers holding the old pointer are unaffected.
 func (c *kialiCacheImpl) UpdateServiceHealth(cluster, namespace, serviceName string, health *models.ServiceHealth) {
+	c.healthUpdateMutex.Lock()
+	defer c.healthUpdateMutex.Unlock()
+
 	key := models.HealthCacheKey(cluster, namespace)
 	cached, found := c.healthStore.Get(key)
 	if !found {
@@ -509,13 +534,21 @@ func (c *kialiCacheImpl) UpdateServiceHealth(cluster, namespace, serviceName str
 		return
 	}
 
-	// Update the specific service health entry
-	if cached.ServiceHealth == nil {
-		cached.ServiceHealth = models.NamespaceServiceHealth{}
+	newMap := make(models.NamespaceServiceHealth, len(cached.ServiceHealth)+1)
+	for k, v := range cached.ServiceHealth {
+		newMap[k] = v
 	}
-	cached.ServiceHealth[serviceName] = health
-	cached.ComputedAt = time.Now()
-	c.healthStore.Set(key, cached)
+	newMap[serviceName] = health
+
+	c.healthStore.Set(key, &models.CachedHealthData{
+		AppHealth:      cached.AppHealth,
+		Cluster:        cached.Cluster,
+		ComputedAt:     time.Now(),
+		Duration:       cached.Duration,
+		Namespace:      cached.Namespace,
+		ServiceHealth:  newMap,
+		WorkloadHealth: cached.WorkloadHealth,
+	})
 
 	c.zl.Debug().
 		Str("cluster", cluster).
@@ -525,7 +558,11 @@ func (c *kialiCacheImpl) UpdateServiceHealth(cluster, namespace, serviceName str
 }
 
 // UpdateWorkloadHealth updates a single workload's health in the cached namespace data.
+// Uses copy-on-write: existing readers holding the old pointer are unaffected.
 func (c *kialiCacheImpl) UpdateWorkloadHealth(cluster, namespace, workloadName string, health *models.WorkloadHealth) {
+	c.healthUpdateMutex.Lock()
+	defer c.healthUpdateMutex.Unlock()
+
 	key := models.HealthCacheKey(cluster, namespace)
 	cached, found := c.healthStore.Get(key)
 	if !found {
@@ -537,13 +574,21 @@ func (c *kialiCacheImpl) UpdateWorkloadHealth(cluster, namespace, workloadName s
 		return
 	}
 
-	// Update the specific workload health entry
-	if cached.WorkloadHealth == nil {
-		cached.WorkloadHealth = models.NamespaceWorkloadHealth{}
+	newMap := make(models.NamespaceWorkloadHealth, len(cached.WorkloadHealth)+1)
+	for k, v := range cached.WorkloadHealth {
+		newMap[k] = v
 	}
-	cached.WorkloadHealth[workloadName] = health
-	cached.ComputedAt = time.Now()
-	c.healthStore.Set(key, cached)
+	newMap[workloadName] = health
+
+	c.healthStore.Set(key, &models.CachedHealthData{
+		AppHealth:      cached.AppHealth,
+		Cluster:        cached.Cluster,
+		ComputedAt:     time.Now(),
+		Duration:       cached.Duration,
+		Namespace:      cached.Namespace,
+		ServiceHealth:  cached.ServiceHealth,
+		WorkloadHealth: newMap,
+	})
 
 	c.zl.Debug().
 		Str("cluster", cluster).

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -671,4 +672,144 @@ func TestGatewayAPIClasses(t *testing.T) {
 		require.Equal("istio", result[0].Name)
 		require.Equal("istio-remote", result[1].Name)
 	})
+}
+
+func newHealthTestCache(t *testing.T) cache.KialiCache {
+	t.Helper()
+	conf := config.NewConfig()
+	client := kubetest.NewFakeK8sClient()
+	return cache.NewTestingCache(t, client, *conf)
+}
+
+func seedHealthCache(t *testing.T, c cache.KialiCache, cluster, namespace string) *models.CachedHealthData {
+	t.Helper()
+	data := &models.CachedHealthData{
+		AppHealth:      models.NamespaceAppHealth{"appA": {WorkloadStatuses: []*models.WorkloadStatus{{Name: "w1"}}}},
+		Cluster:        cluster,
+		ComputedAt:     time.Now(),
+		Duration:       "60s",
+		Namespace:      namespace,
+		ServiceHealth:  models.NamespaceServiceHealth{"svcA": {}},
+		WorkloadHealth: models.NamespaceWorkloadHealth{"wlA": {}},
+	}
+	c.SetHealth(cluster, namespace, data)
+	return data
+}
+
+func TestUpdateAppHealthCopyOnWrite(t *testing.T) {
+	require := require.New(t)
+	c := newHealthTestCache(t)
+
+	cluster, ns := "east", "bookinfo"
+	seedHealthCache(t, c, cluster, ns)
+
+	before, found := c.GetHealth(cluster, ns, "app")
+	require.True(found)
+	require.Contains(before.AppHealth, "appA")
+
+	c.UpdateAppHealth(cluster, ns, "appB", &models.AppHealth{})
+
+	after, found := c.GetHealth(cluster, ns, "app")
+	require.True(found)
+	require.Contains(after.AppHealth, "appA")
+	require.Contains(after.AppHealth, "appB")
+
+	// The old snapshot must still point at the original map (1 entry).
+	require.Len(before.AppHealth, 1, "old pointer must be unchanged after update")
+	require.NotSame(before, after, "update must produce a new CachedHealthData pointer")
+}
+
+func TestUpdateServiceHealthCopyOnWrite(t *testing.T) {
+	require := require.New(t)
+	c := newHealthTestCache(t)
+
+	cluster, ns := "east", "bookinfo"
+	seedHealthCache(t, c, cluster, ns)
+
+	before, _ := c.GetHealth(cluster, ns, "service")
+
+	c.UpdateServiceHealth(cluster, ns, "svcB", &models.ServiceHealth{})
+
+	after, found := c.GetHealth(cluster, ns, "service")
+	require.True(found)
+	require.Contains(after.ServiceHealth, "svcA")
+	require.Contains(after.ServiceHealth, "svcB")
+
+	require.Len(before.ServiceHealth, 1, "old pointer must be unchanged after update")
+	require.NotSame(before, after, "update must produce a new CachedHealthData pointer")
+}
+
+func TestUpdateWorkloadHealthCopyOnWrite(t *testing.T) {
+	require := require.New(t)
+	c := newHealthTestCache(t)
+
+	cluster, ns := "east", "bookinfo"
+	seedHealthCache(t, c, cluster, ns)
+
+	before, _ := c.GetHealth(cluster, ns, "workload")
+
+	c.UpdateWorkloadHealth(cluster, ns, "wlB", &models.WorkloadHealth{})
+
+	after, found := c.GetHealth(cluster, ns, "workload")
+	require.True(found)
+	require.Contains(after.WorkloadHealth, "wlA")
+	require.Contains(after.WorkloadHealth, "wlB")
+
+	require.Len(before.WorkloadHealth, 1, "old pointer must be unchanged after update")
+	require.NotSame(before, after, "update must produce a new CachedHealthData pointer")
+}
+
+func TestUpdateHealthNotInCacheIsNoop(t *testing.T) {
+	require := require.New(t)
+	c := newHealthTestCache(t)
+
+	c.UpdateAppHealth("missing", "ns", "app", &models.AppHealth{})
+	c.UpdateServiceHealth("missing", "ns", "svc", &models.ServiceHealth{})
+	c.UpdateWorkloadHealth("missing", "ns", "wl", &models.WorkloadHealth{})
+
+	_, found := c.GetHealth("missing", "ns", "app")
+	require.False(found)
+}
+
+// This test exercises the race detector (-race flag). Concurrent readers iterate
+// health maps while a writer performs copy-on-write updates. Without copy-on-write
+// this would trigger a fatal "concurrent map read and map write" from the Go runtime.
+func TestUpdateHealthIsConcurrentSafe(t *testing.T) {
+	c := newHealthTestCache(t)
+
+	cluster, ns := "east", "bookinfo"
+	seedHealthCache(t, c, cluster, ns)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if data, ok := c.GetHealth(cluster, ns, "app"); ok {
+					for range data.AppHealth {
+					}
+					for range data.ServiceHealth {
+					}
+					for range data.WorkloadHealth {
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				c.UpdateAppHealth(cluster, ns, "app", &models.AppHealth{})
+				c.UpdateServiceHealth(cluster, ns, "svc", &models.ServiceHealth{})
+				c.UpdateWorkloadHealth(cluster, ns, "wl", &models.WorkloadHealth{})
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/cmd/gather.go
+++ b/cmd/gather.go
@@ -159,7 +159,7 @@ func newGatherCmd(conf *config.Config) *cobra.Command {
 				return fmt.Errorf("failed to write manifest: %v", err)
 			}
 
-			mgr, kubeCaches, err := newManager(ctx, conf, log.Logger(), cf)
+			mgr, kubeCaches, err := newManager(conf, log.Logger(), cf)
 			if err != nil {
 				return fmt.Errorf("unable to setup manager: %s", err)
 			}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -63,7 +63,7 @@ func run(ctx context.Context, conf *config.Config, staticAssetFS fs.FS, clientFa
 	config.Set(conf)
 	log.Infof("TLS policy source [%s] min_version [%s] max_version [%s] cipher_suites count=[%d]", policy.Source, policy.MinVersionName(), policy.MaxVersionName(), len(policy.CipherSuites))
 
-	mgr, kubeCaches, err := newManager(ctx, conf, logger, clientFactory)
+	mgr, kubeCaches, err := newManager(conf, logger, clientFactory)
 	if err != nil {
 		log.Fatalf("Unable to setup manager: %s", err)
 	}
@@ -229,7 +229,77 @@ func asReaders(caches map[string]ctrlcache.Cache) map[string]client.Reader {
 	return readers
 }
 
-func newManager(ctx context.Context, conf *config.Config, logger *zerolog.Logger, clientFactory kubernetes.ClientFactory) (manager.Manager, map[string]ctrlcache.Cache, error) {
+// cacheTransforms returns the per-type cache transforms shared across all clusters.
+// These strip cached objects down to only the fields Kiali uses, significantly reducing
+// memory consumption in large meshes.
+func cacheTransforms() map[client.Object]ctrlcache.ByObject {
+	return map[client.Object]ctrlcache.ByObject{
+		&corev1.Pod{}:     {Transform: cache.TransformPod},
+		&corev1.Service{}: {Transform: cache.TransformService},
+	}
+}
+
+// makeWatchErrorHandler returns a DefaultWatchErrorHandler that tears down all informers
+// when a Forbidden watch error is received (e.g. namespace deletion or access revocation).
+func makeWatchErrorHandler(getCache func() ctrlcache.Cache, k8sClient kubernetes.ClientInterface) func(context.Context, *toolscache.Reflector, error) {
+	return func(ctx context.Context, r *toolscache.Reflector, watchErr error) {
+		if !apierrors.IsForbidden(watchErr) {
+			return
+		}
+		log.Infof("A namespace appears to have been deleted or Kiali is forbidden from seeing it [err=%v]. Shutting down cache.", watchErr)
+		objectsToRemove := []client.Object{
+			&corev1.Pod{},
+			&corev1.Service{},
+			&appsv1.StatefulSet{},
+			&appsv1.DaemonSet{},
+			&corev1.ConfigMap{},
+			&batchv1.CronJob{},
+			&batchv1.Job{},
+			&appsv1.Deployment{},
+			&appsv1.ReplicaSet{},
+			&networkingv1.Gateway{},
+			&networkingv1.DestinationRule{},
+			&networkingv1.Sidecar{},
+			&networkingv1.ServiceEntry{},
+			&networkingv1.VirtualService{},
+			&networkingv1.WorkloadEntry{},
+			&networkingv1.WorkloadGroup{},
+			&extentionsv1alpha1.WasmPlugin{},
+			&networkingv1alpha3.EnvoyFilter{},
+			&securityv1.AuthorizationPolicy{},
+			&securityv1.PeerAuthentication{},
+			&securityv1.RequestAuthentication{},
+			&telemetryv1.Telemetry{},
+		}
+		if k8sClient.IsGatewayAPI() {
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1.Gateway{})
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1.GatewayClass{})
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1.HTTPRoute{})
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1.GRPCRoute{})
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1beta1.ReferenceGrant{})
+		}
+		if k8sClient.IsInferenceAPI() {
+			objectsToRemove = append(objectsToRemove, &k8sinferencev1.InferencePool{})
+		}
+		if k8sClient.IsExpGatewayAPI() {
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1alpha2.TCPRoute{})
+			objectsToRemove = append(objectsToRemove, &k8snetworkingv1alpha2.TLSRoute{})
+		}
+		c := getCache()
+		if c == nil {
+			log.Warningf("Cache not yet available, cannot remove informers")
+			return
+		}
+		for _, obj := range objectsToRemove {
+			log.Debugf("Removing informer for: %T", obj)
+			if err := c.RemoveInformer(ctx, obj); err != nil {
+				log.Errorf("Unable to remove informer: %s", err)
+			}
+		}
+	}
+}
+
+func newManager(conf *config.Config, logger *zerolog.Logger, clientFactory kubernetes.ClientFactory) (manager.Manager, map[string]ctrlcache.Cache, error) {
 	ctrl.SetLogger(zerologr.New(logger))
 
 	// Combine the istio scheme and the kube scheme.
@@ -249,11 +319,6 @@ func newManager(ctx context.Context, conf *config.Config, logger *zerolog.Logger
 		}
 	}
 
-	// Check if APIs are available before trying to remove their informers
-	isGatewayAPI := homeClusterClient.IsGatewayAPI()
-	isInferenceAPI := homeClusterClient.IsInferenceAPI()
-	isExpGatewayAPI := homeClusterClient.IsExpGatewayAPI()
-
 	var mgr manager.Manager
 	mgr, err = ctrl.NewManager(homeClusterInfo.ClientConfig, ctrl.Options{
 		// Disabling caching for ConfigMaps, as in large clusters it can take a lot of unnecessary memory.
@@ -264,70 +329,16 @@ func newManager(ctx context.Context, conf *config.Config, logger *zerolog.Logger
 				},
 			},
 		},
-		// Disable metrics server since Kiali has its own metrics server.
 		Cache: ctrlcache.Options{
 			DefaultNamespaces: defaultNamespaces,
-			DefaultWatchErrorHandler: func(ctx context.Context, r *toolscache.Reflector, err error) {
-				if apierrors.IsForbidden(err) {
-					log.Infof("A namespace appears to have been deleted or Kiali is forbidden from seeing it [err=%v]. Shutting down cache.", err)
-					// These are all the standard types that Kiali caches excluding GW API and experimental.
-					objectsToRemove := []client.Object{
-						&corev1.Pod{},
-						&corev1.Service{},
-						&appsv1.StatefulSet{},
-						&appsv1.DaemonSet{},
-						&corev1.ConfigMap{},
-						&batchv1.CronJob{},
-						&batchv1.Job{},
-						&appsv1.Deployment{},
-						&appsv1.ReplicaSet{},
-						&networkingv1.Gateway{},
-						&networkingv1.DestinationRule{},
-						&networkingv1.Sidecar{},
-						&networkingv1.ServiceEntry{},
-						&networkingv1.VirtualService{},
-						&networkingv1.WorkloadEntry{},
-						&networkingv1.WorkloadGroup{},
-						&extentionsv1alpha1.WasmPlugin{},
-						&networkingv1alpha3.EnvoyFilter{},
-						&securityv1.AuthorizationPolicy{},
-						&securityv1.PeerAuthentication{},
-						&securityv1.RequestAuthentication{},
-						&telemetryv1.Telemetry{},
-					}
-					// Include GW API standard types if available
-					if isGatewayAPI {
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1.Gateway{})
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1.GatewayClass{})
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1.HTTPRoute{})
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1.GRPCRoute{})
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1beta1.ReferenceGrant{})
-					}
-					// Only include experimental types if their APIs are available
-					if isInferenceAPI {
-						objectsToRemove = append(objectsToRemove, &k8sinferencev1.InferencePool{})
-					}
-					if isExpGatewayAPI {
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1alpha2.TCPRoute{})
-						objectsToRemove = append(objectsToRemove, &k8snetworkingv1alpha2.TLSRoute{})
-					}
-					for _, obj := range objectsToRemove {
-						log.Debugf("Removing informer for: %T", obj)
-						if err := mgr.GetCache().RemoveInformer(ctx, obj); err != nil {
-							log.Errorf("Unable to remove informer: %s", err)
-						}
-					}
+			DefaultWatchErrorHandler: makeWatchErrorHandler(func() ctrlcache.Cache {
+				if mgr == nil {
+					return nil
 				}
-			},
+				return mgr.GetCache()
+			}, homeClusterClient),
 			DefaultTransform: ctrlcache.TransformStripManagedFields(),
-			ByObject: map[client.Object]ctrlcache.ByObject{
-				&corev1.Pod{}: {
-					Transform: cache.TransformPod,
-				},
-				&corev1.Service{}: {
-					Transform: cache.TransformService,
-				},
-			},
+			ByObject:         cacheTransforms(),
 		},
 		Metrics: metricsserver.Options{BindAddress: "0"},
 		Scheme:  scheme,
@@ -338,20 +349,32 @@ func newManager(ctx context.Context, conf *config.Config, logger *zerolog.Logger
 
 	kubeCaches := map[string]ctrlcache.Cache{}
 	// We want one manager/reconciler for all clusters.
-	for _, client := range clientFactory.GetSAClients() {
-		if client.ClusterInfo().Name == homeClusterInfo.Name {
-			kubeCaches[client.ClusterInfo().Name] = mgr.GetCache()
+	for _, saClient := range clientFactory.GetSAClients() {
+		if saClient.ClusterInfo().Name == homeClusterInfo.Name {
+			kubeCaches[saClient.ClusterInfo().Name] = mgr.GetCache()
 		} else {
-			cluster, err := cluster.New(client.ClusterInfo().ClientConfig, func(o *cluster.Options) {
+			var remoteCluster cluster.Cluster
+			remoteCluster, err = cluster.New(saClient.ClusterInfo().ClientConfig, func(o *cluster.Options) {
 				o.Scheme = scheme
+				o.Cache.DefaultTransform = ctrlcache.TransformStripManagedFields()
+				o.Cache.ByObject = cacheTransforms()
+				o.Cache.DefaultWatchErrorHandler = makeWatchErrorHandler(
+					func() ctrlcache.Cache {
+						if remoteCluster == nil {
+							return nil
+						}
+						return remoteCluster.GetCache()
+					},
+					saClient,
+				)
 			})
 			if err != nil {
 				log.Fatal(err)
 			}
-			if err := mgr.Add(cluster); err != nil {
+			if err := mgr.Add(remoteCluster); err != nil {
 				log.Fatal(err)
 			}
-			kubeCaches[client.ClusterInfo().Name] = cluster.GetCache()
+			kubeCaches[saClient.ClusterInfo().Name] = remoteCluster.GetCache()
 		}
 	}
 

--- a/prometheus/cache.go
+++ b/prometheus/cache.go
@@ -126,7 +126,7 @@ func (c *promCacheImpl) GetAppRequestRates(namespace, cluster, app, ratesInterva
 	zl := c.zl
 
 	if nsRates, okNs := c.cacheAppRequestRates[namespace]; okNs {
-		if appInterval, okApp := nsRates[app][cluster]; okApp {
+		if appInterval, okApp := nsRates[cluster][app]; okApp {
 			if rtInterval, okRt := appInterval[ratesInterval]; okRt {
 				if !queryTime.Before(rtInterval.queryTime) && queryTime.Sub(rtInterval.queryTime) < c.cacheDuration {
 					zl.Trace().Msgf("GetAppRequestRates [namespace: %s] [app: %s] [ratesInterval: %s] [queryTime: %s]", namespace, app, ratesInterval, queryTime.String())
@@ -148,7 +148,7 @@ func (c *promCacheImpl) SetAppRequestRates(namespace, cluster, app, ratesInterva
 	if _, okCluster := c.cacheAppRequestRates[namespace][cluster]; !okCluster {
 		c.cacheAppRequestRates[namespace][cluster] = make(map[string]map[string]timeInOutResult)
 	}
-	if _, okApp := c.cacheAppRequestRates[namespace][app]; !okApp {
+	if _, okApp := c.cacheAppRequestRates[namespace][cluster][app]; !okApp {
 		c.cacheAppRequestRates[namespace][cluster][app] = make(map[string]timeInOutResult)
 	}
 
@@ -267,10 +267,10 @@ func (c *promCacheImpl) SetWorkloadRequestRates(namespace, cluster, workload, ra
 	if _, okNs := c.cacheWkRequestRates[namespace]; !okNs {
 		c.cacheWkRequestRates[namespace] = make(map[string]map[string]map[string]timeInOutResult)
 	}
-	if _, clusterNs := c.cacheWkRequestRates[namespace][cluster]; !clusterNs {
+	if _, okCluster := c.cacheWkRequestRates[namespace][cluster]; !okCluster {
 		c.cacheWkRequestRates[namespace][cluster] = make(map[string]map[string]timeInOutResult)
 	}
-	if _, okApp := c.cacheWkRequestRates[namespace][workload]; !okApp {
+	if _, okWk := c.cacheWkRequestRates[namespace][cluster][workload]; !okWk {
 		c.cacheWkRequestRates[namespace][cluster][workload] = make(map[string]timeInOutResult)
 	}
 
@@ -281,7 +281,7 @@ func (c *promCacheImpl) SetWorkloadRequestRates(namespace, cluster, workload, ra
 	}
 	// TODO: eventually want to get this from a context we pass into this function
 	zl := c.zl
-	zl.Trace().Msgf("SetAppRequestRates [namespace: %s] [cluster: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, cluster, workload, ratesInterval, queryTime.String())
+	zl.Trace().Msgf("SetWorkloadRequestRates [namespace: %s] [cluster: %s] [workload: %s] [ratesInterval: %s] [queryTime: %s]", namespace, cluster, workload, ratesInterval, queryTime.String())
 }
 
 // Expiration is done globally, this cache is designed as short term, so in the worst case it would populated the queries


### PR DESCRIPTION
## Summary

Backports health cache improvements from master to v2.22, addressing #9476 (Kiali pod crashes during startup in large multi-cluster environments).

- **#9478** — Panic recovery with stack traces in health monitor `Start()`, preventing panics in `RefreshHealth` from crashing the process
- **#9487** — Memory and performance improvements: pre-fetch all workloads once per cluster instead of per-namespace; apply cache transforms (TransformStripManagedFields, TransformPod, TransformService) and watch error handler to remote cluster caches; nil list variables after filtering for GC; fix prom cache key bugs
- **#9500** — Fix concurrent map read/write in health cache by using copy-on-write for `Update*Health` methods, preventing fatal `runtime.throw` panics
- **#9516** — **Critical fix**: make initial health cache refresh non-blocking so `Start()` returns immediately, allowing the HTTP server to pass Kubernetes startup/liveness probes without waiting for the first health computation (which can take 10+ minutes in large environments)

## Backport notes

- PR #9428 ("[Scale] Revise kiali_health_status metric approach") was already backported to v2.22 as a prerequisite
- The validation/TLS/references changes from #9478 (pre-computing rootNamespaces map) were not backported as they depend on #9304 (multi-primary validations) and #9269 (istiod registry removal) which are too large to backport
- The `models/mesh.go` change from #9516 (removing noisy debug in `ControlPlaneForNamespace`) does not apply as that function was introduced in a later PR
- The `cmd/server.go` changes from #9487 were adapted to v2.22's GW API types (TLSRoute in `k8snetworkingv1alpha2` vs `k8snetworkingv1` on master)

## Test plan

- [x] All packages build (`go build ./...`)
- [x] All health-related unit tests pass
- [x] All cache concurrency tests pass
- [ ] Verify Overview page populates health data after initial cache warmup completes

Backport for #9476

Made with [Cursor](https://cursor.com)