### PR TITLE
Add supported branches section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This guide provides coding standards, development workflows, and common commands
 
 ## Table of Contents
 
+- [Supported Branches](#supported-branches)
 - [Quick Reference](#quick-reference)
 - [Code Quality Standards](#code-quality-standards)
 - [Building and Testing](#building-and-testing)
@@ -18,6 +19,23 @@ This guide provides coding standards, development workflows, and common commands
 - [Common Patterns and Best Practices](#common-patterns-and-best-practices)
 - [Troubleshooting](#troubleshooting)
 - [Quick Command Reference](#quick-command-reference)
+
+---
+
+## Supported Branches
+
+The currently supported Kiali release branches (which receive backports and security fixes) are:
+
+| OSSM  | Branch | Kiali Version |
+|-------|--------|---------------|
+| 3.4   | v2.27  | 2.27          |
+| 3.3   | v2.22  | 2.22          |
+| 3.2   | v2.17  | 2.17          |
+| 3.1   | v2.11  | 2.11          |
+| 3.0   | v2.4   | 2.4           |
+| 2.6   | v1.73  | 1.73          |
+
+In addition, `master` is the active development branch for the next release.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a "Supported Branches" section to AGENTS.md documenting which Kiali release branches are currently maintained
- Lists OSSM versions (3.4 down to 2.6), corresponding git branches, and Kiali versions
- Notes that `master` is the active development branch

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm branch/version information is accurate

Made with [Cursor](https://cursor.com)