### PR TITLE
Wait for CA webhook to be patched

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -420,7 +420,16 @@ fi
 
 kubectl apply -f - <<<"$ISTIO_YAML"
 if [ "${WAIT}" == "true" ]; then
+  echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
+  WEBHOOK_NAME="istio-validator-${ISTIO_NAMESPACE}"
+  echo "Waiting for validating webhook ${WEBHOOK_NAME} CA bundle to be patched by istiod..."
+  kubectl wait validatingwebhookconfiguration "${WEBHOOK_NAME}" --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
+
+  if kubectl get validatingwebhookconfiguration istiod-default-validator &>/dev/null; then
+    echo "Waiting for validating webhook istiod-default-validator CA bundle to be patched by istiod..."
+    kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
+  fi
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then


### PR DESCRIPTION
### Describe the change

Istiod will patch the webhook with the CA bundle after istiod comes online. This may happen after the Istio resource counts itself as Ready.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
