### PR TITLE
Use KIALI_BOT_TOKEN for release workflow push to protected branches

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -60,6 +60,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{matrix.branch}}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
         # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
 
     - name: Set version to release
       run: |

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -93,3 +93,4 @@ jobs:
     uses: ./.github/workflows/bump-release-version.yml
     with:
       tag_branches: ${{ inputs.tag_branches }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Follow-up to #9894 and #9897. The previous fixes resolved the `permissions: read-all` conflict, but the workflow still fails because `GITHUB_TOKEN` cannot push to protected release branches.
- Use `KIALI_BOT_TOKEN` in the checkout step of `bump-release-version.yml` so `git push` authenticates as `kiali-bot`, which has bypass permissions on protected branches.
- Pass secrets to the reusable workflow via `secrets: inherit` in `tag-release-creator.yml`.

**Prerequisites (repo admin):**
- `KIALI_BOT_TOKEN` secret must be set in the repo with a PAT for `kiali-bot`
- `kiali-bot` must be in the branch protection bypass list for release branches

## Test plan
- [ ] Trigger the `Release Tag Creator` workflow and verify `bump_version` can push to a protected branch

Made with [Cursor](https://cursor.com)