### PR TITLE
[AI] Fix get_pod_performance tool schema incompatible with OpenAI

### DIFF
--- a/ai/mcp/mcp_tools_test.go
+++ b/ai/mcp/mcp_tools_test.go
@@ -122,29 +122,28 @@ func TestPodPerformanceSchema_RequiredFields(t *testing.T) {
 	assert.Contains(t, required, "namespace", "namespace should be required")
 }
 
-func TestPodPerformanceSchema_AnyOfConstraint(t *testing.T) {
+func TestPodPerformanceSchema_PodOrWorkloadConstraint(t *testing.T) {
 	err := LoadTools()
 	require.NoError(t, err)
 
 	tool := DefaultToolHandlers["get_pod_performance"]
 	schema := tool.GetDefinition()
 
-	anyOf, ok := schema["anyOf"].([]interface{})
-	require.True(t, ok, "schema should have an 'anyOf' field for podName/workloadName")
-	assert.Len(t, anyOf, 2, "anyOf should have exactly 2 entries (podName, workloadName)")
+	// anyOf was removed from the top level to maintain OpenAI compatibility.
+	// The constraint is now expressed in the field descriptions instead.
+	_, hasAnyOf := schema["anyOf"]
+	assert.False(t, hasAnyOf, "schema must not have top-level 'anyOf' to remain compatible with OpenAI")
 
-	var requiredFields []string
-	for _, entry := range anyOf {
-		m, mOk := entry.(map[string]interface{})
-		require.True(t, mOk)
-		req, rOk := m["required"].([]interface{})
-		require.True(t, rOk)
-		for _, r := range req {
-			requiredFields = append(requiredFields, r.(string))
-		}
+	properties, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "schema should have properties")
+
+	for _, field := range []string{"podName", "workloadName"} {
+		prop, exists := properties[field].(map[string]interface{})
+		require.True(t, exists, "property %q should exist", field)
+		desc, _ := prop["description"].(string)
+		assert.Contains(t, desc, "At least one of podName or workloadName must be provided",
+			"property %q description should document the mutual constraint", field)
 	}
-	assert.Contains(t, requiredFields, "podName")
-	assert.Contains(t, requiredFields, "workloadName")
 }
 
 func TestPodPerformanceSchema_PropertiesIncludeExpectedFields(t *testing.T) {

--- a/ai/mcp/tools/get_pod_performance.yaml
+++ b/ai/mcp/tools/get_pod_performance.yaml
@@ -4,19 +4,16 @@
   input_schema:
     type: "object"
     required: ["namespace"]
-    anyOf:
-    - required: ["podName"]
-    - required: ["workloadName"]
     properties:
       namespace:
         type: "string"
         description: "Kubernetes namespace of the Pod."
       podName:
         type: "string"
-        description: "Kubernetes Pod name. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first."
+        description: "Kubernetes Pod name. At least one of podName or workloadName must be provided. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first."
       workloadName:
         type: "string"
-        description: "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName."
+        description: "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). At least one of podName or workloadName must be provided. Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName."
       timeRange:
         type: "string"
         description: "Time window used to compute CPU rate (Prometheus duration like '5m', '10m', '1h', '1d'). Defaults to '10m'."

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -317,7 +317,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetPodPerformance(t *testing.
 	expected := anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        "get_pod_performance",
-			Description: param.NewOpt("Returns a human-readable text summary with current Pod CPU/memory usage (from Prometheus) compared to Kubernetes requests/limits (from the Pod spec). Useful to answer questions like 'Is this workload using too much memory?'. IMPORTANT input constraint: provide at least one of podName, workloadName."),
+			Description: param.NewOpt("Returns a human-readable text summary with current Pod CPU/memory usage (from Prometheus) compared to Kubernetes requests/limits (from the Pod spec). Useful to answer questions like 'Is this workload using too much memory?'."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
 					"namespace": map[string]interface{}{
@@ -326,11 +326,11 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetPodPerformance(t *testing.
 					},
 					"podName": map[string]interface{}{
 						"type":        "string",
-						"description": "Kubernetes Pod name. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first. At least one of these fields is required together with the others listed in this note.",
+						"description": "Kubernetes Pod name. At least one of podName or workloadName must be provided. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.",
 					},
 					"workloadName": map[string]interface{}{
 						"type":        "string",
-						"description": "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName. At least one of these fields is required together with the others listed in this note.",
+						"description": "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). At least one of podName or workloadName must be provided. Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.",
 					},
 					"timeRange": map[string]interface{}{
 						"type":        "string",

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -274,11 +274,11 @@ func TestConvertToolToGoogle_FromToolDefinition_GetPodPerformance(t *testing.T) 
 			},
 			"podName": {
 				Type:        genai.TypeString,
-				Description: "Kubernetes Pod name. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.",
+				Description: "Kubernetes Pod name. At least one of podName or workloadName must be provided. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.",
 			},
 			"workloadName": {
 				Type:        genai.TypeString,
-				Description: "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.",
+				Description: "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). At least one of podName or workloadName must be provided. Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.",
 			},
 			"timeRange": {
 				Type:        genai.TypeString,

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -363,18 +363,6 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetPodPerformance(t *testing.T) 
 					"required": []interface{}{
 						"namespace",
 					},
-					"anyOf": []interface{}{
-						map[string]interface{}{
-							"required": []interface{}{
-								"podName",
-							},
-						},
-						map[string]interface{}{
-							"required": []interface{}{
-								"workloadName",
-							},
-						},
-					},
 					"properties": map[string]interface{}{
 						"namespace": map[string]interface{}{
 							"type":        "string",
@@ -382,11 +370,11 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetPodPerformance(t *testing.T) 
 						},
 						"podName": map[string]interface{}{
 							"type":        "string",
-							"description": "Kubernetes Pod name. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.",
+							"description": "Kubernetes Pod name. At least one of podName or workloadName must be provided. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.",
 						},
 						"workloadName": map[string]interface{}{
 							"type":        "string",
-							"description": "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.",
+							"description": "Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). At least one of podName or workloadName must be provided. Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.",
 						},
 						"timeRange": map[string]interface{}{
 							"type":        "string",


### PR DESCRIPTION
The schema used anyOf at the root level of the parameters object, which OpenAI rejects with 400 Bad Request. This made the Kiali AI chat completely unusable with any OpenAI GPT model.

Removed the top-level anyOf and moved the constraint into the field descriptions instead. The runtime validation in Go already handles the case where neither podName nor workloadName is provided.

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://github.com/kiali/kiali/issues/9756
