### PR TITLE
Added unhealthy Namespaces perf test

### DIFF
--- a/frontend/cypress/fixtures/perf/baselines.json
+++ b/frontend/cypress/fixtures/perf/baselines.json
@@ -13,7 +13,7 @@
   "graphSelected": "2",
   "graphWithoutIstio": "3",
   "namespaceListAll": "2",
-  "namespaceListSelected": "2",
+  "namespaceListUnhealthy": "1",
   "overview": "2",
   "serviceDetails": "1",
   "serviceListAll": "2",

--- a/frontend/cypress/perf/namespacesload.spec.ts
+++ b/frontend/cypress/perf/namespacesload.spec.ts
@@ -6,17 +6,17 @@ describe('Namespaces performance tests', () => {
   });
 
   describe('Namespaces list page', () => {
-    let namespacesUrl: string;
+    let unhealthyNamespacesUrl: string;
     let namespacesUrlAllNamespaces: string;
 
     before(() => {
       cy.fixture('commonParams.json')
         .then(data => {
-          namespacesUrl = encodeURI(
-            `/console/namespaces?namespaces=${data.namespaces}&duration=${data.duration}&refresh=${data.refresh}`
+          unhealthyNamespacesUrl = encodeURI(
+            `/console/namespaces?duration=${data.duration}&refresh=${data.refresh}&health=Failure&health=Not+Ready&health=Degraded&opLabel=or`
           );
           namespacesUrlAllNamespaces = encodeURI(
-            `/console/namespaces?namespaces=${data.allNamespaces}&duration=${data.duration}&refresh=${data.refresh}`
+            `/console/namespaces?duration=${data.duration}&refresh=${data.refresh}`
           );
         })
         .as('data');
@@ -28,8 +28,12 @@ describe('Namespaces performance tests', () => {
       measureListsLoadTime('All Namespaces', Cypress.env(baselines).namespaceListAll, namespacesUrlAllNamespaces);
     });
 
-    it('Measures Selected Namespaces load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
-      measureListsLoadTime('Selected Namespaces', Cypress.env(baselines).namespaceListSelected, namespacesUrl);
+    it('Measures Unhealthy Namespaces load time', { defaultCommandTimeout: Cypress.env('timeout') }, () => {
+      measureListsLoadTime(
+        'Unhealthy Namespaces',
+        Cypress.env(baselines).namespaceListUnhealthy,
+        unhealthyNamespacesUrl
+      );
     });
   });
 });


### PR DESCRIPTION
### Describe the change

Replaced old perf test for Namespaces with a new one,
Loading only unhealthy Namespaces.
In reality in Kiali perf tests environment all namespaces are healthy.
So the test purpose is to make sure that loading much less items is taking much less time.
In test env:
[Namespaces List page]
All Namespaces load time: 4.7879 sec, baseline: 2 sec, difference: +2.7879 sec
Unhealthy Namespaces load time: 1.3196 sec, baseline: 1 sec, difference: +0.31958 sec

