### PR TITLE
[AI] Fix missing "Confirm chat deletion" modal when switching.

### DIFF
--- a/frontend/src/components/ChatBot/ChatBot.tsx
+++ b/frontend/src/components/ChatBot/ChatBot.tsx
@@ -38,6 +38,7 @@ export const ChatBot: React.FC = () => {
   const selectedModel = useSelector((state: KialiAppState) => state.aiChat.selectedModel);
   const providers = useSelector((state: KialiAppState) => state.aiChat.providers);
   const conversationID = useSelector((state: KialiAppState) => state.aiChat.conversationID);
+  const chatHistory = useSelector((state: KialiAppState) => state.aiChat.chatHistory);
   const [newProvider, setNewProvider] = useState<string>('');
   const [newModel, setNewModel] = useState<string>('');
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(false);
@@ -103,7 +104,7 @@ export const ChatBot: React.FC = () => {
       return;
     }
     if (provider.name !== selectedProvider || model.name !== selectedModel) {
-      if (conversationID === '') {
+      if (conversationID === '' && chatHistory.size === 0) {
         dispatch(ChatAIActions.setSelectedProvider({ provider: provider.name }));
         dispatch(ChatAIActions.setSelectedModel({ model: model.name }));
       } else {


### PR DESCRIPTION
### Describe the change
When switching AI providers, the "Confirm chat deletion" modal was only shown when the backend had assigned a conversationID. However, if the current provider is disconnected or failing, the streaming request never succeeds, so conversationID remains empty — even though the user already has messages in the chat (their query + the error response). This caused the modal to be entirely skipped, switching providers immediately without warning.

The fix adds a check for chatHistory.size === 0 alongside the existing conversationID === '' condition. Now the modal appears whenever there is either a server-assigned conversation ID or existing messages in the chat history. A direct (no-modal) provider switch only happens when the chat is truly empty.

### Steps to test the PR
Configure Kiali with two AI providers, one with a broken/unreachable endpoint (e.g. https://localhost:9999/).
Open the AI chat panel; the default provider should be the broken one.
Send a message — it should fail with a connection error displayed in chat.
Switch to the second provider from the dropdown.
Expected: The "Confirm chat deletion" modal appears asking to erase and start a new chat.
Before fix: The provider switched immediately without any confirmation.

### Automation testing
N/A — This is a UI interaction flow. Manual verification is recommended.

### Issue reference
Fixes [#9921](https://github.com/kiali/kiali/issues/9921)