### PR TITLE
Fix Codecov GPG verification failures in CI uploads

### DIFF
--- a/.github/workflows/codecov-master-baseline.yml
+++ b/.github/workflows/codecov-master-baseline.yml
@@ -42,7 +42,7 @@ jobs:
       run: make -e GO_TEST_FLAGS="-race -coverpkg=github.com/kiali/kiali/... -coverprofile=coverage-unit.out" test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         disable_search: true
         fail_ci_if_error: true
@@ -52,3 +52,4 @@ jobs:
         override_commit: ${{ github.sha }}
         slug: kiali/kiali
         token: ${{ secrets.CODECOV_TOKEN }}
+        use_pypi: true

--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -284,6 +284,7 @@ jobs:
         override_commit: ${{ github.event.pull_request.base.sha }}
         slug: kiali/kiali
         token: ${{ secrets.CODECOV_TOKEN }}
+        use_pypi: true
 
   codecov_merge_upload:
     if: |
@@ -352,6 +353,7 @@ jobs:
         run_command: pr-base-picking
         slug: kiali/kiali
         token: ${{ secrets.CODECOV_TOKEN }}
+        use_pypi: true
 
     # Upload on PRs and on push to master/release branches (sail-operator pattern: push + pull_request).
     - name: Upload coverage to Codecov (pull request)
@@ -367,6 +369,7 @@ jobs:
         override_pr: ${{ github.event.pull_request.number }}
         slug: kiali/kiali
         token: ${{ secrets.CODECOV_TOKEN }}
+        use_pypi: true
 
     - name: Upload coverage to Codecov (push)
       if: github.event_name == 'push'
@@ -380,3 +383,4 @@ jobs:
         override_commit: ${{ github.sha }}
         slug: kiali/kiali
         token: ${{ secrets.CODECOV_TOKEN }}
+        use_pypi: true

--- a/CODECOV_Configuration.adoc
+++ b/CODECOV_Configuration.adoc
@@ -33,6 +33,12 @@ Coverage is merged from three artifacts produced elsewhere in the same workflow 
 
 Behavior is configured in `codecov.yml` (paths, ignores, patch/project gates).
 
+== Dependabot pull requests
+
+Workflows triggered by Dependabot do not receive repository *Actions* secrets. Add the same upload token under *Settings → Secrets and variables → Dependabot* with name `CODECOV_TOKEN` (same value as the Actions secret). Workflows still reference `${{ secrets.CODECOV_TOKEN }}`; Dependabot exposes its secrets to jobs it triggers.
+
+See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#storing-credentials-for-dependabot-to-use[Storing credentials for Dependabot to use].
+
 == How to verify that is working
 
 . Open a pull request that runs **Kiali CI** to completion.


### PR DESCRIPTION
Bump codecov-action to v7.0.0 everywhere and use use_pypi to install the CLI without Keybase GPG verification, which broke after Codecov migrated their signing key (codecov/codecov-action#1956).

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
