### PR TITLE
[v2.27] MCP Checker failures fix

### DIFF
--- a/ai/mcp/get_logs/get_logs.go
+++ b/ai/mcp/get_logs/get_logs.go
@@ -190,10 +190,10 @@ func Execute(
 	if len(filtered) == 0 {
 		// If there were logs but they didn't match the severity filter, return a truthful message.
 		if len(parsed.Severities) > 0 && len(unfiltered) > 0 {
-			return "No log lines matched the requested severities within the fetched tail window.", http.StatusOK
+			return LogsResult{Logs: "No log lines matched the requested severities within the fetched tail window."}, http.StatusOK
 		}
 		// Keep message aligned with kubernetes-mcp-server core/pods.go behavior.
-		return fmt.Sprintf("The pod %s in namespace %s has not logged any message yet", parsed.Pod, parsed.Namespace), http.StatusOK
+		return LogsResult{Logs: fmt.Sprintf("The pod %s in namespace %s has not logged any message yet", parsed.Pod, parsed.Namespace)}, http.StatusOK
 	}
 
 	out := strings.Join(entriesToLines(filtered), "\n")
@@ -206,15 +206,15 @@ func Execute(
 	// Defensive: It's possible to get entries that have neither timestamp nor message (or are whitespace-only),
 	// which would render as an empty code block in chat ("no output").
 	if strings.TrimSpace(out) == "" {
-		return fmt.Sprintf("No log content was returned for pod %s in namespace %s (empty log entries).", parsed.Pod, parsed.Namespace), http.StatusOK
+		return LogsResult{Logs: fmt.Sprintf("No log content was returned for pod %s in namespace %s (empty log entries).", parsed.Pod, parsed.Namespace)}, http.StatusOK
 	}
 
 	if parsed.Format == "plain" {
-		return out, http.StatusOK
+		return LogsResult{Logs: out}, http.StatusOK
 	}
 	// Default: wrap in code block so chat preserves line breaks.
 	// Use ~~~ per Kiali prompt requirements.
-	return "~~~\n" + out + "~~~\n", http.StatusOK
+	return LogsResult{Logs: "~~~\n" + out + "~~~\n"}, http.StatusOK
 }
 
 func parseArgs(args map[string]interface{}, conf *config.Config) (GetLogsArgs, string, int) {

--- a/ai/mcp/get_logs/get_logs_test.go
+++ b/ai/mcp/get_logs/get_logs_test.go
@@ -333,9 +333,9 @@ func TestExecute_ValidTailAliases(t *testing.T) {
 		}
 		res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf}, args)
 		require.Equal(t, http.StatusOK, code, "get_logs with tail alias %q must return 200", key)
-		msg, ok := res.(string)
-		require.True(t, ok)
-		assert.Contains(t, msg, "any-pod")
+		lr, ok := res.(LogsResult)
+		require.True(t, ok, "expected LogsResult, got %T", res)
+		assert.Contains(t, lr.Logs, "any-pod")
 	}
 }
 
@@ -367,9 +367,9 @@ func TestExecute_TailCappedAt200(t *testing.T) {
 	}
 	res, code := Execute(&mcputil.KialiInterface{Request: req, BusinessLayer: businessLayer, ClientFactory: clientFactory, KialiCache: kialiCache, Conf: conf}, args)
 	require.Equal(t, http.StatusOK, code, "tail 9999 should be capped and return 200")
-	msg, ok := res.(string)
-	require.True(t, ok, "response must be a string (log output)")
-	assert.Contains(t, msg, "Starting application", "response must contain log content")
-	assert.Contains(t, msg, "Request received", "response must contain log content")
-	assert.Contains(t, msg, "~~~", "response must wrap logs in codeblock")
+	lr, ok := res.(LogsResult)
+	require.True(t, ok, "response must be a LogsResult, got %T", res)
+	assert.Contains(t, lr.Logs, "Starting application", "response must contain log content")
+	assert.Contains(t, lr.Logs, "Request received", "response must contain log content")
+	assert.Contains(t, lr.Logs, "~~~", "response must wrap logs in codeblock")
 }

--- a/ai/mcp/get_logs/types.go
+++ b/ai/mcp/get_logs/types.go
@@ -1,5 +1,11 @@
 package get_logs
 
+// LogsResult wraps log output in a JSON object so the MCP structuredContent
+// requirement (must be a JSON object/record) is satisfied.
+type LogsResult struct {
+	Logs string `json:"logs"`
+}
+
 // GetLogsArgs are the supported input parameters. This is echoed back in the response for transparency.
 type GetLogsArgs struct {
 	ClusterName string `json:"cluster_name,omitempty"`

--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -51,6 +51,13 @@ type IstioListItem struct {
 	Validation ValidationSummary `json:"validation"`
 }
 
+// IstioListResult wraps the list output in a JSON object so the MCP
+// structuredContent requirement (must be a JSON object/record) is satisfied.
+type IstioListResult struct {
+	Cluster string          `json:"cluster"`
+	Items   []IstioListItem `json:"items"`
+}
+
 type ValidationSummary struct {
 	Valid  bool                     `json:"valid"`
 	Checks []ValidationCheckSummary `json:"checks,omitempty"`
@@ -487,7 +494,7 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		return items[i].Name < items[j].Name
 	})
 
-	return items, http.StatusOK
+	return IstioListResult{Cluster: cluster, Items: items}, http.StatusOK
 }
 
 // matchesServiceHost checks if a host specification matches the service name.

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -79,19 +79,20 @@ func TestIstioList_ReturnsCompactYAML(t *testing.T) {
 	res, status := IstioList(context.Background(), args, businessLayer, conf)
 	require.Equal(t, http.StatusOK, status)
 
-	out, ok := res.([]IstioListItem)
-	require.True(t, ok, "expected []IstioListItem output, got %T", res)
-	require.Len(t, out, 2)
+	result, ok := res.(IstioListResult)
+	require.True(t, ok, "expected IstioListResult output, got %T", res)
+	require.Equal(t, "east", result.Cluster)
+	require.Len(t, result.Items, 2)
 
 	// Validate items are present and compact
-	assert.Equal(t, "bookinfo", out[0].Namespace)
-	assert.NotEmpty(t, out[0].Name)
-	assert.NotEmpty(t, out[0].Group)
-	assert.NotEmpty(t, out[0].Version)
-	assert.NotEmpty(t, out[0].Kind)
+	assert.Equal(t, "bookinfo", result.Items[0].Namespace)
+	assert.NotEmpty(t, result.Items[0].Name)
+	assert.NotEmpty(t, result.Items[0].Group)
+	assert.NotEmpty(t, result.Items[0].Version)
+	assert.NotEmpty(t, result.Items[0].Kind)
 
 	// Default validation when validations cannot be found (e.g., in unit tests)
-	for _, item := range out {
+	for _, item := range result.Items {
 		assert.True(t, item.Validation.Valid)
 	}
 }
@@ -144,11 +145,11 @@ func TestIstioList_FilterByService(t *testing.T) {
 	res, status := IstioList(context.Background(), args, businessLayer, conf)
 	require.Equal(t, http.StatusOK, status)
 
-	out, ok := res.([]IstioListItem)
-	require.True(t, ok, "expected []IstioListItem output, got %T", res)
+	result, ok := res.(IstioListResult)
+	require.True(t, ok, "expected IstioListResult output, got %T", res)
 
 	names := map[string]struct{}{}
-	for _, item := range out {
+	for _, item := range result.Items {
 		names[item.Name] = struct{}{}
 	}
 

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -567,9 +567,9 @@ func TestExecuteReadOnly_ListSuccess(t *testing.T) {
 	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
 	require.Equal(t, http.StatusOK, status)
 
-	items, ok := res.([]IstioListItem)
-	require.True(t, ok, "expected []IstioListItem, got %T", res)
-	assert.GreaterOrEqual(t, len(items), 2)
+	result, ok := res.(IstioListResult)
+	require.True(t, ok, "expected IstioListResult, got %T", res)
+	assert.GreaterOrEqual(t, len(result.Items), 2)
 }
 
 func TestExecuteReadOnly_GetSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary

- Backport of #9872 to `v2.27`
- Wraps `get_logs` string returns in `LogsResult` struct so the MCP endpoint returns a JSON object instead of a bare string
- Wraps `manage_istio_config_read` list returns in `IstioListResult` struct so the endpoint returns a JSON object instead of a bare array
- Fixes MCP contract test failures (`kubernetes-mcp-server`) on the v2.27 branch

## Test plan

- [ ] MCP contract tests pass on v2.27 CI


Made with [Cursor](https://cursor.com)