### PR TITLE
[v1.73] upgrade axios to 1.17.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "@patternfly/react-core": "4.276.6",
     "@patternfly/react-table": "4.112.39",
     "@patternfly/react-topology": "4.91.27",
-    "axios": "^1.15.1",
+    "axios": "^1.17.0",
     "bootstrap-slider-without-jquery": "10.0.0",
     "cy-node-html-label": "2.0.0",
     "cytoscape": "3.15.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2925,7 +2925,7 @@ __metadata:
     "@types/react-router-dom": "npm:^5.2.0"
     "@types/react-virtualized": "npm:9.x"
     "@wojtekmaj/enzyme-adapter-react-17": "npm:^0.6.7"
-    axios: "npm:^1.15.1"
+    axios: "npm:^1.17.0"
     axios-mock-adapter: "npm:^1.22.0"
     bootstrap-slider-without-jquery: "npm:10.0.0"
     cy-node-html-label: "npm:2.0.0"
@@ -5444,14 +5444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.1":
-  version: 1.15.2
-  resolution: "axios@npm:1.15.2"
+"axios@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "axios@npm:1.17.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
+  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
   languageName: node
   linkType: hard
 
@@ -9326,23 +9327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
   languageName: node
   linkType: hard
 
@@ -10273,7 +10264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
+"https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:


### PR DESCRIPTION
## Summary

Backport of #9865 — upgrade axios from 1.15.1 to 1.17.0 to fix multiple CVEs:

- CVE-2025-27152
- CVE-2025-30204
- CVE-2025-34583
- CVE-2026-25008
- CVE-2026-31498
- CVE-2026-40498
- CVE-2026-44495

**Note:** Code freeze is active. Do not merge until code freeze is lifted.

Made with [Cursor](https://cursor.com)