### PR TITLE
Eliminate graph test race conditions in OSSMC

### DIFF
--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -5,6 +5,7 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
+import { buildNodeTree, findComponentsInTree } from '../../support/react-utils';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -120,35 +121,56 @@ export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
 };
 
 /**
- * Retryable assertion wrapper for the full-page graph. Uses `.should()` instead
- * of `.then()` so Cypress automatically retries the callback when an assertion
- * fails, eliminating race conditions with graph data loading.
+ * Retryable assertion wrapper for the full-page graph.
+ *
+ * Re-traverses the React fiber tree on every `.should()` retry so that
+ * Cypress always sees the latest committed React state. The previous
+ * approach used `cy.getReact()` which returned a static `cy.wrap()`
+ * snapshot — `.should()` retried the assertion against that stale
+ * snapshot, causing false negatives after graph refetches (the
+ * component matched with old `isLoading:false` before the new fetch
+ * cycle started).
  */
 export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
   cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
+  cy.window({ log: false }).should((win: Window) => {
+    const rootFiber = win.__REACT_ROOT_FIBER__;
+    assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+    const tree = buildNodeTree(rootFiber);
+    const results = findComponentsInTree(tree, 'GraphPageComponent', {
+      state: { graphData: { isLoading: false }, isReady: true }
     });
+    assert.equal(results.length, 1, 'GraphPageComponent should be loaded and ready');
+
+    const { state } = results[0];
+    const controller = state.graphRefs.getController() as Visualization;
+    assert.isTrue(controller.hasGraph());
+    fn(elems(controller), state);
+  });
 };
 
 /**
  * Retryable assertion wrapper for the mini graph card.
+ * Same retry-safe approach as assertGraphReady.
  */
 export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
+  cy.window({ log: false }).should((win: Window) => {
+    const rootFiber = win.__REACT_ROOT_FIBER__;
+    assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+    const tree = buildNodeTree(rootFiber);
+    const results = findComponentsInTree(tree, 'MiniGraphCardComponent', {
+      state: { isReady: true, isLoading: false }
     });
+    assert.equal(results.length, 1, 'MiniGraphCardComponent should be loaded and ready');
+
+    const { state } = results[0];
+    const controller = state.graphRefs.getController() as Visualization;
+    assert.isTrue(controller.hasGraph());
+    fn(elems(controller), state);
+  });
 };
 
 export type SelectOp =

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -5,7 +5,7 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
-import { buildNodeTree, findComponentsInTree } from '../../support/react-utils';
+import { buildNodeTree, findComponentsInTree, getReactFiber } from '../../support/react-utils';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -47,19 +47,28 @@ Then('nodes in the {string} cluster should contain the cluster name in their lin
 Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
-    cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-      .should('have.length', '1')
-      .then($graph => {
-        const { state } = $graph[0];
+    let nodeId: string;
 
+    cy.waitForReact();
+    cy.window({ log: false })
+      .should((win: Window) => {
+        const rootFiber = freshFiber(win);
+        assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+        const tree = buildNodeTree(rootFiber);
+        const results = findComponentsInTree(tree, 'GraphPageComponent', {
+          state: { graphData: { isLoading: false }, isReady: true }
+        });
+        assert.equal(results.length, 1, 'GraphPageComponent should be loaded and ready');
+
+        const { state } = results[0];
         const controller = state.graphRefs.getController() as Visualization;
         assert.isTrue(controller.hasGraph());
         const { nodes } = elems(controller);
 
+        // Workloads are apps in the versioned app graph
         const workloadNode = nodes.filter(
           node =>
-            // Apparently workloads are apps for the versioned app graph.
             node.getData().nodeType === 'app' &&
             node.getData().isBox === undefined &&
             node.getData().workload === workload &&
@@ -68,15 +77,12 @@ Then(
         );
 
         expect(workloadNode.length).to.equal(1);
-        cy.get(`[data-id=${workloadNode[0]?.getId()}]`)
-          .click()
-          .then(() => {
-            // Wait for the side panel to change.
-            // Note we can't use summary-graph-panel since that
-            // element will get unmounted and disappear when
-            // the context changes but the graph-side-panel does not.
-            cy.get('#graph-side-panel').contains(workload);
-          });
+        nodeId = workloadNode[0]?.getId();
+      })
+      .then(() => {
+        cy.get(`[data-id=${nodeId}]`).click();
+        // graph-side-panel persists across context changes unlike summary-graph-panel
+        cy.get('#graph-side-panel').contains(workload);
       });
   }
 );
@@ -121,27 +127,38 @@ export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
 };
 
 /**
- * Retryable assertion wrapper for the full-page graph.
- *
- * Re-traverses the React fiber tree on every `.should()` retry so that
- * Cypress always sees the latest committed React state. The previous
- * approach used `cy.getReact()` which returned a static `cy.wrap()`
- * snapshot — `.should()` retried the assertion against that stale
- * snapshot, causing false negatives after graph refetches (the
- * component matched with old `isLoading:false` before the new fetch
- * cycle started).
+ * Read the React fiber root fresh from the DOM so that `.should()` retries
+ * always see the latest committed React state instead of a stale cached
+ * reference from `waitForReact()`.
  */
-export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+const freshFiber = (win: Window): any => {
+  const rootSelector = Cypress.env('rootSelector') || 'body';
+  const rootEl = win.document.querySelector(rootSelector);
+  return rootEl ? getReactFiber(rootEl as Element) : null;
+};
+
+/**
+ * Retryable assertion wrapper that re-reads the React fiber root from the
+ * DOM on every `.should()` retry, ensuring Cypress always sees the latest
+ * committed React state.
+ *
+ * The previous approach used `cy.getReact()` which returned a static
+ * `cy.wrap()` snapshot — `.should()` retried the assertion against that
+ * stale snapshot, causing false negatives after graph refetches.
+ */
+const assertReady = (
+  componentName: string,
+  stateFilter: Record<string, any>,
+  fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void
+): void => {
   cy.waitForReact();
   cy.window({ log: false }).should((win: Window) => {
-    const rootFiber = win.__REACT_ROOT_FIBER__;
+    const rootFiber = freshFiber(win);
     assert.isNotNull(rootFiber, 'React fiber root must exist');
 
     const tree = buildNodeTree(rootFiber);
-    const results = findComponentsInTree(tree, 'GraphPageComponent', {
-      state: { graphData: { isLoading: false }, isReady: true }
-    });
-    assert.equal(results.length, 1, 'GraphPageComponent should be loaded and ready');
+    const results = findComponentsInTree(tree, componentName, { state: stateFilter });
+    assert.equal(results.length, 1, `${componentName} should be loaded and ready`);
 
     const { state } = results[0];
     const controller = state.graphRefs.getController() as Visualization;
@@ -150,27 +167,12 @@ export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }
   });
 };
 
-/**
- * Retryable assertion wrapper for the mini graph card.
- * Same retry-safe approach as assertGraphReady.
- */
+export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+  assertReady('GraphPageComponent', { graphData: { isLoading: false }, isReady: true }, fn);
+};
+
 export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
-  cy.waitForReact();
-  cy.window({ log: false }).should((win: Window) => {
-    const rootFiber = win.__REACT_ROOT_FIBER__;
-    assert.isNotNull(rootFiber, 'React fiber root must exist');
-
-    const tree = buildNodeTree(rootFiber);
-    const results = findComponentsInTree(tree, 'MiniGraphCardComponent', {
-      state: { isReady: true, isLoading: false }
-    });
-    assert.equal(results.length, 1, 'MiniGraphCardComponent should be loaded and ready');
-
-    const { state } = results[0];
-    const controller = state.graphRefs.getController() as Visualization;
-    assert.isTrue(controller.hasGraph());
-    fn(elems(controller), state);
-  });
+  assertReady('MiniGraphCardComponent', { isReady: true, isLoading: false }, fn);
 };
 
 export type SelectOp =

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -23,7 +23,7 @@ When('user graphs {string} namespaces', (namespaces: string) => {
 });
 
 When('user {string} display menu', (_action: string) => {
-  cy.get('button#display-settings').click();
+  cy.get('button#display-settings').should('not.be.disabled').click();
 });
 
 When('user enables {string} {string} edge labels', (radio: string, edgeLabel: string) => {

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -3,6 +3,8 @@ import { ensureKialiFinishedLoading } from './transition';
 import { assertGraphReady, select, selectAnd, selectOr } from './graph';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
 
+const CLIENT_SIDE_ONLY_OPTIONS = ['filterTrafficAnimation', 'filterSidecars', 'rank'];
+
 When('user graphs {string} namespaces', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
@@ -93,8 +95,7 @@ When('user {string} {string} option', (action: string, option: string) => {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }
 
-  const clientSideOnlyOptions = ['filterTrafficAnimation', 'filterSidecars', 'rank'];
-  if (!clientSideOnlyOptions.includes(option)) {
+  if (!CLIENT_SIDE_ONLY_OPTIONS.includes(option)) {
     cy.wait('@graphNamespaces');
   }
 

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -89,12 +89,15 @@ When('user {string} {string} option', (action: string, option: string) => {
     if (option === 'rank') {
       cy.get(`input#inboundEdges`).check();
     }
-    if (option === 'filterWaypoints') {
-      cy.wait('@graphNamespaces');
-    }
   } else {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }
+
+  const clientSideOnlyOptions = ['filterTrafficAnimation', 'filterSidecars', 'rank'];
+  if (!clientSideOnlyOptions.includes(option)) {
+    cy.wait('@graphNamespaces');
+  }
+
   ensureKialiFinishedLoading();
 });
 

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -20,16 +20,17 @@ When('user closes graph tour', () => {
 });
 
 When('user {string} traffic menu', (action: string) => {
-  cy.get('button#graph-traffic-dropdown').then($button => {
-    const currentState = $button.attr('aria-expanded');
-    const isCurrentlyOpen = currentState === 'true';
-    const shouldBeOpen = action.includes('open');
+  cy.get('button#graph-traffic-dropdown')
+    .should('not.be.disabled')
+    .then($button => {
+      const currentState = $button.attr('aria-expanded');
+      const isCurrentlyOpen = currentState === 'true';
+      const shouldBeOpen = action.includes('open');
 
-    // Only click if the current state is different from the desired state
-    if (isCurrentlyOpen !== shouldBeOpen) {
-      cy.wrap($button).click();
-    }
-  });
+      if (isCurrentlyOpen !== shouldBeOpen) {
+        cy.wrap($button).click();
+      }
+    });
 });
 
 When('user {string} {string} traffic option', (action: string, option: string) => {


### PR DESCRIPTION
## Summary

- Wait for graph toolbar buttons to be enabled before clicking, fixing flaky interactions in OSSMC where buttons are still disabled during graph loading
- Make `assertGraphReady` / `assertMiniGraphReady` re-traverse the React fiber tree on every `.should()` retry, eliminating stale-state false negatives after graph refetches
- Wait for the graph API response (`cy.wait('@graphNamespaces')`) after toggling any server-side display option (idle nodes, idle edges, waypoints, etc.)

## Problem

In OSSMC, the `user graphs "X" namespaces` step explicitly skips `cy.wait('@graphNamespaces')` because OpenShift Console redirects prevent `cy.intercept` from matching the graph API call. This caused three related issues:

1. **Disabled button clicks**: After navigating to the graph page, toolbar buttons may still be disabled (`isLoading=true` → `isDisabled={true}` on `MenuToggle`) when the next step tries to click them. Clicking a disabled button has no effect, so the dropdown never opens and subsequent steps time out.

2. **Stale assertion state**: `assertGraphReady` used `cy.getReact()` which returned a static `cy.wrap()` snapshot. When `.should()` retried, it checked the same stale snapshot rather than re-querying the live React state, causing false negatives after graph refetches (e.g., the component matched with old `isLoading:false` before the new fetch cycle started).

3. **Missing API wait after option toggling**: Toggling display options like "idle nodes" triggers a server-side graph refetch, but the step definition didn't wait for the response. The assertion would run against the old graph data, causing errors like `expected 0 to be above 0` (no idle nodes in stale data) or `expected 13 to equal 0` (stale data still containing nodes).

## Fix

### 1. Defensive button waits (`graph_display.ts`, `graph_toolbar.ts`)

Add `.should('not.be.disabled')` before `.click()` on `button#display-settings` and `button#graph-traffic-dropdown`, making Cypress retry until the button is enabled.

### 2. Retry-safe graph assertions (`graph.ts`)

Replace `cy.getReact('GraphPageComponent', ...).should()` with `cy.window().should()` that re-traverses the React fiber tree (via `buildNodeTree` / `findComponentsInTree` from `react-utils.ts`) on every retry, always checking the latest committed React state.

### 3. API wait after display option toggle (`graph_display.ts`)

After toggling any display option that triggers a server-side graph refetch, wait for `cy.wait('@graphNamespaces')`. Client-side-only options (`filterTrafficAnimation`, `filterSidecars`, `rank`) skip the wait.

## Affected files

| File | Change |
|------|--------|
| `frontend/cypress/integration/common/graph.ts` | Retry-safe `assertGraphReady` / `assertMiniGraphReady` using fiber tree traversal |
| `frontend/cypress/integration/common/graph_display.ts` | Wait for `#display-settings` to be enabled; wait for graph API after toggling server-side options |
| `frontend/cypress/integration/common/graph_toolbar.ts` | Wait for `#graph-traffic-dropdown` to be enabled |

## Test plan

- [ ] Run `graph_display.feature` — "Show idle nodes" and "User disables idle nodes" scenarios should pass
- [ ] Run `graph_traffic.feature` — traffic menu scenarios should pass
- [ ] Verify in OSSMC CI (where the failures were consistently reproduced for 14–23 builds)
- [ ] Verify no regression in standalone Kiali Cypress tests