### PR TITLE
Fix Electron renderer crash in ambient multi-primary CI

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -32,6 +32,14 @@ export default defineConfig({
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
       await addCucumberPreprocessorPlugin(on, config);
 
+      on('before:browser:launch', (browser, launchOptions) => {
+        if (browser.family === 'chromium' || browser.name === 'electron') {
+          launchOptions.args.push('--disable-dev-shm-usage');
+          launchOptions.args.push('--disable-gpu');
+        }
+        return launchOptions;
+      });
+
       on('task', {
         log(message: string) {
           console.log(message);


### PR DESCRIPTION
## Summary

- Add `--disable-dev-shm-usage` and `--disable-gpu` to the Cypress Electron browser launch args to prevent the renderer process from crashing due to exhausted shared memory on resource-constrained CI runners.
- Only the ambient multi-primary suite is affected because it's the heaviest CI environment (2 KinD clusters + Sail + ztunnel + waypoints + double bookinfo + helloworld demo).

## Root Cause

The `ERR_FAILED (-2) loading 'about:blank'` / `network_service_instance_impl.cc crashed` errors occur because:
1. The ambient multi-primary setup consumes most of the runner's 7GB RAM across two KinD containers
2. Electron's sandboxed network service process needs `/dev/shm` for IPC, but it's either full or the kernel denies the allocation under memory pressure
3. The crash happens before any test runs — Electron can't even load `about:blank`

## Fix

`--disable-dev-shm-usage` tells Chrome/Electron to use `/tmp` for shared memory instead of the limited `/dev/shm`. `--disable-gpu` avoids allocating a separate GPU process sandbox (there's no GPU on CI runners anyway; Electron already uses software rendering).

These are standard flags used in Docker/CI environments and have no impact on test behavior or performance.

## Test plan

- [ ] Verify ambient multi-primary CI job passes without Electron crashes
- [ ] Verify other Cypress test suites (core-1, core-2, multi-primary, ambient) still pass


Made with [Cursor](https://cursor.com)