### PR TITLE
Improve service action menu UX in Traffic graph side panel

### DIFF
--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Divider, DropdownGroup, DropdownItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { DropdownGroup, DropdownItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { serverConfig } from 'config';
 import { DestinationRule, getWizardUpdateLabel, K8sHTTPRoute, K8sGRPCRoute, VirtualService } from 'types/IstioObjects';
 import { canDelete, ResourcePermissions } from 'types/Permissions';
@@ -17,7 +17,7 @@ import {
   WIZARD_TCP_TRAFFIC_SHIFTING
 } from './WizardActions';
 import { hasServiceDetailsTrafficRouting } from '../../types/ServiceInfo';
-import { groupMenuStyle } from 'styles/DropdownStyles';
+import { groupMenuStyle, titleStyle } from 'styles/DropdownStyles';
 import { kialiStyle } from 'styles/StyleUtils';
 import { t } from 'utils/I18nUtils';
 
@@ -32,7 +32,6 @@ type Props = {
   k8sHTTPRoutes: K8sHTTPRoute[];
   onAction?: (key: WizardAction, mode: WizardMode) => void;
   onDelete?: (key: string) => void;
-  searchValue?: string;
   virtualServices: VirtualService[];
 };
 
@@ -45,23 +44,10 @@ const optionDisabledStyle = kialiStyle({
   }
 });
 
-const dividerStyle = kialiStyle({
-  paddingTop: '0.5rem'
-});
-
-const groupLabelStyle = kialiStyle({
-  fontSize: '0.875rem',
-  fontWeight: 700,
-  color: 'var(--pf-v6-global--Color--200)',
-  padding: '0.5rem 1rem',
-  textTransform: 'uppercase',
-  letterSpacing: '0.5px'
-});
 
 export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = (props: Props) => {
   const updateLabel = getWizardUpdateLabel(props.virtualServices, props.k8sHTTPRoutes, props.k8sGRPCRoutes);
   const isViewOnly = serverConfig.deployment.viewOnlyMode;
-  const searchLower = (props.searchValue || '').toLowerCase();
 
   const hasTrafficRouting = (): boolean => {
     return hasServiceDetailsTrafficRouting(
@@ -92,11 +78,7 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
     }
   };
 
-  const actionItems = SERVICE_WIZARD_ACTIONS.filter(eventKey => {
-    // Filter by search value
-    const wizardTitle = t(WIZARD_TITLES[eventKey].title).toLowerCase();
-    return wizardTitle.includes(searchLower);
-  }).map(eventKey => {
+  const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
     const isGatewayAPIEnabled =
       eventKey === WIZARD_K8S_REQUEST_ROUTING || eventKey === WIZARD_K8S_GRPC_REQUEST_ROUTING
         ? serverConfig.gatewayAPIEnabled
@@ -153,12 +135,7 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
     }
   });
 
-  // Only show delete action if it matches search filter
-  const deleteText = t('Delete Traffic Routing').toLowerCase();
-  const shouldShowDelete = deleteText.includes(searchLower);
-
-  if (shouldShowDelete) {
-    actionItems.push(<Divider className={dividerStyle} key="actions_separator" />);
+  if (hasTrafficRouting()) {
 
     const deleteDisabled = !canDelete(props.istioPermissions) || !hasTrafficRouting() || props.isDisabled;
 
@@ -192,16 +169,12 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
 
     actionItems.push(deleteDropdownItem);
   }
-  const label = isViewOnly ? t('View') : updateLabel === '' ? t('Create') : t('Update');
 
-  // Don't render the group if no items match the search
-  if (actionItems.length === 0) {
-    return null;
-  }
+  const label = isViewOnly ? t('View') : updateLabel === '' ? t('Create') : t('Update');
 
   return (
     <>
-      <div className={groupLabelStyle}>{label}</div>
+      <div className={titleStyle}>{label}</div>
       <DropdownGroup key={`group_${label}`} className={groupMenuStyle} children={actionItems} />
     </>
   );

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -44,7 +44,6 @@ const optionDisabledStyle = kialiStyle({
   }
 });
 
-
 export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = (props: Props) => {
   const updateLabel = getWizardUpdateLabel(props.virtualServices, props.k8sHTTPRoutes, props.k8sGRPCRoutes);
   const isViewOnly = serverConfig.deployment.viewOnlyMode;
@@ -135,40 +134,37 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
     }
   });
 
-  if (hasTrafficRouting()) {
+  const deleteDisabled = !canDelete(props.istioPermissions) || !hasTrafficRouting() || props.isDisabled;
 
-    const deleteDisabled = !canDelete(props.istioPermissions) || !hasTrafficRouting() || props.isDisabled;
+  let deleteDropdownItem = (
+    <DropdownItem
+      key={DELETE_TRAFFIC_ROUTING}
+      component="button"
+      onClick={() => {
+        if (props.onDelete) {
+          props.onDelete(DELETE_TRAFFIC_ROUTING);
+        }
+      }}
+      isDisabled={deleteDisabled}
+      data-test={DELETE_TRAFFIC_ROUTING}
+    >
+      {t('Delete Traffic Routing')}
+    </DropdownItem>
+  );
 
-    let deleteDropdownItem = (
-      <DropdownItem
-        key={DELETE_TRAFFIC_ROUTING}
-        component="button"
-        onClick={() => {
-          if (props.onDelete) {
-            props.onDelete(DELETE_TRAFFIC_ROUTING);
-          }
-        }}
-        isDisabled={deleteDisabled}
-        data-test={DELETE_TRAFFIC_ROUTING}
+  if (deleteDisabled) {
+    deleteDropdownItem = (
+      <Tooltip
+        key={`tooltip_${DELETE_TRAFFIC_ROUTING}`}
+        position={TooltipPosition.left}
+        content={<>{getDropdownItemTooltipMessage(false, hasTrafficRouting())}</>}
       >
-        {t('Delete Traffic Routing')}
-      </DropdownItem>
+        <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{deleteDropdownItem}</div>
+      </Tooltip>
     );
-
-    if (deleteDisabled) {
-      deleteDropdownItem = (
-        <Tooltip
-          key={`tooltip_${DELETE_TRAFFIC_ROUTING}`}
-          position={TooltipPosition.left}
-          content={<>{getDropdownItemTooltipMessage(false, hasTrafficRouting())}</>}
-        >
-          <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{deleteDropdownItem}</div>
-        </Tooltip>
-      );
-    }
-
-    actionItems.push(deleteDropdownItem);
   }
+
+  actionItems.push(deleteDropdownItem);
 
   const label = isViewOnly ? t('View') : updateLabel === '' ? t('Create') : t('Update');
 

--- a/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizardActionsDropdownGroup.tsx
@@ -32,6 +32,7 @@ type Props = {
   k8sHTTPRoutes: K8sHTTPRoute[];
   onAction?: (key: WizardAction, mode: WizardMode) => void;
   onDelete?: (key: string) => void;
+  searchValue?: string;
   virtualServices: VirtualService[];
 };
 
@@ -48,9 +49,19 @@ const dividerStyle = kialiStyle({
   paddingTop: '0.5rem'
 });
 
+const groupLabelStyle = kialiStyle({
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  color: 'var(--pf-v6-global--Color--200)',
+  padding: '0.5rem 1rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px'
+});
+
 export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> = (props: Props) => {
   const updateLabel = getWizardUpdateLabel(props.virtualServices, props.k8sHTTPRoutes, props.k8sGRPCRoutes);
   const isViewOnly = serverConfig.deployment.viewOnlyMode;
+  const searchLower = (props.searchValue || '').toLowerCase();
 
   const hasTrafficRouting = (): boolean => {
     return hasServiceDetailsTrafficRouting(
@@ -81,7 +92,11 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
     }
   };
 
-  const actionItems = SERVICE_WIZARD_ACTIONS.map(eventKey => {
+  const actionItems = SERVICE_WIZARD_ACTIONS.filter(eventKey => {
+    // Filter by search value
+    const wizardTitle = t(WIZARD_TITLES[eventKey].title).toLowerCase();
+    return wizardTitle.includes(searchLower);
+  }).map(eventKey => {
     const isGatewayAPIEnabled =
       eventKey === WIZARD_K8S_REQUEST_ROUTING || eventKey === WIZARD_K8S_GRPC_REQUEST_ROUTING
         ? serverConfig.gatewayAPIEnabled
@@ -138,40 +153,56 @@ export const ServiceWizardActionsDropdownGroup: React.FunctionComponent<Props> =
     }
   });
 
-  actionItems.push(<Divider className={dividerStyle} key="actions_separator" />);
+  // Only show delete action if it matches search filter
+  const deleteText = t('Delete Traffic Routing').toLowerCase();
+  const shouldShowDelete = deleteText.includes(searchLower);
 
-  const deleteDisabled = !canDelete(props.istioPermissions) || !hasTrafficRouting() || props.isDisabled;
+  if (shouldShowDelete) {
+    actionItems.push(<Divider className={dividerStyle} key="actions_separator" />);
 
-  let deleteDropdownItem = (
-    <DropdownItem
-      key={DELETE_TRAFFIC_ROUTING}
-      component="button"
-      onClick={() => {
-        if (props.onDelete) {
-          props.onDelete(DELETE_TRAFFIC_ROUTING);
-        }
-      }}
-      isDisabled={deleteDisabled}
-      data-test={DELETE_TRAFFIC_ROUTING}
-    >
-      {t('Delete Traffic Routing')}
-    </DropdownItem>
-  );
+    const deleteDisabled = !canDelete(props.istioPermissions) || !hasTrafficRouting() || props.isDisabled;
 
-  if (deleteDisabled) {
-    deleteDropdownItem = (
-      <Tooltip
-        key={`tooltip_${DELETE_TRAFFIC_ROUTING}`}
-        position={TooltipPosition.left}
-        content={<>{getDropdownItemTooltipMessage(false, hasTrafficRouting())}</>}
+    let deleteDropdownItem = (
+      <DropdownItem
+        key={DELETE_TRAFFIC_ROUTING}
+        component="button"
+        onClick={() => {
+          if (props.onDelete) {
+            props.onDelete(DELETE_TRAFFIC_ROUTING);
+          }
+        }}
+        isDisabled={deleteDisabled}
+        data-test={DELETE_TRAFFIC_ROUTING}
       >
-        <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{deleteDropdownItem}</div>
-      </Tooltip>
+        {t('Delete Traffic Routing')}
+      </DropdownItem>
     );
-  }
 
-  actionItems.push(deleteDropdownItem);
+    if (deleteDisabled) {
+      deleteDropdownItem = (
+        <Tooltip
+          key={`tooltip_${DELETE_TRAFFIC_ROUTING}`}
+          position={TooltipPosition.left}
+          content={<>{getDropdownItemTooltipMessage(false, hasTrafficRouting())}</>}
+        >
+          <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{deleteDropdownItem}</div>
+        </Tooltip>
+      );
+    }
+
+    actionItems.push(deleteDropdownItem);
+  }
   const label = isViewOnly ? t('View') : updateLabel === '' ? t('Create') : t('Update');
 
-  return <DropdownGroup key={`group_${label}`} label={label} className={groupMenuStyle} children={actionItems} />;
+  // Don't render the group if no items match the search
+  if (actionItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className={groupLabelStyle}>{label}</div>
+      <DropdownGroup key={`group_${label}`} className={groupMenuStyle} children={actionItems} />
+    </>
+  );
 };

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -19,6 +19,7 @@ import {
   ExpandableSection,
   MenuToggle,
   MenuToggleElement,
+  SearchInput,
   Tab
 } from '@patternfly/react-core';
 import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
@@ -48,10 +49,12 @@ import { getNamespaceDetailUrl } from 'utils/NamespaceUtils';
 
 type SummaryPanelNodeState = {
   isActionOpen: boolean;
+  searchValue: string;
 };
 
 const defaultState: SummaryPanelNodeState = {
-  isActionOpen: false
+  isActionOpen: false,
+  searchValue: ''
 };
 
 type ReduxProps = {
@@ -108,6 +111,34 @@ const nodeInfoStyle = kialiStyle({
 
 const workloadExpandableSectionStyle = classes(expandableSectionStyle, kialiStyle({ display: 'inline' }));
 
+const dropdownMenuStyle = kialiStyle({
+  maxHeight: '400px',
+  overflowY: 'auto'
+});
+
+const searchBoxStyle = kialiStyle({
+  padding: '0.5rem',
+  borderBottom: '1px solid var(--pf-v6-global--BorderColor--100)',
+  position: 'sticky',
+  top: 0,
+  backgroundColor: 'var(--pf-v6-global--BackgroundColor--100)',
+  zIndex: 1
+});
+
+const groupLabelStyle = kialiStyle({
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  color: 'var(--pf-v6-global--Color--200)',
+  padding: '0.5rem 1rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px'
+});
+
+const dividerStyle = kialiStyle({
+  margin: '0.5rem 0',
+  borderTop: '1px solid var(--pf-v6-global--BorderColor--100)'
+});
+
 export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeComponentProps, SummaryPanelNodeState> {
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
@@ -148,24 +179,43 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       this.props.tracingState.info.integration;
 
     const options = getOptions(nodeData);
-    const items = [
-      <DropdownGroup key="show" label="Show" className={groupMenuStyle}>
-        {options.map((o, i) => {
-          return (
-            <DropdownItem key={`option-${i}`} onClick={() => clickHandler(o, this.props.kiosk)}>
-              {o.text} {o.target === '_blank' && <KialiIcon.ExternalLink />}
-            </DropdownItem>
-          );
-        })}
-      </DropdownGroup>
-    ];
+    const searchLower = this.state.searchValue.toLowerCase();
+
+    // Filter options based on search
+    const filteredOptions = options.filter(o => o.text.toLowerCase().includes(searchLower));
+
+    const items: React.ReactNode[] = [];
+
+    // Only show "Show" group if there are filtered options
+    if (filteredOptions.length > 0) {
+      items.push(
+        <React.Fragment key="show-group">
+          <div className={groupLabelStyle}>Show</div>
+          <DropdownGroup key="show" className={groupMenuStyle}>
+            {filteredOptions.map((o, i) => {
+              return (
+                <DropdownItem key={`option-${i}`} onClick={() => clickHandler(o, this.props.kiosk)}>
+                  {o.text} {o.target === '_blank' && <KialiIcon.ExternalLink />}
+                </DropdownItem>
+              );
+            })}
+          </DropdownGroup>
+        </React.Fragment>
+      );
+    }
 
     if (nodeType === NodeType.SERVICE) {
+      // Add divider between Show and Create/Delete sections if Show group exists
+      if (filteredOptions.length > 0) {
+        items.push(<div key="divider" className={dividerStyle} />);
+      }
+
       if (this.props.serviceDetails === undefined) {
-        items.push(<LoadingWizardActionsDropdownGroup />);
+        items.push(<LoadingWizardActionsDropdownGroup key="loading" />);
       } else if (this.props.serviceDetails !== null) {
         items.push(
           <ServiceWizardActionsDropdownGroup
+            key="wizard-actions"
             virtualServices={this.props.serviceDetails.virtualServices ?? []}
             destinationRules={this.props.serviceDetails.destinationRules ?? []}
             k8sHTTPRoutes={this.props.serviceDetails.k8sHTTPRoutes ?? []}
@@ -173,6 +223,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             istioPermissions={this.props.serviceDetails.istioPermissions}
             onAction={this.handleLaunchWizard}
             onDelete={this.handleDeleteTrafficRouting}
+            searchValue={this.state.searchValue}
           />
         );
       }
@@ -237,7 +288,24 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
                   onOpenChange={(isOpen: boolean) => this.onToggleActions(isOpen)}
                   popperProps={{ position: 'right', enableFlip: true }}
                 >
-                  <DropdownList>{items}</DropdownList>
+                  <DropdownList className={dropdownMenuStyle}>
+                    <div className={searchBoxStyle}>
+                      <SearchInput
+                        placeholder="Search actions..."
+                        value={this.state.searchValue}
+                        onChange={(_event, value) => this.setState({ searchValue: value })}
+                        onClear={() => this.setState({ searchValue: '' })}
+                        aria-label="Search menu items"
+                      />
+                    </div>
+                    {items.length > 0 ? (
+                      items
+                    ) : (
+                      <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--pf-v6-global--Color--200)' }}>
+                        No actions found
+                      </div>
+                    )}
+                  </DropdownList>
                 </Dropdown>
               )}
 
@@ -392,7 +460,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
   }
 
   private onToggleActions = (isOpen: boolean): void => {
-    this.setState({ isActionOpen: isOpen });
+    this.setState({
+      isActionOpen: isOpen,
+      // Reset search when closing dropdown
+      searchValue: isOpen ? this.state.searchValue : ''
+    });
 
     if (this.props.onKebabToggled) {
       this.props.onKebabToggled(isOpen);

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -19,8 +19,8 @@ import {
   ExpandableSection,
   MenuToggle,
   MenuToggleElement,
-  SearchInput,
-  Tab
+  Tab,
+  TextInput
 } from '@patternfly/react-core';
 import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
 import { SummaryPanelNodeTraces } from './SummaryPanelNodeTraces';
@@ -290,11 +290,11 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
                 >
                   <DropdownList className={dropdownMenuStyle}>
                     <div className={searchBoxStyle}>
-                      <SearchInput
+                      <TextInput
+                        type="search"
                         placeholder="Search actions..."
                         value={this.state.searchValue}
                         onChange={(_event, value) => this.setState({ searchValue: value })}
-                        onClear={() => this.setState({ searchValue: '' })}
                         aria-label="Search menu items"
                       />
                     </div>

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -19,8 +19,7 @@ import {
   ExpandableSection,
   MenuToggle,
   MenuToggleElement,
-  Tab,
-  TextInput
+  Tab
 } from '@patternfly/react-core';
 import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
 import { SummaryPanelNodeTraces } from './SummaryPanelNodeTraces';
@@ -36,7 +35,7 @@ import { ServiceWizardActionsDropdownGroup } from 'components/IstioWizards/Servi
 import { PeerAuthentication } from '../../types/IstioObjects';
 import { useServiceDetailForGraphNode } from '../../hooks/services';
 import { useKialiSelector } from '../../hooks/redux';
-import { groupMenuStyle, kebabToggleStyle } from 'styles/DropdownStyles';
+import { groupMenuStyle, kebabToggleStyle, titleStyle } from 'styles/DropdownStyles';
 import { isMultiCluster, serverConfig } from '../../config';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from './SummaryPanelStyle';
 import { dicTypeToGVK, gvkType } from '../../types/IstioConfigList';
@@ -49,12 +48,10 @@ import { getNamespaceDetailUrl } from 'utils/NamespaceUtils';
 
 type SummaryPanelNodeState = {
   isActionOpen: boolean;
-  searchValue: string;
 };
 
 const defaultState: SummaryPanelNodeState = {
-  isActionOpen: false,
-  searchValue: ''
+  isActionOpen: false
 };
 
 type ReduxProps = {
@@ -116,28 +113,6 @@ const dropdownMenuStyle = kialiStyle({
   overflowY: 'auto'
 });
 
-const searchBoxStyle = kialiStyle({
-  padding: '0.5rem',
-  borderBottom: '1px solid var(--pf-v6-global--BorderColor--100)',
-  position: 'sticky',
-  top: 0,
-  backgroundColor: 'var(--pf-v6-global--BackgroundColor--100)',
-  zIndex: 1
-});
-
-const groupLabelStyle = kialiStyle({
-  fontSize: '0.875rem',
-  fontWeight: 700,
-  color: 'var(--pf-v6-global--Color--200)',
-  padding: '0.5rem 1rem',
-  textTransform: 'uppercase',
-  letterSpacing: '0.5px'
-});
-
-const dividerStyle = kialiStyle({
-  margin: '0.5rem 0',
-  borderTop: '1px solid var(--pf-v6-global--BorderColor--100)'
-});
 
 export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeComponentProps, SummaryPanelNodeState> {
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
@@ -179,20 +154,14 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
       this.props.tracingState.info.integration;
 
     const options = getOptions(nodeData);
-    const searchLower = this.state.searchValue.toLowerCase();
-
-    // Filter options based on search
-    const filteredOptions = options.filter(o => o.text.toLowerCase().includes(searchLower));
-
     const items: React.ReactNode[] = [];
 
-    // Only show "Show" group if there are filtered options
-    if (filteredOptions.length > 0) {
+    if (options.length > 0) {
       items.push(
         <React.Fragment key="show-group">
-          <div className={groupLabelStyle}>Show</div>
+          <div className={titleStyle}>Show</div>
           <DropdownGroup key="show" className={groupMenuStyle}>
-            {filteredOptions.map((o, i) => {
+            {options.map((o, i) => {
               return (
                 <DropdownItem key={`option-${i}`} onClick={() => clickHandler(o, this.props.kiosk)}>
                   {o.text} {o.target === '_blank' && <KialiIcon.ExternalLink />}
@@ -205,11 +174,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     }
 
     if (nodeType === NodeType.SERVICE) {
-      // Add divider between Show and Create/Delete sections if Show group exists
-      if (filteredOptions.length > 0) {
-        items.push(<div key="divider" className={dividerStyle} />);
-      }
-
       if (this.props.serviceDetails === undefined) {
         items.push(<LoadingWizardActionsDropdownGroup key="loading" />);
       } else if (this.props.serviceDetails !== null) {
@@ -223,7 +187,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             istioPermissions={this.props.serviceDetails.istioPermissions}
             onAction={this.handleLaunchWizard}
             onDelete={this.handleDeleteTrafficRouting}
-            searchValue={this.state.searchValue}
           />
         );
       }
@@ -288,24 +251,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
                   onOpenChange={(isOpen: boolean) => this.onToggleActions(isOpen)}
                   popperProps={{ position: 'right', enableFlip: true }}
                 >
-                  <DropdownList className={dropdownMenuStyle}>
-                    <div className={searchBoxStyle}>
-                      <TextInput
-                        type="search"
-                        placeholder="Search actions..."
-                        value={this.state.searchValue}
-                        onChange={(_event, value) => this.setState({ searchValue: value })}
-                        aria-label="Search menu items"
-                      />
-                    </div>
-                    {items.length > 0 ? (
-                      items
-                    ) : (
-                      <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--pf-v6-global--Color--200)' }}>
-                        No actions found
-                      </div>
-                    )}
-                  </DropdownList>
+                  <DropdownList className={dropdownMenuStyle}>{items}</DropdownList>
                 </Dropdown>
               )}
 
@@ -461,9 +407,7 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
 
   private onToggleActions = (isOpen: boolean): void => {
     this.setState({
-      isActionOpen: isOpen,
-      // Reset search when closing dropdown
-      searchValue: isOpen ? this.state.searchValue : ''
+      isActionOpen: isOpen
     });
 
     if (this.props.onKebabToggled) {

--- a/frontend/src/pages/Graph/SummaryPanelNode.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNode.tsx
@@ -113,7 +113,6 @@ const dropdownMenuStyle = kialiStyle({
   overflowY: 'auto'
 });
 
-
 export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeComponentProps, SummaryPanelNodeState> {
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 


### PR DESCRIPTION
Fixes #9112

Added three key improvements to the service action menu:

1. Search/filter input box at the top of the dropdown menu
   - Filters all menu items (Show options and Create/Delete actions)
   - Sticky positioning keeps it visible while scrolling
   - Resets on menu close for fresh start

2. Height limiting with scrolling
   - Max-height of 400px prevents page overflow
   - Overflow-y auto enables scrolling for long lists
   - Maintains page stability with many menu items

3. Improved visual hierarchy
   - Styled group headers (uppercase, bold, distinct color)
   - Visual divider between "Show" and "Create/Delete" sections
   - Better differentiation between sections and menu items

Changes:
- Updated SummaryPanelNode.tsx with search state, filtering logic, styled headers, and max-height scrolling
- Updated ServiceWizardActionsDropdownGroup.tsx to support search filtering and use styled headers

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
