### PR TITLE
[master] Fix @core-caching hook not enabling caching on OpenShift

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
       await addCucumberPreprocessorPlugin(on, config);
 
+      on('task', {
+        log(message: string) {
+          console.log(message);
+          return null;
+        }
+      });
+
       on(
         'file:preprocessor',
         createBundler({

--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -159,7 +159,10 @@ Before({ tags: '@loggers-app' }, () => {
 // be the LAST tag group in composite cypress:run / cypress:run:junit
 // scripts in package.json to avoid affecting other suites.
 Before({ tags: '@core-caching' }, () => {
+  cy.task('log', '[CACHING_HOOK] Before @core-caching hook ENTERED');
+
   if (Cypress.env('CACHING_ENABLED')) {
+    cy.task('log', '[CACHING_HOOK] CACHING_ENABLED already set — returning early');
     return;
   }
 
@@ -167,7 +170,9 @@ Before({ tags: '@core-caching' }, () => {
   // requested tag filter. Otherwise this scenario was matched by another tag
   // (e.g. @smoke) and caching infrastructure isn't relevant.
   const tags = (Cypress.env('TAGS') ?? '') as string;
+  cy.task('log', `[CACHING_HOOK] TAGS env = "${tags}"`);
   if (!tags.includes('@core-caching')) {
+    cy.task('log', '[CACHING_HOOK] TAGS does not include @core-caching — skipping setup, setting CACHING_ENABLED');
     Cypress.env('CACHING_ENABLED', true);
     return;
   }
@@ -188,37 +193,64 @@ Before({ tags: '@core-caching' }, () => {
     );
   };
 
+  cy.task('log', '[CACHING_HOOK] Calling discoverKialiRuntimeInfo()...');
   discoverKialiRuntimeInfo().then(info => {
+    cy.task(
+      'log',
+      `[CACHING_HOOK] Discovered Kiali: deployment=${info.deploymentName}, namespace=${info.namespace}, configMap=${info.configMapName}`
+    );
     cy.exec(
       `kubectl get deployment/${info.deploymentName} -n ${info.namespace} -o jsonpath="{.metadata.annotations.operator-sdk\\/primary-resource}"`,
       { failOnNonZeroExit: false }
     ).then(result => {
       const primaryResource = result.stdout.trim();
+      cy.task(
+        'log',
+        `[CACHING_HOOK] operator-sdk/primary-resource annotation = "${primaryResource}" (code=${result.code})`
+      );
 
       const checkDone = (configText: string, isJson: boolean): void => {
-        if (bothCachesEnabled(configText, isJson)) {
+        const alreadyEnabled = bothCachesEnabled(configText, isJson);
+        cy.task(
+          'log',
+          `[CACHING_HOOK] bothCachesEnabled(json=${isJson}) = ${alreadyEnabled}, configText length = ${configText.length}`
+        );
+        if (configText.length < 500) {
+          cy.task('log', `[CACHING_HOOK] configText = ${configText}`);
+        } else {
+          cy.task('log', `[CACHING_HOOK] configText (first 500 chars) = ${configText.substring(0, 500)}`);
+        }
+
+        if (alreadyEnabled) {
+          cy.task('log', '[CACHING_HOOK] Caching already enabled — no restart needed');
           Cypress.env('CACHING_ENABLED', true);
           return;
         }
 
+        cy.task('log', '[CACHING_HOOK] Caching NOT enabled — calling enableKialiCaching()...');
         enableKialiCaching(info);
         cy.then(() => {
+          cy.task('log', '[CACHING_HOOK] enableKialiCaching() complete — setting CACHING_ENABLED');
           Cypress.env('CACHING_ENABLED', true);
         });
       };
 
       if (primaryResource) {
         const parts = primaryResource.split('/');
+        cy.task('log', `[CACHING_HOOK] Operator path: kubectl get kiali ${parts[1]} -n ${parts[0]}`);
         cy.exec(`kubectl get kiali ${parts[1]} -n ${parts[0]} -o jsonpath="{.spec}"`, {
           failOnNonZeroExit: false
         }).then(crResult => {
+          cy.task('log', `[CACHING_HOOK] Kiali CR spec fetch: code=${crResult.code}, stderr="${crResult.stderr}"`);
           checkDone(crResult.stdout, true);
         });
       } else {
+        cy.task('log', `[CACHING_HOOK] Helm path: kubectl get configmap ${info.configMapName} -n ${info.namespace}`);
         cy.exec(
           `kubectl get configmap ${info.configMapName} -n ${info.namespace} -o jsonpath="{.data.config\\\\.yaml}"`,
           { failOnNonZeroExit: false }
         ).then(cmResult => {
+          cy.task('log', `[CACHING_HOOK] ConfigMap fetch: code=${cmResult.code}, stderr="${cmResult.stderr}"`);
           checkDone(cmResult.stdout, false);
         });
       }

--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -178,18 +178,22 @@ Before({ tags: '@core-caching' }, () => {
   }
 
   // Detect both caches and health status metric enabled. Operator path returns JSON, Helm returns YAML.
+  // The regex must match "enabled: true" only within the immediate cache block,
+  // not an unrelated "enabled: true" elsewhere in the config.
   const bothCachesEnabled = (text: string, json: boolean): boolean => {
     if (json) {
+      // JSON: "graph_cache": { ... "enabled": true ... } — match within the same braces
       return (
-        /"graph_cache"[\s\S]*?"enabled"\s*:\s*true/.test(text) &&
-        /"health_cache"[\s\S]*?"enabled"\s*:\s*true/.test(text) &&
-        /"health_status"[\s\S]*?"enabled"\s*:\s*true/.test(text)
+        /"graph_cache"\s*:\s*\{[^}]*"enabled"\s*:\s*true/.test(text) &&
+        /"health_cache"\s*:\s*\{[^}]*"enabled"\s*:\s*true/.test(text) &&
+        /"health_status"\s*:\s*\{[^}]*"enabled"\s*:\s*true/.test(text)
       );
     }
+    // YAML: "enabled: true" must appear on the next indented line after the cache key
     return (
-      /graph_cache:[\s\S]*?enabled:\s*true/.test(text) &&
-      /health_cache:[\s\S]*?enabled:\s*true/.test(text) &&
-      /health_status:[\s\S]*?enabled:\s*true/.test(text)
+      /graph_cache:\s*\n\s+enabled:\s*true/.test(text) &&
+      /health_cache:\s*\n\s+enabled:\s*true/.test(text) &&
+      /health_status:\s*\n\s+enabled:\s*true/.test(text)
     );
   };
 

--- a/frontend/cypress/integration/common/hooks.ts
+++ b/frontend/cypress/integration/common/hooks.ts
@@ -1,6 +1,6 @@
 import { Before, After } from '@badeball/cypress-cucumber-preprocessor';
 import { discoverKialiRuntimeInfo, enableKialiCaching } from './kiali-config';
-import { waitForKialiApiReady, waitForResourceDeletion } from './transition';
+import { waitForResourceDeletion } from './transition';
 
 const CLUSTER1_CONTEXT = Cypress.env('CLUSTER1_CONTEXT');
 const CLUSTER2_CONTEXT = Cypress.env('CLUSTER2_CONTEXT');
@@ -202,7 +202,6 @@ Before({ tags: '@core-caching' }, () => {
         }
 
         enableKialiCaching(info);
-        waitForKialiApiReady();
         cy.then(() => {
           Cypress.env('CACHING_ENABLED', true);
         });

--- a/frontend/cypress/integration/common/kiali-config.ts
+++ b/frontend/cypress/integration/common/kiali-config.ts
@@ -69,6 +69,10 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
       { failOnNonZeroExit: false }
     )
     .then(result => {
+      cy.task(
+        'log',
+        `[DISCOVER_KIALI] label query: code=${result.code}, stdout="${result.stdout.trim()}", stderr="${result.stderr}"`
+      );
       const lines = result.stdout
         .trim()
         .split('\n')
@@ -76,6 +80,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
         .filter(Boolean);
 
       if (!lines.length || lines[0] === '') {
+        cy.task('log', '[DISCOVER_KIALI] Label query returned no results — trying fallback');
         // Fallback: look for a deployment named "kiali" in any namespace.
         return cy
           .exec(
@@ -94,6 +99,8 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
               .filter(l => l.includes('/kiali'))
               .filter(Boolean);
 
+            cy.task('log', `[DISCOVER_KIALI] Fallback matches: ${JSON.stringify(fallbackLines)}`);
+
             const preferredNamespaces = ['istio-system', 'kiali-operator', 'default'];
 
             let fallbackChosen: string | undefined;
@@ -111,6 +118,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
               );
             }
 
+            cy.task('log', `[DISCOVER_KIALI] Fallback chosen: ${fallbackChosen}`);
             const [namespace, deploymentName] = fallbackChosen.split('/');
             return resolveConfigMap(namespace, deploymentName);
           });
@@ -120,6 +128,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
       const parts = lines[0].split(/\s+/);
       const namespace = parts[0];
       const deploymentName = parts[1];
+      cy.task('log', `[DISCOVER_KIALI] Found via label: namespace=${namespace}, deployment=${deploymentName}`);
       return resolveConfigMap(namespace, deploymentName);
     });
 };
@@ -227,9 +236,13 @@ export const enableKialiFeature = (featureConfig: KialiFeatureConfig, value = tr
  * (operator vs Helm) don't have to re-discover deployment info.
  */
 export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
+  cy.task('log', `[ENABLE_CACHING] enableKialiCaching called, existingInfo=${existingInfo ? 'provided' : 'null'}`);
+
   const doPatch = (info: KialiRuntimeInfo): void => {
     const doRestart = (): void => {
+      cy.task('log', `[ENABLE_CACHING] Restarting Kiali: deployment/${info.deploymentName} -n ${info.namespace}`);
       restartKiali(info.deploymentName, info.namespace);
+      cy.task('log', '[ENABLE_CACHING] Kiali restart complete');
     };
 
     cy.exec(
@@ -237,6 +250,7 @@ export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
       { failOnNonZeroExit: false }
     ).then(result => {
       const primaryResource = result.stdout.trim();
+      cy.task('log', `[ENABLE_CACHING] primary-resource="${primaryResource}" (code=${result.code})`);
 
       if (primaryResource) {
         const parts = primaryResource.split('/');
@@ -255,12 +269,18 @@ export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
             }
           }
         });
-        cy.exec(`kubectl patch kiali ${parts[1]} -n ${parts[0]} --type merge -p '${patchJson}'`).then(() =>
-          doRestart()
-        );
+        cy.task('log', `[ENABLE_CACHING] Operator path: patching kiali ${parts[1]} -n ${parts[0]} with ${patchJson}`);
+        cy.exec(`kubectl patch kiali ${parts[1]} -n ${parts[0]} --type merge -p '${patchJson}'`).then(patchResult => {
+          cy.task(
+            'log',
+            `[ENABLE_CACHING] Patch result: code=${patchResult.code}, stdout="${patchResult.stdout}", stderr="${patchResult.stderr}"`
+          );
+          doRestart();
+        });
         return;
       }
 
+      cy.task('log', `[ENABLE_CACHING] Helm path: updating configmap ${info.configMapName} -n ${info.namespace}`);
       cy.exec(
         `kubectl get configmap ${info.configMapName} -n ${info.namespace} -o jsonpath="{.data.config\\\\.yaml}" > /tmp/kiali-config.yaml`
       );
@@ -269,7 +289,10 @@ export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
       );
       cy.exec(
         `kubectl create configmap ${info.configMapName} -n ${info.namespace} --from-file=config.yaml=/tmp/kiali-config.yaml -o yaml --dry-run=client | kubectl apply -f -`
-      ).then(() => doRestart());
+      ).then(() => {
+        cy.task('log', '[ENABLE_CACHING] ConfigMap updated');
+        doRestart();
+      });
     });
   };
 


### PR DESCRIPTION
## Summary
Cherry-pick of fixes from v2.27 (PR #9833) to master.

- **Remove `waitForKialiApiReady()` from the `@core-caching` Before hook**: it used `cy.request('/api/status')` which returns 401 on OpenShift because the hook runs before login. `enableKialiCaching()` already waits via `kubectl rollout status`.
- **Fix `bothCachesEnabled()` regex**: the `[\s\S]*?` pattern crossed YAML/JSON section boundaries, matching an unrelated `enabled: true` and falsely reporting caching was already on — causing the hook to skip setup entirely.
- **Add `cy.task('log')` diagnostics**: instrument the hook with `[CACHING_HOOK]`, `[DISCOVER_KIALI]`, and `[ENABLE_CACHING]` prefixed log lines that print to the Node.js terminal (captured by CI).

## Test plan
- [x] CI passed on v2.27 with these changes
- [ ] CI passes on master

Made with [Cursor](https://cursor.com)