### PR TITLE
[v2.27] [Ambient] Check all clusters for ambientEnabled, not just home cluster

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -110,6 +110,12 @@ type KialiCache interface {
 	// by checking if the ztunnel daemonset exists on the cluster.
 	IsAmbientEnabled(cluster string) bool
 
+	// IsAmbientEnabledInAnyCluster returns true when at least one of the
+	// supplied clusters has the istio Ambient profile enabled. Short-circuits
+	// on the first match. Reuses the per-cluster cache populated by
+	// IsAmbientEnabled, so repeated calls are cheap.
+	IsAmbientEnabledInAnyCluster(clusters []string) bool
+
 	// IsControlPlaneNamespaceAmbient validates if a control plane namespace should be considered ambient
 	IsControlPlaneNamespaceAmbient(ctx context.Context, cluster string, namespace string, istiodName string) bool
 
@@ -333,6 +339,19 @@ func (in *kialiCacheImpl) IsAmbientEnabled(cluster string) bool {
 	}
 
 	return check
+}
+
+// IsAmbientEnabledInAnyCluster returns true when at least one cluster in the
+// supplied slice has the istio Ambient profile enabled. The check delegates
+// to IsAmbientEnabled, so per-cluster results are reused from the existing
+// ambientChecksPerCluster cache.
+func (in *kialiCacheImpl) IsAmbientEnabledInAnyCluster(clusters []string) bool {
+	for _, cluster := range clusters {
+		if in.IsAmbientEnabled(cluster) {
+			return true
+		}
+	}
+	return false
 }
 
 // GetZtunnelPods returns the pods list from ztunnel daemonset
@@ -680,7 +699,14 @@ func (c *kialiCacheImpl) GatewayAPIClasses(cluster string) []config.GatewayAPICl
 		if len(c.clients) > 1 {
 			result = append(result, config.GatewayAPIClass{Name: "istio-east-west", ClassName: "istio-east-west"})
 		}
-		if c.IsAmbientEnabled(cluster) {
+		// Iterate all configured clusters so istio-waypoint is included even
+		// when the caller's cluster has no ambient (e.g. standalone-mgmt with
+		// clustering.ignore_home_cluster=true).
+		allClusters := make([]string, 0, len(c.clients))
+		for name := range c.clients {
+			allClusters = append(allClusters, name)
+		}
+		if c.IsAmbientEnabledInAnyCluster(allClusters) {
 			result = append(result, config.GatewayAPIClass{Name: "istio-waypoint", ClassName: "istio-waypoint"})
 		}
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -175,6 +175,31 @@ func TestIsAmbientMultiCluster(t *testing.T) {
 	require.False(cache.IsAmbientEnabled("west"))
 }
 
+func TestIsAmbientEnabledInAnyCluster(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "mgmt"
+	mgmt := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("istio-system"),
+	)
+	member := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("istio-system"),
+		ztunnelDaemonSet(),
+	)
+	clientFactory := kubetest.NewK8SClientFactoryMock(nil)
+	clientFactory.SetClients(map[string]kubernetes.UserClientInterface{
+		"mgmt":   mgmt,
+		"member": member,
+	})
+	cache := cache.NewTestingCacheWithFactory(t, clientFactory, *conf)
+
+	require.True(cache.IsAmbientEnabledInAnyCluster([]string{"mgmt", "member"}), "ambient on member should be detected")
+	require.True(cache.IsAmbientEnabledInAnyCluster([]string{"member"}), "single ambient-enabled cluster")
+	require.False(cache.IsAmbientEnabledInAnyCluster([]string{"mgmt"}), "no ambient on mgmt alone")
+	require.False(cache.IsAmbientEnabledInAnyCluster(nil), "nil slice")
+	require.False(cache.IsAmbientEnabledInAnyCluster([]string{}), "empty slice")
+}
+
 // This test only tests anything when the '-race' flag is passed to 'go test'.
 func TestIsAmbientIsThreadSafe(t *testing.T) {
 	conf := config.NewConfig()
@@ -618,6 +643,44 @@ func TestGatewayAPIClasses(t *testing.T) {
 		require.Equal("istio", result[0].Name)
 		require.Equal("istio-remote", result[1].Name)
 		require.Equal("istio-waypoint", result[2].Name)
+	})
+
+	// Waypoint included when only a remote cluster has ambient
+	t.Run("DefaultValuesWithAmbientOnRemoteCluster", func(t *testing.T) {
+		conf := config.NewConfig()
+		config.Set(conf)
+		mgmt := kubetest.NewFakeK8sClient()
+		mgmt.GatewayAPIEnabled = true
+		member := kubetest.NewFakeK8sClient(
+			kubetest.FakeNamespace("istio-system"),
+			ztunnelDaemonSet(),
+		)
+		member.GatewayAPIEnabled = true
+		saClients := map[string]kubernetes.ClientInterface{
+			"mgmt":   mgmt,
+			"member": member,
+		}
+		readers := map[string]ctrlclient.Reader{
+			"mgmt":   mgmt,
+			"member": member,
+		}
+
+		conf.Deployment.ClusterWideAccess = true
+		conf.KubernetesConfig.ClusterName = "mgmt"
+		conf.ExternalServices.Istio.GatewayAPIClasses = []config.GatewayAPIClass{}
+
+		kialiCache, err := cache.NewKialiCache(t.Context(), saClients, readers, *conf)
+		require.NoError(err)
+
+		result := kialiCache.GatewayAPIClasses("mgmt")
+		var hasWaypoint bool
+		for _, gwClass := range result {
+			if gwClass.ClassName == "istio-waypoint" {
+				hasWaypoint = true
+				break
+			}
+		}
+		require.True(hasWaypoint, "istio-waypoint should be included when a remote cluster has ambient enabled")
 	})
 
 	// Bad label selector

--- a/hack/istio/multicluster/install-external-kiali.sh
+++ b/hack/istio/multicluster/install-external-kiali.sh
@@ -16,6 +16,9 @@ infomsg() {
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${SCRIPT_DIR}/env.sh "$@"
+source ${SCRIPT_DIR}/../functions.sh
+# Sourced for install_ambient_on_cluster when --ambient true is passed.
+source ${SCRIPT_DIR}/install-ambient-multicluster.sh "$@"
 
 # The names of each cluster
 if [ "${CLUSTER1_NAME}" == "east" ]; then
@@ -215,7 +218,12 @@ source ${SCRIPT_DIR}/setup-ca.sh
 
 echo "==== INSTALL ISTIO ON CLUSTER #2 [${CLUSTER2_NAME}] - ${CLUSTER2_CONTEXT}"
 switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
-install_istio --patch-file "${MC_MESH_YAML}" -a "prometheus jaeger"
+if [ "${AMBIENT}" == "true" ]; then
+  ensure_gateway_api_crds "" "--context=${CLUSTER2_CONTEXT}"
+  install_ambient_on_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}" "${CLUSTER2_NAME}" "${NETWORK2_ID}" "${SAIL}"
+else
+  install_istio --patch-file "${MC_MESH_YAML}" -a "prometheus jaeger"
+fi
 
 echo "==== INSTALL ADDONS ON CLUSTER #1 [${CLUSTER1_NAME}] - ${CLUSTER1_CONTEXT}"
 ADDONS="prometheus grafana jaeger"
@@ -256,5 +264,11 @@ fi
 if [ "${BOOKINFO_ENABLED}" == "true" ]; then
   switch_cluster "${CLUSTER2_CONTEXT}" "${CLUSTER2_USER}" "${CLUSTER2_PASS}"
   echo "Installing bookinfo demo in namespace [${BOOKINFO_NAMESPACE}] on [${CLUSTER2_CONTEXT}]"
-  source ${SCRIPT_DIR}/../install-bookinfo-demo.sh --client-exe "${CLIENT_EXE}" --istio-dir "${ISTIO_DIR}" --istio-namespace "${ISTIO_NAMESPACE}" --namespace "${BOOKINFO_NAMESPACE}" --kube-context "${CLUSTER2_CONTEXT}" -tg --mongo
+  # In ambient mode, skip sidecar injection; install-bookinfo-demo.sh will apply
+  # the istio.io/dataplane-mode=ambient label instead.
+  bookinfo_ambient_arg=""
+  if [ "${AMBIENT}" == "true" ]; then
+    bookinfo_ambient_arg="-ai false"
+  fi
+  source ${SCRIPT_DIR}/../install-bookinfo-demo.sh --client-exe "${CLIENT_EXE}" --istio-dir "${ISTIO_DIR}" --istio-namespace "${ISTIO_NAMESPACE}" --namespace "${BOOKINFO_NAMESPACE}" --kube-context "${CLUSTER2_CONTEXT}" ${bookinfo_ambient_arg} -tg --mongo
 fi

--- a/hack/keycloak.sh
+++ b/hack/keycloak.sh
@@ -70,6 +70,9 @@ fi
 if [ "$_CMD" = "create-ca" ]; then
   echo "Creating CA for keycloak. Files will be stored at '${KEYCLOAK_CERTS_DIR}'"
 
+  # Ensure the output directory exists; openssl does not create parent dirs.
+  mkdir -p "${KEYCLOAK_CERTS_DIR}"
+
   # Generate root CA for keycloak/oidc.
   openssl genrsa -out "${KEYCLOAK_CERTS_DIR}"/root-ca-key.pem 2048
 

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -164,13 +164,37 @@ func Config(conf *config.Config, cache cache.KialiCache, discovery istio.MeshDis
 			return
 		}
 
-		if client := userClients[conf.KubernetesConfig.ClusterName]; client != nil {
-			publicConfig.GatewayAPIEnabled = client.IsGatewayAPI()
-			publicConfig.IstioGatewayInstalled = client.IsIstioGateway()
-			publicConfig.IstioAPIInstalled = client.IsIstioAPI()
+		// Aggregate mesh-wide capability flags across all clusters this user can
+		// reach (home cluster is empty under ignore_home_cluster=true).
+		accessibleClusters := make([]string, 0, len(userClients))
+		for clusterName := range userClients {
+			accessibleClusters = append(accessibleClusters, clusterName)
 		}
-		publicConfig.AmbientEnabled = cache.IsAmbientEnabled(conf.KubernetesConfig.ClusterName)
-		publicConfig.GatewayAPIClasses = cache.GatewayAPIClasses(conf.KubernetesConfig.ClusterName)
+
+		for _, cluster := range accessibleClusters {
+			if client := userClients[cluster]; client != nil {
+				if client.IsGatewayAPI() {
+					publicConfig.GatewayAPIEnabled = true
+				}
+				if client.IsIstioGateway() {
+					publicConfig.IstioGatewayInstalled = true
+				}
+				if client.IsIstioAPI() {
+					publicConfig.IstioAPIInstalled = true
+				}
+			}
+		}
+		publicConfig.AmbientEnabled = cache.IsAmbientEnabledInAnyCluster(accessibleClusters)
+		// Dedupe gateway API classes by ClassName across clusters.
+		seenClasses := make(map[string]bool)
+		for _, cluster := range accessibleClusters {
+			for _, gwClass := range cache.GatewayAPIClasses(cluster) {
+				if !seenClasses[gwClass.ClassName] {
+					seenClasses[gwClass.ClassName] = true
+					publicConfig.GatewayAPIClasses = append(publicConfig.GatewayAPIClasses, gwClass)
+				}
+			}
+		}
 
 		// Fetch the list of all clusters in the mesh
 		// One usage of this data is to cross-link Kiali instances, when possible.

--- a/handlers/config_test.go
+++ b/handlers/config_test.go
@@ -13,11 +13,14 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/require"
 	istiov1alpha1 "istio.io/api/mesh/v1alpha1"
+	apps_v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/handlers"
 	"github.com/kiali/kiali/istio/istiotest"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/prometheus/prometheustest"
@@ -286,4 +289,80 @@ func TestConfigHandlerMeshErrorFallsBackToDefault(t *testing.T) {
 	var confResp handlers.PublicConfig
 	require.NoError(json.Unmarshal(actual, &confResp))
 	require.Equal("svc.cluster.local", confResp.IstioIdentityDomain)
+}
+
+func TestConfigHandlerAmbientEnabledChecksAllClusters(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "mgmt-cluster"
+	conf.Clustering.IgnoreHomeCluster = true
+
+	// Home cluster: bare management cluster (no ztunnel, no Gateway API,
+	// no Istio CRDs).
+	homeClient := kubetest.NewFakeK8sClient()
+	homeClient.GatewayAPIEnabled = false
+	homeClient.IstioGatewayInstalled = false
+	homeClient.IstioAPIInstalled = false
+	// Remote cluster: has a ztunnel DaemonSet (ambient enabled), Gateway API,
+	// and Istio CRDs.
+	remoteClient := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("istio-system"),
+		&apps_v1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ztunnel",
+				Namespace: "istio-system",
+				Labels:    map[string]string{"app.kubernetes.io/name": "ztunnel"},
+			},
+			Spec: apps_v1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "ztunnel"},
+				},
+			},
+		},
+	)
+	remoteClient.GatewayAPIEnabled = true
+	remoteClient.IstioGatewayInstalled = true
+	remoteClient.IstioAPIInstalled = true
+
+	clients := map[string]kubernetes.UserClientInterface{
+		"mgmt-cluster": homeClient,
+		"member-1":     remoteClient,
+	}
+	cf := kubetest.NewFakeClientFactory(conf, clients)
+	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
+	discovery := &istiotest.FakeDiscovery{}
+
+	prom := &fakePromClient{PromClientMock: prometheustest.PromClientMock{}}
+
+	handler := handlers.WithFakeAuthInfo(conf, handlers.Config(conf, kialiCache, discovery, cf, prom))
+	mr := mux.NewRouter()
+	mr.Handle("/api/config", handler)
+
+	ts := httptest.NewServer(mr)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/config")
+	require.NoError(err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	actual, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	require.Equal(200, resp.StatusCode, string(actual))
+
+	var confResp handlers.PublicConfig
+	require.NoError(json.Unmarshal(actual, &confResp))
+	require.True(confResp.AmbientEnabled, "ambientEnabled should be true when a remote cluster has ztunnel")
+	require.True(confResp.GatewayAPIEnabled, "gatewayAPIEnabled should be true when a remote cluster has Gateway API CRDs")
+	require.True(confResp.IstioGatewayInstalled, "istioGatewayInstalled should be true when a remote cluster has Istio Gateway CRD")
+	require.True(confResp.IstioAPIInstalled, "istioAPIInstalled should be true when a remote cluster has Istio API CRDs")
+
+	var hasWaypoint bool
+	for _, gwClass := range confResp.GatewayAPIClasses {
+		if gwClass.ClassName == "istio-waypoint" {
+			hasWaypoint = true
+			break
+		}
+	}
+	require.True(hasWaypoint, "GatewayAPIClasses should include istio-waypoint when a remote cluster has ztunnel")
 }


### PR DESCRIPTION
## Summary

Backport of #9785 to v2.27.

- When Kiali runs on a standalone management cluster with `ignore_home_cluster=true`, the home cluster has no ztunnel DaemonSet, so `ambientEnabled` was always `false`. This hid the Ambient Traffic dropdown, causing the graph to default to `ambientTraffic=none` and show all-TCP edges.
- Iterate all accessible clusters so `ambientEnabled` is `true` when any cluster has ambient mode active.
- Adds a multicluster test verifying `ambientEnabled=true` when only a remote cluster has ztunnel.

Fixes #9784


Made with [Cursor](https://cursor.com)