### PR TITLE
Add default export for rootReducer

### DIFF
--- a/frontend/src/reducers/index.ts
+++ b/frontend/src/reducers/index.ts
@@ -43,3 +43,6 @@ export const rootReducer = combineReducers<KialiAppState, KialiAppAction>({
   tracingState: TracingStateReducer,
   userSettings: UserSettingsStateReducer
 });
+
+/* eslint-disable import/no-default-export */
+export default rootReducer;


### PR DESCRIPTION
## Summary

- Adds a default export for `rootReducer` in `frontend/src/reducers/index.ts`, alongside the existing named export.
- This allows OSSMC to reference the vendored `reducers/index.ts` directly as the plugin's `ReduxReducer` exposed module, which the OpenShift Console dynamic plugin SDK requires to be a default export.
- Eliminates the need for a separate duplicate `Reducer.ts` file in the OSSMC repo.

## Impact

- The existing named import (`import { rootReducer } from '../reducers'`) in `ConfigStore.ts` is **unaffected**.
- No functional or behavioral changes to Kiali.

## Test plan

- [x] Verified `yarn lint` passes (with inline `eslint-disable` matching existing precedent in the codebase)
- [x] Verified OSSMC builds successfully when using this file as its `ReduxReducer` module

Made with [Cursor](https://cursor.com)