### PR TITLE
Update js-cookie to fix CVE-2026-46625 [v2.22]

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -181,6 +181,7 @@
   },
   "resolutions": {
     "esbuild": "^0.25.2",
+    "js-cookie": "^3.0.8",
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",
     "unist-util-visit-parents": "5.1.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12232,10 +12232,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.1":
-  version: 3.0.1
-  resolution: "js-cookie@npm:3.0.1"
-  checksum: 10c0/a7dab91286c49610fb198bcc0d78fbafe9be869cf3cea6f7eaea515abdfdc9d347982fe22316e34666b479a0701119482d46faa3a350a3a3404eb954405edf72
+"js-cookie@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of #9923 to v2.22.

Add yarn resolution for js-cookie ^3.0.8 to fix CVE-2026-46625 (Cookie attribute manipulation via prototype pollution).

Made with [Cursor](https://cursor.com)