### PR TITLE
Add tests for TrafficExtension filtering, merging, and MCP criteria

### DIFF
--- a/CACHE.md
+++ b/CACHE.md
@@ -42,6 +42,7 @@ Kiali maintains an internal cache for commonly used Kubernetes resources such as
   - Sidecars
   - ServiceEntries
   - Telemetries
+  - TrafficExtensions
   - VirtualServices
   - WasmPlugins
   - WorkloadEntries

--- a/ai/mcp/get_action_ui/istio_objects_helper.go
+++ b/ai/mcp/get_action_ui/istio_objects_helper.go
@@ -35,8 +35,9 @@ const (
 	WorkloadGroup   = "WorkloadGroup"
 
 	// Istio Extensions / Telemetry
-	WasmPlugin = "WasmPlugin"
-	Telemetry  = "Telemetry"
+	TrafficExtension = "TrafficExtension"
+	WasmPlugin       = "WasmPlugin"
+	Telemetry        = "Telemetry"
 
 	// K8s Gateway API
 	K8sGateway        = "K8sGateway"
@@ -78,8 +79,9 @@ var DicTypeToGVK = map[string]GroupVersionKind{
 	WorkloadGroup:   {Group: "networking.istio.io", Version: "v1", Kind: WorkloadGroup},
 
 	// Istio Extensions / Telemetry
-	WasmPlugin: {Group: "extensions.istio.io", Version: "v1alpha1", Kind: WasmPlugin},
-	Telemetry:  {Group: "telemetry.istio.io", Version: "v1", Kind: Telemetry},
+	TrafficExtension: {Group: "extensions.istio.io", Version: "v1alpha1", Kind: TrafficExtension},
+	WasmPlugin:       {Group: "extensions.istio.io", Version: "v1alpha1", Kind: WasmPlugin},
+	Telemetry:        {Group: "telemetry.istio.io", Version: "v1", Kind: Telemetry},
 
 	// K8s Gateway API
 	// Note: The 'Kind' here is hardcoded string (e.g. "Gateway") rather than the key constant (K8sGateway)
@@ -152,6 +154,7 @@ func filterIstioObjectsByName(istioObjectsList *models.IstioConfigList, name str
 	result = appendFiltered(result, istioObjectsList.ServiceEntries, name)
 	result = appendFiltered(result, istioObjectsList.Sidecars, name)
 	result = appendFiltered(result, istioObjectsList.Telemetries, name)
+	result = appendFiltered(result, istioObjectsList.TrafficExtensions, name)
 	result = appendFiltered(result, istioObjectsList.VirtualServices, name)
 	result = appendFiltered(result, istioObjectsList.WasmPlugins, name)
 	result = appendFiltered(result, istioObjectsList.WorkloadEntries, name)

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -156,6 +156,8 @@ func shortKind(kind string) string {
 		return "WE"
 	case "WorkloadGroup":
 		return "WG"
+	case "TrafficExtension":
+		return "TX"
 	case "WasmPlugin":
 		return "WP"
 	case "Telemetry":

--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -38,6 +38,7 @@ var istioConfigCriteria = business.IstioConfigCriteria{
 	IncludeWorkloadEntries:        true,
 	IncludeWorkloadGroups:         true,
 	IncludeEnvoyFilters:           true,
+	IncludeTrafficExtensions:      true,
 	IncludeWasmPlugins:            true,
 	IncludeTelemetry:              true,
 }
@@ -106,6 +107,7 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 	envoyFilters := istioConfig.EnvoyFilters
 	workloadEntries := istioConfig.WorkloadEntries
 	workloadGroups := istioConfig.WorkloadGroups
+	trafficExtensions := istioConfig.TrafficExtensions
 	wasmPlugins := istioConfig.WasmPlugins
 	telemetries := istioConfig.Telemetries
 	authorizationPolicies := istioConfig.AuthorizationPolicies
@@ -324,6 +326,19 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 			Version:    kubernetes.WorkloadGroups.Version,
 			Kind:       kubernetes.WorkloadGroups.Kind,
 			Validation: validationSummaryForRuntimeObject(wg, kubernetes.WorkloadGroups, istioValidations, cluster),
+		})
+	}
+	for _, te := range trafficExtensions {
+		if te == nil {
+			continue
+		}
+		items = append(items, IstioListItem{
+			Name:       te.Name,
+			Namespace:  te.Namespace,
+			Group:      kubernetes.TrafficExtensions.Group,
+			Version:    kubernetes.TrafficExtensions.Version,
+			Kind:       kubernetes.TrafficExtensions.Kind,
+			Validation: validationSummaryForRuntimeObject(te, kubernetes.TrafficExtensions, istioValidations, cluster),
 		})
 	}
 	for _, wp := range wasmPlugins {
@@ -726,6 +741,21 @@ func criteriaForListFilter(group, kind string) business.IstioConfigCriteria {
 		switch kind {
 		case "InferencePool":
 			c.IncludeK8sInferencePools = true
+			return c
+		}
+	case "extensions.istio.io":
+		switch kind {
+		case "TrafficExtension":
+			c.IncludeTrafficExtensions = true
+			return c
+		case "WasmPlugin":
+			c.IncludeWasmPlugins = true
+			return c
+		}
+	case "telemetry.istio.io":
+		switch kind {
+		case "Telemetry":
+			c.IncludeTelemetry = true
 			return c
 		}
 	}

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
@@ -164,4 +165,114 @@ func TestIstioList_FilterByService(t *testing.T) {
 	_, hasRatingsDR := names["ratings-dr"]
 	assert.False(t, hasRatingsVS)
 	assert.False(t, hasRatingsDR)
+}
+
+func TestCriteriaForListFilter(t *testing.T) {
+	tests := []struct {
+		name          string
+		group         string
+		kind          string
+		expectDefault bool
+		checkField    func(business.IstioConfigCriteria) bool
+	}{
+		{
+			name:       "TrafficExtension returns targeted criteria",
+			group:      "extensions.istio.io",
+			kind:       "TrafficExtension",
+			checkField: func(c business.IstioConfigCriteria) bool { return c.IncludeTrafficExtensions },
+		},
+		{
+			name:       "WasmPlugin returns targeted criteria",
+			group:      "extensions.istio.io",
+			kind:       "WasmPlugin",
+			checkField: func(c business.IstioConfigCriteria) bool { return c.IncludeWasmPlugins },
+		},
+		{
+			name:       "Telemetry returns targeted criteria",
+			group:      "telemetry.istio.io",
+			kind:       "Telemetry",
+			checkField: func(c business.IstioConfigCriteria) bool { return c.IncludeTelemetry },
+		},
+		{
+			name:       "VirtualService returns targeted criteria",
+			group:      "networking.istio.io",
+			kind:       "VirtualService",
+			checkField: func(c business.IstioConfigCriteria) bool { return c.IncludeVirtualServices },
+		},
+		{
+			name:       "DestinationRule returns targeted criteria",
+			group:      "networking.istio.io",
+			kind:       "DestinationRule",
+			checkField: func(c business.IstioConfigCriteria) bool { return c.IncludeDestinationRules },
+		},
+		{
+			name:          "unknown group/kind returns default (include-all) criteria",
+			group:         "unknown.io",
+			kind:          "Unknown",
+			expectDefault: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := criteriaForListFilter(tt.group, tt.kind)
+
+			if tt.expectDefault {
+				assert.True(t, c.IncludeTrafficExtensions)
+				assert.True(t, c.IncludeWasmPlugins)
+				assert.True(t, c.IncludeVirtualServices)
+				assert.True(t, c.IncludeTelemetry)
+				return
+			}
+
+			assert.True(t, tt.checkField(c), "expected criteria field to be true for %s/%s", tt.group, tt.kind)
+
+			allOthersOff := !c.IncludeGateways &&
+				!c.IncludeK8sGateways &&
+				!c.IncludeK8sGRPCRoutes &&
+				!c.IncludeK8sHTTPRoutes
+			assert.True(t, allOthersOff, "non-targeted criteria fields should remain false for %s/%s", tt.group, tt.kind)
+		})
+	}
+}
+
+func TestCriteriaForListFilter_ExtensionsMutualExclusion(t *testing.T) {
+	txCriteria := criteriaForListFilter("extensions.istio.io", "TrafficExtension")
+	assert.True(t, txCriteria.IncludeTrafficExtensions)
+	assert.False(t, txCriteria.IncludeWasmPlugins)
+
+	wpCriteria := criteriaForListFilter("extensions.istio.io", "WasmPlugin")
+	assert.True(t, wpCriteria.IncludeWasmPlugins)
+	assert.False(t, wpCriteria.IncludeTrafficExtensions)
+}
+
+func TestCriteriaForListFilter_UnknownKindInKnownGroup(t *testing.T) {
+	c := criteriaForListFilter("extensions.istio.io", "NonExistent")
+	assert.True(t, c.IncludeTrafficExtensions, "unknown kind in known group should fall through to default")
+	assert.True(t, c.IncludeWasmPlugins)
+	assert.True(t, c.IncludeVirtualServices)
+}
+
+func TestIstioList_IncludesTrafficExtensions(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	ns := &core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "bookinfo"}}
+	k8s := kubetest.NewFakeK8sClient(ns)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+
+	args := map[string]interface{}{
+		"namespace": "bookinfo",
+		"group":     kubernetes.TrafficExtensions.Group,
+		"kind":      kubernetes.TrafficExtensions.Kind,
+	}
+
+	res, status := IstioList(context.Background(), args, businessLayer, conf)
+	require.Equal(t, http.StatusOK, status)
+
+	result, ok := res.(IstioListResult)
+	require.True(t, ok)
+	assert.Equal(t, "east", result.Cluster)
+	assert.Empty(t, result.Items)
 }

--- a/business/checkers/traffic_extension_checker.go
+++ b/business/checkers/traffic_extension_checker.go
@@ -1,0 +1,22 @@
+package checkers
+
+import (
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+
+	"github.com/kiali/kiali/models"
+)
+
+type TrafficExtensionChecker struct {
+	Namespaces        models.Namespaces
+	TrafficExtensions []*extentions_v1alpha1.TrafficExtension
+}
+
+// An Object Checker runs all checkers for an specific object type (i.e.: pod, route rule,...)
+// It run two kinds of checkers:
+// 1. Individual checks: validating individual objects.
+// 2. Group checks: validating behaviour between configurations.
+func (in TrafficExtensionChecker) Check() models.IstioValidations {
+	validations := models.IstioValidations{}
+
+	return validations
+}

--- a/business/checkers/traffic_extension_checker_test.go
+++ b/business/checkers/traffic_extension_checker_test.go
@@ -1,0 +1,50 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiali/kiali/models"
+)
+
+func TestTrafficExtensionCheckerReturnsNoValidations(t *testing.T) {
+	checker := TrafficExtensionChecker{
+		Namespaces: models.Namespaces{},
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "my-filter", Namespace: "test"}},
+		},
+	}
+
+	validations := checker.Check()
+	assert.NotNil(t, validations)
+	assert.Empty(t, validations)
+}
+
+func TestTrafficExtensionCheckerHandlesNilList(t *testing.T) {
+	checker := TrafficExtensionChecker{
+		Namespaces:        models.Namespaces{},
+		TrafficExtensions: nil,
+	}
+
+	validations := checker.Check()
+	assert.NotNil(t, validations)
+	assert.Empty(t, validations)
+}
+
+func TestTrafficExtensionCheckerHandlesMultipleItems(t *testing.T) {
+	checker := TrafficExtensionChecker{
+		Namespaces: models.Namespaces{},
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "ns1"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-b", Namespace: "ns1"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-c", Namespace: "ns2"}},
+		},
+	}
+
+	validations := checker.Check()
+	assert.NotNil(t, validations)
+	assert.Empty(t, validations)
+}

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -45,6 +45,9 @@ type IstioConfigService struct {
 }
 
 type IstioConfigCriteria struct {
+	IncludeAuthorizationPolicies  bool
+	IncludeDestinationRules       bool
+	IncludeEnvoyFilters           bool
 	IncludeGateways               bool
 	IncludeK8sGateways            bool
 	IncludeK8sGRPCRoutes          bool
@@ -53,19 +56,16 @@ type IstioConfigCriteria struct {
 	IncludeK8sReferenceGrants     bool
 	IncludeK8sTCPRoutes           bool
 	IncludeK8sTLSRoutes           bool
-	IncludeVirtualServices        bool
-	IncludeDestinationRules       bool
+	IncludePeerAuthentications    bool
+	IncludeRequestAuthentications bool
 	IncludeServiceEntries         bool
 	IncludeSidecars               bool
-	IncludeAuthorizationPolicies  bool
-	IncludePeerAuthentications    bool
+	IncludeTelemetry              bool
+	IncludeTrafficExtensions      bool
+	IncludeVirtualServices        bool
+	IncludeWasmPlugins            bool
 	IncludeWorkloadEntries        bool
 	IncludeWorkloadGroups         bool
-	IncludeRequestAuthentications bool
-	IncludeEnvoyFilters           bool
-	IncludeTrafficExtensions      bool
-	IncludeWasmPlugins            bool
-	IncludeTelemetry              bool
 	LabelSelector                 string
 	WorkloadSelector              string
 }
@@ -74,6 +74,12 @@ func (icc IstioConfigCriteria) Include(resource schema.GroupVersionKind) bool {
 	// Flag used to skip object that are not used in a query when a WorkloadSelector is present
 	isWorkloadSelector := icc.WorkloadSelector != ""
 	switch resource {
+	case kubernetes.AuthorizationPolicies:
+		return icc.IncludeAuthorizationPolicies
+	case kubernetes.DestinationRules:
+		return icc.IncludeDestinationRules && !isWorkloadSelector
+	case kubernetes.EnvoyFilters:
+		return icc.IncludeEnvoyFilters
 	case kubernetes.Gateways:
 		return icc.IncludeGateways
 	case kubernetes.K8sGateways:
@@ -90,32 +96,26 @@ func (icc IstioConfigCriteria) Include(resource schema.GroupVersionKind) bool {
 		return icc.IncludeK8sTCPRoutes
 	case kubernetes.K8sTLSRoutes:
 		return icc.IncludeK8sTLSRoutes
-	case kubernetes.VirtualServices:
-		return icc.IncludeVirtualServices && !isWorkloadSelector
-	case kubernetes.DestinationRules:
-		return icc.IncludeDestinationRules && !isWorkloadSelector
+	case kubernetes.PeerAuthentications:
+		return icc.IncludePeerAuthentications
+	case kubernetes.RequestAuthentications:
+		return icc.IncludeRequestAuthentications
 	case kubernetes.ServiceEntries:
 		return icc.IncludeServiceEntries && !isWorkloadSelector
 	case kubernetes.Sidecars:
 		return icc.IncludeSidecars
-	case kubernetes.AuthorizationPolicies:
-		return icc.IncludeAuthorizationPolicies
-	case kubernetes.PeerAuthentications:
-		return icc.IncludePeerAuthentications
+	case kubernetes.Telemetries:
+		return icc.IncludeTelemetry
+	case kubernetes.TrafficExtensions:
+		return icc.IncludeTrafficExtensions
+	case kubernetes.VirtualServices:
+		return icc.IncludeVirtualServices && !isWorkloadSelector
+	case kubernetes.WasmPlugins:
+		return icc.IncludeWasmPlugins
 	case kubernetes.WorkloadEntries:
 		return icc.IncludeWorkloadEntries && !isWorkloadSelector
 	case kubernetes.WorkloadGroups:
 		return icc.IncludeWorkloadGroups
-	case kubernetes.RequestAuthentications:
-		return icc.IncludeRequestAuthentications
-	case kubernetes.EnvoyFilters:
-		return icc.IncludeEnvoyFilters
-	case kubernetes.TrafficExtensions:
-		return icc.IncludeTrafficExtensions
-	case kubernetes.WasmPlugins:
-		return icc.IncludeWasmPlugins
-	case kubernetes.Telemetries:
-		return icc.IncludeTelemetry
 	}
 	return false
 }

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -13,6 +13,7 @@ import (
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	telemetry_v1 "istio.io/client-go/pkg/apis/telemetry/v1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	api_meta "k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -62,6 +63,7 @@ type IstioConfigCriteria struct {
 	IncludeWorkloadGroups         bool
 	IncludeRequestAuthentications bool
 	IncludeEnvoyFilters           bool
+	IncludeTrafficExtensions      bool
 	IncludeWasmPlugins            bool
 	IncludeTelemetry              bool
 	LabelSelector                 string
@@ -108,6 +110,8 @@ func (icc IstioConfigCriteria) Include(resource schema.GroupVersionKind) bool {
 		return icc.IncludeRequestAuthentications
 	case kubernetes.EnvoyFilters:
 		return icc.IncludeEnvoyFilters
+	case kubernetes.TrafficExtensions:
+		return icc.IncludeTrafficExtensions
 	case kubernetes.WasmPlugins:
 		return icc.IncludeWasmPlugins
 	case kubernetes.Telemetries:
@@ -204,16 +208,17 @@ func ToPtrs[T any](s []T) []*T {
 
 func (in *IstioConfigService) getIstioConfigList(ctx context.Context, cluster string, namespace string, criteria IstioConfigCriteria) (*models.IstioConfigList, error) {
 	istioConfigList := &models.IstioConfigList{
-		DestinationRules: []*networking_v1.DestinationRule{},
-		EnvoyFilters:     []*networking_v1alpha3.EnvoyFilter{},
-		Gateways:         []*networking_v1.Gateway{},
-		VirtualServices:  []*networking_v1.VirtualService{},
-		ServiceEntries:   []*networking_v1.ServiceEntry{},
-		Sidecars:         []*networking_v1.Sidecar{},
-		WorkloadEntries:  []*networking_v1.WorkloadEntry{},
-		WorkloadGroups:   []*networking_v1.WorkloadGroup{},
-		WasmPlugins:      []*extentions_v1alpha1.WasmPlugin{},
-		Telemetries:      []*telemetry_v1.Telemetry{},
+		DestinationRules:  []*networking_v1.DestinationRule{},
+		EnvoyFilters:      []*networking_v1alpha3.EnvoyFilter{},
+		Gateways:          []*networking_v1.Gateway{},
+		VirtualServices:   []*networking_v1.VirtualService{},
+		ServiceEntries:    []*networking_v1.ServiceEntry{},
+		Sidecars:          []*networking_v1.Sidecar{},
+		WorkloadEntries:   []*networking_v1.WorkloadEntry{},
+		WorkloadGroups:    []*networking_v1.WorkloadGroup{},
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{},
+		WasmPlugins:       []*extentions_v1alpha1.WasmPlugin{},
+		Telemetries:       []*telemetry_v1.Telemetry{},
 
 		K8sGateways:        []*k8s_networking_v1.Gateway{},
 		K8sGRPCRoutes:      []*k8s_networking_v1.GRPCRoute{},
@@ -457,6 +462,24 @@ func (in *IstioConfigService) getIstioConfigList(ctx context.Context, cluster st
 		}
 	}
 
+	// TrafficExtension is only available on Istio >= 1.30 extended channel.
+	// If the CRD is not present in the cluster the cache List returns a "no match for kind"
+	// error; skip it gracefully so older Istio versions keep working.
+	if userClient.IsIstioAPI() && criteria.Include(kubernetes.TrafficExtensions) {
+		list := &extentions_v1alpha1.TrafficExtensionList{}
+		if err := kubeCache.List(ctx, list, listOpts...); err != nil {
+			if !api_meta.IsNoMatchError(err) {
+				return nil, err
+			}
+			log.FromContext(ctx).Debug().Msgf("TrafficExtension CRD not available in cluster [%s], skipping", cluster)
+		} else {
+			if err := kubernetes.EnsureTypeMeta(list); err != nil {
+				return nil, err
+			}
+			istioConfigList.TrafficExtensions = list.Items
+		}
+	}
+
 	if criteria.Include(kubernetes.WasmPlugins) {
 		list := &extentions_v1alpha1.WasmPluginList{}
 		if err := kubeCache.List(ctx, list, listOpts...); err != nil {
@@ -567,6 +590,7 @@ func (in *IstioConfigService) GetIstioConfigList(ctx context.Context, cluster st
 		ServiceEntries:         kubernetes.FilterByNamespaceNames(istioConfigs.ServiceEntries, namespaceNames),
 		Sidecars:               kubernetes.FilterByNamespaceNames(istioConfigs.Sidecars, namespaceNames),
 		Telemetries:            kubernetes.FilterByNamespaceNames(istioConfigs.Telemetries, namespaceNames),
+		TrafficExtensions:      kubernetes.FilterByNamespaceNames(istioConfigs.TrafficExtensions, namespaceNames),
 		VirtualServices:        kubernetes.FilterByNamespaceNames(istioConfigs.VirtualServices, namespaceNames),
 		WasmPlugins:            kubernetes.FilterByNamespaceNames(istioConfigs.WasmPlugins, namespaceNames),
 		WorkloadEntries:        kubernetes.FilterByNamespaceNames(istioConfigs.WorkloadEntries, namespaceNames),
@@ -726,6 +750,13 @@ func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, cluster
 			istioConfigDetail.WorkloadGroup.APIVersion = kubernetes.WorkloadGroups.GroupVersion().String()
 			istioConfigDetail.Object = istioConfigDetail.WorkloadGroup
 		}
+	case kubernetes.TrafficExtensions:
+		istioConfigDetail.TrafficExtension, err = in.userClients[cluster].Istio().ExtensionsV1alpha1().TrafficExtensions(namespace).Get(ctx, object, getOpts)
+		if err == nil {
+			istioConfigDetail.TrafficExtension.Kind = kubernetes.TrafficExtensions.Kind
+			istioConfigDetail.TrafficExtension.APIVersion = kubernetes.TrafficExtensions.GroupVersion().String()
+			istioConfigDetail.Object = istioConfigDetail.TrafficExtension
+		}
 	case kubernetes.WasmPlugins:
 		istioConfigDetail.WasmPlugin, err = in.userClients[cluster].Istio().ExtensionsV1alpha1().WasmPlugins(namespace).Get(ctx, object, getOpts)
 		if err == nil {
@@ -834,6 +865,8 @@ func (in *IstioConfigService) DeleteIstioConfigDetail(ctx context.Context, clust
 		err = userClient.Istio().SecurityV1().PeerAuthentications(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.RequestAuthentications:
 		err = userClient.Istio().SecurityV1().RequestAuthentications(namespace).Delete(ctx, name, delOpts)
+	case kubernetes.TrafficExtensions:
+		err = userClient.Istio().ExtensionsV1alpha1().TrafficExtensions(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.WasmPlugins:
 		err = userClient.Istio().ExtensionsV1alpha1().WasmPlugins(namespace).Delete(ctx, name, delOpts)
 	case kubernetes.Telemetries:
@@ -988,6 +1021,10 @@ func (in *IstioConfigService) UpdateIstioConfigDetail(ctx context.Context, clust
 		istioConfigDetail.RequestAuthentication = &security_v1.RequestAuthentication{}
 		istioConfigDetail.RequestAuthentication, err = userClient.Istio().SecurityV1().RequestAuthentications(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
 		istioConfigDetail.Object = istioConfigDetail.RequestAuthentication
+	case kubernetes.TrafficExtensions.String():
+		istioConfigDetail.TrafficExtension = &extentions_v1alpha1.TrafficExtension{}
+		istioConfigDetail.TrafficExtension, err = userClient.Istio().ExtensionsV1alpha1().TrafficExtensions(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
+		istioConfigDetail.Object = istioConfigDetail.TrafficExtension
 	case kubernetes.WasmPlugins.String():
 		istioConfigDetail.WasmPlugin = &extentions_v1alpha1.WasmPlugin{}
 		istioConfigDetail.WasmPlugin, err = userClient.Istio().ExtensionsV1alpha1().WasmPlugins(namespace).Patch(ctx, name, patchType, bytePatch, patchOpts)
@@ -1149,6 +1186,15 @@ func (in *IstioConfigService) CreateIstioConfigDetail(ctx context.Context, clust
 		istioConfigDetail.WorkloadGroup, err = userClient.Istio().NetworkingV1().WorkloadGroups(namespace).Create(ctx, istioConfigDetail.WorkloadGroup, createOpts)
 		istioConfigDetail.Object = istioConfigDetail.WorkloadGroup
 		name = istioConfigDetail.WorkloadGroup.Name
+	case kubernetes.TrafficExtensions.String():
+		istioConfigDetail.TrafficExtension = &extentions_v1alpha1.TrafficExtension{}
+		err = json.Unmarshal(body, istioConfigDetail.TrafficExtension)
+		if err != nil {
+			return istioConfigDetail, api_errors.NewBadRequest(err.Error())
+		}
+		istioConfigDetail.TrafficExtension, err = userClient.Istio().ExtensionsV1alpha1().TrafficExtensions(namespace).Create(ctx, istioConfigDetail.TrafficExtension, createOpts)
+		istioConfigDetail.Object = istioConfigDetail.TrafficExtension
+		name = istioConfigDetail.TrafficExtension.Name
 	case kubernetes.WasmPlugins.String():
 		istioConfigDetail.WasmPlugin = &extentions_v1alpha1.WasmPlugin{}
 		err = json.Unmarshal(body, istioConfigDetail.WasmPlugin)
@@ -1385,6 +1431,7 @@ func ParseIstioConfigCriteria(objects, labelSelector, workloadSelector string) I
 	criteria.IncludeWorkloadGroups = defaultInclude
 	criteria.IncludeRequestAuthentications = defaultInclude
 	criteria.IncludeEnvoyFilters = defaultInclude
+	criteria.IncludeTrafficExtensions = defaultInclude
 	criteria.IncludeWasmPlugins = defaultInclude
 	criteria.IncludeTelemetry = defaultInclude
 	criteria.LabelSelector = labelSelector
@@ -1442,6 +1489,9 @@ func ParseIstioConfigCriteria(objects, labelSelector, workloadSelector string) I
 	}
 	if checkType(types, kubernetes.WorkloadGroups.String()) {
 		criteria.IncludeWorkloadGroups = true
+	}
+	if checkType(types, kubernetes.TrafficExtensions.String()) {
+		criteria.IncludeTrafficExtensions = true
 	}
 	if checkType(types, kubernetes.WasmPlugins.String()) {
 		criteria.IncludeWasmPlugins = true

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -2,6 +2,7 @@ package business
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	api_networking_v1 "istio.io/api/networking/v1"
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	auth_v1 "k8s.io/api/authorization/v1"
 	core_v1 "k8s.io/api/core/v1"
@@ -686,6 +688,157 @@ deployment:
 	require.NoError(err)
 
 	assert.Len(istioConfigList.Gateways, 4)
+}
+
+func fakeGetTrafficExtensions() []*extentions_v1alpha1.TrafficExtension {
+	tx1 := &extentions_v1alpha1.TrafficExtension{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "my-wasm-filter",
+			Namespace: "test",
+		},
+	}
+	tx2 := &extentions_v1alpha1.TrafficExtension{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "my-lua-filter",
+			Namespace: "test",
+		},
+	}
+	return []*extentions_v1alpha1.TrafficExtension{tx1, tx2}
+}
+
+func TestGetIstioConfigListIncludesTrafficExtensions(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	fakeIstioObjects := []runtime.Object{
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "test"}},
+	}
+	for _, tx := range fakeGetTrafficExtensions() {
+		fakeIstioObjects = append(fakeIstioObjects, tx.DeepCopyObject())
+	}
+	k8s := kubetest.NewFakeK8sClient(fakeIstioObjects...)
+
+	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
+
+	// Without IncludeTrafficExtensions, list should be empty.
+	criteria := IstioConfigCriteria{IncludeTrafficExtensions: false}
+	list, err := configService.GetIstioConfigList(context.TODO(), cluster, criteria)
+	assert.Nil(err)
+	assert.Equal(0, len(list.TrafficExtensions))
+
+	// With IncludeTrafficExtensions, both objects should be returned.
+	criteria.IncludeTrafficExtensions = true
+	list, err = configService.GetIstioConfigList(context.TODO(), cluster, criteria)
+	assert.Nil(err)
+	assert.Equal(2, len(list.TrafficExtensions))
+
+	names := []string{list.TrafficExtensions[0].Name, list.TrafficExtensions[1].Name}
+	assert.Contains(names, "my-wasm-filter")
+	assert.Contains(names, "my-lua-filter")
+}
+
+func TestGetIstioConfigDetailsTrafficExtension(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	txObjects := fakeGetTrafficExtensions()
+	fakeIstioObjects := []runtime.Object{
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "test"}},
+		txObjects[0],
+	}
+	k8s := kubetest.NewFakeK8sClient(fakeIstioObjects...)
+	k8s.OpenShift = true
+
+	configService := NewLayerBuilder(t, conf).WithClient(&fakeAccessReview{k8s}).Build().IstioConfig
+
+	details, err := configService.GetIstioConfigDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "test", kubernetes.TrafficExtensions, "my-wasm-filter")
+	assert.Nil(err)
+	assert.NotNil(details.TrafficExtension)
+	assert.Equal("my-wasm-filter", details.TrafficExtension.Name)
+	assert.Equal("test", details.TrafficExtension.Namespace)
+}
+
+func TestDeleteIstioConfigDetailsTrafficExtension(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	tx := fakeGetTrafficExtensions()[0]
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("test"),
+		tx,
+	)
+
+	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
+
+	err := configService.DeleteIstioConfigDetail(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.TrafficExtensions, "my-wasm-filter")
+	assert.Nil(err)
+}
+
+func TestCreateIstioConfigDetailsTrafficExtension(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("test"))
+	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
+
+	payload, _ := json.Marshal(map[string]any{
+		"apiVersion": "extensions.istio.io/v1alpha1",
+		"kind":       "TrafficExtension",
+		"metadata":   map[string]string{"name": "new-filter", "namespace": "test"},
+	})
+	details, err := configService.CreateIstioConfigDetail(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.TrafficExtensions, payload)
+	assert.Nil(err)
+	assert.Equal("test", details.Namespace.Name)
+	assert.Equal(conf.KubernetesConfig.ClusterName, details.Namespace.Cluster)
+	assert.Equal(kubernetes.TrafficExtensions.String(), details.ObjectGVK.String())
+}
+
+func TestUpdateIstioConfigDetailsTrafficExtension(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	tx := fakeGetTrafficExtensions()[0]
+	k8s := kubetest.NewFakeK8sClient(
+		kubetest.FakeNamespace("test"),
+		tx,
+	)
+	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
+
+	updated, err := configService.UpdateIstioConfigDetail(context.Background(), conf.KubernetesConfig.ClusterName, "test", kubernetes.TrafficExtensions, "my-wasm-filter", "{}")
+	require.NoError(err)
+	assert.Equal("test", updated.Namespace.Name)
+	assert.Equal(conf.KubernetesConfig.ClusterName, updated.Namespace.Cluster)
+	assert.Equal(kubernetes.TrafficExtensions.String(), updated.ObjectGVK.String())
+	assert.Equal("my-wasm-filter", updated.TrafficExtension.Name)
+}
+
+func TestGetIstioConfigListTrafficExtensionsMissingCRD(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	// Build a client without any TrafficExtension objects - the cache will simply return empty.
+	// A missing CRD is handled in GetIstioConfigList via api_meta.IsNoMatchError; here we verify
+	// that when IsIstioAPI() returns true (the default for the fake client) and the list succeeds
+	// with zero items, the result is an empty (non-nil) slice.
+	k8s := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "test"}},
+	)
+	configService := NewLayerBuilder(t, conf).WithClient(k8s).Build().IstioConfig
+
+	criteria := IstioConfigCriteria{IncludeTrafficExtensions: true}
+	list, err := configService.GetIstioConfigList(context.TODO(), cluster, criteria)
+	assert.Nil(err)
+	assert.NotNil(list.TrafficExtensions)
+	assert.Equal(0, len(list.TrafficExtensions))
 }
 
 func TestUpdateIstioObjectWithoutValidations(t *testing.T) {

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -32,6 +32,8 @@ func TestParseListParams(t *testing.T) {
 	assert.True(t, criteria.IncludeVirtualServices)
 	assert.True(t, criteria.IncludeDestinationRules)
 	assert.True(t, criteria.IncludeServiceEntries)
+	assert.True(t, criteria.IncludeTrafficExtensions)
+	assert.True(t, criteria.IncludeWasmPlugins)
 
 	objects = kubernetes.Gateways.String()
 	criteria = ParseIstioConfigCriteria(objects, labelSelector, "")
@@ -89,6 +91,22 @@ func TestParseListParams(t *testing.T) {
 	assert.True(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
 
+	objects = kubernetes.TrafficExtensions.String()
+	criteria = ParseIstioConfigCriteria(objects, labelSelector, "")
+
+	assert.True(t, criteria.IncludeTrafficExtensions)
+	assert.False(t, criteria.IncludeWasmPlugins)
+	assert.False(t, criteria.IncludeGateways)
+	assert.False(t, criteria.IncludeVirtualServices)
+	assert.False(t, criteria.IncludeDestinationRules)
+
+	objects = kubernetes.WasmPlugins.String()
+	criteria = ParseIstioConfigCriteria(objects, labelSelector, "")
+
+	assert.True(t, criteria.IncludeWasmPlugins)
+	assert.False(t, criteria.IncludeTrafficExtensions)
+	assert.False(t, criteria.IncludeGateways)
+
 	objects = "notsupported"
 	criteria = ParseIstioConfigCriteria(objects, labelSelector, "")
 
@@ -96,6 +114,7 @@ func TestParseListParams(t *testing.T) {
 	assert.False(t, criteria.IncludeVirtualServices)
 	assert.False(t, criteria.IncludeDestinationRules)
 	assert.False(t, criteria.IncludeServiceEntries)
+	assert.False(t, criteria.IncludeTrafficExtensions)
 }
 
 func TestGetIstioConfigList(t *testing.T) {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -479,6 +479,9 @@ func detectClusterConfigChange(vInfo *validationInfo) bool {
 	for _, c := range config.VirtualServices {
 		change = vInfo.update("VS", cluster, c.Namespace, c.Name, c.ResourceVersion) || change
 	}
+	for _, c := range config.TrafficExtensions {
+		change = vInfo.update("TX", cluster, c.Namespace, c.Name, c.ResourceVersion) || change
+	}
 	for _, c := range config.WasmPlugins {
 		change = vInfo.update("WP", cluster, c.Namespace, c.Name, c.ResourceVersion) || change
 	}
@@ -507,6 +510,7 @@ func detectClusterConfigChange(vInfo *validationInfo) bool {
 		len(config.VirtualServices) +
 		len(config.WorkloadEntries) +
 		len(config.WorkloadGroups) +
+		len(config.TrafficExtensions) +
 		len(config.WasmPlugins)
 	change = vInfo.update("validation-num-config", cluster, "", "", strconv.Itoa(numConfig)) || change
 
@@ -554,6 +558,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) (
 		checkers.NewSidecarChecker(cluster, conf, identityDomain, vInfo.clusterInfo.rootNamespaces, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace),
 		checkers.TelemetryChecker{Namespaces: namespaces, Telemetries: istioConfigList.Telemetries},
 		checkers.VirtualServiceChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices},
+		checkers.TrafficExtensionChecker{Namespaces: namespaces, TrafficExtensions: istioConfigList.TrafficExtensions},
 		checkers.WasmPluginChecker{Namespaces: namespaces, WasmPlugins: istioConfigList.WasmPlugins},
 		checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, vInfo.clusterInfo.rootNamespaces, namespaces, workloadsPerNamespace),
 		checkers.WorkloadGroupsChecker{Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, ServiceAccounts: vInfo.saMap, WorkloadGroups: istioConfigList.WorkloadGroups},
@@ -752,6 +757,8 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		objectCheckers = []checkers.ObjectChecker{requestAuthnChecker}
 	case kubernetes.EnvoyFilters:
 		// Validation on EnvoyFilters are not yet in place
+	case kubernetes.TrafficExtensions:
+		// Validation on TrafficExtensions is not expected
 	case kubernetes.WasmPlugins:
 		// Validation on WasmPlugins is not expected
 	case kubernetes.Telemetries:
@@ -1130,6 +1137,7 @@ func filterIstioConfigByManagedNamespaces(config *models.IstioConfigList, mesh *
 	config.Sidecars = kubernetes.FilterByNamespaceNames(config.Sidecars, allowedNames)
 	config.Telemetries = kubernetes.FilterByNamespaceNames(config.Telemetries, allowedNames)
 	config.VirtualServices = kubernetes.FilterByNamespaceNames(config.VirtualServices, allowedNames)
+	config.TrafficExtensions = kubernetes.FilterByNamespaceNames(config.TrafficExtensions, allowedNames)
 	config.WasmPlugins = kubernetes.FilterByNamespaceNames(config.WasmPlugins, allowedNames)
 	config.WorkloadEntries = kubernetes.FilterByNamespaceNames(config.WorkloadEntries, allowedNames)
 	config.WorkloadGroups = kubernetes.FilterByNamespaceNames(config.WorkloadGroups, allowedNames)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -287,6 +287,7 @@ func makeWatchErrorHandler(getCache func() ctrlcache.Cache, k8sClient kubernetes
 			&networkingv1.VirtualService{},
 			&networkingv1.WorkloadEntry{},
 			&networkingv1.WorkloadGroup{},
+			&extentionsv1alpha1.TrafficExtension{},
 			&extentionsv1alpha1.WasmPlugin{},
 			&networkingv1alpha3.EnvoyFilter{},
 			&securityv1.AuthorizationPolicy{},

--- a/frontend/cypress/integration/common/istio_config_type_filters.ts
+++ b/frontend/cypress/integration/common/istio_config_type_filters.ts
@@ -44,6 +44,7 @@ Then('user can see the filter options', () => {
     'ServiceEntry',
     'Sidecar',
     'Telemetry',
+    'TrafficExtension',
     'VirtualService',
     'WasmPlugin',
     'WorkloadEntry',

--- a/frontend/src/components/Pf/PfBadges.tsx
+++ b/frontend/src/components/Pf/PfBadges.tsx
@@ -92,6 +92,7 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
   ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadgeType,
   ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadgeType,
   Sidecar: { badge: 'SC', tt: 'Sidecar' } as PFBadgeType,
+  TrafficExtension: { badge: 'TX', tt: 'Istio Traffic Extension' } as PFBadgeType,
   WasmPlugin: { badge: 'WP', tt: 'Istio Wasm Plugin' } as PFBadgeType,
   Telemetry: { badge: 'TM', tt: 'Istio Telemetry' } as PFBadgeType,
   Template: { badge: 'T', tt: 'Template' } as PFBadgeType,

--- a/frontend/src/mocks/handlers/istio.ts
+++ b/frontend/src/mocks/handlers/istio.ts
@@ -406,6 +406,7 @@ const createPermissionsForNamespace = (): Record<string, { create: boolean; dele
   'networking.istio.io/v1, Kind=WorkloadGroup': { create: true, delete: true, update: true },
   'networking.istio.io/v1alpha3, Kind=EnvoyFilter': { create: true, delete: true, update: true },
   'telemetry.istio.io/v1, Kind=Telemetry': { create: true, delete: true, update: true },
+  'extensions.istio.io/v1alpha1, Kind=TrafficExtension': { create: true, delete: true, update: true },
   'extensions.istio.io/v1alpha1, Kind=WasmPlugin': { create: true, delete: true, update: true },
   'gateway.networking.k8s.io/v1, Kind=Gateway': { create: true, delete: true, update: true },
   'gateway.networking.k8s.io/v1, Kind=HTTPRoute': { create: true, delete: true, update: true },

--- a/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/frontend/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -166,6 +166,10 @@ export const istioTypeFilter: FilterType = {
       title: 'Telemetry'
     },
     {
+      id: 'TrafficExtension',
+      title: 'TrafficExtension'
+    },
+    {
       id: 'VirtualService',
       title: 'VirtualService'
     },

--- a/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/frontend/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -79,6 +79,7 @@ describe('IstioConfigList#filterByName', () => {
     expect(filtered.resources[getGVKTypeString(gvkType.VirtualService)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.DestinationRule)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.ServiceEntry)].length).toBe(0);
+    expect(filtered.resources[getGVKTypeString(gvkType.TrafficExtension)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.WasmPlugin)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.Telemetry)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.K8sGateway)].length).toBe(0);

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -61,6 +61,7 @@ export enum gvkType {
   WorkloadEntry = 'WorkloadEntry',
   WorkloadGroup = 'WorkloadGroup',
 
+  TrafficExtension = 'TrafficExtension',
   WasmPlugin = 'WasmPlugin',
   Telemetry = 'Telemetry',
 
@@ -98,6 +99,7 @@ export const dicTypeToGVK: { [key in gvkType]: GroupVersionKind } = {
   [gvkType.WorkloadEntry]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadEntry },
   [gvkType.WorkloadGroup]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadGroup },
 
+  [gvkType.TrafficExtension]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.TrafficExtension },
   [gvkType.WasmPlugin]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.WasmPlugin },
   [gvkType.Telemetry]: { Group: 'telemetry.istio.io', Version: 'v1', Kind: gvkType.Telemetry },
 

--- a/frontend/src/types/IstioConfigList.ts
+++ b/frontend/src/types/IstioConfigList.ts
@@ -53,17 +53,17 @@ export enum gvkType {
   RequestAuthentication = 'RequestAuthentication',
 
   DestinationRule = 'DestinationRule',
-  Gateway = 'Gateway',
   EnvoyFilter = 'EnvoyFilter',
-  Sidecar = 'Sidecar',
+  Gateway = 'Gateway',
   ServiceEntry = 'ServiceEntry',
+  Sidecar = 'Sidecar',
   VirtualService = 'VirtualService',
   WorkloadEntry = 'WorkloadEntry',
   WorkloadGroup = 'WorkloadGroup',
 
+  Telemetry = 'Telemetry',
   TrafficExtension = 'TrafficExtension',
   WasmPlugin = 'WasmPlugin',
-  Telemetry = 'Telemetry',
 
   K8sGateway = 'K8sGateway',
   K8sGatewayClass = 'K8sGatewayClass',
@@ -91,17 +91,17 @@ export const dicTypeToGVK: { [key in gvkType]: GroupVersionKind } = {
   [gvkType.RequestAuthentication]: { Group: 'security.istio.io', Version: 'v1', Kind: gvkType.RequestAuthentication },
 
   [gvkType.DestinationRule]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.DestinationRule },
-  [gvkType.Gateway]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Gateway },
   [gvkType.EnvoyFilter]: { Group: 'networking.istio.io', Version: 'v1alpha3', Kind: gvkType.EnvoyFilter },
-  [gvkType.Sidecar]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Sidecar },
+  [gvkType.Gateway]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Gateway },
   [gvkType.ServiceEntry]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.ServiceEntry },
+  [gvkType.Sidecar]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Sidecar },
   [gvkType.VirtualService]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.VirtualService },
   [gvkType.WorkloadEntry]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadEntry },
   [gvkType.WorkloadGroup]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadGroup },
 
+  [gvkType.Telemetry]: { Group: 'telemetry.istio.io', Version: 'v1', Kind: gvkType.Telemetry },
   [gvkType.TrafficExtension]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.TrafficExtension },
   [gvkType.WasmPlugin]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.WasmPlugin },
-  [gvkType.Telemetry]: { Group: 'telemetry.istio.io', Version: 'v1', Kind: gvkType.Telemetry },
 
   [gvkType.K8sGateway]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'Gateway' },
   [gvkType.K8sGatewayClass]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'GatewayClass' },

--- a/frontend/src/types/IstioObjects.ts
+++ b/frontend/src/types/IstioObjects.ts
@@ -1138,6 +1138,41 @@ export interface ServiceEntry extends IstioObject {
   spec: ServiceEntrySpec;
 }
 
+export interface TrafficExtension extends IstioObject {
+  spec: TrafficExtensionSpec;
+}
+
+export interface TrafficExtensionSpec {
+  lua?: TrafficExtensionLuaConfig;
+  match?: TrafficExtensionSelector[];
+  phase?: string;
+  priority?: number;
+  selector?: WorkloadSelector;
+  targetRefs?: Array<{ group?: string; kind: string; name: string; namespace?: string }>;
+  wasm?: TrafficExtensionWasmConfig;
+}
+
+export interface TrafficExtensionWasmConfig {
+  failStrategy?: string;
+  imagePullPolicy?: string;
+  imagePullSecret?: string;
+  pluginConfig?: { [key: string]: any };
+  pluginName?: string;
+  sha256?: string;
+  type?: string;
+  url: string;
+  vmConfig?: { [key: string]: any };
+}
+
+export interface TrafficExtensionLuaConfig {
+  inlineCode: string;
+}
+
+export interface TrafficExtensionSelector {
+  mode?: string;
+  ports?: Array<{ number: number }>;
+}
+
 export interface WasmPlugin extends IstioObject {
   spec: WasmPluginSpec;
 }

--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,8 @@ require (
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
-	istio.io/api v1.29.0
-	istio.io/client-go v1.29.0
+	istio.io/api v1.30.1-0.20260529120535-23c54ad84d6e
+	istio.io/client-go v1.30.1
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,12 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 istio.io/api v1.29.0 h1:E4rokccO3xqtxWd2zmLjlq+sKuWakrzmskhaFNFqCbs=
 istio.io/api v1.29.0/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
+istio.io/api v1.30.1-0.20260529120535-23c54ad84d6e h1:GPtgMkMjv1bE0m/bhVzoQdPm2abGy24bD7I4mFLJ55k=
+istio.io/api v1.30.1-0.20260529120535-23c54ad84d6e/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
 istio.io/client-go v1.29.0 h1:IDspkwSIOdlMCywgIvTGoRA0OOSrgkoAWs8ms+Rd9WI=
 istio.io/client-go v1.29.0/go.mod h1:iCVud7UDjvGbxjqUH+cRk9OruaKdrK69CFDmnV+NOFw=
+istio.io/client-go v1.30.1 h1:xOkdcxewkuc0ayw5o/osNINAAZfS9hevmnDq6GThrkU=
+istio.io/client-go v1.30.1/go.mod h1:M6zHgHi2uud1EMrphZ9gcKx+6Wwn3j1UjtHss5TQyA4=
 k8s.io/api v0.35.3 h1:pA2fiBc6+N9PDf7SAiluKGEBuScsTzd2uYBkA5RzNWQ=
 k8s.io/api v0.35.3/go.mod h1:9Y9tkBcFwKNq2sxwZTQh1Njh9qHl81D0As56tu42GA4=
 k8s.io/apiextensions-apiserver v0.35.3 h1:2fQUhEO7P17sijylbdwt0nBdXP0TvHrHj0KeqHD8FiU=

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -9,16 +9,17 @@ import (
 
 const (
 	// Networking
-	DestinationRuleType = "DestinationRule"
-	GatewayType         = "Gateway"
-	EnvoyFilterType     = "EnvoyFilter"
-	SidecarType         = "Sidecar"
-	ServiceEntryType    = "ServiceEntry"
-	VirtualServiceType  = "VirtualService"
-	WorkloadEntryType   = "WorkloadEntry"
-	WorkloadGroupType   = "WorkloadGroup"
-	WasmPluginType      = "WasmPlugin"
-	TelemetryType       = "Telemetry"
+	DestinationRuleType  = "DestinationRule"
+	GatewayType          = "Gateway"
+	EnvoyFilterType      = "EnvoyFilter"
+	SidecarType          = "Sidecar"
+	ServiceEntryType     = "ServiceEntry"
+	VirtualServiceType   = "VirtualService"
+	WorkloadEntryType    = "WorkloadEntry"
+	WorkloadGroupType    = "WorkloadGroup"
+	TrafficExtensionType = "TrafficExtension"
+	WasmPluginType       = "WasmPlugin"
+	TelemetryType        = "Telemetry"
 
 	// K8s Networking
 	K8sGatewayType        = "Gateway"
@@ -55,16 +56,17 @@ const (
 
 var (
 	// Networking
-	DestinationRules = NetworkingGroupVersionV1.WithKind(DestinationRuleType)
-	Gateways         = NetworkingGroupVersionV1.WithKind(GatewayType)
-	EnvoyFilters     = NetworkingGroupVersionV1Alpha3.WithKind(EnvoyFilterType)
-	Sidecars         = NetworkingGroupVersionV1.WithKind(SidecarType)
-	ServiceEntries   = NetworkingGroupVersionV1.WithKind(ServiceEntryType)
-	VirtualServices  = NetworkingGroupVersionV1.WithKind(VirtualServiceType)
-	WorkloadEntries  = NetworkingGroupVersionV1.WithKind(WorkloadEntryType)
-	WorkloadGroups   = NetworkingGroupVersionV1.WithKind(WorkloadGroupType)
-	WasmPlugins      = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
-	Telemetries      = TelemetryGroupV1.WithKind(TelemetryType)
+	DestinationRules  = NetworkingGroupVersionV1.WithKind(DestinationRuleType)
+	Gateways          = NetworkingGroupVersionV1.WithKind(GatewayType)
+	EnvoyFilters      = NetworkingGroupVersionV1Alpha3.WithKind(EnvoyFilterType)
+	Sidecars          = NetworkingGroupVersionV1.WithKind(SidecarType)
+	ServiceEntries    = NetworkingGroupVersionV1.WithKind(ServiceEntryType)
+	VirtualServices   = NetworkingGroupVersionV1.WithKind(VirtualServiceType)
+	WorkloadEntries   = NetworkingGroupVersionV1.WithKind(WorkloadEntryType)
+	WorkloadGroups    = NetworkingGroupVersionV1.WithKind(WorkloadGroupType)
+	TrafficExtensions = ExtensionGroupVersionV1Alpha1.WithKind(TrafficExtensionType)
+	WasmPlugins       = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
+	Telemetries       = TelemetryGroupV1.WithKind(TelemetryType)
 
 	// K8s Networking
 	K8sGateways        = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayType)
@@ -179,16 +181,17 @@ var (
 
 	// Resources
 	ResourceTypesToAPI = map[string]schema.GroupVersionKind{
-		DestinationRules.String(): DestinationRules,
-		EnvoyFilters.String():     EnvoyFilters,
-		Gateways.String():         Gateways,
-		ServiceEntries.String():   ServiceEntries,
-		Sidecars.String():         Sidecars,
-		VirtualServices.String():  VirtualServices,
-		WorkloadEntries.String():  WorkloadEntries,
-		WorkloadGroups.String():   WorkloadGroups,
-		WasmPlugins.String():      WasmPlugins,
-		Telemetries.String():      Telemetries,
+		DestinationRules.String():  DestinationRules,
+		EnvoyFilters.String():      EnvoyFilters,
+		Gateways.String():          Gateways,
+		ServiceEntries.String():    ServiceEntries,
+		Sidecars.String():          Sidecars,
+		VirtualServices.String():   VirtualServices,
+		WorkloadEntries.String():   WorkloadEntries,
+		WorkloadGroups.String():    WorkloadGroups,
+		TrafficExtensions.String(): TrafficExtensions,
+		WasmPlugins.String():       WasmPlugins,
+		Telemetries.String():       Telemetries,
 
 		K8sGateways.String():        K8sGateways,
 		K8sGRPCRoutes.String():      K8sGRPCRoutes,

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -10,16 +10,16 @@ import (
 const (
 	// Networking
 	DestinationRuleType  = "DestinationRule"
-	GatewayType          = "Gateway"
 	EnvoyFilterType      = "EnvoyFilter"
-	SidecarType          = "Sidecar"
+	GatewayType          = "Gateway"
 	ServiceEntryType     = "ServiceEntry"
+	SidecarType          = "Sidecar"
+	TelemetryType        = "Telemetry"
+	TrafficExtensionType = "TrafficExtension"
 	VirtualServiceType   = "VirtualService"
+	WasmPluginType       = "WasmPlugin"
 	WorkloadEntryType    = "WorkloadEntry"
 	WorkloadGroupType    = "WorkloadGroup"
-	TrafficExtensionType = "TrafficExtension"
-	WasmPluginType       = "WasmPlugin"
-	TelemetryType        = "Telemetry"
 
 	// K8s Networking
 	K8sGatewayType        = "Gateway"
@@ -57,16 +57,16 @@ const (
 var (
 	// Networking
 	DestinationRules  = NetworkingGroupVersionV1.WithKind(DestinationRuleType)
-	Gateways          = NetworkingGroupVersionV1.WithKind(GatewayType)
 	EnvoyFilters      = NetworkingGroupVersionV1Alpha3.WithKind(EnvoyFilterType)
-	Sidecars          = NetworkingGroupVersionV1.WithKind(SidecarType)
+	Gateways          = NetworkingGroupVersionV1.WithKind(GatewayType)
 	ServiceEntries    = NetworkingGroupVersionV1.WithKind(ServiceEntryType)
+	Sidecars          = NetworkingGroupVersionV1.WithKind(SidecarType)
+	Telemetries       = TelemetryGroupV1.WithKind(TelemetryType)
+	TrafficExtensions = ExtensionGroupVersionV1Alpha1.WithKind(TrafficExtensionType)
 	VirtualServices   = NetworkingGroupVersionV1.WithKind(VirtualServiceType)
+	WasmPlugins       = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
 	WorkloadEntries   = NetworkingGroupVersionV1.WithKind(WorkloadEntryType)
 	WorkloadGroups    = NetworkingGroupVersionV1.WithKind(WorkloadGroupType)
-	TrafficExtensions = ExtensionGroupVersionV1Alpha1.WithKind(TrafficExtensionType)
-	WasmPlugins       = ExtensionGroupVersionV1Alpha1.WithKind(WasmPluginType)
-	Telemetries       = TelemetryGroupV1.WithKind(TelemetryType)
 
 	// K8s Networking
 	K8sGateways        = K8sNetworkingGroupVersionV1.WithKind(K8sGatewayType)
@@ -186,12 +186,12 @@ var (
 		Gateways.String():          Gateways,
 		ServiceEntries.String():    ServiceEntries,
 		Sidecars.String():          Sidecars,
+		Telemetries.String():       Telemetries,
+		TrafficExtensions.String(): TrafficExtensions,
 		VirtualServices.String():   VirtualServices,
+		WasmPlugins.String():       WasmPlugins,
 		WorkloadEntries.String():   WorkloadEntries,
 		WorkloadGroups.String():    WorkloadGroups,
-		TrafficExtensions.String(): TrafficExtensions,
-		WasmPlugins.String():       WasmPlugins,
-		Telemetries.String():       Telemetries,
 
 		K8sGateways.String():        K8sGateways,
 		K8sGRPCRoutes.String():      K8sGRPCRoutes,

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -22,16 +22,17 @@ import (
 // This type is used for returning a response of IstioConfigList
 // swagger:model IstioConfigList
 type IstioConfigList struct {
-	DestinationRules []*networking_v1.DestinationRule   `json:"-"`
-	EnvoyFilters     []*networking_v1alpha3.EnvoyFilter `json:"-"`
-	Gateways         []*networking_v1.Gateway           `json:"-"`
-	ServiceEntries   []*networking_v1.ServiceEntry      `json:"-"`
-	Sidecars         []*networking_v1.Sidecar           `json:"-"`
-	VirtualServices  []*networking_v1.VirtualService    `json:"-"`
-	WorkloadEntries  []*networking_v1.WorkloadEntry     `json:"-"`
-	WorkloadGroups   []*networking_v1.WorkloadGroup     `json:"-"`
-	WasmPlugins      []*extentions_v1alpha1.WasmPlugin  `json:"-"`
-	Telemetries      []*telemetry_v1.Telemetry          `json:"-"`
+	DestinationRules  []*networking_v1.DestinationRule        `json:"-"`
+	EnvoyFilters      []*networking_v1alpha3.EnvoyFilter      `json:"-"`
+	Gateways          []*networking_v1.Gateway                `json:"-"`
+	ServiceEntries    []*networking_v1.ServiceEntry           `json:"-"`
+	Sidecars          []*networking_v1.Sidecar                `json:"-"`
+	VirtualServices   []*networking_v1.VirtualService         `json:"-"`
+	WorkloadEntries   []*networking_v1.WorkloadEntry          `json:"-"`
+	WorkloadGroups    []*networking_v1.WorkloadGroup          `json:"-"`
+	TrafficExtensions []*extentions_v1alpha1.TrafficExtension `json:"-"`
+	WasmPlugins       []*extentions_v1alpha1.WasmPlugin       `json:"-"`
+	Telemetries       []*telemetry_v1.Telemetry               `json:"-"`
 
 	K8sGateways        []*k8s_networking_v1.Gateway             `json:"-"`
 	K8sGRPCRoutes      []*k8s_networking_v1.GRPCRoute           `json:"-"`
@@ -61,6 +62,7 @@ func (i IstioConfigList) MarshalJSON() ([]byte, error) {
 	resources[kubernetes.VirtualServices.String()] = i.VirtualServices
 	resources[kubernetes.WorkloadEntries.String()] = i.WorkloadEntries
 	resources[kubernetes.WorkloadGroups.String()] = i.WorkloadGroups
+	resources[kubernetes.TrafficExtensions.String()] = i.TrafficExtensions
 	resources[kubernetes.WasmPlugins.String()] = i.WasmPlugins
 	resources[kubernetes.Telemetries.String()] = i.Telemetries
 	resources[kubernetes.K8sGateways.String()] = i.K8sGateways
@@ -130,6 +132,10 @@ func (i *IstioConfigList) UnmarshalJSON(data []byte) error {
 			}
 		case kubernetes.WorkloadGroups.String():
 			if err := json.Unmarshal(rawMessage, &i.WorkloadGroups); err != nil {
+				return err
+			}
+		case kubernetes.TrafficExtensions.String():
+			if err := json.Unmarshal(rawMessage, &i.TrafficExtensions); err != nil {
 				return err
 			}
 		case kubernetes.WasmPlugins.String():
@@ -219,6 +225,9 @@ func (i *IstioConfigList) ConvertToResponse() {
 	if i.WorkloadGroups == nil {
 		i.WorkloadGroups = []*networking_v1.WorkloadGroup{}
 	}
+	if i.TrafficExtensions == nil {
+		i.TrafficExtensions = []*extentions_v1alpha1.TrafficExtension{}
+	}
 	if i.WasmPlugins == nil {
 		i.WasmPlugins = []*extentions_v1alpha1.WasmPlugin{}
 	}
@@ -268,19 +277,20 @@ type IstioConfigDetails struct {
 
 	Object client.Object `json:"-"`
 
-	AuthorizationPolicy   *security_v1.AuthorizationPolicy   `json:"-"`
-	DestinationRule       *networking_v1.DestinationRule     `json:"-"`
-	EnvoyFilter           *networking_v1alpha3.EnvoyFilter   `json:"-"`
-	Gateway               *networking_v1.Gateway             `json:"-"`
-	PeerAuthentication    *security_v1.PeerAuthentication    `json:"-"`
-	RequestAuthentication *security_v1.RequestAuthentication `json:"-"`
-	ServiceEntry          *networking_v1.ServiceEntry        `json:"-"`
-	Sidecar               *networking_v1.Sidecar             `json:"-"`
-	VirtualService        *networking_v1.VirtualService      `json:"-"`
-	WorkloadEntry         *networking_v1.WorkloadEntry       `json:"-"`
-	WorkloadGroup         *networking_v1.WorkloadGroup       `json:"-"`
-	WasmPlugin            *extentions_v1alpha1.WasmPlugin    `json:"-"`
-	Telemetry             *telemetry_v1.Telemetry            `json:"-"`
+	AuthorizationPolicy   *security_v1.AuthorizationPolicy      `json:"-"`
+	DestinationRule       *networking_v1.DestinationRule        `json:"-"`
+	EnvoyFilter           *networking_v1alpha3.EnvoyFilter      `json:"-"`
+	Gateway               *networking_v1.Gateway                `json:"-"`
+	PeerAuthentication    *security_v1.PeerAuthentication       `json:"-"`
+	RequestAuthentication *security_v1.RequestAuthentication    `json:"-"`
+	ServiceEntry          *networking_v1.ServiceEntry           `json:"-"`
+	Sidecar               *networking_v1.Sidecar                `json:"-"`
+	VirtualService        *networking_v1.VirtualService         `json:"-"`
+	WorkloadEntry         *networking_v1.WorkloadEntry          `json:"-"`
+	WorkloadGroup         *networking_v1.WorkloadGroup          `json:"-"`
+	TrafficExtension      *extentions_v1alpha1.TrafficExtension `json:"-"`
+	WasmPlugin            *extentions_v1alpha1.WasmPlugin       `json:"-"`
+	Telemetry             *telemetry_v1.Telemetry               `json:"-"`
 
 	K8sGateway        *k8s_networking_v1.Gateway             `json:"-"`
 	K8sGRPCRoute      *k8s_networking_v1.GRPCRoute           `json:"-"`
@@ -325,6 +335,8 @@ func (i IstioConfigDetails) MarshalJSON() ([]byte, error) {
 		resource = i.WorkloadEntry
 	} else if i.WorkloadGroup != nil {
 		resource = i.WorkloadGroup
+	} else if i.TrafficExtension != nil {
+		resource = i.TrafficExtension
 	} else if i.WasmPlugin != nil {
 		resource = i.WasmPlugin
 	} else if i.Telemetry != nil {
@@ -461,6 +473,13 @@ func (icd *IstioConfigDetails) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		icd.WorkloadGroup = &wg
+
+	case kubernetes.TrafficExtensions:
+		var te extentions_v1alpha1.TrafficExtension
+		if err := json.Unmarshal(temp.Resource, &te); err != nil {
+			return err
+		}
+		icd.TrafficExtension = &te
 
 	case kubernetes.WasmPlugins:
 		var wp extentions_v1alpha1.WasmPlugin
@@ -631,6 +650,15 @@ var IstioConfigHelpMessages = map[string][]IstioConfigHelp{
 		{ObjectField: "spec.template", Message: "Template to be used for the generation of WorkloadEntry resources that belong to this WorkloadGroup."},
 		{ObjectField: "spec.probe", Message: "ReadinessProbe describes the configuration the user must provide for healthchecking on their workload."},
 	},
+	kubernetes.TrafficExtensions.String(): {
+		{ObjectField: "spec.selector", Message: "Criteria used to select the specific set of pods/VMs on which this TrafficExtension should be applied. At most one of selector or targetRefs can be set."},
+		{ObjectField: "spec.targetRefs", Message: "List of resources the policy should be applied to (e.g. Gateway, Service). At most one of selector or targetRefs can be set. Required for waypoint proxies."},
+		{ObjectField: "spec.phase", Message: "Determines where in the filter chain this TrafficExtension is to be injected (UNSPECIFIED, AUTHN, AUTHZ, STATS)."},
+		{ObjectField: "spec.priority", Message: "Determines ordering of TrafficExtensions in the same phase. Higher values are applied first. Defaults to 0."},
+		{ObjectField: "spec.match", Message: "Specifies the criteria to determine which traffic is passed to the TrafficExtension."},
+		{ObjectField: "spec.wasm", Message: "WebAssembly filter configuration. Exactly one of wasm or lua must be set."},
+		{ObjectField: "spec.lua", Message: "Lua filter configuration. Exactly one of wasm or lua must be set."},
+	},
 	kubernetes.WasmPlugins.String(): { // TODO
 		{},
 	},
@@ -711,6 +739,7 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			filtered[ns].AuthorizationPolicies = []*security_v1.AuthorizationPolicy{}
 			filtered[ns].PeerAuthentications = []*security_v1.PeerAuthentication{}
 			filtered[ns].RequestAuthentications = []*security_v1.RequestAuthentication{}
+			filtered[ns].TrafficExtensions = []*extentions_v1alpha1.TrafficExtension{}
 			filtered[ns].WasmPlugins = []*extentions_v1alpha1.WasmPlugin{}
 			filtered[ns].Telemetries = []*telemetry_v1.Telemetry{}
 		}
@@ -804,6 +833,12 @@ func (configList IstioConfigList) FilterIstioConfigs(nss []string) *IstioConfigs
 			}
 		}
 
+		for _, te := range configList.TrafficExtensions {
+			if te.Namespace == ns {
+				filtered[ns].TrafficExtensions = append(filtered[ns].TrafficExtensions, te)
+			}
+		}
+
 		for _, wp := range configList.WasmPlugins {
 			if wp.Namespace == ns {
 				filtered[ns].WasmPlugins = append(filtered[ns].WasmPlugins, wp)
@@ -860,6 +895,7 @@ func (configList IstioConfigList) MergeConfigs(ns IstioConfigList) IstioConfigLi
 	configList.ServiceEntries = append(configList.ServiceEntries, ns.ServiceEntries...)
 	configList.Sidecars = append(configList.Sidecars, ns.Sidecars...)
 	configList.Telemetries = append(configList.Telemetries, ns.Telemetries...)
+	configList.TrafficExtensions = append(configList.TrafficExtensions, ns.TrafficExtensions...)
 	configList.VirtualServices = append(configList.VirtualServices, ns.VirtualServices...)
 	configList.WasmPlugins = append(configList.WasmPlugins, ns.WasmPlugins...)
 	configList.WorkloadEntries = append(configList.WorkloadEntries, ns.WorkloadEntries...)

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -27,12 +27,12 @@ type IstioConfigList struct {
 	Gateways          []*networking_v1.Gateway                `json:"-"`
 	ServiceEntries    []*networking_v1.ServiceEntry           `json:"-"`
 	Sidecars          []*networking_v1.Sidecar                `json:"-"`
+	Telemetries       []*telemetry_v1.Telemetry               `json:"-"`
+	TrafficExtensions []*extentions_v1alpha1.TrafficExtension `json:"-"`
 	VirtualServices   []*networking_v1.VirtualService         `json:"-"`
+	WasmPlugins       []*extentions_v1alpha1.WasmPlugin       `json:"-"`
 	WorkloadEntries   []*networking_v1.WorkloadEntry          `json:"-"`
 	WorkloadGroups    []*networking_v1.WorkloadGroup          `json:"-"`
-	TrafficExtensions []*extentions_v1alpha1.TrafficExtension `json:"-"`
-	WasmPlugins       []*extentions_v1alpha1.WasmPlugin       `json:"-"`
-	Telemetries       []*telemetry_v1.Telemetry               `json:"-"`
 
 	K8sGateways        []*k8s_networking_v1.Gateway             `json:"-"`
 	K8sGRPCRoutes      []*k8s_networking_v1.GRPCRoute           `json:"-"`
@@ -285,12 +285,12 @@ type IstioConfigDetails struct {
 	RequestAuthentication *security_v1.RequestAuthentication    `json:"-"`
 	ServiceEntry          *networking_v1.ServiceEntry           `json:"-"`
 	Sidecar               *networking_v1.Sidecar                `json:"-"`
+	Telemetry             *telemetry_v1.Telemetry               `json:"-"`
+	TrafficExtension      *extentions_v1alpha1.TrafficExtension `json:"-"`
 	VirtualService        *networking_v1.VirtualService         `json:"-"`
+	WasmPlugin            *extentions_v1alpha1.WasmPlugin       `json:"-"`
 	WorkloadEntry         *networking_v1.WorkloadEntry          `json:"-"`
 	WorkloadGroup         *networking_v1.WorkloadGroup          `json:"-"`
-	TrafficExtension      *extentions_v1alpha1.TrafficExtension `json:"-"`
-	WasmPlugin            *extentions_v1alpha1.WasmPlugin       `json:"-"`
-	Telemetry             *telemetry_v1.Telemetry               `json:"-"`
 
 	K8sGateway        *k8s_networking_v1.Gateway             `json:"-"`
 	K8sGRPCRoute      *k8s_networking_v1.GRPCRoute           `json:"-"`

--- a/models/istio_config_test.go
+++ b/models/istio_config_test.go
@@ -127,3 +127,77 @@ func TestMarshalUnmarshalJSON_TrafficExtensionList(t *testing.T) {
 	assert.Contains(t, names, "filter-a")
 	assert.Contains(t, names, "filter-b")
 }
+
+func TestFilterIstioConfigs_TrafficExtensions(t *testing.T) {
+	configList := models.IstioConfigList{
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "bookinfo"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-b", Namespace: "bookinfo"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-c", Namespace: "other"}},
+		},
+	}
+
+	filtered := configList.FilterIstioConfigs([]string{"bookinfo"})
+	require.NotNil(t, filtered)
+
+	bookinfoConfigs := (*filtered)["bookinfo"]
+	require.NotNil(t, bookinfoConfigs)
+	require.Len(t, bookinfoConfigs.TrafficExtensions, 2)
+
+	names := []string{bookinfoConfigs.TrafficExtensions[0].Name, bookinfoConfigs.TrafficExtensions[1].Name}
+	assert.Contains(t, names, "filter-a")
+	assert.Contains(t, names, "filter-b")
+
+	_, hasOther := (*filtered)["other"]
+	assert.False(t, hasOther)
+}
+
+func TestFilterIstioConfigs_TrafficExtensionsEmptyNamespace(t *testing.T) {
+	configList := models.IstioConfigList{
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "bookinfo"}},
+		},
+	}
+
+	filtered := configList.FilterIstioConfigs([]string{"empty-ns"})
+	require.NotNil(t, filtered)
+
+	emptyConfigs := (*filtered)["empty-ns"]
+	require.NotNil(t, emptyConfigs)
+	assert.Empty(t, emptyConfigs.TrafficExtensions)
+}
+
+func TestMergeConfigs_TrafficExtensions(t *testing.T) {
+	list1 := models.IstioConfigList{
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "ns1"}},
+		},
+	}
+	list2 := models.IstioConfigList{
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-b", Namespace: "ns2"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-c", Namespace: "ns2"}},
+		},
+	}
+
+	merged := list1.MergeConfigs(list2)
+	require.Len(t, merged.TrafficExtensions, 3)
+
+	names := []string{merged.TrafficExtensions[0].Name, merged.TrafficExtensions[1].Name, merged.TrafficExtensions[2].Name}
+	assert.Contains(t, names, "filter-a")
+	assert.Contains(t, names, "filter-b")
+	assert.Contains(t, names, "filter-c")
+}
+
+func TestMergeConfigs_TrafficExtensionsWithEmpty(t *testing.T) {
+	list1 := models.IstioConfigList{
+		TrafficExtensions: []*extentions_v1alpha1.TrafficExtension{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "ns1"}},
+		},
+	}
+	list2 := models.IstioConfigList{}
+
+	merged := list1.MergeConfigs(list2)
+	require.Len(t, merged.TrafficExtensions, 1)
+	assert.Equal(t, "filter-a", merged.TrafficExtensions[0].Name)
+}

--- a/models/istio_config_test.go
+++ b/models/istio_config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	extentions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -66,4 +67,63 @@ func TestUnmarshalJSON_PrefersNamespaceCluster(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(jsonData), &details))
 
 	assert.Equal(t, "east", details.Namespace.Cluster)
+}
+
+func TestMarshalJSON_TrafficExtensionDetails(t *testing.T) {
+	details := models.IstioConfigDetails{}
+	details.Namespace = models.Namespace{Cluster: "east", Name: "bookinfo"}
+	details.ObjectGVK = schema.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "TrafficExtension"}
+	details.TrafficExtension = &extentions_v1alpha1.TrafficExtension{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "my-filter", Namespace: "bookinfo"},
+	}
+
+	data, err := json.Marshal(details)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	var cluster string
+	require.NoError(t, json.Unmarshal(raw["cluster"], &cluster))
+	assert.Equal(t, "east", cluster)
+
+	_, hasResource := raw["resource"]
+	assert.True(t, hasResource, "marshalled details should include 'resource' key")
+}
+
+func TestUnmarshalJSON_TrafficExtensionDetails(t *testing.T) {
+	jsonData := `{
+		"cluster": "east",
+		"namespace": {"name": "bookinfo"},
+		"gvk": {"Group": "extensions.istio.io", "Version": "v1alpha1", "Kind": "TrafficExtension"},
+		"permissions": {},
+		"resource": {"metadata": {"name": "my-filter", "namespace": "bookinfo"}, "kind": "TrafficExtension", "apiVersion": "extensions.istio.io/v1alpha1"}
+	}`
+
+	var details models.IstioConfigDetails
+	require.NoError(t, json.Unmarshal([]byte(jsonData), &details))
+
+	assert.Equal(t, "east", details.Namespace.Cluster)
+	assert.Equal(t, "bookinfo", details.Namespace.Name)
+	require.NotNil(t, details.TrafficExtension)
+	assert.Equal(t, "my-filter", details.TrafficExtension.Name)
+}
+
+func TestMarshalUnmarshalJSON_TrafficExtensionList(t *testing.T) {
+	original := models.IstioConfigList{}
+	original.TrafficExtensions = []*extentions_v1alpha1.TrafficExtension{
+		{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-a", Namespace: "ns1"}},
+		{ObjectMeta: meta_v1.ObjectMeta{Name: "filter-b", Namespace: "ns1"}},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var roundTripped models.IstioConfigList
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+
+	require.Len(t, roundTripped.TrafficExtensions, 2)
+	names := []string{roundTripped.TrafficExtensions[0].Name, roundTripped.TrafficExtensions[1].Name}
+	assert.Contains(t, names, "filter-a")
+	assert.Contains(t, names, "filter-b")
 }


### PR DESCRIPTION
## Summary
- Add `FilterIstioConfigs` tests verifying TrafficExtensions are correctly filtered by namespace (including empty-namespace edge case)
- Add `MergeConfigs` tests verifying TrafficExtensions are properly combined across config lists (including merge-with-empty edge case)
- Add `criteriaForListFilter` tests covering the `extensions.istio.io` group routing (TrafficExtension/WasmPlugin mutual exclusion, unknown kind fallback, table-driven coverage for multiple groups)
- Add `IstioList` integration test verifying TrafficExtension group/kind filter works end-to-end through the MCP layer

Supplements #9887 with additional tests for areas not covered by the existing TrafficExtension test suite.

## Test plan
- [x] `go test ./models/ -run "TestFilterIstioConfigs_TrafficExtension|TestMergeConfigs_TrafficExtension"` — all 4 pass
- [x] `go test ./ai/mcp/manage_istio_config/ -run "TestCriteriaForListFilter|TestIstioList_IncludesTrafficExtensions"` — all 5 pass
- [x] Full package test suites pass: `go test ./models/ ./ai/mcp/manage_istio_config/`

### Issue reference

Relates to #9887 / Fixes https://github.com/kiali/kiali/issues/9839

🤖 Generated with [Claude Code](https://claude.com/claude-code)