### PR TITLE
[CI] Wait for the istiod pod

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -31,7 +31,76 @@ ensure_command () {
   fi
 }
 
-requirements=("yq" "helm")
+# Ensures the Istio validating webhook has a non-empty caBundle.
+# If the validating webhook's caBundle is empty, copies it from the mutating webhook
+# (istiod patches the mutating webhook first during startup).
+ensure_istiod_validating_webhook_cabundle() {
+  local namespace="${1:-istio-system}"
+  local timeout_seconds="${2:-120}"
+  local sleep_seconds=5
+  local elapsed=0
+  local attempt=1
+  local max_attempts=1
+  local validator_config=""
+  local validator_index=""
+  local validator_len=0
+  local mutating_cabundle=""
+
+  if [[ "${timeout_seconds}" =~ ^[0-9]+$ ]] && [ "${timeout_seconds}" -gt 0 ]; then
+    max_attempts=$(((timeout_seconds + sleep_seconds - 1) / sleep_seconds))
+  fi
+
+  validator_config=$(kubectl get validatingwebhookconfigurations -o json | \
+    jq -r '.items[] | select(any(.webhooks[]?; .name=="validation.istio.io" and .clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'")) | .metadata.name' | head -n1)
+  if [ -z "${validator_config}" ]; then
+    echo "WARNING: No Istio validating webhook configuration found in namespace [${namespace}]"
+    return 0
+  fi
+
+  validator_index=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+    jq -r '.webhooks | to_entries[] | select(.value.name=="validation.istio.io") | .key')
+  if [ -z "${validator_index}" ]; then
+    echo "WARNING: validation.istio.io webhook not found in configuration [${validator_config}]"
+    return 0
+  fi
+
+  while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
+    validator_len=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+      jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
+    if [ "${validator_len}" -gt 0 ]; then
+      echo "Istio validating webhook caBundle is ready in [${validator_config}]"
+      return 0
+    fi
+
+    mutating_cabundle=$(kubectl get mutatingwebhookconfigurations -o json | \
+      jq -r '.items[] | .webhooks[]? | select(.clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'" and (.clientConfig.caBundle | length) > 0) | .clientConfig.caBundle' | head -n1)
+    if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
+      echo "Istio validating webhook caBundle is empty in [${validator_config}]; copying CA bundle from mutating webhook"
+      kubectl patch validatingwebhookconfiguration "${validator_config}" --type='json' \
+        -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
+
+      validator_len=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
+      if [ "${validator_len}" -gt 0 ]; then
+        echo "Istio validating webhook caBundle copied successfully in [${validator_config}]"
+        return 0
+      fi
+
+      echo "ERROR: Istio validating webhook caBundle is still empty after patching in [${validator_config}]"
+      return 1
+    fi
+
+    echo "Waiting for Istio validating webhook caBundle in [${validator_config}] (${attempt}/${max_attempts})"
+    sleep "${sleep_seconds}"
+    elapsed=$((elapsed + sleep_seconds))
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: Could not find a non-empty Istio mutating webhook caBundle in namespace [${namespace}]"
+  return 1
+}
+
+requirements=("jq" "yq" "helm")
 for req in "${requirements[@]}"; do
   ensure_command "$req"
 done
@@ -422,35 +491,7 @@ kubectl apply -f - <<<"$ISTIO_YAML"
 if [ "${WAIT}" == "true" ]; then
   echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
-  WEBHOOK_NAME="istio-validator-${ISTIO_NAMESPACE}"
-  echo "Waiting for validating webhook ${WEBHOOK_NAME} CA bundle to be patched by istiod..."
-  kubectl wait validatingwebhookconfiguration "${WEBHOOK_NAME}" --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
-
-  if kubectl get validatingwebhookconfiguration istiod-default-validator &>/dev/null; then
-    echo "Waiting for validating webhook istiod-default-validator CA bundle to be patched by istiod..."
-    kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
-  fi
-
-  # istiod patches the webhook caBundle early in its startup, before it is fully
-  # ready to accept connections. On older kubectl versions, `kubectl wait pods --for=condition=Ready`
-  # with a label selector can return 0 immediately when no pods match yet, so we use a
-  # direct endpoint check instead: this guarantees the istiod service has a live backend pod
-  # before any subsequent kubectl apply triggers the validating webhook.
-  echo "Waiting for istiod service endpoint to be available..."
-  for i in $(seq 1 60); do
-    ISTIOD_ENDPOINT=$(kubectl get endpoints/istiod -n "${ISTIO_NAMESPACE}" \
-      -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
-    if [ -n "${ISTIOD_ENDPOINT}" ]; then
-      echo "istiod service endpoint is available (${ISTIOD_ENDPOINT})"
-      break
-    fi
-    if [ "${i}" -eq 60 ]; then
-      echo "ERROR: istiod service endpoint did not become available in time"
-      exit 1
-    fi
-    echo "  Waiting for istiod endpoint (attempt ${i}/60)..."
-    sleep 5
-  done
+  ensure_istiod_validating_webhook_cabundle "${ISTIO_NAMESPACE}" 300
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -430,6 +430,12 @@ if [ "${WAIT}" == "true" ]; then
     echo "Waiting for validating webhook istiod-default-validator CA bundle to be patched by istiod..."
     kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
   fi
+
+  # istiod patches the webhook caBundle early in its startup, before the webhook server is
+  # fully ready to accept connections. Wait for the istiod pod itself to be Ready so that
+  # subsequent kubectl applies that trigger the validating webhook do not get connection refused.
+  echo "Waiting for istiod pods to be ready to serve webhook requests..."
+  kubectl wait pods -n "${ISTIO_NAMESPACE}" -l app=istiod --for=condition=Ready --timeout=120s
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -493,11 +493,6 @@ if [ "${WAIT}" == "true" ]; then
   echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
   ensure_istiod_validating_webhook_cabundle "${ISTIO_NAMESPACE}" 300
-  # The Sail Istio CR can reach Ready before the istiod deployment rollout completes.
-  # Wait for the rollout so the webhook port is accepting connections before addons
-  # (which may contain Istio resources) are applied.
-  echo "Waiting for istiod deployment rollout to complete..."
-  kubectl rollout status deployment/istiod -n "${ISTIO_NAMESPACE}" --timeout=120s
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -431,11 +431,26 @@ if [ "${WAIT}" == "true" ]; then
     kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
   fi
 
-  # istiod patches the webhook caBundle early in its startup, before the webhook server is
-  # fully ready to accept connections. Wait for the istiod pod itself to be Ready so that
-  # subsequent kubectl applies that trigger the validating webhook do not get connection refused.
-  echo "Waiting for istiod pods to be ready to serve webhook requests..."
-  kubectl wait pods -n "${ISTIO_NAMESPACE}" -l app=istiod --for=condition=Ready --timeout=120s
+  # istiod patches the webhook caBundle early in its startup, before it is fully
+  # ready to accept connections. On older kubectl versions, `kubectl wait pods --for=condition=Ready`
+  # with a label selector can return 0 immediately when no pods match yet, so we use a
+  # direct endpoint check instead: this guarantees the istiod service has a live backend pod
+  # before any subsequent kubectl apply triggers the validating webhook.
+  echo "Waiting for istiod service endpoint to be available..."
+  for i in $(seq 1 60); do
+    ISTIOD_ENDPOINT=$(kubectl get endpoints/istiod -n "${ISTIO_NAMESPACE}" \
+      -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
+    if [ -n "${ISTIOD_ENDPOINT}" ]; then
+      echo "istiod service endpoint is available (${ISTIOD_ENDPOINT})"
+      break
+    fi
+    if [ "${i}" -eq 60 ]; then
+      echo "ERROR: istiod service endpoint did not become available in time"
+      exit 1
+    fi
+    echo "  Waiting for istiod endpoint (attempt ${i}/60)..."
+    sleep 5
+  done
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -31,9 +31,9 @@ ensure_command () {
   fi
 }
 
-# Ensures the Istio validating webhook has a non-empty caBundle.
-# If the validating webhook's caBundle is empty, copies it from the mutating webhook
-# (istiod patches the mutating webhook first during startup).
+# Ensures the Istio validating webhook caBundle matches the current istiod certificate.
+# istiod updates the mutating webhook caBundle first; if the validating webhook has a stale
+# or empty caBundle (e.g. from a previous installation), it is patched to match.
 ensure_istiod_validating_webhook_cabundle() {
   local namespace="${1:-istio-system}"
   local timeout_seconds="${2:-120}"
@@ -43,7 +43,6 @@ ensure_istiod_validating_webhook_cabundle() {
   local max_attempts=1
   local validator_config=""
   local validator_index=""
-  local validator_len=0
   local mutating_cabundle=""
 
   if [[ "${timeout_seconds}" =~ ^[0-9]+$ ]] && [ "${timeout_seconds}" -gt 0 ]; then
@@ -65,32 +64,34 @@ ensure_istiod_validating_webhook_cabundle() {
   fi
 
   while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
-    validator_len=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
-      jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
-    if [ "${validator_len}" -gt 0 ]; then
-      echo "Istio validating webhook caBundle is ready in [${validator_config}]"
-      return 0
-    fi
-
     mutating_cabundle=$(kubectl get mutatingwebhookconfigurations -o json | \
       jq -r '.items[] | .webhooks[]? | select(.clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'" and (.clientConfig.caBundle | length) > 0) | .clientConfig.caBundle' | head -n1)
-    if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
-      echo "Istio validating webhook caBundle is empty in [${validator_config}]; copying CA bundle from mutating webhook"
-      kubectl patch validatingwebhookconfiguration "${validator_config}" --type='json' \
-        -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
 
-      validator_len=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
-        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle | length')
-      if [ "${validator_len}" -gt 0 ]; then
-        echo "Istio validating webhook caBundle copied successfully in [${validator_config}]"
+    if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
+      validator_cabundle=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle // ""')
+
+      if [ "${validator_cabundle}" == "${mutating_cabundle}" ]; then
+        echo "Istio validating webhook caBundle is in sync with mutating webhook in [${validator_config}]"
         return 0
       fi
 
-      echo "ERROR: Istio validating webhook caBundle is still empty after patching in [${validator_config}]"
+      echo "Istio validating webhook caBundle is stale or empty in [${validator_config}]; syncing from mutating webhook"
+      kubectl patch validatingwebhookconfiguration "${validator_config}" --type='json' \
+        -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
+
+      validator_cabundle=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle // ""')
+      if [ "${validator_cabundle}" == "${mutating_cabundle}" ]; then
+        echo "Istio validating webhook caBundle synced successfully in [${validator_config}]"
+        return 0
+      fi
+
+      echo "ERROR: Istio validating webhook caBundle still does not match after patching in [${validator_config}]"
       return 1
     fi
 
-    echo "Waiting for Istio validating webhook caBundle in [${validator_config}] (${attempt}/${max_attempts})"
+    echo "Waiting for Istio mutating webhook caBundle in namespace [${namespace}] (${attempt}/${max_attempts})"
     sleep "${sleep_seconds}"
     elapsed=$((elapsed + sleep_seconds))
     attempt=$((attempt + 1))
@@ -492,6 +493,11 @@ if [ "${WAIT}" == "true" ]; then
   echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
   ensure_istiod_validating_webhook_cabundle "${ISTIO_NAMESPACE}" 300
+  # The Sail Istio CR can reach Ready before the istiod deployment rollout completes.
+  # Wait for the rollout so the webhook port is accepting connections before addons
+  # (which may contain Istio resources) are applied.
+  echo "Waiting for istiod deployment rollout to complete..."
+  kubectl rollout status deployment/istiod -n "${ISTIO_NAMESPACE}" --timeout=120s
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -112,7 +112,10 @@ spec:
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
-install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
+# The remote cluster has no local istiod (profile: remote). Install the Istio CR without
+# addons first so that Sail can reconcile and create the remote RBAC before create-remote-secret
+# runs (if istioctl creates the RBAC first, Sail loses ownership of those resources).
+install_istio -a "" --patch-file "${MC_WEST_YAML}" --wait "false"
 
 # We need the istio reconcile to get to the point where it has created the remote RBAC but fails on pinging the primary's istiod.
 # If we don't wait until the RBAC is created by istio, then the Sail reconiliation will fail because istioctl create-remote-secret
@@ -126,6 +129,13 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     SERVER_FLAG="--server=https://${CLUSTER2_CONTAINER_IP}:6443"
 fi
 ${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2_NAME} ${SERVER_FLAG} | ${CLIENT_EXE} apply -f - --context="${CLUSTER1_CONTEXT}"
+
+# Once the remote secret is created, the primary's istiod connects to the remote cluster and
+# the remote Istio CR transitions to Ready. Only then is the Istio validating webhook on the
+# remote cluster functional. Wait for Ready before installing addons that may contain Istio
+# resources (e.g. PeerAuthentication in prometheus.yaml).
+kubectl --context="${CLUSTER2_CONTEXT}" wait --for=condition=Ready istios/default --timeout=5m
+install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
 
 helm install istio-eastwestgateway gateway \
   --repo https://istio-release.storage.googleapis.com/charts \

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -134,8 +134,10 @@ ${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2
 # the remote Istio CR transitions to Ready. Only then is the Istio validating webhook on the
 # remote cluster functional. Wait for Ready before installing addons that may contain Istio
 # resources (e.g. PeerAuthentication in prometheus.yaml).
+# Using the default WAIT=true so that ensure_istiod_validating_webhook_cabundle also runs
+# and fixes any stale caBundle left by a previous installation on the remote cluster.
 kubectl --context="${CLUSTER2_CONTEXT}" wait --for=condition=Ready istios/default --timeout=5m
-install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
+install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}"
 
 helm install istio-eastwestgateway gateway \
   --repo https://istio-release.storage.googleapis.com/charts \

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -132,12 +132,16 @@ ${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2
 
 # Once the remote secret is created, the primary's istiod connects to the remote cluster and
 # the remote Istio CR transitions to Ready. Only then is the Istio validating webhook on the
-# remote cluster functional. Wait for Ready before installing addons that may contain Istio
-# resources (e.g. PeerAuthentication in prometheus.yaml).
-# Using the default WAIT=true so that ensure_istiod_validating_webhook_cabundle also runs
-# and fixes any stale caBundle left by a previous installation on the remote cluster.
+# remote cluster functional. Wait for Ready, then install the prometheus addon directly.
+# Addons like prometheus may include Istio resources (e.g. PeerAuthentication) that would
+# fail if applied before the webhook is operational.
 kubectl --context="${CLUSTER2_CONTEXT}" wait --for=condition=Ready istios/default --timeout=5m
-install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}"
+istio_version=$(kubectl --context="${CLUSTER2_CONTEXT}" get istios default -o jsonpath='{.spec.version}')
+addon_version="${istio_version:1:4}"
+echo "Installing prometheus addon on remote cluster (Istio ${addon_version:-default})"
+curl -s "https://raw.githubusercontent.com/istio/istio/refs/heads/release-${addon_version}/samples/addons/prometheus.yaml" | \
+  yq "select(.metadata) | .metadata.namespace = \"${ISTIO_NAMESPACE}\"" - | \
+  kubectl apply --context="${CLUSTER2_CONTEXT}" -n "${ISTIO_NAMESPACE}" -f -
 
 helm install istio-eastwestgateway gateway \
   --repo https://istio-release.storage.googleapis.com/charts \

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -180,7 +180,7 @@ get_remote_cluster_token() {
     #fi
     local token_secret="${KIALI_RESOURCE_NAME}"
 
-    for _ in 1 2 3 4 5 6; do
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
       local encoded_token="$(${CLIENT_EXE_REMOTE_CLUSTER} get secrets -n ${REMOTE_CLUSTER_NAMESPACE} ${token_secret} -o jsonpath='{.data.token}' 2>/dev/null)" \
         && [ "${encoded_token}" != "" ] \
         && break \


### PR DESCRIPTION
### Describe the change

`install-istio-via-sail.sh`

Replace hardcoded kubectl wait for webhook caBundle with a new ensure_istiod_validating_webhook_cabundle function that dynamically discovers the validating webhook and syncs its caBundle from the mutating webhook. This also fixes stale caBundles on Istio reinstalls.
Add jq to required dependencies.

`multicluster/install-primary-remote.sh`

Install the remote cluster's Istio CR without addons first, then install prometheus separately after the remote Istio CR becomes Ready. This avoids webhook connection refused errors caused by applying PeerAuthentication (bundled with prometheus) before the remote validating webhook is functional.

`multicluster/kiali-prepare-remote-cluster.sh`

Double the retry timeout for the Kiali ServiceAccount token from ~30s to ~60s to avoid spurious failures on slow clusters.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Should fix https://github.com/kiali/kiali/issues/9864
Ref. #9860 
