### PR TITLE
Fixed false positive of KIA1401 validations for K8s Gateway allowedRoutes

### DIFF
--- a/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go
@@ -113,6 +113,52 @@ func TestFoundSharedK8sGateway(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestFoundSharedK8sGatewayWithMatchExpressions(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedListenerWithMatchExpressions("test", "host.com", 80, "http", "kubernetes.io/metadata.name", []string{"bookinfo"}),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{data.CreateNamespaceWithLabels("bookinfo", map[string]string{"kubernetes.io/metadata.name": "bookinfo"})},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestNotSharedNSK8sGatewayWithMatchExpressionsError(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sGRPCRoute: data.AddGatewayParentRefToGRPCRoute("sharedgw", "gwns",
+			data.CreateEmptyGRPCRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedListenerWithMatchExpressions("test", "host.com", 80, "http", "kubernetes.io/metadata.name", []string{"other-ns"}),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{data.CreateNamespaceWithLabels("bookinfo", map[string]string{"kubernetes.io/metadata.name": "bookinfo"})},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
+}
+
 func TestFoundSharedToAllK8sGateway(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker.go
@@ -77,7 +77,11 @@ func IsGatewaySharedWithNS(namespace string, cluster string, gw k8s_networking_v
 		return false
 	}
 	for _, l := range gw.Spec.Listeners {
-		if *l.AllowedRoutes.Namespaces.From == "All" {
+    if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil || l.AllowedRoutes.Namespaces.From == nil {
+        continue
+    }
+
+	if *l.AllowedRoutes.Namespaces.From == "All" {
 			return true
 		}
 		if *l.AllowedRoutes.Namespaces.From == "Selector" && l.AllowedRoutes.Namespaces.Selector != nil {

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker.go
@@ -77,11 +77,11 @@ func IsGatewaySharedWithNS(namespace string, cluster string, gw k8s_networking_v
 		return false
 	}
 	for _, l := range gw.Spec.Listeners {
-    if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil || l.AllowedRoutes.Namespaces.From == nil {
-        continue
-    }
+		if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil || l.AllowedRoutes.Namespaces.From == nil {
+			continue
+		}
 
-	if *l.AllowedRoutes.Namespaces.From == "All" {
+		if *l.AllowedRoutes.Namespaces.From == "All" {
 			return true
 		}
 		if *l.AllowedRoutes.Namespaces.From == "Selector" && l.AllowedRoutes.Namespaces.Selector != nil {

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker.go
@@ -3,11 +3,13 @@ package k8shttproutes
 import (
 	"fmt"
 
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
 )
 
@@ -66,18 +68,27 @@ func CheckGateway(gwName, gwNs, routeNs, cluster string, gatewayNames map[string
 	return false
 }
 
-// If K8sGateway's allowedRoutes selector matches the labels of given namespace
+// IsGatewaySharedWithNS returns true if any listener on the Gateway allows
+// routes from the given namespace via allowedRoutes.namespaces. It supports
+// the full Kubernetes LabelSelector (both matchLabels and matchExpressions).
 func IsGatewaySharedWithNS(namespace string, cluster string, gw k8s_networking_v1.Gateway, nss models.Namespaces) bool {
 	ns := nss.GetNamespace(namespace, cluster)
 	if ns == nil {
 		return false
 	}
 	for _, l := range gw.Spec.Listeners {
-		if *l.AllowedRoutes.Namespaces.From == "All" ||
-			(*l.AllowedRoutes.Namespaces.From == "Selector" &&
-				l.AllowedRoutes.Namespaces.Selector != nil &&
-				labels.SelectorFromSet(labels.Set(l.AllowedRoutes.Namespaces.Selector.MatchLabels)).Matches(labels.Set(ns.Labels))) {
+		if *l.AllowedRoutes.Namespaces.From == "All" {
 			return true
+		}
+		if *l.AllowedRoutes.Namespaces.From == "Selector" && l.AllowedRoutes.Namespaces.Selector != nil {
+			selector, err := meta_v1.LabelSelectorAsSelector(l.AllowedRoutes.Namespaces.Selector)
+			if err != nil {
+				log.Errorf("skipping invalid gateway allowedRoutes selector: %v", err)
+				continue
+			}
+			if selector.Matches(labels.Set(ns.Labels)) {
+				return true
+			}
 		}
 	}
 	return false

--- a/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
@@ -113,6 +113,52 @@ func TestFoundSharedK8sGateway(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestFoundSharedK8sGatewayWithMatchExpressions(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("sharedgw", "gwns",
+			data.CreateEmptyHTTPRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedListenerWithMatchExpressions("test", "host.com", 80, "http", "kubernetes.io/metadata.name", []string{"bookinfo"}),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{data.CreateNamespaceWithLabels("bookinfo", map[string]string{"kubernetes.io/metadata.name": "bookinfo"})},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestNotSharedNSK8sGatewayWithMatchExpressionsError(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("sharedgw", "gwns",
+			data.CreateEmptyHTTPRoute("route", "bookinfo", []string{"bookinfo"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedListenerWithMatchExpressions("test", "host.com", 80, "http", "kubernetes.io/metadata.name", []string{"other-ns"}),
+				data.CreateEmptyK8sGateway("sharedgw", "gwns")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{data.CreateNamespaceWithLabels("bookinfo", map[string]string{"kubernetes.io/metadata.name": "bookinfo"})},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
+}
+
 func TestFoundSharedToAllK8sGateway(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/tests/data/k8sgateway_data.go
+++ b/tests/data/k8sgateway_data.go
@@ -224,6 +224,36 @@ func CreateReferenceGrantByKind(name string, namespace string, fromNamespace str
 	return &rg
 }
 
+func CreateSharedListenerWithMatchExpressions(name string, hostname string, port int, protocol string, key string, values []string) k8s_networking_v1.Listener {
+	hn := k8s_networking_v1.Hostname(hostname)
+	namespaceFromSelector := k8s_networking_v1.NamespacesFromSelector
+	listener := k8s_networking_v1.Listener{
+		Name:     k8s_networking_v1.SectionName(name),
+		Hostname: &hn,
+		Port:     k8s_networking_v1.PortNumber(port),
+		Protocol: k8s_networking_v1.ProtocolType(protocol),
+		AllowedRoutes: &k8s_networking_v1.AllowedRoutes{
+			Namespaces: &k8s_networking_v1.RouteNamespaces{
+				From: &namespaceFromSelector,
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      key,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   values,
+						},
+					},
+				},
+			},
+		},
+	}
+	return listener
+}
+
 func CreateSharedNamespace(name string) models.Namespace {
 	return models.Namespace{Name: name, Labels: map[string]string{"shared-gateway-access": "true"}}
+}
+
+func CreateNamespaceWithLabels(name string, labelsMap map[string]string) models.Namespace {
+	return models.Namespace{Name: name, Labels: labelsMap}
 }


### PR DESCRIPTION
### Describe the change
Fix KIA1401 false positive when a Gateway's allowedRoutes.namespaces.selector uses matchExpressions instead of (or in addition to) matchLabels.

The IsGatewaySharedWithNS function was building a selector using only MatchLabels via labels.SelectorFromSet(), which completely ignored MatchExpressions. This caused valid cross-namespace HTTPRoutes and GRPCRoutes to be flagged with KIA1401 Route is pointing to a non-existent or inaccessible K8s gateway even though the Gateway explicitly allowed them.

The fix replaces labels.SelectorFromSet(MatchLabels) with metav1.LabelSelectorAsSelector(), which handles the full Kubernetes LabelSelector semantics (both matchLabels and matchExpressions). This is the same pattern already used in istio/discovery_selectors.go for discovery selector evaluation.

### Steps to test the PR
Create a Gateway with a listener that uses matchExpressions in allowedRoutes.namespaces.selector:
allowedRoutes:
```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: shared-gateway
  namespace: istio-system
spec:
  gatewayClassName: istio
  listeners:
    - name: http
      hostname: "*.example.com"
      protocol: HTTP
      port: 80
      allowedRoutes:
        namespaces:
          from: Selector
          selector:
            matchExpressions:
              - key: kubernetes.io/metadata.name
                operator: In
                values:
                  - bookinfo
```

Create an HTTPRoute referencing that Gateway as a parentRef
```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: productpage
  namespace: bookinfo
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      namespace: istio-system
      name: shared-gateway
  hostnames:
    - productpage.bookinfo.example.com
  rules:
    - backendRefs:
        - name: productpage
          port: 9080
```
Open the route in Kiali -- it should not show KIA1401

- [x] Verify that an HTTPRoute in a namespace which is matching the expression does not trigger KIA1401

Now spoil the Gateway to matchExpressions point to not existing namespace:
```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: shared-gateway
  namespace: istio-system
spec:
  gatewayClassName: istio
  listeners:
    - name: http
      hostname: "*.example.com"
      protocol: HTTP
      port: 80
      allowedRoutes:
        namespaces:
          from: Selector
          selector:
            matchExpressions:
              - key: kubernetes.io/metadata.name
                operator: In
                values:
                  - other-ns
```


- [x] Verify that an HTTPRoute in a namespace which is not matching the expression is triggering KIA1401

### Automation testing
Unit tests added for both HTTPRoute and GRPCRoute checkers:

TestFoundSharedK8sGatewayWithMatchExpressions -- validates that a route targeting a Gateway with a matchExpressions selector is accepted when the namespace labels match (no KIA1401)
TestNotSharedNSK8sGatewayWithMatchExpressionsError -- validates that KIA1401 is correctly emitted when the namespace labels do not satisfy the matchExpressions selector
Tests are in:
business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
business/checkers/k8sgrpcroutes/no_k8sgateway_checker_test.go

### Issue reference
Fixes #9819