### PR TITLE
Migrate ChatBot tests from Jest to Rstest

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -403,7 +403,7 @@ First, start the Kiali Server backend, either within a cluster or by using the `
 Next, run the GUI frontend using the following command: `make -e KIALI_PROXY_URL=<kiali-url> yarn-start` where `<kiali-url>` is the Kiali backend URL including its `web_root` path (check `server.web_root` in your Kiali config YAML; the default is `/`). The frontend dev server defaults to port `3001`. Some examples:
 
 * If the Kiali Server is running locally with the default `web_root` (`/`), then run `make -e KIALI_PROXY_URL=http://localhost:20001 yarn-start`.
-* If the Kiali Server is running in minikube with a port-forward exposing it (typically `web_root: /kiali`), then run `make -e KIALI_PROXY_URL=http://localhost:20001/kiali yarn-start`.
+* If the Kiali Server is running in Minikube/KinD with a port-forward exposing it (typically `web_root: /kiali`), then run `make -e KIALI_PROXY_URL=http://localhost:20001/kiali yarn-start`.
 * If the Kiali Server is running in OpenShift with the usual Kiali Route exposing it, then run `make -e KIALI_PROXY_URL=https://<Kiali-OpenShift-Route-IP>/ yarn-start`.
 
 The `yarn-start` make command will start the Kiali GUI frontend on a local endpoint. Once ready, check the output for the "Local" URL to access it. The output will resemble the following:

--- a/frontend/src/components/ChatBot/EntryChat/__tests__/ChatMessageMarkdown.test.tsx
+++ b/frontend/src/components/ChatBot/EntryChat/__tests__/ChatMessageMarkdown.test.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ChatMessageMarkdown } from '../ChatMessageMarkdown';
 
 // navigator.clipboard is not available in jsdom; provide a writable stub.
-const writeTextMock = jest.fn();
+const writeTextMock = rstest.fn();
 
 beforeAll(() => {
   Object.defineProperty(navigator, 'clipboard', {
@@ -102,7 +101,7 @@ describe('ChatMessageMarkdown', () => {
     });
 
     it('shows a check icon after clicking copy and reverts after 3 seconds', async () => {
-      jest.useFakeTimers();
+      rstest.useFakeTimers();
 
       const content = '```\necho hello\n```';
       render(<ChatMessageMarkdown content={content} codeBlockProps={{}} />);
@@ -119,10 +118,10 @@ describe('ChatMessageMarkdown', () => {
 
       // Advance timers past the 3-second reset
       act(() => {
-        jest.advanceTimersByTime(3100);
+        rstest.advanceTimersByTime(3100);
       });
 
-      jest.useRealTimers();
+      rstest.useRealTimers();
     });
   });
 

--- a/frontend/src/components/ChatBot/EntryChat/__tests__/EntryChat.test.tsx
+++ b/frontend/src/components/ChatBot/EntryChat/__tests__/EntryChat.test.tsx
@@ -12,7 +12,7 @@ import { EntryChat } from '../EntryChat';
 // ChatbotDisplayMode is used by the ChatAIState reducer initial state, so it must
 // be included in the mock. Hardcoding the enum values avoids the circular-require
 // that occurs when calling require('@patternfly/chatbot') inside its own mock factory.
-jest.mock('@patternfly/chatbot', () => ({
+rstest.mock('@patternfly/chatbot', () => ({
   ChatbotDisplayMode: { default: 'default', docked: 'docked', embedded: 'embedded', fullscreen: 'fullscreen' },
   Message: ({
     name,

--- a/frontend/src/components/ChatBot/EntryChat/__tests__/ResponseTools.test.tsx
+++ b/frontend/src/components/ChatBot/EntryChat/__tests__/ResponseTools.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from 'store/ConfigStore';

--- a/frontend/src/components/ChatBot/EntryChat/__tests__/ToolModal.test.tsx
+++ b/frontend/src/components/ChatBot/EntryChat/__tests__/ToolModal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from 'store/ConfigStore';
@@ -9,8 +8,8 @@ import { ToolModal } from '../ToolModal';
 // The Trans component receives i18next interpolation objects like {{ name }} as
 // direct React children, which are plain JS objects and not valid React children.
 // The mock factory must use require() instead of the imported React reference
-// because jest.mock() is hoisted before import statements.
-jest.mock('react-i18next', () => {
+// because rstest.mock() is hoisted before import statements.
+rstest.mock('react-i18next', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const ReactModule = require('react');
 


### PR DESCRIPTION
## Summary

- Migrate ChatBot unit tests (added after #9653) from Jest to Rstest: replace `jest.fn()`, `jest.mock()`, `jest.useFakeTimers()` / `advanceTimersByTime()` / `useRealTimers()` with their `rstest.*` equivalents
- Remove unused `import * as React from 'react'` statements (no longer needed with `react-jsx` automatic runtime)
- Apply @jshaughn's suggestion from [#9653 review](https://github.com/kiali/kiali/pull/9653#discussion_r3468084929): change "minikube" to "Minikube/KinD" in README.adoc port-forward instructions

## Test plan

- [x] `npx rstest run src/components/ChatBot` — all 82 ChatBot tests pass


Made with [Cursor](https://cursor.com)