### PR TITLE
Add workflow to notify OSSMC on frontend changes

### DIFF
--- a/.github/workflows/notify-ossmc-sync.yml
+++ b/.github/workflows/notify-ossmc-sync.yml
@@ -1,0 +1,27 @@
+name: Notify OSSMC Frontend Sync
+
+on:
+  push:
+    branches: [v2.27, v2.22, v2.17, v2.11, v2.4]
+    paths:
+    - 'frontend/src/**'
+    - 'frontend/public/locales/**'
+    - 'frontend/cypress/integration/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dispatch to OSSMC
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ secrets.KIALI_BOT_TOKEN }}
+        script: |
+          await github.rest.repos.createDispatchEvent({
+            owner: 'kiali',
+            repo: 'openshift-servicemesh-plugin',
+            event_type: 'kiali-frontend-updated',
+            client_payload: {
+              branch: '${{ github.ref_name }}'
+            }
+          });


### PR DESCRIPTION
Related to kiali/openshift-servicemesh-plugin#752

## Summary
- Add `.github/workflows/notify-ossmc-sync.yml` that triggers on push to supported release branches (`v2.27`, `v2.22`, `v2.17`, `v2.11`, `v2.4`) when `frontend/src/`, `frontend/public/locales/`, or `frontend/cypress/integration/` change
- Uses `actions/github-script` with `KIALI_BOT_TOKEN` to dispatch a `kiali-frontend-updated` event to `kiali/openshift-servicemesh-plugin`
- The OSSMC repo handles the event in its `copy-kiali-frontend.yml` workflow (companion PR: kiali/openshift-servicemesh-plugin#751)

## How it works
1. A merge lands on a release branch that touches frontend paths
2. This workflow fires and calls the GitHub Dispatch API
3. OSSMC receives the event, runs the copy script, and pushes the synced code to the matching branch

## Test plan
- [ ] Merge the companion OSSMC PR first
- [ ] Push a test commit to a release branch touching `frontend/src/` and verify the dispatch triggers the OSSMC workflow