### PR TITLE
Remove workflow-level permissions from reusable bump-release-version workflow

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -15,7 +15,6 @@ on:
         required: true
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
-permissions: read-all
 
 jobs:
   initialize:


### PR DESCRIPTION
## Summary
- Follow-up to #9894. The previous fix added `permissions: contents: write` to the calling job, but `bump-release-version.yml` still has `permissions: read-all` at the workflow level.
- When called via `workflow_call`, `permissions: read-all` requires the caller to grant `read` on **every** scope. Since the calling job only grants `contents: write`, GitHub rejects all other scopes.
- Removing the workflow-level `permissions: read-all` fixes this because each job already declares its own permissions explicitly (`contents: read` for `initialize`, `contents: write` for `bump_version`).

## Test plan
- [ ] Verify the workflow file passes GitHub Actions validation
- [ ] Run the `Release Tag Creator` workflow on a test branch

Made with [Cursor](https://cursor.com)