### PR TITLE
[v2.27] Fix waypoint i18n imports and improve Cypress test selectors for OSSMC data-label attributes (#9818)

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -597,7 +597,7 @@ Then('the user sees the waypoint attribute', () => {
 });
 
 Then('the proxy status is {string}', (status: string) => {
-  cy.get('[data-label=Status]').get(`.icon-${status}`).should('exist');
+  cy.get('[data-test=workload-details-card]').find(`span[class*="icon-${status}"]`).should('be.visible');
 });
 
 Then(
@@ -639,10 +639,10 @@ Then("the {string} subtab doesn't exist", (subtab: string) => {
 
 Then('validates Services data', () => {
   cy.get('[data-test="enrolled-data-title"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', 'productpage');
-  cy.get('[role="grid"]').should('be.visible').get('#pfbadge-S').should('exist');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', 'bookinfo');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', 'namespace');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', 'productpage');
+  cy.get('[role="grid"]').should('be.visible').find('#pfbadge-S').should('exist');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', 'namespace');
 });
 
 Then(
@@ -650,28 +650,28 @@ Then(
   (rows: number, workload: string, ns: string, label: string, badge: string) => {
     cy.get('[data-test="enrolled-data-title"]').should('be.visible');
     cy.get('table tbody tr').should('have.length', rows);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', workload);
-    cy.get('[role="grid"]').should('be.visible').get(`#${badge}`).should('exist');
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', ns);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', label);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', workload);
+    cy.get('[role="grid"]').should('be.visible').find(`#${badge}`).should('exist');
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', ns);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', label);
   }
 );
 
 Then('validates waypoint Info data for {string}', (type: string) => {
   cy.get('[data-test=waypointfor-title]').should('exist').and('contain', type);
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=RDS]').and('contain', 'IGNORED');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="RDS"]').should('contain', 'IGNORED');
 });
 
 When('the user validates the Ztunnel tab for the {string} namespace', (namespace: string) => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Waypoint]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Service VIP"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Waypoint"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   cy.get('#ztunnel-details').should('be.visible').contains('Workloads').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Node]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Pod Name"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Node"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   // Validate filters in the Namespace column
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'Namespace').click();

--- a/frontend/src/components/Ambient/WaypointLabel.tsx
+++ b/frontend/src/components/Ambient/WaypointLabel.tsx
@@ -3,7 +3,7 @@ import { PFBadge, PFBadges } from '../Pf/PfBadges';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { infoStyle } from '../../styles/IconStyle';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 export const renderWaypointLabel = (bgsize?: string): React.ReactNode => {
   const badgeSize = bgsize === 'global' || bgsize === 'sm' ? bgsize : 'global';

--- a/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
@@ -12,7 +12,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { SortableCompareTh } from './ZtunnelConfig';
 import { WaypointInfo, WorkloadInfo } from '../../types/Workload';
 import { isMultiCluster } from '../../config';

--- a/frontend/src/components/ChatBot/EntryChat/EntryChat.tsx
+++ b/frontend/src/components/ChatBot/EntryChat/EntryChat.tsx
@@ -5,7 +5,7 @@ import { KialiAppState } from 'store/Store';
 import { ChatEntry, ReferencedDoc } from 'types/Chatbot';
 import { copyToClipboard } from './clipboard';
 import { Alert } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { ResponseTools } from './ResponseTools';
 import userAvatar from '../../../assets/img/kiali/ai/img_avatar-light.svg';
 import aiAvatar from '../../../assets/img/kiali/ai/img-ai-lightbkg.svg';

--- a/frontend/src/components/ChatBot/NewChat/NewChatModal.tsx
+++ b/frontend/src/components/ChatBot/NewChat/NewChatModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionGroup, Button, Content, Form } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { ChatModal } from './ChatModal';
 
 type Props = {

--- a/frontend/src/components/ChatBot/error.ts
+++ b/frontend/src/components/ChatBot/error.ts
@@ -1,5 +1,5 @@
 import { ErrorType } from 'types/Chatbot';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 export type FetchError = {
   json?: {

--- a/frontend/src/utils/I18nUtils.ts
+++ b/frontend/src/utils/I18nUtils.ts
@@ -1,5 +1,5 @@
 import { i18n } from 'i18n';
-import { TOptions } from 'i18next';
+import type { TOptions } from 'i18next';
 import { UseTranslationResponse, useTranslation } from 'react-i18next';
 
 const I18N_NAMESPACE = process.env.I18N_NAMESPACE;


### PR DESCRIPTION
Backport of #9818 to v2.27.

## Summary

- Fix waypoint Cypress test selectors that fail in OSSMC environment by switching from `.get()` to `.find()` for proper scoping within `[role="grid"]` containers
- Scope proxy status icon selector to `workload-details-card` container to prevent matching unintended health icons
- Standardize all `data-label` attribute selectors to use quoted values
- Fix 5 files importing `t` from `'i18next'` instead of `'utils/I18nUtils'`
- Change `TOptions` import in `I18nUtils.ts` to a type-only import

## Test plan

- Run ambient waypoint Cypress tests: `npx cypress run -e TAGS="@ambient"`
- Verify all 62 ambient scenarios pass in both standalone Kiali and OSSMC environments

Made with [Cursor](https://cursor.com)