### PR TITLE
Fix K8s Gateway wizard Create button disabled after RBAC permission cleanup

### DIFF
--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1350,7 +1350,7 @@ func getPermissionsApi(ctx context.Context, k8s kubernetes.ClientInterface, clus
 			}
 		}
 	} else {
-		log.FromContext(ctx).Error().Msgf("Error getting permissions [namespace: %s, api: %s, resourceType: %s]: %v", namespace, api, "*", permErr)
+		log.FromContext(ctx).Error().Msgf("Error getting permissions [namespace: %s, api: %s, resourceType: %s]: %v", namespace, api, resourceType, permErr)
 	}
 	return canCreate, canPatch, canDelete
 }

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1266,11 +1266,7 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 				defer wg.Done()
 				isGatewayAPI := in.userClients[cluster].IsGatewayAPI()
 				for _, rs := range newK8sNetworkingConfigTypes {
-					// RBAC requires plural resource names, not Kind. This simple conversion
-					// works for current types but will break for irregular plurals.
-					// If new types are added to newK8sNetworkingConfigTypes with irregular plural forms,
-					// this conversion will need updating.
-					resourceName := strings.ToLower(rs.Kind) + "s"
+					resourceName := kubernetes.PluralResourceName(rs.Kind)
 					canCreate, canUpdate, canDelete := getPermissionsApi(ctx, k8s, cluster, namespace, rs.Group, resourceName, in.conf)
 					k8sNetworkingRP[rs.String()] = &models.ResourcePermissions{
 						Create: canCreate && isGatewayAPI,
@@ -1316,7 +1312,8 @@ func getPermissions(ctx context.Context, k8s kubernetes.ClientInterface, cluster
 	var canCreate, canPatch, canDelete bool
 
 	if _, ok := kubernetes.ResourceTypesToAPI[objectGVK.String()]; ok {
-		return getPermissionsApi(ctx, k8s, cluster, namespace, objectGVK.Group, objectGVK.Kind, conf)
+		resourceType := kubernetes.PluralResourceName(objectGVK.Kind)
+		return getPermissionsApi(ctx, k8s, cluster, namespace, objectGVK.Group, resourceType, conf)
 	}
 	return canCreate, canPatch, canDelete
 }

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1234,7 +1234,7 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 		securityPermissions := make(models.IstioConfigPermissions, len(namespaces))
 
 		wg := sync.WaitGroup{}
-		// We will query 2 times per namespace (networking.istio.io and security.istio.io)
+		// 3 goroutines per namespace: networking.istio.io, gateway.networking.k8s.io, security.istio.io
 		wg.Add(len(namespaces) * 3)
 		for _, ns := range namespaces {
 			networkingRP := make(models.ResourcesPermissions, len(newNetworkingConfigTypes))
@@ -1244,12 +1244,11 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 			k8sNetworkingPermissions[ns] = &k8sNetworkingRP
 			securityPermissions[ns] = &securityRP
 			/*
-				We can optimize this logic.
-				Instead of query all editable objects of networking.istio.io and security.istio.io we can query
-				only one per API, that will save several queries to the backend.
+				For networking.istio.io and security.istio.io, we check permissions once per API group
+				using a wildcard resource since all resources in those groups share the same verb set.
 
-				Synced with:
-				https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/templates/kubernetes/role.yaml#L62
+				For gateway.networking.k8s.io, we check per resource type because different resources
+				have different write permissions (e.g., GatewayClass is read-only, TCPRoute has no create).
 			*/
 			go func(ctx context.Context, namespace string, wg *sync.WaitGroup, networkingPermissions *models.ResourcesPermissions) {
 				defer wg.Done()
@@ -1265,12 +1264,13 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 
 			go func(ctx context.Context, namespace string, wg *sync.WaitGroup, k8sNetworkingPermissions *models.ResourcesPermissions) {
 				defer wg.Done()
-				canCreate, canUpdate, canDelete := getPermissionsApi(ctx, k8s, cluster, namespace, kubernetes.K8sNetworkingGroupVersionV1.Group, allResources, in.conf)
+				isGatewayAPI := in.userClients[cluster].IsGatewayAPI()
 				for _, rs := range newK8sNetworkingConfigTypes {
+					canCreate, canUpdate, canDelete := getPermissionsApi(ctx, k8s, cluster, namespace, rs.Group, rs.Kind, in.conf)
 					k8sNetworkingRP[rs.String()] = &models.ResourcePermissions{
-						Create: canCreate && in.userClients[cluster].IsGatewayAPI(),
-						Update: canUpdate && in.userClients[cluster].IsGatewayAPI(),
-						Delete: canDelete && in.userClients[cluster].IsGatewayAPI(),
+						Create: canCreate && isGatewayAPI,
+						Update: canUpdate && isGatewayAPI,
+						Delete: canDelete && isGatewayAPI,
 					}
 				}
 			}(ctx, ns, &wg, &k8sNetworkingRP)

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -1266,7 +1266,12 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 				defer wg.Done()
 				isGatewayAPI := in.userClients[cluster].IsGatewayAPI()
 				for _, rs := range newK8sNetworkingConfigTypes {
-					canCreate, canUpdate, canDelete := getPermissionsApi(ctx, k8s, cluster, namespace, rs.Group, rs.Kind, in.conf)
+					// RBAC requires plural resource names, not Kind. This simple conversion
+					// works for current types but will break for irregular plurals.
+					// If new types are added to newK8sNetworkingConfigTypes with irregular plural forms,
+					// this conversion will need updating.
+					resourceName := strings.ToLower(rs.Kind) + "s"
+					canCreate, canUpdate, canDelete := getPermissionsApi(ctx, k8s, cluster, namespace, rs.Group, resourceName, in.conf)
 					k8sNetworkingRP[rs.String()] = &models.ResourcePermissions{
 						Create: canCreate && isGatewayAPI,
 						Update: canUpdate && isGatewayAPI,

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -226,13 +226,13 @@ func (in *K8SClient) IsGatewayAPI() bool {
 	}
 	if in.isGatewayAPI == nil {
 		v1Types := map[string]string{
-			K8sGatewayType:      "gateways",
-			K8sGatewayClassType: "gatewayclasses",
-			K8sHTTPRouteType:    "httproutes",
-			K8sGRPCRouteType:    "grpcroutes",
+			K8sGatewayType:      PluralNames[K8sGatewayType],
+			K8sGatewayClassType: PluralNames[K8sGatewayClassType],
+			K8sHTTPRouteType:    PluralNames[K8sHTTPRouteType],
+			K8sGRPCRouteType:    PluralNames[K8sGRPCRouteType],
 		}
 		v1beta1Types := map[string]string{
-			K8sReferenceGrantType: "referencegrants",
+			K8sReferenceGrantType: PluralNames[K8sReferenceGrantType],
 		}
 		isGatewayAPIV1 := checkGatewayAPIs(in, K8sNetworkingGroupVersionV1.String(), v1Types, false)
 		isGatewayAPI := isGatewayAPIV1 && checkGatewayAPIs(in, K8sNetworkingGroupVersionV1Beta1.String(), v1beta1Types, false)
@@ -250,7 +250,7 @@ func (in *K8SClient) HasTLSRouteInV1() bool {
 	}
 	if in.hasTLSRouteInV1 == nil {
 		v1Types := map[string]string{
-			K8sTLSRouteType: "tlsroutes",
+			K8sTLSRouteType: PluralNames[K8sTLSRouteType],
 		}
 		hasTLSRoute := checkGatewayAPIs(in, K8sNetworkingGroupVersionV1.String(), v1Types, true)
 		in.hasTLSRouteInV1 = &hasTLSRoute
@@ -266,7 +266,7 @@ func (in *K8SClient) IsInferenceAPI() bool {
 	}
 	if in.isInferenceAPI == nil {
 		v1alpha2Types := map[string]string{
-			K8sInferencePoolsType: "inferencepools",
+			K8sInferencePoolsType: PluralNames[K8sInferencePoolsType],
 		}
 		isInferenceAPI := checkInferenceAPIs(in, K8sInferenceGroupVersionV1.String(), v1alpha2Types)
 		in.isInferenceAPI = &isInferenceAPI
@@ -311,7 +311,7 @@ func (in *K8SClient) IsExpGatewayAPI() bool {
 	}
 	if in.isExpGatewayAPI == nil {
 		v1alpha2Types := map[string]string{
-			K8sTCPRouteType: "tcproutes",
+			K8sTCPRouteType: PluralNames[K8sTCPRouteType],
 		}
 		isGatewayAPIV1Alpha2 := checkGatewayAPIs(in, K8sNetworkingGroupVersionV1Alpha2.String(), v1alpha2Types, true)
 		in.isExpGatewayAPI = &isGatewayAPIV1Alpha2

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -164,6 +164,19 @@ var (
 		Version: "v1",
 	}
 
+	// PluralNames maps Kind to the lowercase plural resource name used in RBAC.
+	// Kubernetes SSAR ResourceAttributes.Resource requires the plural form.
+	PluralNames = map[string]string{
+		K8sGatewayType:        "gateways",
+		K8sGatewayClassType:   "gatewayclasses",
+		K8sGRPCRouteType:      "grpcroutes",
+		K8sHTTPRouteType:      "httproutes",
+		K8sInferencePoolsType: "inferencepools",
+		K8sReferenceGrantType: "referencegrants",
+		K8sTCPRouteType:       "tcproutes",
+		K8sTLSRouteType:       "tlsroutes",
+	}
+
 	// Resources
 	ResourceTypesToAPI = map[string]schema.GroupVersionKind{
 		DestinationRules.String(): DestinationRules,
@@ -190,6 +203,16 @@ var (
 		RequestAuthentications.String(): RequestAuthentications,
 	}
 )
+
+// PluralResourceName returns the RBAC plural resource name for a Kind.
+// Uses the PluralNames map for types with explicit RBAC rules; falls back
+// to the Kind itself for types that still use wildcard resources: ["*"].
+func PluralResourceName(kind string) string {
+	if plural, ok := PluralNames[kind]; ok {
+		return plural
+	}
+	return kind
+}
 
 // MTLSDetails is a wrapper to group all Istio objects related to non-local mTLS configurations
 type MTLSDetails struct {

--- a/kubernetes/types_test.go
+++ b/kubernetes/types_test.go
@@ -1,0 +1,39 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestPluralResourceName(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected string
+	}{
+		{K8sGatewayType, "gateways"},
+		{K8sGatewayClassType, "gatewayclasses"},
+		{K8sGRPCRouteType, "grpcroutes"},
+		{K8sHTTPRouteType, "httproutes"},
+		{K8sInferencePoolsType, "inferencepools"},
+		{K8sReferenceGrantType, "referencegrants"},
+		{K8sTCPRouteType, "tcproutes"},
+		{K8sTLSRouteType, "tlsroutes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := PluralResourceName(tt.kind)
+			if got != tt.expected {
+				t.Errorf("PluralResourceName(%q) = %q, want %q", tt.kind, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPluralResourceNameFallback(t *testing.T) {
+	// Types not in PluralNames should return the Kind unchanged (used for
+	// Istio types that still use wildcard resources: ["*"] in RBAC).
+	got := PluralResourceName("DestinationRule")
+	if got != "DestinationRule" {
+		t.Errorf("PluralResourceName(%q) = %q, want %q (fallback to Kind)", "DestinationRule", got, "DestinationRule")
+	}
+}


### PR DESCRIPTION
The permission check for K8s Gateway API resources used a wildcard resource ("*") in the SelfSubjectAccessReview, which no longer matches after the role templates were split into specific resources. Changed to check permissions per resource type (e.g., Gateway, ReferenceGrant) instead of using the wildcard, correctly reflecting that different K8s Gateway resources have different write permissions.

fixes: https://github.com/kiali/kiali/issues/9880

Generated-by: Cursor