### PR TITLE
[v1.73] Upgrade ip-address for CVE-2026-42338

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10510,9 +10510,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Backport of #9843 to `v1.73` (OSSM 2.6).

- Upgrades transitive `ip-address` dependency from 10.1.0 to 10.2.0 in `frontend/yarn.lock`
- Addresses CVE-2026-42338 (XSS via improper HTML escaping in `Address6`; fixed in 10.1.1)

## Test plan

- [x] `yarn install --no-immutable` succeeded on `v1.73`