### PR TITLE
Better error codes for ServiceEntry validations.

### DIFF
--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -299,12 +299,12 @@ var checkDescriptors = map[string]IstioCheck{
 		Severity: WarningSeverity,
 	},
 	"serviceentries.multimatch": {
-		Code:     "KIA1202",
+		Code:     "KIA1211",
 		Message:  "More than one ServiceEntry for the same host and port",
 		Severity: WarningSeverity,
 	},
 	"serviceentries.port.protocol.conflict": {
-		Code:     "KIA1203",
+		Code:     "KIA1212",
 		Message:  "ServiceEntries have conflicting protocols for the same host and port",
 		Severity: WarningSeverity,
 	},


### PR DESCRIPTION
Follow-up PR for issue https://github.com/kiali/kiali/issues/9800

Fixing Error codes to have more space between KIA120[X] to KIA121[X] for the future for WorkloadEntry and ServiceEntry validations.

KIA1202 -> KIA1211
KIA1203 -> KIA1212