### PR TITLE
[CI] Improved the Ambient multicluster test suite CI to validate tracing

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,4 +1,4 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading, openTab, waitForKialiApiReady } from './transition';
 import { getCellsForCol } from './table';
 import { Pod } from 'types/IstioObjects';
@@ -431,15 +431,6 @@ Then('the graph page has enough data for L7', () => {
 
 Then('the graph page has enough data for L7 in the {string} namespace', (namespace: string) => {
   waitForBookinfoWaypointTrafficGeneratedInGraph(namespace, 'waypoint');
-});
-
-Before({ tags: '@use-waypoint-name' }, function () {
-  cy.request({ url: '/api/tracing', failOnStatusCode: false }).then(response => {
-    if (!response.body?.useWaypointName) {
-      cy.log('use_waypoint_name is not enabled, skipping test');
-      this.skip();
-    }
-  });
 });
 
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,4 +1,4 @@
-import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading, openTab, waitForKialiApiReady } from './transition';
 import { getCellsForCol } from './table';
 import { Pod } from 'types/IstioObjects';
@@ -433,10 +433,25 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
   waitForBookinfoWaypointTrafficGeneratedInGraph(namespace, 'waypoint');
 });
 
+Before({ tags: '@use-waypoint-name' }, function () {
+  cy.request({ url: '/api/tracing', failOnStatusCode: false }).then(response => {
+    if (!response.body?.useWaypointName) {
+      cy.log('use_waypoint_name is not enabled, skipping test');
+      this.skip();
+    }
+  });
+});
+
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
-  // Poll the traces endpoint so downstream assertions on tracing UI don't flake.
   waitForWorkloadTracesInApi(namespace, workload);
 });
+
+Then(
+  'the {string} tracing data is ready in the {string} namespace for the {string} cluster',
+  (workload: string, namespace: string, clusterName: string) => {
+    waitForWaypointTracesInApi(namespace, workload, clusterName);
+  }
+);
 
 Then('the tracing data is ready for the {string} {string}', (targetType: string, namespacedName: string) => {
   const [namespace, name] = namespacedName.split('/');

--- a/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
@@ -52,7 +52,6 @@ Feature: Kiali Waypoint in Ambient Multi-Primary (multi-cluster)
     Then the user sees the L7 "waypoint" link
     And the waypoint link points to the "west" cluster
 
-  @use-waypoint-name
   Scenario: [Tracing] Verify traces for productpage-v1 in east cluster
     Given the "productpage-v1" tracing data is ready in the "bookinfo-waypoints" namespace for the "east" cluster
     And user is at the details page for the "workload" "bookinfo-waypoints/productpage-v1" located in the "east" cluster

--- a/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
@@ -52,4 +52,10 @@ Feature: Kiali Waypoint in Ambient Multi-Primary (multi-cluster)
     Then the user sees the L7 "waypoint" link
     And the waypoint link points to the "west" cluster
 
-
+  @use-waypoint-name
+  Scenario: [Tracing] Verify traces for productpage-v1 in east cluster
+    Given the "productpage-v1" tracing data is ready in the "bookinfo-waypoints" namespace for the "east" cluster
+    And user is at the details page for the "workload" "bookinfo-waypoints/productpage-v1" located in the "east" cluster
+    Then user sees trace information
+    When user selects a trace
+    Then user sees trace details

--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -36,7 +36,7 @@ deploy_kiali() {
   #Enable tracing
   helm_args+=(--set external_services.tracing.enabled="true")
 
-  # For ambient tests, Istio < 1.28 requires using the waypoint name for tracing lookups
+  # use_waypoint_name is needed for Istio < 1.28 and Istio >= 1.30 (not for 1.28.x / 1.29.x)
   if [ "${AMBIENT}" == "true" ]; then
     local effective_version=""
     if [ -n "${ISTIO_VERSION:-}" ]; then
@@ -52,7 +52,7 @@ deploy_kiali() {
       }
     fi
 
-    if kiali_istio_version_lt "${effective_version}" "1.28.0"; then
+    if kiali_istio_version_lt "${effective_version}" "1.28.0" || ! kiali_istio_version_lt "${effective_version}" "1.30.0"; then
       echo "Ambient detected. Istio version resolved to [${effective_version}]. Setting external_services.tracing.use_waypoint_name=true"
       helm_args+=(--set external_services.tracing.use_waypoint_name="true")
     fi

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -106,6 +106,11 @@ create_resources_in_remote_cluster() {
     local helm_version_arg="--version ${KIALI_VERSION}"
   fi
 
+  local helm_repo_arg="--repo https://kiali.org/helm-charts"
+  if [ -f "${KIALI_SERVER_HELM_CHARTS}" ]; then
+    helm_repo_arg=""
+  fi
+
   local helm_template_output="$(${HELM} template            \
       ${helm_version_arg:-}                                 \
       --namespace ${REMOTE_CLUSTER_NAMESPACE}               \
@@ -115,7 +120,7 @@ create_resources_in_remote_cluster() {
       --set deployment.cluster_wide_access=true             \
       --set deployment.view_only_mode=${VIEW_ONLY}          \
       --set auth.strategy=anonymous                         \
-      --repo https://kiali.org/helm-charts                  \
+      ${helm_repo_arg}                                      \
       kiali-server                                          \
       ${KIALI_SERVER_HELM_CHARTS})"
 

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -27,8 +27,7 @@ infomsg() {
 }
 
 determine_tracing_use_waypoint_name() {
-  # For ambient tests, Istio < 1.28 requires using the waypoint name for tracing lookups.
-  # For Istio >= 1.28, the default behavior (false) is expected.
+  # use_waypoint_name is needed for Istio < 1.28 and Istio >= 1.30 (not for 1.28.x / 1.29.x)
   if [ -z "${AMBIENT:-}" ]; then
     echo "false"
     return 0
@@ -48,7 +47,7 @@ determine_tracing_use_waypoint_name() {
     }
   fi
 
-  if kiali_istio_version_lt "${effective_version}" "1.28.0"; then
+  if kiali_istio_version_lt "${effective_version}" "1.28.0" || ! kiali_istio_version_lt "${effective_version}" "1.30.0"; then
     echo "true"
   else
     echo "false"
@@ -851,20 +850,25 @@ setup_kind_multicluster() {
     return
   fi
 
-  "${SCRIPT_DIR}"/istio/multicluster/deploy-kiali.sh \
-    --cluster1-context ${cluster1_context} \
-    --cluster2-context ${cluster2_context} \
-    --cluster1-name ${cluster1_name} \
-    --cluster2-name ${cluster2_name} \
-    --ignore-home-cluster ${ignore_home_cluster} \
-    --manage-kind true \
-    "${auth_flags[@]}" \
-    -dorp docker \
-    -kas "${AUTH_STRATEGY}" \
-    -kudi true \
-    -kshc "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz \
-    --tempo ${TEMPO} \
+  local deploy_kiali_args=(
+    --cluster1-context "${cluster1_context}"
+    --cluster2-context "${cluster2_context}"
+    --cluster1-name "${cluster1_name}"
+    --cluster2-name "${cluster2_name}"
+    --ignore-home-cluster "${ignore_home_cluster}"
+    --manage-kind true
+    "${auth_flags[@]}"
+    -dorp docker
+    -kas "${AUTH_STRATEGY}"
+    -kudi true
+    -kshc "${HELM_CHARTS_DIR}"/_output/charts/kiali-server-*.tgz
+    --tempo "${TEMPO}"
     -ci true
+  )
+  if [ -n "${AMBIENT:-}" ]; then
+    deploy_kiali_args+=(--ambient true)
+  fi
+  "${SCRIPT_DIR}"/istio/multicluster/deploy-kiali.sh "${deploy_kiali_args[@]}"
 }
 
 if [ -n "${MULTICLUSTER}" ]; then


### PR DESCRIPTION
### Describe the change

Ambient multicluster CI is now setting `external_services.tracing.enable_waypoint_name=true` and verifying Traces in `bookinfo-waypoints` namespace.
Done for Istio < 1.28 and Istio > 1.29 versions.
Did some small fixes in scripts.

### Steps to test the PR

CI should pass.
Manually install Ambient MC locally by running:
`hack/run-integration-tests.sh   --test-suite frontend-multi-primary   --ambient true   --waypoint true   --sail false   --istio-version 1.30.1`
Then verify that the `enable_waypoint_name ` is set `true`:
`oc get configmap kiali -n istio-system -o yaml | grep enable_waypoint_name`
Go to 'rpoductpage-v1' workload of `bookinfo-waypoints` namespace and verify that Traces are there.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

https://github.com/kiali/kiali/issues/9816
