### PR TITLE
[v2.27] Wait for istiod webhook to be ready before creating resources

### DIFF
--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -420,7 +420,16 @@ fi
 
 kubectl apply -f - <<<"$ISTIO_YAML"
 if [ "${WAIT}" == "true" ]; then
+  echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
+  WEBHOOK_NAME="istio-validator-${ISTIO_NAMESPACE}"
+  echo "Waiting for validating webhook ${WEBHOOK_NAME} CA bundle to be patched by istiod..."
+  kubectl wait validatingwebhookconfiguration "${WEBHOOK_NAME}" --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
+
+  if kubectl get validatingwebhookconfiguration istiod-default-validator &>/dev/null; then
+    echo "Waiting for validating webhook istiod-default-validator CA bundle to be patched by istiod..."
+    kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
+  fi
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/install-istio-via-sail.sh
+++ b/hack/istio/install-istio-via-sail.sh
@@ -31,7 +31,77 @@ ensure_command () {
   fi
 }
 
-requirements=("yq" "helm")
+# Ensures the Istio validating webhook caBundle matches the current istiod certificate.
+# istiod updates the mutating webhook caBundle first; if the validating webhook has a stale
+# or empty caBundle (e.g. from a previous installation), it is patched to match.
+ensure_istiod_validating_webhook_cabundle() {
+  local namespace="${1:-istio-system}"
+  local timeout_seconds="${2:-120}"
+  local sleep_seconds=5
+  local elapsed=0
+  local attempt=1
+  local max_attempts=1
+  local validator_config=""
+  local validator_index=""
+  local mutating_cabundle=""
+
+  if [[ "${timeout_seconds}" =~ ^[0-9]+$ ]] && [ "${timeout_seconds}" -gt 0 ]; then
+    max_attempts=$(((timeout_seconds + sleep_seconds - 1) / sleep_seconds))
+  fi
+
+  validator_config=$(kubectl get validatingwebhookconfigurations -o json | \
+    jq -r '.items[] | select(any(.webhooks[]?; .name=="validation.istio.io" and .clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'")) | .metadata.name' | head -n1)
+  if [ -z "${validator_config}" ]; then
+    echo "WARNING: No Istio validating webhook configuration found in namespace [${namespace}]"
+    return 0
+  fi
+
+  validator_index=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+    jq -r '.webhooks | to_entries[] | select(.value.name=="validation.istio.io") | .key')
+  if [ -z "${validator_index}" ]; then
+    echo "WARNING: validation.istio.io webhook not found in configuration [${validator_config}]"
+    return 0
+  fi
+
+  while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
+    mutating_cabundle=$(kubectl get mutatingwebhookconfigurations -o json | \
+      jq -r '.items[] | .webhooks[]? | select(.clientConfig.service.name=="istiod" and .clientConfig.service.namespace=="'"${namespace}"'" and (.clientConfig.caBundle | length) > 0) | .clientConfig.caBundle' | head -n1)
+
+    if [ -n "${mutating_cabundle}" ] && [ "${mutating_cabundle}" != "null" ]; then
+      validator_cabundle=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle // ""')
+
+      if [ "${validator_cabundle}" == "${mutating_cabundle}" ]; then
+        echo "Istio validating webhook caBundle is in sync with mutating webhook in [${validator_config}]"
+        return 0
+      fi
+
+      echo "Istio validating webhook caBundle is stale or empty in [${validator_config}]; syncing from mutating webhook"
+      kubectl patch validatingwebhookconfiguration "${validator_config}" --type='json' \
+        -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${validator_index}/clientConfig/caBundle\",\"value\":\"${mutating_cabundle}\"}]"
+
+      validator_cabundle=$(kubectl get validatingwebhookconfiguration "${validator_config}" -o json | \
+        jq -r '.webhooks['"${validator_index}"'].clientConfig.caBundle // ""')
+      if [ "${validator_cabundle}" == "${mutating_cabundle}" ]; then
+        echo "Istio validating webhook caBundle synced successfully in [${validator_config}]"
+        return 0
+      fi
+
+      echo "ERROR: Istio validating webhook caBundle still does not match after patching in [${validator_config}]"
+      return 1
+    fi
+
+    echo "Waiting for Istio mutating webhook caBundle in namespace [${namespace}] (${attempt}/${max_attempts})"
+    sleep "${sleep_seconds}"
+    elapsed=$((elapsed + sleep_seconds))
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: Could not find a non-empty Istio mutating webhook caBundle in namespace [${namespace}]"
+  return 1
+}
+
+requirements=("jq" "yq" "helm")
 for req in "${requirements[@]}"; do
   ensure_command "$req"
 done
@@ -422,14 +492,7 @@ kubectl apply -f - <<<"$ISTIO_YAML"
 if [ "${WAIT}" == "true" ]; then
   echo "Waiting for Istio to be ready..."
   kubectl wait --for=condition=Ready istios -l kiali.io/testing --timeout=300s
-  WEBHOOK_NAME="istio-validator-${ISTIO_NAMESPACE}"
-  echo "Waiting for validating webhook ${WEBHOOK_NAME} CA bundle to be patched by istiod..."
-  kubectl wait validatingwebhookconfiguration "${WEBHOOK_NAME}" --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
-
-  if kubectl get validatingwebhookconfiguration istiod-default-validator &>/dev/null; then
-    echo "Waiting for validating webhook istiod-default-validator CA bundle to be patched by istiod..."
-    kubectl wait validatingwebhookconfiguration istiod-default-validator --for='jsonpath={.webhooks[0].clientConfig.caBundle}' --timeout=300s
-  fi
+  ensure_istiod_validating_webhook_cabundle "${ISTIO_NAMESPACE}" 300
 fi
 
 if [ "${CONFIG_PROFILE}" == "ambient" ]; then

--- a/hack/istio/multicluster/install-primary-remote.sh
+++ b/hack/istio/multicluster/install-primary-remote.sh
@@ -112,7 +112,10 @@ spec:
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
-install_istio -a "prometheus" --patch-file "${MC_WEST_YAML}" --wait "false"
+# The remote cluster has no local istiod (profile: remote). Install the Istio CR without
+# addons first so that Sail can reconcile and create the remote RBAC before create-remote-secret
+# runs (if istioctl creates the RBAC first, Sail loses ownership of those resources).
+install_istio -a "" --patch-file "${MC_WEST_YAML}" --wait "false"
 
 # We need the istio reconcile to get to the point where it has created the remote RBAC but fails on pinging the primary's istiod.
 # If we don't wait until the RBAC is created by istio, then the Sail reconiliation will fail because istioctl create-remote-secret
@@ -126,6 +129,19 @@ if [ "${MANAGE_KIND}" == "true" ]; then
     SERVER_FLAG="--server=https://${CLUSTER2_CONTAINER_IP}:6443"
 fi
 ${ISTIOCTL} create-remote-secret --context=${CLUSTER2_CONTEXT} --name=${CLUSTER2_NAME} ${SERVER_FLAG} | ${CLIENT_EXE} apply -f - --context="${CLUSTER1_CONTEXT}"
+
+# Once the remote secret is created, the primary's istiod connects to the remote cluster and
+# the remote Istio CR transitions to Ready. Only then is the Istio validating webhook on the
+# remote cluster functional. Wait for Ready, then install the prometheus addon directly.
+# Addons like prometheus may include Istio resources (e.g. PeerAuthentication) that would
+# fail if applied before the webhook is operational.
+kubectl --context="${CLUSTER2_CONTEXT}" wait --for=condition=Ready istios/default --timeout=5m
+istio_version=$(kubectl --context="${CLUSTER2_CONTEXT}" get istios default -o jsonpath='{.spec.version}')
+addon_version="${istio_version:1:4}"
+echo "Installing prometheus addon on remote cluster (Istio ${addon_version:-default})"
+curl -s "https://raw.githubusercontent.com/istio/istio/refs/heads/release-${addon_version}/samples/addons/prometheus.yaml" | \
+  yq "select(.metadata) | .metadata.namespace = \"${ISTIO_NAMESPACE}\"" - | \
+  kubectl apply --context="${CLUSTER2_CONTEXT}" -n "${ISTIO_NAMESPACE}" -f -
 
 helm install istio-eastwestgateway gateway \
   --repo https://istio-release.storage.googleapis.com/charts \

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -180,7 +180,7 @@ get_remote_cluster_token() {
     #fi
     local token_secret="${KIALI_RESOURCE_NAME}"
 
-    for _ in 1 2 3 4 5 6; do
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
       local encoded_token="$(${CLIENT_EXE_REMOTE_CLUSTER} get secrets -n ${REMOTE_CLUSTER_NAMESPACE} ${token_secret} -o jsonpath='{.data.token}' 2>/dev/null)" \
         && [ "${encoded_token}" != "" ] \
         && break \


### PR DESCRIPTION
## Summary

Backport of #9860 and #9863 to v2.27.

Fixes the CI workflow error:
```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.istio.io": failed to call webhook: Post "https://istiod.istio-system.svc:443/validate?timeout=10s": dial tcp 10.96.83.35:443: connect: connection refused
```

- **#9860** - Wait for CA webhook to be patched: istiod patches the validation webhook with the CA bundle after it comes online, which may happen after the Istio resource reports Ready.
- **#9863** - Wait for the istiod pod: adds more robust waiting for istiod to be fully operational (pod ready + webhook ready) before proceeding with resource creation.

## Test plan

- [ ] CI workflows that install Istio via Sail no longer hit the webhook connection refused error

Made with [Cursor](https://cursor.com)