### PR TITLE
Refactored includeAmbient from metrics options and usage of reporter.

### DIFF
--- a/ai/mcp/tools/get_metrics.yaml
+++ b/ai/mcp/tools/get_metrics.yaml
@@ -29,8 +29,7 @@
         enum: ["inbound", "outbound"]
       reporter:
         type: "string"
-        description: "Metrics reporter: 'source', 'destination', or 'both'. Optional, defaults to 'source'"
-        enum: ["source", "destination", "both"]
+        description: "Metrics reporter(s). Comma-separated list of: 'source', 'destination', 'waypoint', or the special value 'both' (no reporter filter). Optional, defaults to 'source'. Example: 'source,waypoint'"
       requestProtocol:
         type: "string"
         description: "Desired request protocol for the telemetry: For example, 'http' or 'grpc'. Optional"

--- a/ai/mcputil/access_validations.go
+++ b/ai/mcputil/access_validations.go
@@ -31,17 +31,9 @@ func ExtractIstioMetricsQueryParams(args map[string]interface{}, q *models.Istio
 	}
 	q.Direction = dir
 
-	if includeAmbientParam := GetStringArg(args, "includeAmbient"); includeAmbientParam != "" {
-		includeAmbient, err := strconv.ParseBool(includeAmbientParam)
-		if err != nil {
-			return errors.New("bad request, query parameter 'includeAmbient' must be either 'true' or 'false'")
-		}
-		q.IncludeAmbient = includeAmbient
-	}
-
 	reporter := GetStringOrDefault(args, DefaultReporter, "reporter")
-	if reporter != "both" && reporter != "destination" && reporter != "source" {
-		return errors.New("bad request, query parameter 'reporter' must be one of 'both, 'destination', or 'source'")
+	if err := models.ValidateReporter(reporter); err != nil {
+		return err
 	}
 	q.Reporter = reporter
 

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -306,8 +306,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetMetrics(t *testing.T) {
 					},
 					"reporter": map[string]interface{}{
 						"type":        "string",
-						"description": "Metrics reporter: 'source', 'destination', or 'both'. Optional, defaults to 'source'",
-						"enum":        []interface{}{"source", "destination", "both"},
+						"description": "Metrics reporter(s). Comma-separated list of: 'source', 'destination', 'waypoint', or the special value 'both' (no reporter filter). Optional, defaults to 'source'. Example: 'source,waypoint'",
 					},
 					"requestProtocol": map[string]interface{}{
 						"type":        "string",

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -254,8 +254,7 @@ func TestConvertToolToGoogle_FromToolDefinition_GetMetrics(t *testing.T) {
 			},
 			"reporter": {
 				Type:        genai.TypeString,
-				Description: "Metrics reporter: 'source', 'destination', or 'both'. Optional, defaults to 'source'",
-				Enum:        []string{"source", "destination", "both"},
+				Description: "Metrics reporter(s). Comma-separated list of: 'source', 'destination', 'waypoint', or the special value 'both' (no reporter filter). Optional, defaults to 'source'. Example: 'source,waypoint'",
 			},
 			"requestProtocol": {
 				Type:        genai.TypeString,

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -339,12 +339,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetMetrics(t *testing.T) {
 						},
 						"reporter": map[string]interface{}{
 							"type":        "string",
-							"description": "Metrics reporter: 'source', 'destination', or 'both'. Optional, defaults to 'source'",
-							"enum": []interface{}{
-								"source",
-								"destination",
-								"both",
-							},
+							"description": "Metrics reporter(s). Comma-separated list of: 'source', 'destination', 'waypoint', or the special value 'both' (no reporter filter). Optional, defaults to 'source'. Example: 'source,waypoint'",
 						},
 						"requestProtocol": map[string]interface{}{
 							"type":        "string",

--- a/business/metrics.go
+++ b/business/metrics.go
@@ -33,7 +33,7 @@ func (in *MetricsService) GetMetrics(ctx context.Context, q models.IstioMetricsQ
 func createMetricsLabelsBuilder(q *models.IstioMetricsQuery, conf *config.Config) *MetricsLabelsBuilder {
 	lb := NewMetricsLabelsBuilder(q.Direction, conf)
 	if q.Reporter != "both" {
-		lb.Reporter(q.Reporter, q.IncludeAmbient)
+		lb.Reporters(strings.Split(q.Reporter, ","))
 	}
 
 	namespaceSet := false

--- a/business/metrics_labels_builder.go
+++ b/business/metrics_labels_builder.go
@@ -53,13 +53,6 @@ func (lb *MetricsLabelsBuilder) addSided(partialKey, value, side string) *Metric
 	return lb
 }
 
-func (lb *MetricsLabelsBuilder) Reporter(name string, includeAmbient bool) *MetricsLabelsBuilder {
-	if includeAmbient {
-		return lb.AddOp("reporter", fmt.Sprintf("%s|%s", name, "waypoint"), "=~")
-	}
-	return lb.Add("reporter", name)
-}
-
 func (lb *MetricsLabelsBuilder) Reporters(reporters []string) *MetricsLabelsBuilder {
 	if len(reporters) == 0 {
 		return lb

--- a/business/metrics_labels_builder_test.go
+++ b/business/metrics_labels_builder_test.go
@@ -14,7 +14,7 @@ func TestMetricsLabelsBuilderInboundHttp(t *testing.T) {
 
 	lb := NewMetricsLabelsBuilder("inbound", config.Get())
 	lb.App("test", "ns")
-	lb.Reporter("source", false)
+	lb.Reporters([]string{"source"})
 	lb.Protocol("http")
 	assert.Equal(`{destination_workload_namespace="ns",destination_canonical_service="test",reporter="source",request_protocol="http"}`, lb.Build())
 
@@ -29,7 +29,7 @@ func TestMetricsLabelsBuilderOutboundGrpc(t *testing.T) {
 
 	lb := NewMetricsLabelsBuilder("outbound", config.Get())
 	lb.Workload("test", "ns")
-	lb.Reporter("destination", false)
+	lb.Reporters([]string{"destination"})
 	lb.Protocol("grpc")
 	assert.Equal(`{source_workload_namespace="ns",source_workload="test",reporter="destination",request_protocol="grpc"}`, lb.Build())
 
@@ -37,6 +37,17 @@ func TestMetricsLabelsBuilderOutboundGrpc(t *testing.T) {
 	assert.Len(errs, 2)
 	assert.Equal(`{source_workload_namespace="ns",source_workload="test",reporter="destination",request_protocol="grpc",response_code=~"^0$|^[4-5]\\d\\d$"}`, errs[0])
 	assert.Equal(`{source_workload_namespace="ns",source_workload="test",reporter="destination",request_protocol="grpc",grpc_response_status=~"^[1-9]$|^1[0-6]$",response_code!~"^0$|^[4-5]\\d\\d$"}`, errs[1])
+}
+
+func TestMetricsLabelsBuilderWithWaypoint(t *testing.T) {
+	assert := assert.New(t)
+	config.Set(config.NewConfig())
+
+	lb := NewMetricsLabelsBuilder("inbound", config.Get())
+	lb.App("test", "ns")
+	lb.Reporters([]string{"destination", "waypoint"})
+	lb.Protocol("http")
+	assert.Equal(`{destination_workload_namespace="ns",destination_canonical_service="test",reporter=~"destination|waypoint",request_protocol="http"}`, lb.Build())
 }
 
 func TestMetricsLabelsBuilderInboundPeerLabels(t *testing.T) {

--- a/frontend/src/components/Ambient/ZtunnelMetrics.tsx
+++ b/frontend/src/components/Ambient/ZtunnelMetrics.tsx
@@ -3,7 +3,7 @@ import { DirectionType, TimeInMilliseconds, TimeRange } from '../../types/Common
 import * as API from '../../services/Api';
 import { addError } from '../../utils/AlertUtils';
 import { computePrometheusRateParams } from '../../services/Prometheus';
-import { IstioMetricsOptions } from '../../types/MetricsOptions';
+import { IstioMetricsOptions, buildReporter } from '../../types/MetricsOptions';
 import { location, router } from 'app/History';
 import { serverConfig } from '../../config';
 import * as MetricsHelper from '../Metrics/Helper';
@@ -52,9 +52,8 @@ export const ZtunnelMetrics: React.FC<ZtunnelMetricsProps> = (props: ZtunnelMetr
     direction: direction,
     duration: props.rangeDuration.rangeDuration,
     filters: ['request_count', 'request_error_count'],
-    includeAmbient: serverConfig.ambientEnabled,
     rateInterval: rateParams.rateInterval,
-    reporter: 'source',
+    reporter: buildReporter(direction, serverConfig.ambientEnabled),
     step: rateParams.step
   };
 

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -15,7 +15,7 @@ import {
 import * as API from 'services/Api';
 import { KialiAppState } from 'store/Store';
 import { TimeRange, evalTimeRange, TimeInMilliseconds, isEqualTimeRange, IntervalInMilliseconds } from 'types/Common';
-import { Direction, IstioMetricsOptions, Reporter } from 'types/MetricsOptions';
+import { Direction, IstioMetricsOptions, withWaypoint } from 'types/MetricsOptions';
 import { addError } from 'utils/AlertUtils';
 import * as MetricsHelper from './Helper';
 import { KioskElement } from '../Kiosk/KioskElement';
@@ -65,7 +65,7 @@ type ObjectId = {
 
 type IstioMetricsProps = ObjectId & {
   direction: Direction;
-  includeAmbient: boolean;
+  includeWaypoint: boolean;
   objectType: MetricsObjectTypes;
 } & {
   lastRefreshAt: TimeInMilliseconds;
@@ -119,10 +119,10 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
   }
 
   private initOptions(settings: MetricsSettings): IstioMetricsOptions {
+    const initialReporter = MetricsReporter.initialReporter(this.props.direction);
     const options: IstioMetricsOptions = {
       direction: this.props.direction,
-      includeAmbient: this.props.includeAmbient,
-      reporter: MetricsReporter.initialReporter(this.props.direction)
+      reporter: withWaypoint(initialReporter, this.props.includeWaypoint)
     };
 
     const defaultLabels = [
@@ -294,8 +294,8 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
     this.setState({ labelsSettings: labelsFilters });
   };
 
-  private onReporterChanged = (reporter: Reporter): void => {
-    this.options.reporter = reporter;
+  private onReporterChanged = (reporter: string): void => {
+    this.options.reporter = withWaypoint(reporter, this.props.includeWaypoint);
     this.fetchMetrics();
   };
 

--- a/frontend/src/components/Metrics/IstioMetrics.tsx
+++ b/frontend/src/components/Metrics/IstioMetrics.tsx
@@ -15,7 +15,7 @@ import {
 import * as API from 'services/Api';
 import { KialiAppState } from 'store/Store';
 import { TimeRange, evalTimeRange, TimeInMilliseconds, isEqualTimeRange, IntervalInMilliseconds } from 'types/Common';
-import { Direction, IstioMetricsOptions, withWaypoint } from 'types/MetricsOptions';
+import { Direction, IstioMetricsOptions, withWaypoint, baseReporter } from 'types/MetricsOptions';
 import { addError } from 'utils/AlertUtils';
 import * as MetricsHelper from './Helper';
 import { KioskElement } from '../Kiosk/KioskElement';
@@ -431,7 +431,7 @@ class IstioMetricsComponent extends React.Component<Props, MetricsState> {
               <MetricsReporter
                 onChanged={this.onReporterChanged}
                 direction={this.props.direction}
-                reporter={this.options.reporter}
+                reporter={baseReporter(this.options.reporter)}
               />
             </ToolbarItem>
 

--- a/frontend/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/frontend/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -110,7 +110,7 @@ describe('Metrics for a service', () => {
             object="svc"
             objectType={MetricsObjectTypes.SERVICE}
             direction={'inbound'}
-            includeAmbient={false}
+            includeWaypoint={false}
           />
         </MemoryRouter>
       </Provider>
@@ -128,7 +128,7 @@ describe('Metrics for a service', () => {
           object="svc"
           objectType={MetricsObjectTypes.SERVICE}
           direction={'inbound'}
-          includeAmbient={false}
+          includeWaypoint={false}
           lastRefreshAt={1720526431902}
         />
       )
@@ -158,7 +158,7 @@ describe('Metrics for a service', () => {
           object="svc"
           objectType={MetricsObjectTypes.SERVICE}
           direction={'inbound'}
-          includeAmbient={false}
+          includeWaypoint={false}
           lastRefreshAt={1720526431902}
         />
       )
@@ -204,7 +204,7 @@ describe('Inbound Metrics for a workload', () => {
             object="svc"
             objectType={MetricsObjectTypes.WORKLOAD}
             direction={'inbound'}
-            includeAmbient={false}
+            includeWaypoint={false}
           />
         </MemoryRouter>
       </Provider>
@@ -222,7 +222,7 @@ describe('Inbound Metrics for a workload', () => {
           object="wkd"
           objectType={MetricsObjectTypes.WORKLOAD}
           direction={'inbound'}
-          includeAmbient={false}
+          includeWaypoint={false}
           lastRefreshAt={1720526431902}
         />
       )
@@ -252,7 +252,7 @@ describe('Inbound Metrics for a workload', () => {
           object="wkd"
           objectType={MetricsObjectTypes.WORKLOAD}
           direction={'inbound'}
-          includeAmbient={false}
+          includeWaypoint={false}
           lastRefreshAt={1720526431902}
         />
       )

--- a/frontend/src/components/MetricsOptions/MetricsReporter.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsReporter.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { URLParam, HistoryManager } from '../../app/History';
 import { ToolbarDropdown } from '../Dropdown/ToolbarDropdown';
-import { Reporter, Direction } from '../../types/MetricsOptions';
+import { Direction } from '../../types/MetricsOptions';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -11,8 +11,8 @@ import { classes } from 'typestyle';
 
 interface Props {
   direction: Direction;
-  onChanged: (reproter: Reporter) => void;
-  reporter: Reporter;
+  onChanged: (reporter: string) => void;
+  reporter: string;
 }
 
 const metricsReporterInfoStyle = kialiStyle({
@@ -28,11 +28,11 @@ export class MetricsReporter extends React.Component<Props> {
     both: 'Both'
   };
 
-  static initialReporter = (direction: Direction): Reporter => {
+  static initialReporter = (direction: Direction): string => {
     const reporterParam = HistoryManager.getParam(URLParam.REPORTER);
 
     if (reporterParam !== undefined) {
-      return reporterParam as Reporter;
+      return reporterParam;
     }
 
     return direction === 'inbound' ? 'destination' : 'source';
@@ -40,8 +40,7 @@ export class MetricsReporter extends React.Component<Props> {
 
   onReporterChanged = (reporter: string): void => {
     HistoryManager.setParam(URLParam.REPORTER, reporter);
-    const newReporter = reporter as Reporter;
-    this.props.onChanged(newReporter);
+    this.props.onChanged(reporter);
   };
 
   reportTooltip = (

--- a/frontend/src/components/TracingIntegration/TraceTooltip.tsx
+++ b/frontend/src/components/TracingIntegration/TraceTooltip.tsx
@@ -53,7 +53,7 @@ const rightStyle = kialiStyle({
 });
 
 type TraceLabelOwnProps = {
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
   trace: JaegerTrace;
 };
 
@@ -104,8 +104,8 @@ const mapStateToProps = (
   state: KialiAppState,
   props: TraceLabelOwnProps
 ): { isStatsMatrixComplete: boolean; statsMatrix: StatsMatrix } => {
-  const includeAmbient = !!props.includeAmbient || props.trace.spans.some(span => isWaypointProxySpan(span));
-  const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true, includeAmbient);
+  const includeWaypoint = !!props.includeWaypoint || props.trace.spans.some(span => isWaypointProxySpan(span));
+  const { matrix, isComplete } = reduceMetricsStats(props.trace, state.metricsStats.data, true, includeWaypoint);
   return {
     statsMatrix: matrix,
     isStatsMatrixComplete: isComplete
@@ -117,7 +117,7 @@ const TraceLabelContainer = connect(mapStateToProps)(TraceLabel);
 type FlyoutOrientation = 'top' | 'bottom' | 'left' | 'right';
 type FlyoutOrientationProps = Pick<ChartLabelProps, 'x' | 'y' | 'width'>;
 type TooltipProps = HookedTooltipProps<JaegerLineInfo> & {
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
 };
 
 export const computeFlyoutOrientation = (props: FlyoutOrientationProps): FlyoutOrientation => {
@@ -156,7 +156,7 @@ export class TraceTooltip extends React.Component<TooltipProps> {
           flyoutHeight={flyoutHeight}
           orientation={this.getOrientation}
           flyoutComponent={<ChartCursorFlyout style={{ stroke: 'none', fillOpacity: 0.6, pointerEvents: 'none' }} />}
-          labelComponent={<TraceLabelContainer trace={trace} includeAmbient={this.props.includeAmbient} />}
+          labelComponent={<TraceLabelContainer trace={trace} includeWaypoint={this.props.includeWaypoint} />}
         />
       );
     }

--- a/frontend/src/components/TracingIntegration/TracesComponent.tsx
+++ b/frontend/src/components/TracingIntegration/TracesComponent.tsx
@@ -60,7 +60,7 @@ type ReduxProps = {
 type TracesProps = ReduxProps & {
   cluster?: string;
   fromWaypoint: boolean;
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
   lastRefreshAt: TimeInMilliseconds;
   namespace: string;
   target: string;
@@ -190,7 +190,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
   };
 
   private fetchPercentiles = (): Promise<Map<string, number>> => {
-    const includeAmbient = this.shouldIncludeAmbient();
+    const includeWaypoint = this.shouldIncludeWaypoint();
     // We'll fetch percentiles on a large enough interval (unrelated to the selected interval)
     // in order to have stable values and avoid constantly fetching again
     const query: MetricsStatsQuery = {
@@ -204,13 +204,13 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
       interval: '1h',
       direction: 'inbound',
       avg: false,
-      reporters: getStatsReporters('inbound', includeAmbient),
+      reporters: getStatsReporters('inbound', includeWaypoint),
       quantiles: percentilesOptions.map(p => p.id).filter(id => id !== 'all')
     };
     const queries: MetricsStatsQuery[] =
       this.props.targetKind === 'service'
         ? [query]
-        : [query, { ...query, direction: 'outbound', reporters: getStatsReporters('outbound', includeAmbient) }];
+        : [query, { ...query, direction: 'outbound', reporters: getStatsReporters('outbound', includeWaypoint) }];
     return API.getMetricsStats(queries).then(r => this.percentilesFetched(query, r.data));
   };
 
@@ -260,7 +260,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
   private getUrlProvider = (): TracingUrlProvider | undefined =>
     GetTracingUrlProvider(this.props.externalServices, this.props.provider);
 
-  private shouldIncludeAmbient = (): boolean => !!this.props.includeAmbient || this.props.fromWaypoint;
+  private shouldIncludeWaypoint = (): boolean => !!this.props.includeWaypoint || this.props.fromWaypoint;
 
   private getTracingUrl = (): string | undefined => {
     if (!this.urlProvider || !this.state.targetApp || !this.urlProvider.HomeUrl()) {
@@ -360,7 +360,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                 traces={this.state.traces}
                 errorFetchTraces={this.state.tracingErrors}
                 errorTraces={true}
-                includeAmbient={this.shouldIncludeAmbient()}
+                includeWaypoint={this.shouldIncludeWaypoint()}
                 cluster={this.props.cluster ? this.props.cluster : ''} // TODO: Test single cluster
               />
             </CardBody>
@@ -381,7 +381,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                       targetKind={this.props.targetKind}
                       tracingURLProvider={this.urlProvider}
                       otherTraces={this.state.traces}
-                      includeAmbient={this.shouldIncludeAmbient()}
+                      includeWaypoint={this.shouldIncludeWaypoint()}
                       cluster={this.props.cluster ? this.props.cluster : ''}
                       provider={this.props.provider}
                     />
@@ -395,7 +395,7 @@ class TracesComp extends React.Component<TracesProps, TracesState> {
                       traceID={this.props.selectedTrace.traceID}
                       cluster={this.props.cluster ? this.props.cluster : ''}
                       fromWaypoint={this.props.fromWaypoint}
-                      includeAmbient={this.shouldIncludeAmbient()}
+                      includeWaypoint={this.shouldIncludeWaypoint()}
                       waypointServiceFilter={this.props.waypointServiceFilter}
                     />
                   </Tab>

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanDetails.tsx
@@ -15,7 +15,7 @@ interface SpanDetailsProps {
   cluster?: string;
   externalURLProvider?: TracingUrlProvider;
   fromWaypoint: boolean;
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
   items: RichSpanData[];
   namespace: string;
   target: string;
@@ -46,7 +46,7 @@ export const SpanDetails: React.FC<SpanDetailsProps> = (props: SpanDetailsProps)
             namespace={props.namespace}
             externalURLProvider={props.externalURLProvider}
             cluster={props.cluster}
-            includeAmbient={props.includeAmbient}
+            includeWaypoint={props.includeWaypoint}
             target={props.waypointServiceFilter ? props.waypointServiceFilter : props.target}
             traceID={props.traceID}
             fromWaypoint={props.fromWaypoint}

--- a/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/SpanTable.tsx
@@ -40,7 +40,7 @@ type Props = ReduxProps &
     cluster?: string;
     externalURLProvider?: TracingUrlProvider;
     fromWaypoint: boolean; // If the traces come from a waypoint proxy
-    includeAmbient?: boolean;
+    includeWaypoint?: boolean;
     items: RichSpanData[];
     namespace: string;
     target: string;
@@ -203,12 +203,12 @@ class SpanTableComponent extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(items: RichSpanData[]): void {
-    const queries = buildQueriesFromSpans(items, false, this.shouldIncludeAmbient());
+    const queries = buildQueriesFromSpans(items, false, this.shouldIncludeWaypoint());
     this.props.loadMetricsStats(queries, false);
   }
 
-  private shouldIncludeAmbient = (): boolean =>
-    !!this.props.includeAmbient || this.props.items.some(item => isWaypointProxySpan(item));
+  private shouldIncludeWaypoint = (): boolean =>
+    !!this.props.includeWaypoint || this.props.items.some(item => isWaypointProxySpan(item));
 
   private rows = (): IRow[] => {
     const compare = columns[this.state.sortIndex].compare;
@@ -559,7 +559,7 @@ class SpanTableComponent extends React.Component<Props, State> {
             item,
             !this.isExpanded(item.spanID),
             this.props.metricsStats,
-            this.shouldIncludeAmbient(),
+            this.shouldIncludeWaypoint(),
             () => this.fetchComparisonMetrics([item])
           )}
       </div>

--- a/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
@@ -75,10 +75,10 @@ export const renderMetricsComparison = (
   item: RichSpanData,
   isCompact: boolean,
   metricsStats: Map<string, MetricsStats>,
-  includeAmbient: boolean,
+  includeWaypoint: boolean,
   load: () => void
 ): React.ReactNode => {
-  const itemStats = getSpanStats(item, metricsStats, isCompact, includeAmbient);
+  const itemStats = getSpanStats(item, metricsStats, isCompact, includeWaypoint);
   const key = `${item.spanID}-metcomp`;
 
   if (itemStats.length > 0) {

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -45,7 +45,7 @@ type StateProps = {
 
 type OwnProps = {
   cluster?: string;
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
   namespace: string;
   otherTraces: JaegerTrace[];
   provider?: string;
@@ -90,7 +90,7 @@ class TraceDetailsComponent extends React.Component<Props, State> {
   }
 
   private fetchComparisonMetrics(spans: RichSpanData[]): void {
-    const queries = buildQueriesFromSpans(spans, false, !!this.props.includeAmbient);
+    const queries = buildQueriesFromSpans(spans, false, !!this.props.includeWaypoint);
     this.props.loadMetricsStats(queries, false, this.props.cluster);
   }
 
@@ -271,13 +271,13 @@ class TraceDetailsComponent extends React.Component<Props, State> {
 
 const mapStateToProps = (state: KialiAppState, props: OwnProps): StateProps => {
   if (state.tracingState.selectedTrace) {
-    const includeAmbient =
-      !!props.includeAmbient || state.tracingState.selectedTrace.spans.some(span => isWaypointProxySpan(span));
+    const includeWaypoint =
+      !!props.includeWaypoint || state.tracingState.selectedTrace.spans.some(span => isWaypointProxySpan(span));
     const { matrix, isComplete } = reduceMetricsStats(
       state.tracingState.selectedTrace,
       state.metricsStats.data,
       false,
-      includeAmbient
+      includeWaypoint
     );
 
     return {

--- a/frontend/src/components/TracingIntegration/TracingScatter.tsx
+++ b/frontend/src/components/TracingIntegration/TracingScatter.tsx
@@ -36,7 +36,7 @@ interface TracingScatterProps {
   duration: number;
   errorFetchTraces?: TracingError[];
   errorTraces?: boolean;
-  includeAmbient?: boolean;
+  includeWaypoint?: boolean;
   loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean) => Promise<any>;
   provider?: string;
   selectedTrace?: JaegerTrace;
@@ -172,7 +172,7 @@ export class TracingScatterComponent extends React.Component<TracingScatterProps
             onClick={dp => this.props.setTraceId(this.props.cluster, dp.trace.traceID)}
             onTooltipClose={dp => this.onTooltipClose(dp.trace)}
             onTooltipOpen={dp => this.onTooltipOpen(dp.trace)}
-            labelComponent={<TraceTooltip includeAmbient={this.props.includeAmbient} />}
+            labelComponent={<TraceTooltip includeWaypoint={this.props.includeWaypoint} />}
             pointer={true}
           />
         </div>
@@ -200,7 +200,7 @@ export class TracingScatterComponent extends React.Component<TracingScatterProps
       this.seletedTraceMatched = trace.matched;
     }
 
-    const queries = buildQueriesFromSpans(trace.spans, true, !!this.props.includeAmbient);
+    const queries = buildQueriesFromSpans(trace.spans, true, !!this.props.includeWaypoint);
 
     this.props
       .loadMetricsStats(queries, true)

--- a/frontend/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/frontend/src/pages/AppDetails/AppDetailsPage.tsx
@@ -192,7 +192,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
           cluster={this.state.cluster}
           data-test="inbound-metrics-component"
           direction={'inbound'}
-          includeAmbient={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for app
+          includeWaypoint={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for app
           lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.appId.namespace}
           object={this.props.appId.app}
@@ -207,7 +207,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
           cluster={this.state.cluster}
           data-test="outbound-metrics-component"
           direction={'outbound'}
-          includeAmbient={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for app
+          includeWaypoint={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for app
           lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.appId.namespace}
           object={this.props.appId.app}
@@ -241,7 +241,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
                 target={this.props.appId.app}
                 targetKind={'app'}
                 fromWaypoint={fromWaypoint}
-                includeAmbient={fromWaypoint || !!this.state.app?.isAmbient}
+                includeWaypoint={fromWaypoint || !!this.state.app?.isAmbient}
               />
             </Tab>
           );

--- a/frontend/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -25,7 +25,6 @@ import {
   getTitle
 } from './SummaryPanelCommon';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
-import { Reporter } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { KialiIcon } from 'config/KialiIcon';
 import { getOptions, clickHandler } from 'pages/Graph/ContextMenu/NodeContextMenu';
@@ -380,7 +379,7 @@ export class SummaryPanelAppBox extends React.Component<SummaryPanelPropType, Su
       if (filters.length > 0) {
         // use source metrics for outbound, except for:
         // - istio namespace nodes (no source telemetry)
-        const reporter: Reporter = nodeData.isIstio ? 'destination' : 'source';
+        const reporter = nodeData.isIstio ? 'destination' : 'source';
 
         // note: request_protocol is not a valid byLabel for tcp/grpc-message filters but it is ignored by prometheus
         const byLabels = nodeData.isOutside

--- a/frontend/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelCommon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
 import { NodeType, SummaryPanelPropType, Protocol, DecoratedGraphNodeData, BoxByType } from '../../types/Graph';
-import { IstioMetricsOptions, Reporter, Direction } from '../../types/MetricsOptions';
+import { IstioMetricsOptions, Direction, withWaypoint } from '../../types/MetricsOptions';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
 import { KialiIcon } from 'config/KialiIcon';
@@ -106,8 +106,8 @@ export const getNodeMetrics = (
   props: SummaryPanelPropType,
   filters: Array<string>,
   direction: Direction,
-  reporter: Reporter,
-  includeAmbient?: boolean,
+  reporter: string,
+  includeWaypoint?: boolean,
   requestProtocol?: string,
   quantiles?: Array<string>,
   byLabels?: Array<string>
@@ -117,11 +117,10 @@ export const getNodeMetrics = (
     direction: direction,
     duration: props.duration,
     filters: filters,
-    includeAmbient: !!includeAmbient,
     quantiles: quantiles,
     queryTime: props.queryTime,
     rateInterval: props.rateInterval,
-    reporter: reporter,
+    reporter: withWaypoint(reporter, !!includeWaypoint),
     requestProtocol: requestProtocol,
     step: props.step
   };

--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -25,6 +25,7 @@ import {
   summaryFont,
   summaryPanelWidth
 } from './SummaryPanelCommon';
+import { buildReporter } from '../../types/MetricsOptions';
 import { Datapoint, IstioMetricsMap, Labels } from '../../types/Metrics';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { KialiIcon } from 'config/KialiIcon';
@@ -617,11 +618,10 @@ export class SummaryPanelGraph extends React.Component<SummaryPanelPropType, Sum
         byLabels: ['request_protocol'], // ignored by prom if it doesn't exist
         direction: 'inbound',
         duration: props.duration,
-        includeAmbient: serverConfig.ambientEnabled,
         filters: filters,
         queryTime: props.queryTime,
         rateInterval: props.rateInterval,
-        reporter: 'destination',
+        reporter: buildReporter('inbound', serverConfig.ambientEnabled),
         step: props.step
       });
 
@@ -630,10 +630,9 @@ export class SummaryPanelGraph extends React.Component<SummaryPanelPropType, Sum
         direction: 'outbound',
         duration: props.duration,
         filters: filters,
-        includeAmbient: serverConfig.ambientEnabled,
         queryTime: props.queryTime,
         rateInterval: props.rateInterval,
-        reporter: 'source',
+        reporter: buildReporter('outbound', serverConfig.ambientEnabled),
         step: props.step
       });
     }

--- a/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -25,6 +25,7 @@ import {
   getTitle,
   noTrafficStyle
 } from './SummaryPanelCommon';
+import { buildReporter } from '../../types/MetricsOptions';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { KialiIcon } from 'config/KialiIcon';
@@ -584,10 +585,9 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           direction: 'inbound',
           duration: props.duration,
           filters: filters,
-          includeAmbient: serverConfig.ambientEnabled, // TODO change to "nodeData.isAmbient" when it is set for this node type
           queryTime: props.queryTime,
           rateInterval: props.rateInterval,
-          reporter: 'destination',
+          reporter: buildReporter('inbound', serverConfig.ambientEnabled), // TODO change to "nodeData.isAmbient" when it is set for this node type
           step: props.step
         },
         cluster
@@ -599,10 +599,9 @@ export class SummaryPanelNamespaceBox extends React.Component<SummaryPanelPropTy
           direction: 'outbound',
           duration: props.duration,
           filters: filters,
-          includeAmbient: serverConfig.ambientEnabled, // TODO change to "nodeData.isAmbient" when it is set for this node type
           queryTime: props.queryTime,
           rateInterval: props.rateInterval,
-          reporter: 'source',
+          reporter: buildReporter('outbound', serverConfig.ambientEnabled), // TODO change to "nodeData.isAmbient" when it is set for this node type
           step: props.step
         },
         cluster

--- a/frontend/src/pages/Graph/SummaryPanelNodeTraffic.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelNodeTraffic.tsx
@@ -29,7 +29,6 @@ import {
   hr
 } from './SummaryPanelCommon';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { Reporter } from '../../types/MetricsOptions';
 import { KialiIcon } from 'config/KialiIcon';
 import { edgesOut, nodesIn, nodesOut, select } from 'helpers/GraphHelpers';
 import { ApiResponse } from 'types/Api';
@@ -161,7 +160,7 @@ export class SummaryPanelNodeTraffic extends React.Component<SummaryPanelNodePro
         const filtersRps = ['request_count', 'request_error_count'];
 
         // use dest metrics for inbound, except for service nodes which need source metrics to capture source errors
-        let reporter: Reporter = nodeData.nodeType === NodeType.SERVICE && nodeData.isIstio ? 'source' : 'destination';
+        let reporter = nodeData.nodeType === NodeType.SERVICE && nodeData.isIstio ? 'source' : 'destination';
 
         // For special service dest nodes we want to narrow the data to only TS with 'unknown' workloads (see the related
         // comparator in getNodeDatapoints).
@@ -247,8 +246,7 @@ export class SummaryPanelNodeTraffic extends React.Component<SummaryPanelNodePro
         // use source metrics for outbound, except for:
         // - unknown nodes (no source telemetry)
         // - istio namespace nodes (no source telemetry)
-        const reporter: Reporter =
-          nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio ? 'destination' : 'source';
+        const reporter = nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio ? 'destination' : 'source';
 
         // note: request_protocol is not a valid byLabel for tcp filters but it is ignored by prometheus
         const byLabels = nodeData.isOutside

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
@@ -18,7 +18,7 @@ import { DirectionType } from 'types/Common';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import { TLSInfo } from 'components/Overview/TLSInfo';
 import * as API from '../../../services/Api';
-import { IstioMetricsOptions } from 'types/MetricsOptions';
+import { IstioMetricsOptions, buildReporter } from 'types/MetricsOptions';
 import { computePrometheusRateParams } from 'services/Prometheus';
 import { ApiError } from 'types/Api';
 import { DEGRADED, FAILURE, HEALTHY, Health, NOT_READY } from 'types/Health';
@@ -367,9 +367,8 @@ export class TargetPanelControlPlane extends React.Component<
       direction: direction,
       duration: this.props.duration,
       filters: ['request_count', 'request_error_count'],
-      includeAmbient: serverConfig.ambientEnabled,
       rateInterval: rateParams.rateInterval,
-      reporter: direction === 'inbound' ? 'destination' : 'source',
+      reporter: buildReporter(direction, serverConfig.ambientEnabled),
       step: rateParams.step
     };
 

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
@@ -19,7 +19,7 @@ import { ValidationSummaryLink } from 'components/Link/ValidationSummaryLink';
 import { ValidationSummary } from 'components/Validations/ValidationSummary';
 import { NamespaceTrafficChart } from '../components/NamespaceTrafficChart';
 import * as API from '../../../services/Api';
-import { IstioMetricsOptions } from 'types/MetricsOptions';
+import { IstioMetricsOptions, buildReporter } from 'types/MetricsOptions';
 import { computePrometheusRateParams } from 'services/Prometheus';
 import { ApiError } from 'types/Api';
 import { DEGRADED, FAILURE, HEALTHY, Health, NOT_READY } from 'types/Health';
@@ -424,9 +424,8 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
       direction: direction,
       duration: this.props.duration,
       filters: ['request_count', 'request_error_count'],
-      includeAmbient: serverConfig.ambientEnabled,
       rateInterval: rateParams.rateInterval,
-      reporter: direction === 'inbound' ? 'destination' : 'source',
+      reporter: buildReporter(direction, serverConfig.ambientEnabled),
       step: rateParams.step
     };
 

--- a/frontend/src/pages/Mesh/target/TargetPanelMetrics.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMetrics.tsx
@@ -17,7 +17,7 @@ import { TargetPanelControlPlaneMetrics } from './TargetPanelControlPlaneMetrics
 import * as API from '../../../services/Api';
 import { addError } from '../../../utils/AlertUtils';
 import { computePrometheusRateParams } from '../../../services/Prometheus';
-import { IstioMetricsOptions } from '../../../types/MetricsOptions';
+import { IstioMetricsOptions, buildReporter } from '../../../types/MetricsOptions';
 import { isPrometheusAvailable, serverConfig } from '../../../config';
 
 type TargetPanelMetricsProps<T extends MeshNodeData> = TargetPanelCommonProps & {
@@ -38,9 +38,8 @@ export const TargetPanelMetrics: React.FC<TargetPanelMetricsProps<MeshNodeData>>
       direction: 'outbound',
       duration: props.duration,
       filters: ['request_count', 'request_error_count'],
-      includeAmbient: serverConfig.ambientEnabled,
       rateInterval: rateParams.rateInterval,
-      reporter: 'source',
+      reporter: buildReporter('outbound', serverConfig.ambientEnabled),
       step: rateParams.step
     };
 

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -31,7 +31,7 @@ import { ValidationSummaryLink } from 'components/Link/ValidationSummaryLink';
 import { ValidationSummary } from 'components/Validations/ValidationSummary';
 import { NamespaceTrafficChart } from '../components/NamespaceTrafficChart';
 import * as API from '../../../services/Api';
-import { IstioMetricsOptions } from 'types/MetricsOptions';
+import { IstioMetricsOptions, buildReporter } from 'types/MetricsOptions';
 import { computePrometheusRateParams } from 'services/Prometheus';
 import { ApiError } from 'types/Api';
 import { t } from 'utils/I18nUtils';
@@ -521,9 +521,8 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
       direction: direction,
       duration: this.props.duration,
       filters: ['request_count', 'request_error_count'],
-      includeAmbient: serverConfig.ambientEnabled,
       rateInterval: rateParams.rateInterval,
-      reporter: direction === 'inbound' ? 'destination' : 'source',
+      reporter: buildReporter(direction, serverConfig.ambientEnabled),
       step: rateParams.step
     };
 

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -257,7 +257,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
         <IstioMetrics
           cluster={this.state.cluster}
           direction={'inbound'}
-          includeAmbient={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for service
+          includeWaypoint={serverConfig.ambientEnabled} // TODO: replace this with actual `isAmbient` when supported for service
           lastRefreshAt={this.props.lastRefreshAt}
           namespace={this.props.serviceId.namespace}
           object={this.props.serviceId.service}
@@ -282,7 +282,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
             target={this.props.serviceId.service}
             targetKind={'service'}
             fromWaypoint={fromWaypoint}
-            includeAmbient={fromWaypoint || !!this.state.serviceDetails?.isAmbient}
+            includeWaypoint={fromWaypoint || !!this.state.serviceDetails?.isAmbient}
           />
         </Tab>
       );

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -225,7 +225,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
             <IstioMetrics
               data-test="inbound-metrics-component"
               direction="inbound"
-              includeAmbient={!!this.state.workload?.isAmbient}
+              includeWaypoint={!!this.state.workload?.isAmbient}
               lastRefreshAt={this.props.lastRefreshAt}
               namespace={this.props.workloadId.namespace}
               object={this.props.workloadId.workload}
@@ -237,7 +237,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
             <IstioMetrics
               data-test="outbound-metrics-component"
               direction="outbound"
-              includeAmbient={!!this.state.workload?.isAmbient}
+              includeWaypoint={!!this.state.workload?.isAmbient}
               lastRefreshAt={this.props.lastRefreshAt}
               namespace={this.props.workloadId.namespace}
               object={this.props.workloadId.workload}
@@ -260,7 +260,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
               target={this.props.workloadId.workload}
               targetKind="workload"
               fromWaypoint={fromWaypoint}
-              includeAmbient={fromWaypoint || !!this.state.workload?.isAmbient}
+              includeWaypoint={fromWaypoint || !!this.state.workload?.isAmbient}
               waypointServiceFilter={this.state.waypointServiceFilter}
             />
           </Tab>

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -24,14 +24,12 @@ export type Aggregator = 'sum' | 'avg' | 'min' | 'max' | 'stddev' | 'stdvar';
 export interface IstioMetricsOptions extends MetricsQuery {
   direction: Direction;
   filters?: string[];
-  includeAmbient: boolean;
-  reporter: Reporter;
+  reporter: string;
   requestProtocol?: string;
 }
 
-export type Reporter = 'source' | 'destination' | 'both';
 export type Direction = 'inbound' | 'outbound';
-export type StatsReporter = Exclude<Reporter, 'both'> | 'waypoint';
+export type StatsReporter = 'source' | 'destination' | 'waypoint';
 
 export interface Target {
   cluster?: string;
@@ -72,6 +70,14 @@ export const genStatsKey = (
 const genTargetKey = (target: Target): string => {
   return `${target.namespace}:${target.kind}:${target.name}`;
 };
+
+export const buildReporter = (direction: Direction, includeWaypoint: boolean): string => {
+  const base = direction === 'inbound' ? 'destination' : 'source';
+  return includeWaypoint ? `${base},waypoint` : base;
+};
+
+export const withWaypoint = (reporter: string, includeWaypoint: boolean): string =>
+  includeWaypoint && reporter !== 'both' ? `${reporter},waypoint` : reporter;
 
 export const getStatsReporters = (direction: Direction, includeWaypoint = false): StatsReporter[] => {
   const sideReporter: StatsReporter = direction === 'outbound' ? 'source' : 'destination';

--- a/frontend/src/types/MetricsOptions.ts
+++ b/frontend/src/types/MetricsOptions.ts
@@ -76,8 +76,16 @@ export const buildReporter = (direction: Direction, includeWaypoint: boolean): s
   return includeWaypoint ? `${base},waypoint` : base;
 };
 
-export const withWaypoint = (reporter: string, includeWaypoint: boolean): string =>
-  includeWaypoint && reporter !== 'both' ? `${reporter},waypoint` : reporter;
+export const withWaypoint = (reporter: string, includeWaypoint: boolean): string => {
+  if (!includeWaypoint || reporter === 'both') {
+    return reporter;
+  }
+  const parts = reporter.split(',').filter(r => r !== 'waypoint');
+  parts.push('waypoint');
+  return parts.join(',');
+};
+
+export const baseReporter = (reporter: string): string => (reporter === 'both' ? 'both' : reporter.split(',')[0]);
 
 export const getStatsReporters = (direction: Direction, includeWaypoint = false): StatsReporter[] => {
   const sideReporter: StatsReporter = direction === 'outbound' ? 'source' : 'destination';

--- a/frontend/src/utils/tracing/TraceStats.ts
+++ b/frontend/src/utils/tracing/TraceStats.ts
@@ -70,10 +70,10 @@ export let statsCompareKind: 'app' | 'workload' = 'workload';
 export const buildQueriesFromSpans = (
   items: RichSpanData[],
   isCompact: boolean,
-  includeAmbient = false
+  includeWaypoint = false
 ): MetricsStatsQuery[] => {
   const queryTime = Math.floor(Date.now() / 1000);
-  const shouldIncludeAmbient = includeAmbient || items.some(item => isWaypointProxySpan(item));
+  const shouldIncludeWaypoint = includeWaypoint || items.some(item => isWaypointProxySpan(item));
   // Load stats for up to 8 spans to limit the heavy loading. More stats can be loaded individually.
   const queries = items
     .filter(s => s.type === 'envoy')
@@ -100,7 +100,7 @@ export const buildQueriesFromSpans = (
         peerTarget: statsPerPeer ? info.peer : undefined,
         quantiles: isCompact ? compactStatsQuantiles : statsQuantiles,
         queryTime: queryTime,
-        reporters: getStatsReporters(info.direction, shouldIncludeAmbient),
+        reporters: getStatsReporters(info.direction, shouldIncludeWaypoint),
         target: {
           namespace: item.namespace,
           name: name,
@@ -150,7 +150,7 @@ export const getSpanStats = (
   item: RichSpanData,
   metricsStats: Map<string, MetricsStats>,
   isCompact: boolean,
-  includeAmbient: boolean
+  includeWaypoint: boolean
 ): StatsWithIntervalIndex[] => {
   const intervals = isCompact ? compactStatsIntervals : statsIntervals;
 
@@ -167,7 +167,7 @@ export const getSpanStats = (
       statsPerPeer ? info.peer : undefined,
       info.direction!,
       interval,
-      getStatsReporters(info.direction!, includeAmbient)
+      getStatsReporters(info.direction!, includeWaypoint)
     );
     if (key) {
       const stats = metricsStats.get(key);
@@ -187,7 +187,7 @@ export const reduceMetricsStats = (
   trace: JaegerTrace,
   allStats: Map<string, MetricsStats>,
   isCompact: boolean,
-  includeAmbient: boolean
+  includeWaypoint: boolean
 ): { isComplete: boolean; matrix: StatsMatrix } => {
   let isComplete = true;
   const intervals = isCompact ? compactStatsIntervals : statsIntervals;
@@ -199,7 +199,7 @@ export const reduceMetricsStats = (
   trace.spans
     .filter(s => s.type === 'envoy')
     .forEach(span => {
-      const spanStats = getSpanStats(span, allStats, isCompact, includeAmbient);
+      const spanStats = getSpanStats(span, allStats, isCompact, includeWaypoint);
       if (spanStats.length > 0) {
         spanStats.forEach(statsPerInterval => {
           statsPerInterval.responseTimes.forEach(stat => {

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -415,19 +415,10 @@ func extractIstioMetricsQueryParams(r *http.Request, q *models.IstioMetricsQuery
 		q.Direction = dir
 	}
 
-	includeAmbientParam := queryParams.Get("includeAmbient")
-	if includeAmbientParam != "" {
-		includeAmbient, err := strconv.ParseBool(includeAmbientParam)
-		if err != nil {
-			return errors.New("bad request, query parameter 'includeAmbient' must be either 'true' or 'false'")
-		}
-		q.IncludeAmbient = includeAmbient
-	}
-
 	reporter := queryParams.Get("reporter")
 	if reporter != "" {
-		if reporter != "both" && reporter != "destination" && reporter != "source" {
-			return errors.New("bad request, query parameter 'reporter' must be one of 'both, 'destination', or 'source'")
+		if err := models.ValidateReporter(reporter); err != nil {
+			return err
 		}
 		q.Reporter = reporter
 	}

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -24,7 +24,6 @@ type IstioMetricsQuery struct {
 	App             string
 	Cluster         string
 	Direction       string // outbound | inbound
-	IncludeAmbient  bool
 	Filters         []string
 	Namespace       string
 	RequestProtocol string // e.g. http | grpc
@@ -36,9 +35,28 @@ type IstioMetricsQuery struct {
 // FillDefaults fills the struct with default parameters
 func (q *IstioMetricsQuery) FillDefaults() {
 	q.Direction = "outbound"
-	q.IncludeAmbient = false
 	q.RangeQuery.FillDefaults()
 	q.Reporter = "source"
+}
+
+var validReporterValues = map[string]bool{
+	"destination": true,
+	"source":      true,
+	"waypoint":    true,
+}
+
+// ValidateReporter checks that a reporter string is valid.
+// Accepts "both" or a comma-separated list of "source", "destination", "waypoint".
+func ValidateReporter(reporter string) error {
+	if reporter == "both" {
+		return nil
+	}
+	for _, r := range strings.Split(reporter, ",") {
+		if !validReporterValues[r] {
+			return fmt.Errorf("bad request, query parameter 'reporter' contains invalid value %q; valid values are 'source', 'destination', 'waypoint', or 'both'", r)
+		}
+	}
+	return nil
 }
 
 // CustomMetricsQuery holds query parameters for a custom metrics query

--- a/models/metrics_test.go
+++ b/models/metrics_test.go
@@ -1,6 +1,39 @@
 package models
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateReporter(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"both", false},
+		{"source", false},
+		{"destination", false},
+		{"waypoint", false},
+		{"source,waypoint", false},
+		{"destination,waypoint", false},
+		{"invalid", true},
+		{"source,invalid", true},
+		{"source,both", true},
+		{"both,source", true},
+		{"", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			err := ValidateReporter(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err, "ValidateReporter(%q) should return an error", tc.input)
+			} else {
+				assert.NoError(t, err, "ValidateReporter(%q) should not return an error", tc.input)
+			}
+		})
+	}
+}
 
 func TestMetricsStatsQueryGenKeyIncludesReporters(t *testing.T) {
 	base := MetricsStatsQuery{


### PR DESCRIPTION
### Describe the change
Removes the includeAmbient boolean from the metrics API and frontend, replacing it with an explicit comma-separated reporter parameter that can include waypoint alongside source or destination (e.g. reporter=destination,waypoint).

**Backend**:

- Removed IncludeAmbient field from models.IstioMetricsQuery and its FillDefaults().
- Removed the includeAmbient query parameter parsing from both handlers/metrics.go and ai/mcputil/access_validations.go.
- Removed the old Reporter(name, includeAmbient) method from MetricsLabelsBuilder, which embedded the ambient→waypoint logic. The existing Reporters([]string) method now handles all reporter combinations.
- In business/metrics.go, createMetricsLabelsBuilder now calls lb.Reporters(strings.Split(q.Reporter, ",")) instead of lb.Reporter(q.Reporter, q.IncludeAmbient).
- The reporter query parameter now accepts comma-separated values (source,waypoint, destination,waypoint) validated by a shared models.ValidateReporter() function used by both HTTP handlers and MCP tool handlers.
- Updated the MCP tool YAML to document the new format and removed the fixed enum constraint.

**Frontend**:

- Removed the includeAmbient field from IstioMetricsOptions interface; reporter is now string instead of the Reporter union type.
- Removed the orphaned Reporter type ('source' | 'destination' | 'both') from MetricsOptions.ts.
- Added two utility functions in MetricsOptions.ts:
  - buildReporter(direction, includeWaypoint) — derives the reporter from direction, optionally appending ,waypoint. Used where there is no user-selected reporter (Mesh panels, Graph summary panels, Ztunnel metrics).
  - withWaypoint(reporter, includeWaypoint) — appends ,waypoint to an existing user-selected reporter string while respecting both. Used in IstioMetrics and SummaryPanelCommon.
- Renamed the includeAmbient prop to includeWaypoint across all detail pages and tracing components (~15 files) for semantic clarity.
- Updated MetricsReporter component to use string instead of Reporter type.

### Steps to test the PR
- [ ] Workload/App/Service metrics pages: Open any workload, app, or service detail page with ambient mesh enabled. Verify the inbound/outbound metrics tabs load correctly and the Reporter dropdown works (switching between source/destination/both).
- [ ] Waypoint metrics: For an ambient workload (or waypoint proxy), verify that waypoint metrics are included — the reporter query parameter sent to the API should include ,waypoint (check browser DevTools Network tab).
- [ ] Graph summary panels: Click on graph nodes and verify mini-charts in the side panel display correctly, including for ambient-enabled namespaces.
- [ ] Mesh target panels: Navigate to the Mesh view, click on namespace/control plane targets, verify metrics load.
- [ ] Tracing integration: Open the Traces tab for a workload/service. Verify trace statistics comparison loads correctly, including for waypoint proxy spans.
- [ ] MCP tool: If using the AI chat, invoke get_metrics with reporter: "source,waypoint" and verify it returns results.
- [ ] Backward compatibility: Verify that existing bookmarks/URLs with reporter=source or reporter=destination still work (no regression).

### Automation testing

- business/metrics_labels_builder_test.go:
  - TestMetricsLabelsBuilderInboundHttp / TestMetricsLabelsBuilderOutboundGrpc — updated to use Reporters([]string{...}) instead of the removed Reporter() method.
  - TestMetricsLabelsBuilderWithWaypoint — new test validating that Reporters(["destination", "waypoint"]) produces the correct regex label reporter=~"destination|waypoint".
- frontend/src/components/Metrics/__tests__/IstioMetrics.test.tsx — updated prop from includeAmbient to includeWaypoint.

### Issue reference

https://github.com/kiali/kiali/issues/9722
