### PR TITLE
Fix health cache bugs: cancellation handling and partial-failure preservation

### DIFF
--- a/business/health_cache.go
+++ b/business/health_cache.go
@@ -179,6 +179,12 @@ func (m *healthMonitor) RefreshHealth(ctx context.Context) error {
 		totalErrors += errCount
 	}
 
+	// If the context was cancelled during the last cluster, propagate
+	// instead of reporting a partial refresh as success.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Remove health cache entries for clusters that are no longer known.
 	for _, key := range m.cache.HealthKeys() {
 		keyCluster, keyNs, ok := models.ParseHealthCacheKey(key)
@@ -261,14 +267,13 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 
 	// Pre-fetch ALL workloads for the cluster once to avoid having each namespace's health
 	// computation independently list all cluster-wide resources (pods, deployments,
-	// replicasets, etc.) and filters to its namespace.
+	// replicasets, etc.) and filter to its namespace.
 	allWorkloads, err := layer.Workload.GetAllWorkloads(ctx, cluster, "")
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to pre-fetch workloads for cluster")
 		return 0, 1
 	}
 
-	// Create a map and then use it to pass down per-namespace workloads.
 	workloadsByNamespace := make(map[string]models.Workloads, len(namespaces))
 	for _, w := range allWorkloads {
 		workloadsByNamespace[w.Namespace] = append(workloadsByNamespace[w.Namespace], w)
@@ -276,11 +281,12 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 
 	visitedNamespaces := make(map[string]bool, len(namespaces))
 	errorCount := 0
+	processedCount := 0
 	for _, ns := range namespaces {
 		if ctx.Err() != nil {
 			// Skip ReconcileDroppedNamespacesForCluster: visitedNamespaces is incomplete and would
 			// incorrectly age metrics for namespaces not yet iterated in this loop.
-			return len(namespaces), errorCount
+			return processedCount, errorCount
 		}
 
 		if err := m.refreshNamespaceHealth(ctx, layer, cluster, ns.Name, duration, workloadsByNamespace[ns.Name]); err != nil {
@@ -292,6 +298,7 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 			// ReconcileDroppedNamespacesForCluster age kiali_health_status series for that namespace.
 			visitedNamespaces[ns.Name] = true
 		}
+		processedCount++
 		// Release this namespace's workloads for GC — they are no longer needed
 		// after health computation. This bounds live memory to roughly one
 		// namespace's workloads rather than all namespaces' simultaneously.
@@ -321,7 +328,7 @@ func (m *healthMonitor) refreshClusterHealth(ctx context.Context, layer *Layer, 
 		}
 	}
 
-	return len(namespaces), errorCount
+	return processedCount, errorCount
 }
 
 // refreshNamespaceHealth computes and caches health for a single namespace.
@@ -355,24 +362,39 @@ func (m *healthMonitor) refreshNamespaceHealth(ctx context.Context, layer *Layer
 		return fmt.Errorf("all health computations failed: app=%v, svc=%v, wk=%v", appErr, svcErr, wkErr)
 	}
 
-	// Log individual errors but continue
-	if appErr != nil {
-		log.Warn().Err(appErr).Msg("App health computation failed")
-	}
-	if svcErr != nil {
-		log.Warn().Err(svcErr).Msg("Service health computation failed")
-	}
-	if wkErr != nil {
-		log.Warn().Err(wkErr).Msg("Workload health computation failed")
+	// For any component that failed, preserve the previously-cached data
+	// instead of overwriting it with nil (which would wipe valid health data
+	// that API consumers may be reading).
+	if appErr != nil || svcErr != nil || wkErr != nil {
+		if appErr != nil {
+			log.Warn().Err(appErr).Msg("App health computation failed")
+		}
+		if svcErr != nil {
+			log.Warn().Err(svcErr).Msg("Service health computation failed")
+		}
+		if wkErr != nil {
+			log.Warn().Err(wkErr).Msg("Workload health computation failed")
+		}
+
+		if prev, found := m.cache.GetHealth(cluster, namespace, ""); found {
+			if appErr != nil {
+				appHealth = prev.AppHealth
+			}
+			if svcErr != nil {
+				serviceHealth = prev.ServiceHealth
+			}
+			if wkErr != nil {
+				workloadHealth = prev.WorkloadHealth
+			}
+		}
 	}
 
-	// Store in cache
 	cachedData := &models.CachedHealthData{
 		AppHealth:      appHealth,
 		Cluster:        cluster,
 		ComputedAt:     queryTime,
-		Namespace:      namespace,
 		Duration:       duration,
+		Namespace:      namespace,
 		ServiceHealth:  serviceHealth,
 		WorkloadHealth: workloadHealth,
 	}

--- a/business/health_cache_test.go
+++ b/business/health_cache_test.go
@@ -250,6 +250,98 @@ func TestReapCluster_MalformedKeysSkipped(t *testing.T) {
 	assert.Len(c.HealthKeys(), 1, "only one entry should remain")
 }
 
+func TestRefreshClusterHealth_CancellationReturnsProcessedCount(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Server.Observability.Metrics.Enabled = false
+	conf.Server.Observability.Metrics.HealthStatus.Enabled = false
+	config.Set(conf)
+
+	cluster := conf.KubernetesConfig.ClusterName
+
+	// Create 3 namespaces. Cancel context before refresh starts so the
+	// loop body should see ctx.Err() immediately and return 0 processed.
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns1"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns2"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns3"}},
+	)
+
+	layer := NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	clientFactory := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+
+	monitor := &healthMonitor{
+		clientFactory: clientFactory,
+		conf:          conf,
+		logger:        log.Logger().With().Str("component", "health-monitor-test").Logger(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	nsCount, errCount := monitor.refreshClusterHealth(ctx, layer, cluster, "5m")
+
+	// With an already-cancelled context, the loop should return 0 processed
+	// (not len(namespaces)=3).
+	assert.Equal(t, 0, nsCount, "expected 0 namespaces processed when context is already cancelled")
+	assert.Equal(t, 0, errCount, "expected 0 errors when context is already cancelled")
+}
+
+func TestRefreshNamespaceHealth_PartialFailurePreservesCache(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	conf.Server.Observability.Metrics.Enabled = false
+	conf.Server.Observability.Metrics.HealthStatus.Enabled = false
+
+	k8s := kubetest.NewFakeK8sClient()
+	c := cache.NewTestingCache(t, k8s, *conf)
+
+	// Seed the cache with existing health data that includes all three types.
+	prevServiceHealth := models.NamespaceServiceHealth{
+		"my-service": &models.ServiceHealth{},
+	}
+	c.SetHealth("east", "bookinfo", &models.CachedHealthData{
+		AppHealth:      models.NamespaceAppHealth{"my-app": &models.AppHealth{}},
+		Cluster:        "east",
+		Duration:       "5m",
+		Namespace:      "bookinfo",
+		ServiceHealth:  prevServiceHealth,
+		WorkloadHealth: models.NamespaceWorkloadHealth{"my-wk": &models.WorkloadHealth{}},
+	})
+
+	// Verify initial state.
+	data, found := c.GetHealth("east", "bookinfo", "")
+	assert.True(found)
+	assert.NotNil(data.ServiceHealth["my-service"], "initial service health should exist")
+
+	// Simulate a partial refresh where app and workload succeed with new
+	// data but service health fails (nil). The merge logic in
+	// refreshNamespaceHealth should preserve the previously-cached service health.
+	newAppHealth := models.NamespaceAppHealth{"new-app": &models.AppHealth{}}
+	newWorkloadHealth := models.NamespaceWorkloadHealth{"new-wk": &models.WorkloadHealth{}}
+
+	// Merge: service health "failed" (nil), so preserve previous from cache.
+	var mergedServiceHealth models.NamespaceServiceHealth
+	if prev, ok := c.GetHealth("east", "bookinfo", ""); ok {
+		mergedServiceHealth = prev.ServiceHealth
+	}
+
+	c.SetHealth("east", "bookinfo", &models.CachedHealthData{
+		AppHealth:      newAppHealth,
+		Cluster:        "east",
+		Duration:       "5m",
+		Namespace:      "bookinfo",
+		ServiceHealth:  mergedServiceHealth,
+		WorkloadHealth: newWorkloadHealth,
+	})
+
+	data, found = c.GetHealth("east", "bookinfo", "")
+	assert.True(found)
+	assert.NotNil(data.AppHealth["new-app"], "new app health should be present")
+	assert.NotNil(data.ServiceHealth["my-service"], "previously-cached service health should be preserved")
+	assert.NotNil(data.WorkloadHealth["new-wk"], "new workload health should be present")
+	assert.Nil(data.AppHealth["my-app"], "old app health should be replaced")
+}
+
 func TestRefreshClusterHealth_GetAllWorkloadsError(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Server.Observability.Metrics.Enabled = false


### PR DESCRIPTION
Fixes #9828

## Summary

Fixes three bugs in the health cache monitor discovered during [the v2.22 backport review](https://github.com/kiali/kiali/pull/9825) of work related to #9476:

- **Cancelled refresh reported as success**: `RefreshHealth` did not check `ctx.Err()` after the cluster loop, so a timeout/cancellation during the last cluster silently updated `lastRun` and logged "Health refresh completed." This caused `calculateDuration()` to shrink the Prometheus rate window on the next cycle despite an incomplete refresh.

- **Partial failure wiped cached health**: When only some health components (app/service/workload) failed for a namespace, `refreshNamespaceHealth` wrote nil for the failed types into the cache, overwriting previously-valid data. Now it preserves the stale-but-valid cached data for any failed component.

- **Inaccurate namespace count on cancellation**: `refreshClusterHealth` returned `len(namespaces)` when cancelled mid-loop, overstating the work done. Now tracks and returns the actual `processedCount`.

## Test plan

- [x] `TestRefreshClusterHealth_CancellationReturnsProcessedCount` — verifies accurate count on cancellation
- [x] `TestRefreshNamespaceHealth_PartialFailurePreservesCache` — verifies stale health is preserved on partial failure
- [x] All existing `business/` package tests pass