### PR TITLE
[CI] Perses link fix

### DIFF
--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -3,7 +3,7 @@ sidecar:
 logLevel: "debug"
 config:
   provisioning:
-    interval: 5s
+    interval: 1m
 volumes:
 - name: plugins
   emptyDir: {}

--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -3,7 +3,7 @@ sidecar:
 logLevel: "debug"
 config:
   provisioning:
-    interval: 1m
+    interval: 5s
 volumes:
 - name: provisioning
   projected:

--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -3,8 +3,10 @@ sidecar:
 logLevel: "debug"
 config:
   provisioning:
-    interval: 1m
+    interval: 5s
 volumes:
+- name: plugins
+  emptyDir: {}
 - name: provisioning
   projected:
     sources:
@@ -15,6 +17,8 @@ volumes:
     - configMap:
         name: perses-provisioning
 volumeMounts:
+- name: plugins
+  mountPath: /etc/perses/plugins
 - name: provisioning
   mountPath: /etc/perses/provisioning
   readOnly: true

--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -1,6 +1,20 @@
 sidecar:
-  enabled: true
+  enabled: false
 logLevel: "debug"
 config:
   provisioning:
-    interval: 5s
+    interval: 1m
+volumes:
+- name: provisioning
+  projected:
+    sources:
+    - configMap:
+        name: perses-provisioning-py
+    - configMap:
+        name: perses-provisioning-dsh
+    - configMap:
+        name: perses-provisioning
+volumeMounts:
+- name: provisioning
+  mountPath: /etc/perses/provisioning
+  readOnly: true

--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -1,20 +1,6 @@
 sidecar:
-  enabled: false
+  enabled: true
 logLevel: "debug"
 config:
   provisioning:
     interval: 5s
-volumes:
-- name: provisioning
-  projected:
-    sources:
-    - configMap:
-        name: perses-provisioning-py
-    - configMap:
-        name: perses-provisioning-dsh
-    - configMap:
-        name: perses-provisioning
-volumeMounts:
-- name: provisioning
-  mountPath: /etc/perses/provisioning
-  readOnly: true

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -458,7 +458,37 @@ setup_kind_singlecluster() {
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
     ${HELM} install perses perses/perses -n istio-system --wait --timeout 120s -f "${SCRIPT_DIR}"/istio/perses/values.yaml
-    infomsg "Perses installed. Sidecar will provision dashboards from ConfigMaps."
+
+    infomsg "=== Perses Debug: Pod status ==="
+    kubectl get pods -n istio-system -l app.kubernetes.io/name=perses -o wide
+    infomsg "=== Perses Debug: StatefulSet volumes ==="
+    kubectl get sts perses -n istio-system -o jsonpath='{.spec.template.spec.volumes}' 2>&1
+    echo ""
+    infomsg "=== Perses Debug: StatefulSet volumeMounts ==="
+    kubectl get sts perses -n istio-system -o jsonpath='{.spec.template.spec.containers[0].volumeMounts}' 2>&1
+    echo ""
+    infomsg "=== Perses Debug: ConfigMap perses (Perses config) ==="
+    kubectl get configmap perses -n istio-system -o jsonpath='{.data.config\.yaml}' 2>&1
+    echo ""
+    infomsg "=== Perses Debug: Perses logs (last 50 lines) ==="
+    kubectl logs -n istio-system perses-0 -c perses --tail=50 2>&1
+    infomsg "=== Perses Debug: Waiting 90s for provisioning (interval=1m) ==="
+    sleep 90
+    infomsg "=== Perses Debug: Perses logs AFTER wait (last 50 lines) ==="
+    kubectl logs -n istio-system perses-0 -c perses --tail=50 2>&1
+    infomsg "=== Perses Debug: Checking dashboard via port-forward ==="
+    kubectl port-forward -n istio-system svc/perses 14000:8080 &
+    local pf_pid=$!
+    sleep 3
+    infomsg "=== Perses Debug: List projects ==="
+    curl -sv http://localhost:14000/api/v1/projects 2>&1 || true
+    infomsg "=== Perses Debug: List dashboards in project istio ==="
+    curl -sv http://localhost:14000/api/v1/projects/istio/dashboards 2>&1 || true
+    infomsg "=== Perses Debug: Get specific dashboard ==="
+    curl -sv http://localhost:14000/api/v1/projects/istio/dashboards/istio-mesh-dashboard 2>&1 | head -c 500 || true
+    echo ""
+    kill "${pf_pid}" 2>/dev/null || true
+    infomsg "=== Perses Debug: End ==="
 
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -457,14 +457,12 @@ setup_kind_singlecluster() {
     kubectl apply -f "${SCRIPT_DIR}"/istio/perses/dashboard.yaml
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
-    ${HELM} install perses perses/perses -n istio-system --wait --timeout 120s -f "${SCRIPT_DIR}"/istio/perses/values.yaml
-    infomsg "Perses installed with plugins emptyDir volume for writable plugin extraction."
+    ${HELM} install perses perses/perses -n istio-system -f "${SCRIPT_DIR}"/istio/perses/values.yaml
 
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"
         "--set" "external_services.perses.internal_url=http://perses.istio-system:8080"
         "--set" "external_services.perses.external_url=http://localhost:4000"
-        "--set" "external_services.perses.project=istio"
         "--set" "external_services.perses.dashboards[0].name=Istio Mesh Dashboard"
         "--set" "external_services.perses.dashboards[0].variables.namespace=var-namespace"
         "--set" "external_services.perses.dashboards[0].variables.workload=var-workload"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -462,6 +462,7 @@ setup_kind_singlecluster() {
         "--set" "external_services.perses.enabled=true"
         "--set" "external_services.perses.internal_url=http://perses.istio-system:8080"
         "--set" "external_services.perses.external_url=http://localhost:4000"
+        "--set" "external_services.perses.project=istio"
         "--set" "external_services.perses.dashboards[0].name=Istio Mesh Dashboard"
         "--set" "external_services.perses.dashboards[0].variables.namespace=var-namespace"
         "--set" "external_services.perses.dashboards[0].variables.workload=var-workload"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -457,21 +457,8 @@ setup_kind_singlecluster() {
     kubectl apply -f "${SCRIPT_DIR}"/istio/perses/dashboard.yaml
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
-    ${HELM} install perses perses/perses -n istio-system --wait -f "${SCRIPT_DIR}"/istio/perses/values.yaml
-
-    infomsg "Waiting for Perses dashboards to be provisioned..."
-    local retries=0
-    while [ "${retries}" -lt 30 ]; do
-      if kubectl exec -n istio-system deploy/perses -- wget -q -O- http://localhost:8080/api/v1/projects/istio/dashboards/istio-mesh-dashboard 2>/dev/null | grep -q "istio-mesh-dashboard"; then
-        infomsg "Perses dashboards are ready."
-        break
-      fi
-      retries=$((retries + 1))
-      sleep 5
-    done
-    if [ "${retries}" -ge 30 ]; then
-      infomsg "WARNING: Perses dashboards may not be fully provisioned after 150s"
-    fi
+    ${HELM} install perses perses/perses -n istio-system --wait --timeout 120s -f "${SCRIPT_DIR}"/istio/perses/values.yaml
+    infomsg "Perses installed. Sidecar will provision dashboards from ConfigMaps."
 
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -458,37 +458,7 @@ setup_kind_singlecluster() {
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
     ${HELM} install perses perses/perses -n istio-system --wait --timeout 120s -f "${SCRIPT_DIR}"/istio/perses/values.yaml
-
-    infomsg "=== Perses Debug: Pod status ==="
-    kubectl get pods -n istio-system -l app.kubernetes.io/name=perses -o wide
-    infomsg "=== Perses Debug: StatefulSet volumes ==="
-    kubectl get sts perses -n istio-system -o jsonpath='{.spec.template.spec.volumes}' 2>&1
-    echo ""
-    infomsg "=== Perses Debug: StatefulSet volumeMounts ==="
-    kubectl get sts perses -n istio-system -o jsonpath='{.spec.template.spec.containers[0].volumeMounts}' 2>&1
-    echo ""
-    infomsg "=== Perses Debug: ConfigMap perses (Perses config) ==="
-    kubectl get configmap perses -n istio-system -o jsonpath='{.data.config\.yaml}' 2>&1
-    echo ""
-    infomsg "=== Perses Debug: Perses logs (last 50 lines) ==="
-    kubectl logs -n istio-system perses-0 -c perses --tail=50 2>&1
-    infomsg "=== Perses Debug: Waiting 90s for provisioning (interval=1m) ==="
-    sleep 90
-    infomsg "=== Perses Debug: Perses logs AFTER wait (last 50 lines) ==="
-    kubectl logs -n istio-system perses-0 -c perses --tail=50 2>&1
-    infomsg "=== Perses Debug: Checking dashboard via port-forward ==="
-    kubectl port-forward -n istio-system svc/perses 14000:8080 &
-    local pf_pid=$!
-    sleep 3
-    infomsg "=== Perses Debug: List projects ==="
-    curl -sv http://localhost:14000/api/v1/projects 2>&1 || true
-    infomsg "=== Perses Debug: List dashboards in project istio ==="
-    curl -sv http://localhost:14000/api/v1/projects/istio/dashboards 2>&1 || true
-    infomsg "=== Perses Debug: Get specific dashboard ==="
-    curl -sv http://localhost:14000/api/v1/projects/istio/dashboards/istio-mesh-dashboard 2>&1 | head -c 500 || true
-    echo ""
-    kill "${pf_pid}" 2>/dev/null || true
-    infomsg "=== Perses Debug: End ==="
+    infomsg "Perses installed with plugins emptyDir volume for writable plugin extraction."
 
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -457,7 +457,22 @@ setup_kind_singlecluster() {
     kubectl apply -f "${SCRIPT_DIR}"/istio/perses/dashboard.yaml
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
-    ${HELM} install perses perses/perses -n istio-system -f "${SCRIPT_DIR}"/istio/perses/values.yaml
+    ${HELM} install perses perses/perses -n istio-system --wait -f "${SCRIPT_DIR}"/istio/perses/values.yaml
+
+    infomsg "Waiting for Perses dashboards to be provisioned..."
+    local retries=0
+    while [ "${retries}" -lt 30 ]; do
+      if kubectl exec -n istio-system deploy/perses -- wget -q -O- http://localhost:8080/api/v1/projects/istio/dashboards/istio-mesh-dashboard 2>/dev/null | grep -q "istio-mesh-dashboard"; then
+        infomsg "Perses dashboards are ready."
+        break
+      fi
+      retries=$((retries + 1))
+      sleep 5
+    done
+    if [ "${retries}" -ge 30 ]; then
+      infomsg "WARNING: Perses dashboards may not be fully provisioned after 150s"
+    fi
+
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"
         "--set" "external_services.perses.internal_url=http://perses.istio-system:8080"


### PR DESCRIPTION
### Describe the change

The Perses "See workload Perses link" test was failing in CI but passing locally because Perses v0.53.1 needs to extract plugin archives (BarChart, etc.) into `/etc/perses/plugins/` at startup, but that path was read-only in the container. Without the plugins loaded, variable and datasource schemas are not initialized, so dashboard provisioning is rejected with "variable schemas are not loaded". Locally it appeared to work because the PVC persisted the already-extracted plugins from a previous installation, masking the issue; in CI (and locally after a clean helm uninstall) every run starts fresh with no PVC data. We added extensive diagnostic logging to `setup-kind-in-ci.sh` to confirm this root cause, then fixed it by adding an emptyDir volume mounted at `/etc/perses/plugins` in `hack/istio/perses/values.yaml` so Perses can write there.

### Steps to test the PR
Test pass

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9929 
