### PR TITLE
Fix validations ignoring Istio configs in unmanaged namespaces

### DIFF
--- a/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
+++ b/business/checkers/k8shttproutes/no_k8sgateway_checker_test.go
@@ -248,3 +248,81 @@ func TestNotSharedNSK8sGatewayError(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
 }
+
+// Regression test for https://github.com/kiali/kiali/issues/9937
+// HTTPRoute in an Ambient namespace referencing a Gateway in an unmanaged namespace
+// (istio-ingress) with allowedRoutes.namespaces.from: All should NOT trigger KIA1401.
+func TestAmbientHTTPRouteWithSharedToAllGatewayInUnmanagedNS(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("gateway-internal", "istio-ingress",
+			data.CreateEmptyHTTPRoute("app", "app-ambient", []string{"app.example.com"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedToAllListener("default", "*.example.com", 80, "HTTP"),
+				data.CreateEmptyK8sGateway("gateway-internal", "istio-ingress")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{
+			{Name: "app-ambient", IsAmbient: true, Labels: map[string]string{config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue}},
+			{Name: "istio-ingress"},
+		},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid, "HTTPRoute in Ambient namespace should be valid when Gateway allows routes from all namespaces")
+	assert.Empty(vals, "no KIA1401 should be reported")
+}
+
+// Non-Ambient namespace with the same cross-namespace Gateway (from: All) should also pass.
+func TestNonAmbientHTTPRouteWithSharedToAllGatewayInUnmanagedNS(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("gateway-internal", "istio-ingress",
+			data.CreateEmptyHTTPRoute("app", "app-non-ambient", []string{"app.example.com"})),
+		GatewayNames: kubernetes.K8sGatewayNames([]*k8s_networking_v1.Gateway{
+			data.AddListenerToK8sGateway(
+				data.CreateSharedToAllListener("default", "*.example.com", 80, "HTTP"),
+				data.CreateEmptyK8sGateway("gateway-internal", "istio-ingress")),
+		}, "svc.cluster.local"),
+		Namespaces: models.Namespaces{
+			{Name: "app-non-ambient"},
+			{Name: "istio-ingress"},
+		},
+	}
+
+	vals, valid := checker.Check()
+	assert.True(valid, "HTTPRoute in non-Ambient namespace should be valid when Gateway allows routes from all namespaces")
+	assert.Empty(vals, "no KIA1401 should be reported")
+}
+
+// When the Gateway truly does not exist, KIA1401 must be reported regardless
+// of whether the namespace is Ambient or not.
+func TestAmbientHTTPRouteWithNonExistentGateway(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	checker := NoK8sGatewayChecker{
+		IdentityDomain: "svc.cluster.local",
+		K8sHTTPRoute: data.AddGatewayParentRefToHTTPRoute("does-not-exist", "istio-ingress",
+			data.CreateEmptyHTTPRoute("app", "app-ambient", []string{"app.example.com"})),
+		GatewayNames: make(map[string]k8s_networking_v1.Gateway),
+		Namespaces: models.Namespaces{
+			{Name: "app-ambient", IsAmbient: true, Labels: map[string]string{config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue}},
+			{Name: "istio-ingress"},
+		},
+	}
+
+	vals, valid := checker.Check()
+	assert.False(valid, "HTTPRoute referencing a non-existent Gateway should be invalid")
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[0]))
+}

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -1015,10 +1015,10 @@ func (in *IstioValidationsService) filterVSExportToNamespaces(vsList []*networki
 		var meshExportTo []string
 		if nsMeshConfigs != nil && nsMeshConfigs[vs.Namespace] != nil {
 			meshExportTo = nsMeshConfigs[vs.Namespace].DefaultVirtualServiceExportTo
-		} else {
-			log.Debugf("filterVSExportToNamespaces: no mesh config found for namespace %s in cluster %s, skipping", vs.Namespace, cluster)
-			continue
 		}
+		// When no mesh config is found (unmanaged namespace), meshExportTo stays nil.
+		// isExportedObjectIncluded treats empty exportTo + empty meshExportTo as
+		// "exported to all namespaces", matching Istio's default behavior.
 		if in.isExportedObjectIncluded(vs.Spec.ExportTo, meshExportTo, vs.Namespace, vInfo) {
 			result = append(result, vs)
 		}
@@ -1045,9 +1045,6 @@ func (in *IstioValidationsService) filterDRExportToNamespaces(dr []*networking_v
 		var meshExportTo []string
 		if nsMeshConfigs != nil && nsMeshConfigs[d.Namespace] != nil {
 			meshExportTo = nsMeshConfigs[d.Namespace].DefaultDestinationRuleExportTo
-		} else {
-			log.Debugf("filterDRExportToNamespaces: no mesh config found for namespace %s in cluster %s, skipping", d.Namespace, cluster)
-			continue
 		}
 		if in.isExportedObjectIncluded(d.Spec.ExportTo, meshExportTo, d.Namespace, vInfo) {
 			result = append(result, d)
@@ -1075,9 +1072,6 @@ func (in *IstioValidationsService) filterSEExportToNamespaces(se []*networking_v
 		var meshExportTo []string
 		if nsMeshConfigs != nil && nsMeshConfigs[s.Namespace] != nil {
 			meshExportTo = nsMeshConfigs[s.Namespace].DefaultServiceExportTo
-		} else {
-			log.Debugf("filterSEExportToNamespaces: no mesh config found for namespace %s in cluster %s, skipping", s.Namespace, cluster)
-			continue
 		}
 		if in.isExportedObjectIncluded(s.Spec.ExportTo, meshExportTo, s.Namespace, vInfo) {
 			result = append(result, s)
@@ -1112,16 +1106,35 @@ func (in *IstioValidationsService) isExportedObjectIncluded(exportTo []string, m
 	return false
 }
 
-// filterIstioConfigByManagedNamespaces removes Istio configs from namespaces that are not in
-// the mesh, preventing configs from non-mesh namespaces (e.g., "default") from being used in
-// validation of mesh-belonging namespaces. Uses BuildNamespaceToMeshConfig to determine which
-// namespaces are managed, and also includes root/control plane namespaces for mesh-wide configs.
+// filterIstioConfigByManagedNamespaces keeps Istio configs from namespaces that are managed by
+// a control plane on this cluster, as well as configs from namespaces that are not managed by
+// ANY control plane. Istio processes configs from all namespaces (unless discovery selectors
+// restrict this), so configs in non-injected namespaces can still affect the mesh and must not
+// be silently dropped. Only configs from namespaces that belong to a DIFFERENT control plane
+// in a multi-primary setup would ideally be excluded, but that scoping is handled later by the
+// per-namespace export-to filters.
 func filterIstioConfigByManagedNamespaces(config *models.IstioConfigList, mesh *models.Mesh, cluster string, namespaces []string) {
 	if mesh == nil {
 		return
 	}
-	allowed := mesh.BuildNamespaceToMeshConfig(cluster, namespaces)
-	allowedNames := slices.Collect(maps.Keys(allowed))
+	managed := mesh.BuildNamespaceToMeshConfig(cluster, namespaces)
+	allowedSet := make(map[string]struct{})
+	for ns := range managed {
+		allowedSet[ns] = struct{}{}
+	}
+
+	// Also allow namespaces that appear in the config objects but aren't managed by any CP.
+	// These could contain valid configs (ServiceEntries, DestinationRules, etc.) that affect
+	// mesh traffic even though the namespace itself doesn't have injection enabled.
+	for _, ns := range config.Namespaces() {
+		if _, alreadyAllowed := allowedSet[ns]; !alreadyAllowed {
+			if _, err := mesh.ControlPlaneForNamespace(cluster, ns); err != nil {
+				allowedSet[ns] = struct{}{}
+			}
+		}
+	}
+
+	allowedNames := slices.Collect(maps.Keys(allowedSet))
 
 	config.AuthorizationPolicies = kubernetes.FilterByNamespaceNames(config.AuthorizationPolicies, allowedNames)
 	config.DestinationRules = kubernetes.FilterByNamespaceNames(config.DestinationRules, allowedNames)
@@ -1158,9 +1171,13 @@ func buildNamespaceToExportTo(mesh *models.Mesh, cluster string, services []core
 func (in *IstioValidationsService) setNonLocalMTLSConfig(vInfo *validationInfo) error {
 	cluster := vInfo.clusterInfo.cluster
 	namespace := vInfo.nsInfo.namespace.Name
-	cp, err := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
-	if cp == nil || err != nil {
-		return err
+	// Error is intentionally ignored: ControlPlaneForNamespace returns an error for
+	// unmanaged namespaces (no injection/ambient labels). This is a lookup miss, not a
+	// failure. Unmanaged namespaces can still have valid Istio config that needs validation;
+	// auto-mTLS simply stays at its zero value, which the validation pipeline handles.
+	cp, _ := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
+	if cp == nil {
+		return nil
 	}
 	if cp.MeshConfig != nil && cp.MeshConfig.EnableAutoMtls != nil {
 		vInfo.nsInfo.mtlsDetails.EnabledAutoMtls = cp.MeshConfig.EnableAutoMtls.Value
@@ -1171,9 +1188,10 @@ func (in *IstioValidationsService) setNonLocalMTLSConfig(vInfo *validationInfo) 
 func (in *IstioValidationsService) isGatewayToNamespace(vInfo *validationInfo) (bool, error) {
 	cluster := vInfo.clusterInfo.cluster
 	namespace := vInfo.nsInfo.namespace.Name
-	cp, err := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
-	if cp == nil || err != nil {
-		return false, err
+	// Error ignored: unmanaged namespaces have no CP — default to false (conservative).
+	cp, _ := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
+	if cp == nil {
+		return false, nil
 	}
 	return cp.IsGatewayToNamespace, nil
 }
@@ -1181,9 +1199,10 @@ func (in *IstioValidationsService) isGatewayToNamespace(vInfo *validationInfo) (
 func (in *IstioValidationsService) isPolicyAllowAny(vInfo *validationInfo) (bool, error) {
 	cluster := vInfo.clusterInfo.cluster
 	namespace := vInfo.nsInfo.namespace.Name
-	cp, err := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
-	if cp == nil || err != nil {
-		return false, err
+	// Error ignored: unmanaged namespaces have no CP — default to false (REGISTRY_ONLY).
+	cp, _ := vInfo.mesh.ControlPlaneForNamespace(cluster, namespace)
+	if cp == nil {
+		return false, nil
 	}
 	if cp.MeshConfig != nil && cp.MeshConfig.OutboundTrafficPolicy != nil {
 		return cp.MeshConfig.OutboundTrafficPolicy.Mode == istiov1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY, nil

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -528,6 +528,316 @@ func TestMultiPrimaryWithUnmanagedNamespace(t *testing.T) {
 	assert.NotContains(filteredNames, "vs-mesh2", "mesh2 VS should not leak into mesh1")
 }
 
+// Regression test for https://github.com/kiali/kiali/issues/9937
+// Validates the full pipeline for HTTPRoutes referencing K8s Gateways across
+// managed, Ambient, and unmanaged namespaces.
+func TestHTTPRouteWithGatewayInUnmanagedNamespace(t *testing.T) {
+	ambientNS := "app-ambient"
+	nonAmbientNS := "app-non-ambient"
+	unmanagedGWNS := "istio-ingress"
+
+	// An HTTPRoute in an Ambient namespace referencing a Gateway in an unmanaged
+	// namespace with allowedRoutes.namespaces.from: All must NOT produce KIA1401.
+	t.Run("ambient ns with existing gateway no KIA1401", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		conf := config.NewConfig()
+		config.Set(conf)
+
+		gateway := data.AddListenerToK8sGateway(
+			data.CreateSharedToAllListener("default", "*.example.com", 80, "HTTP"),
+			data.CreateEmptyK8sGateway("gateway-internal", unmanagedGWNS),
+		)
+		httpRoute := data.AddGatewayParentRefToHTTPRoute("gateway-internal", unmanagedGWNS,
+			data.CreateEmptyHTTPRoute("app", ambientNS, []string{"app.example.com"}),
+		)
+
+		objects := []runtime.Object{
+			kubetest.FakeNamespaceWithLabels(ambientNS, map[string]string{
+				config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+			}),
+			kubetest.FakeNamespace(unmanagedGWNS),
+			kubetest.FakeNamespace("istio-system"),
+			&core_v1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+			gateway, httpRoute,
+		}
+
+		mesh := models.Mesh{
+			ControlPlanes: []models.ControlPlane{{
+				Cluster:         &models.KubeCluster{IsKialiHome: true},
+				IstiodNamespace: "istio-system",
+				MeshConfig:      models.NewMeshConfig(),
+				RootNamespace:   "istio-system",
+				ManagedNamespaces: []models.Namespace{
+					{Name: ambientNS, IsAmbient: true},
+					{Name: "istio-system"},
+				},
+			}},
+		}
+
+		k8s := kubetest.NewFakeK8sClient(objects...)
+		k8s.GatewayAPIEnabled = true
+		kialiCache := cache.NewTestingCache(t, k8s, *conf)
+		discovery := &istiotest.FakeDiscovery{MeshReturn: mesh}
+		vs := NewLayerBuilder(t, conf).WithClient(k8s).WithCache(kialiCache).WithDiscovery(discovery).Build().Validations
+
+		vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
+		require.NoError(err)
+		validationPerformed, vals, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+		require.NoError(err)
+		assert.True(validationPerformed)
+
+		routeKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: ambientNS, Name: "app"}
+		assert.Contains(vals, routeKey, "HTTPRoute should be validated")
+
+		for _, chk := range vals[routeKey].Checks {
+			assert.NotEqual("k8sroutes.nok8sgateway", chk.Code,
+				"KIA1401 must not be reported for an Ambient HTTPRoute referencing a Gateway in an unmanaged namespace with allowedRoutes from: All")
+		}
+	})
+
+	// An HTTPRoute in a non-Ambient, non-managed namespace referencing the same
+	// Gateway must also be validated without a false-positive KIA1401.
+	t.Run("non-ambient unmanaged ns with existing gateway no KIA1401", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		conf := config.NewConfig()
+		config.Set(conf)
+
+		gateway := data.AddListenerToK8sGateway(
+			data.CreateSharedToAllListener("default", "*.example.com", 80, "HTTP"),
+			data.CreateEmptyK8sGateway("gateway-internal", unmanagedGWNS),
+		)
+		httpRoute := data.AddGatewayParentRefToHTTPRoute("gateway-internal", unmanagedGWNS,
+			data.CreateEmptyHTTPRoute("app", nonAmbientNS, []string{"app.example.com"}),
+		)
+
+		objects := []runtime.Object{
+			kubetest.FakeNamespaceWithLabels(ambientNS, map[string]string{
+				config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+			}),
+			kubetest.FakeNamespace(nonAmbientNS),
+			kubetest.FakeNamespace(unmanagedGWNS),
+			kubetest.FakeNamespace("istio-system"),
+			&core_v1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+			gateway, httpRoute,
+		}
+
+		mesh := models.Mesh{
+			ControlPlanes: []models.ControlPlane{{
+				Cluster:         &models.KubeCluster{IsKialiHome: true},
+				IstiodNamespace: "istio-system",
+				MeshConfig:      models.NewMeshConfig(),
+				RootNamespace:   "istio-system",
+				ManagedNamespaces: []models.Namespace{
+					{Name: ambientNS, IsAmbient: true},
+					{Name: nonAmbientNS},
+					{Name: "istio-system"},
+				},
+			}},
+		}
+
+		k8s := kubetest.NewFakeK8sClient(objects...)
+		k8s.GatewayAPIEnabled = true
+		kialiCache := cache.NewTestingCache(t, k8s, *conf)
+		discovery := &istiotest.FakeDiscovery{MeshReturn: mesh}
+		vs := NewLayerBuilder(t, conf).WithClient(k8s).WithCache(kialiCache).WithDiscovery(discovery).Build().Validations
+
+		vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
+		require.NoError(err)
+		validationPerformed, vals, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+		require.NoError(err)
+		assert.True(validationPerformed)
+
+		routeKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: nonAmbientNS, Name: "app"}
+		assert.Contains(vals, routeKey, "HTTPRoute in non-Ambient namespace should be validated")
+
+		for _, chk := range vals[routeKey].Checks {
+			assert.NotEqual("k8sroutes.nok8sgateway", chk.Code,
+				"KIA1401 must not be reported for a non-Ambient HTTPRoute referencing a Gateway in an unmanaged namespace with allowedRoutes from: All")
+		}
+	})
+
+	// When the referenced Gateway truly does not exist, KIA1401 must be reported.
+	t.Run("non-existent gateway produces KIA1401", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		conf := config.NewConfig()
+		config.Set(conf)
+
+		httpRouteAmbient := data.AddGatewayParentRefToHTTPRoute("does-not-exist", unmanagedGWNS,
+			data.CreateEmptyHTTPRoute("app-ambient", ambientNS, []string{"app.example.com"}),
+		)
+		httpRouteNonAmbient := data.AddGatewayParentRefToHTTPRoute("does-not-exist", unmanagedGWNS,
+			data.CreateEmptyHTTPRoute("app-non-ambient", nonAmbientNS, []string{"app2.example.com"}),
+		)
+
+		objects := []runtime.Object{
+			kubetest.FakeNamespaceWithLabels(ambientNS, map[string]string{
+				config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+			}),
+			kubetest.FakeNamespace(nonAmbientNS),
+			kubetest.FakeNamespace(unmanagedGWNS),
+			kubetest.FakeNamespace("istio-system"),
+			&core_v1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+			httpRouteAmbient, httpRouteNonAmbient,
+		}
+
+		mesh := models.Mesh{
+			ControlPlanes: []models.ControlPlane{{
+				Cluster:         &models.KubeCluster{IsKialiHome: true},
+				IstiodNamespace: "istio-system",
+				MeshConfig:      models.NewMeshConfig(),
+				RootNamespace:   "istio-system",
+				ManagedNamespaces: []models.Namespace{
+					{Name: ambientNS, IsAmbient: true},
+					{Name: nonAmbientNS},
+					{Name: "istio-system"},
+				},
+			}},
+		}
+
+		k8s := kubetest.NewFakeK8sClient(objects...)
+		k8s.GatewayAPIEnabled = true
+		kialiCache := cache.NewTestingCache(t, k8s, *conf)
+		discovery := &istiotest.FakeDiscovery{MeshReturn: mesh}
+		vs := NewLayerBuilder(t, conf).WithClient(k8s).WithCache(kialiCache).WithDiscovery(discovery).Build().Validations
+
+		vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, nil)
+		require.NoError(err)
+		validationPerformed, vals, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+		require.NoError(err)
+		assert.True(validationPerformed)
+
+		ambientKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: ambientNS, Name: "app-ambient"}
+		assert.Contains(vals, ambientKey, "Ambient HTTPRoute should be validated")
+		assert.False(vals[ambientKey].Valid, "HTTPRoute referencing non-existent Gateway should be invalid")
+		assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[ambientKey].Checks[0]))
+
+		nonAmbientKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: nonAmbientNS, Name: "app-non-ambient"}
+		assert.Contains(vals, nonAmbientKey, "Non-Ambient HTTPRoute should be validated")
+		assert.False(vals[nonAmbientKey].Valid, "HTTPRoute referencing non-existent Gateway should be invalid")
+		assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nok8sgateway", vals[nonAmbientKey].Checks[0]))
+	})
+}
+
+// Validates that ValidateIstioObject (the details-page path) produces validations
+// for objects in unmanaged namespaces. ControlPlaneForNamespace returns an error
+// for unmanaged namespaces, and the helper functions setNonLocalMTLSConfig,
+// isGatewayToNamespace, and isPolicyAllowAny must ignore that error. If they
+// propagate it, ValidateIstioObject aborts early and returns nil validations
+// with nil error, making it appear as if the object has no issues.
+func TestValidateIstioObjectInUnmanagedNamespace(t *testing.T) {
+	ambientNS := "app-ambient"
+	nonAmbientNS := "app-non-ambient"
+	unmanagedGWNS := "istio-ingress"
+
+	buildTestEnv := func(t *testing.T, routeNS string, managedNamespaces []models.Namespace) IstioValidationsService {
+		t.Helper()
+		conf := config.NewConfig()
+		config.Set(conf)
+
+		gateway := data.AddListenerToK8sGateway(
+			data.CreateSharedToAllListener("default", "*.example.com", 80, "HTTP"),
+			data.CreateEmptyK8sGateway("gateway-internal", unmanagedGWNS),
+		)
+		httpRoute := data.AddBackendRefToHTTPRoute("non-existent-svc", routeNS,
+			data.AddGatewayParentRefToHTTPRoute("gateway-internal", unmanagedGWNS,
+				data.CreateEmptyHTTPRoute("app", routeNS, []string{"app.example.com"}),
+			),
+		)
+
+		objects := []runtime.Object{
+			kubetest.FakeNamespaceWithLabels(ambientNS, map[string]string{
+				config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+			}),
+			kubetest.FakeNamespace(nonAmbientNS),
+			kubetest.FakeNamespace(unmanagedGWNS),
+			kubetest.FakeNamespace("istio-system"),
+			&core_v1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+			gateway, httpRoute,
+		}
+
+		mesh := models.Mesh{
+			ControlPlanes: []models.ControlPlane{{
+				Cluster:           &models.KubeCluster{IsKialiHome: true},
+				IstiodNamespace:   "istio-system",
+				MeshConfig:        models.NewMeshConfig(),
+				RootNamespace:     "istio-system",
+				ManagedNamespaces: managedNamespaces,
+			}},
+		}
+
+		k8s := kubetest.NewFakeK8sClient(objects...)
+		k8s.GatewayAPIEnabled = true
+		kialiCache := cache.NewTestingCache(t, k8s, *conf)
+		discovery := &istiotest.FakeDiscovery{MeshReturn: mesh}
+		return NewLayerBuilder(t, conf).WithClient(k8s).WithCache(kialiCache).WithDiscovery(discovery).Build().Validations
+	}
+
+	// HTTPRoute in Ambient namespace (managed) — setNonLocalMTLSConfig, isPolicyAllowAny,
+	// and isGatewayToNamespace must not block validation.
+	t.Run("ambient namespace produces KIA1402 for missing service", func(t *testing.T) {
+		assert := assert.New(t)
+		conf := config.NewConfig()
+		vs := buildTestEnv(t, ambientNS, []models.Namespace{
+			{Name: ambientNS, IsAmbient: true},
+			{Name: "istio-system"},
+		})
+
+		vals, _, err := vs.ValidateIstioObject(context.Background(), conf.KubernetesConfig.ClusterName, ambientNS, kubernetes.K8sHTTPRoutes, "app")
+		assert.NoError(err)
+
+		routeKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: ambientNS, Name: "app"}
+		assert.Contains(vals, routeKey, "ValidateIstioObject should return validations for Ambient namespace")
+		assert.False(vals[routeKey].Valid)
+		assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[routeKey].Checks[0]))
+	})
+
+	// HTTPRoute in a non-Ambient managed namespace — same assertion.
+	t.Run("non-ambient managed namespace produces KIA1402 for missing service", func(t *testing.T) {
+		assert := assert.New(t)
+		conf := config.NewConfig()
+		vs := buildTestEnv(t, nonAmbientNS, []models.Namespace{
+			{Name: ambientNS, IsAmbient: true},
+			{Name: nonAmbientNS},
+			{Name: "istio-system"},
+		})
+
+		vals, _, err := vs.ValidateIstioObject(context.Background(), conf.KubernetesConfig.ClusterName, nonAmbientNS, kubernetes.K8sHTTPRoutes, "app")
+		assert.NoError(err)
+
+		routeKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: nonAmbientNS, Name: "app"}
+		assert.Contains(vals, routeKey, "ValidateIstioObject should return validations for managed namespace")
+		assert.False(vals[routeKey].Valid)
+		assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[routeKey].Checks[0]))
+	})
+
+	// HTTPRoute in an unmanaged namespace — the critical case. If setNonLocalMTLSConfig,
+	// isGatewayToNamespace, or isPolicyAllowAny propagate the ControlPlaneForNamespace
+	// error instead of ignoring it, ValidateIstioObject returns nil validations with nil error,
+	// making it appear as if the object has no issues.
+	t.Run("unmanaged namespace produces KIA1402 for missing service", func(t *testing.T) {
+		assert := assert.New(t)
+		conf := config.NewConfig()
+		vs := buildTestEnv(t, unmanagedGWNS, []models.Namespace{
+			{Name: ambientNS, IsAmbient: true},
+			{Name: "istio-system"},
+		})
+
+		vals, _, err := vs.ValidateIstioObject(context.Background(), conf.KubernetesConfig.ClusterName, unmanagedGWNS, kubernetes.K8sHTTPRoutes, "app")
+		assert.NoError(err)
+
+		routeKey := models.IstioValidationKey{ObjectGVK: kubernetes.K8sHTTPRoutes, Namespace: unmanagedGWNS, Name: "app"}
+		assert.Contains(vals, routeKey,
+			"ValidateIstioObject must return validations even for objects in unmanaged namespaces; "+
+				"if this fails, setNonLocalMTLSConfig/isGatewayToNamespace/isPolicyAllowAny likely "+
+				"propagate the ControlPlaneForNamespace error instead of ignoring it")
+		assert.False(vals[routeKey].Valid)
+		assert.NoError(validations.ConfirmIstioCheckMessage("k8sroutes.nohost.namenotfound", vals[routeKey].Checks[0]))
+	})
+}
+
 func TestFilterExportToNamespacesVS(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -110,7 +110,7 @@ func TestNamespaceLabelChangeTriggersValidation(t *testing.T) {
 	assert.True(vInfo.hasBaseChange, "Namespace label change should set hasBaseChange to true")
 }
 
-func TestValidateSkipsUnmanagedNamespaces(t *testing.T) {
+func TestValidateIncludesConfigsFromUnmanagedNamespaces(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	conf := config.NewConfig()
@@ -161,10 +161,11 @@ func TestValidateSkipsUnmanagedNamespaces(t *testing.T) {
 	bookinfoKey := models.IstioValidationKey{ObjectGVK: kubernetes.VirtualServices, Namespace: bookinfo, Name: "reviews-vs"}
 	assert.Contains(validations, bookinfoKey, "managed namespace should have validations")
 
-	// orphan-ns is NOT managed: nothing should appear for it
-	for key := range validations {
-		assert.NotEqual(orphan, key.Namespace, "unmanaged namespace %q should have no validations", orphan)
-	}
+	// orphan-ns VS should also be validated because Istio processes configs from all
+	// namespaces (unless discovery selectors restrict this). Configs from unmanaged
+	// namespaces are included in the validation pool and validated alongside managed ones.
+	orphanKey := models.IstioValidationKey{ObjectGVK: kubernetes.VirtualServices, Namespace: orphan, Name: "ratings-vs"}
+	assert.Contains(validations, orphanKey, "configs from unmanaged namespaces should be validated")
 }
 
 func TestAmbientNamespaceWaypointDoesNotTriggerWaypointNotFound(t *testing.T) {
@@ -452,6 +453,79 @@ func TestMultiPrimaryFilterExportToNamespacesVS(t *testing.T) {
 	assert.Len(filteredBookinfo2, 1, "viewing bookinfo2: only bookinfo2 VS should be included")
 	assert.Equal("ratings", filteredBookinfo2[0].Name)
 	assert.Equal("bookinfo2", filteredBookinfo2[0].Namespace)
+}
+
+func TestMultiPrimaryWithUnmanagedNamespace(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	// Multi-primary: CP1 manages mesh1-ns (exportTo "."), CP2 manages mesh2-ns (exportTo "*").
+	// "ingress-ns" is unmanaged by either CP but has a VirtualService.
+	mesh := models.Mesh{
+		ControlPlanes: []models.ControlPlane{
+			{
+				Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: true},
+				ManagedClusters:   []*models.KubeCluster{{Name: cluster}},
+				ManagedNamespaces: []models.Namespace{{Name: "mesh1-ns"}},
+				MeshConfig: &models.MeshConfig{
+					MeshConfig: &istiov1alpha1.MeshConfig{
+						DefaultVirtualServiceExportTo: []string{"."},
+					},
+				},
+			},
+			{
+				Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: false},
+				ManagedClusters:   []*models.KubeCluster{{Name: cluster}},
+				ManagedNamespaces: []models.Namespace{{Name: "mesh2-ns"}},
+				MeshConfig: &models.MeshConfig{
+					MeshConfig: &istiov1alpha1.MeshConfig{
+						DefaultVirtualServiceExportTo: []string{"."},
+					},
+				},
+			},
+		},
+	}
+
+	vsMesh1 := &networking_v1.VirtualService{
+		ObjectMeta: v1.ObjectMeta{Name: "vs-mesh1", Namespace: "mesh1-ns"},
+		Spec:       apinetworkingv1.VirtualService{Hosts: []string{"svc1"}},
+	}
+	vsMesh2 := &networking_v1.VirtualService{
+		ObjectMeta: v1.ObjectMeta{Name: "vs-mesh2", Namespace: "mesh2-ns"},
+		Spec:       apinetworkingv1.VirtualService{Hosts: []string{"svc2"}},
+	}
+	// VS from unmanaged namespace, no explicit exportTo
+	vsIngress := &networking_v1.VirtualService{
+		ObjectMeta: v1.ObjectMeta{Name: "vs-ingress", Namespace: "ingress-ns"},
+		Spec:       apinetworkingv1.VirtualService{Hosts: []string{"ingress-svc"}},
+	}
+	vsList := []*networking_v1.VirtualService{vsMesh1, vsMesh2, vsIngress}
+
+	// 1) filterIstioConfigByManagedNamespaces should preserve all three VS
+	configList := &models.IstioConfigList{VirtualServices: vsList}
+	filterIstioConfigByManagedNamespaces(configList, &mesh, cluster, []string{"mesh1-ns", "mesh2-ns", "ingress-ns"})
+	assert.Len(configList.VirtualServices, 3, "all VS should be preserved (managed + unmanaged)")
+
+	// 2) Export-to filtering from mesh1-ns perspective:
+	//    - vsMesh1 (mesh1-ns, "."): visible in own namespace -> included
+	//    - vsMesh2 (mesh2-ns, "."): only visible in mesh2-ns -> excluded
+	//    - vsIngress (ingress-ns, unmanaged, no exportTo): no mesh default -> exported to all -> included
+	objs := mockEmpty(t, conf)
+	v := fakeValidationMeshServiceWithMesh(t, *conf, mesh, objs...)
+	vInfoMesh1 := mockValidationInfo(conf, map[string]bool{"mesh1-ns": false, "mesh2-ns": false, "ingress-ns": false}, "mesh1-ns")
+	vInfoMesh1.mesh = &mesh
+	filteredMesh1 := v.filterVSExportToNamespaces(configList.VirtualServices, &vInfoMesh1)
+	assert.Len(filteredMesh1, 2, "viewing mesh1-ns: mesh1 VS + unmanaged VS should be included, mesh2 VS excluded")
+
+	filteredNames := make([]string, 0, len(filteredMesh1))
+	for _, vs := range filteredMesh1 {
+		filteredNames = append(filteredNames, vs.Name)
+	}
+	assert.Contains(filteredNames, "vs-mesh1", "mesh1 VS visible in own namespace")
+	assert.Contains(filteredNames, "vs-ingress", "unmanaged VS exported to all")
+	assert.NotContains(filteredNames, "vs-mesh2", "mesh2 VS should not leak into mesh1")
 }
 
 func TestFilterExportToNamespacesVS(t *testing.T) {
@@ -1252,6 +1326,135 @@ func getGateway(name, namespace string) []*networking_v1.Gateway {
 				"app": "real",
 			})),
 	}
+}
+
+func TestFilterIstioConfigByManagedNamespacesIncludesUnmanaged(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	cluster := conf.KubernetesConfig.ClusterName
+
+	mesh := &models.Mesh{
+		ControlPlanes: []models.ControlPlane{{
+			Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: true},
+			ManagedNamespaces: []models.Namespace{{Name: "bookinfo"}},
+			MeshConfig:        models.NewMeshConfig(),
+		}},
+	}
+
+	configList := &models.IstioConfigList{
+		VirtualServices: []*networking_v1.VirtualService{
+			{ObjectMeta: v1.ObjectMeta{Name: "vs-managed", Namespace: "bookinfo"}},
+			{ObjectMeta: v1.ObjectMeta{Name: "vs-unmanaged", Namespace: "unmanaged-ns"}},
+		},
+		DestinationRules: []*networking_v1.DestinationRule{
+			{ObjectMeta: v1.ObjectMeta{Name: "dr-unmanaged", Namespace: "another-unmanaged"}},
+		},
+		ServiceEntries: []*networking_v1.ServiceEntry{
+			{ObjectMeta: v1.ObjectMeta{Name: "se-managed", Namespace: "bookinfo"}},
+		},
+	}
+
+	filterIstioConfigByManagedNamespaces(configList, mesh, cluster, []string{"bookinfo", "unmanaged-ns", "another-unmanaged"})
+
+	assert.Len(configList.VirtualServices, 2, "VS in unmanaged namespace should be preserved")
+	assert.Len(configList.DestinationRules, 1, "DR in unmanaged namespace should be preserved")
+	assert.Len(configList.ServiceEntries, 1, "SE in managed namespace should be preserved")
+}
+
+func TestFilterVSExportToNamespacesIncludesUnmanagedNamespace(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	mesh := &models.Mesh{
+		ControlPlanes: []models.ControlPlane{{
+			Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: true},
+			ManagedNamespaces: []models.Namespace{{Name: "bookinfo"}},
+			MeshConfig:        models.NewMeshConfig(),
+		}},
+	}
+
+	// VS in an unmanaged namespace with no explicit exportTo should be exported to all (Istio default)
+	vsUnmanaged := &networking_v1.VirtualService{
+		ObjectMeta: v1.ObjectMeta{Name: "reviews", Namespace: "unmanaged-ns"},
+		Spec:       apinetworkingv1.VirtualService{Hosts: []string{"reviews"}},
+	}
+	vsManaged := &networking_v1.VirtualService{
+		ObjectMeta: v1.ObjectMeta{Name: "ratings", Namespace: "bookinfo"},
+		Spec:       apinetworkingv1.VirtualService{Hosts: []string{"ratings"}},
+	}
+	vsList := []*networking_v1.VirtualService{vsUnmanaged, vsManaged}
+
+	objs := mockEmpty(t, conf)
+	v := fakeValidationMeshService(t, *conf, objs...)
+	vInfo := mockValidationInfo(conf, map[string]bool{"bookinfo": false, "unmanaged-ns": false}, "bookinfo")
+	vInfo.mesh = mesh
+
+	filtered := v.filterVSExportToNamespaces(vsList, &vInfo)
+	assert.Len(filtered, 2, "VS from unmanaged namespace should be included (exported to all by default)")
+}
+
+func TestFilterDRExportToNamespacesIncludesUnmanagedNamespace(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	mesh := &models.Mesh{
+		ControlPlanes: []models.ControlPlane{{
+			Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: true},
+			ManagedNamespaces: []models.Namespace{{Name: "bookinfo"}},
+			MeshConfig:        models.NewMeshConfig(),
+		}},
+	}
+
+	drUnmanaged := &networking_v1.DestinationRule{
+		ObjectMeta: v1.ObjectMeta{Name: "reviews", Namespace: "unmanaged-ns"},
+	}
+	drManaged := &networking_v1.DestinationRule{
+		ObjectMeta: v1.ObjectMeta{Name: "ratings", Namespace: "bookinfo"},
+	}
+	drList := []*networking_v1.DestinationRule{drUnmanaged, drManaged}
+
+	objs := mockEmpty(t, conf)
+	v := fakeValidationMeshService(t, *conf, objs...)
+	vInfo := mockValidationInfo(conf, map[string]bool{"bookinfo": false, "unmanaged-ns": false}, "bookinfo")
+	vInfo.mesh = mesh
+
+	filtered := v.filterDRExportToNamespaces(drList, &vInfo)
+	assert.Len(filtered, 2, "DR from unmanaged namespace should be included (exported to all by default)")
+}
+
+func TestFilterSEExportToNamespacesIncludesUnmanagedNamespace(t *testing.T) {
+	assert := assert.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+
+	mesh := &models.Mesh{
+		ControlPlanes: []models.ControlPlane{{
+			Cluster:           &models.KubeCluster{Name: cluster, IsKialiHome: true},
+			ManagedNamespaces: []models.Namespace{{Name: "bookinfo"}},
+			MeshConfig:        models.NewMeshConfig(),
+		}},
+	}
+
+	seUnmanaged := &networking_v1.ServiceEntry{
+		ObjectMeta: v1.ObjectMeta{Name: "external-api", Namespace: "unmanaged-ns"},
+	}
+	seManaged := &networking_v1.ServiceEntry{
+		ObjectMeta: v1.ObjectMeta{Name: "internal-svc", Namespace: "bookinfo"},
+	}
+	seList := []*networking_v1.ServiceEntry{seUnmanaged, seManaged}
+
+	objs := mockEmpty(t, conf)
+	v := fakeValidationMeshService(t, *conf, objs...)
+	vInfo := mockValidationInfo(conf, map[string]bool{"bookinfo": false, "unmanaged-ns": false}, "bookinfo")
+	vInfo.mesh = mesh
+
+	filtered := v.filterSEExportToNamespaces(seList, &vInfo)
+	assert.Len(filtered, 2, "SE from unmanaged namespace should be included (exported to all by default)")
 }
 
 func loadVirtualService(file string, t *testing.T) *networking_v1.VirtualService {

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -130,10 +130,10 @@ func (a ServiceEntryAppender) loadServiceEntryHosts(cluster, namespace string, n
 	}
 
 	serviceEntryHosts, found := getServiceEntryHosts(cluster, namespace, globalInfo)
-	defaultServiceExportTo, ok := nsExportTo[cluster+":"+namespace]
-	if !ok {
-		return false
-	}
+	defaultServiceExportTo := nsExportTo[cluster+":"+namespace]
+	// When no mesh config is found for this namespace (e.g., unmanaged namespace),
+	// defaultServiceExportTo is nil, which means no default export restriction.
+	// isExportedToNamespace handles nil exportTo by exporting to all namespaces.
 	if !found {
 		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(context.TODO(), cluster, business.IstioConfigCriteria{
 			IncludeServiceEntries: true,

--- a/models/istio_config.go
+++ b/models/istio_config.go
@@ -48,6 +48,51 @@ type IstioConfigList struct {
 	IstioValidations       IstioValidations                     `json:"-"`
 }
 
+// Namespaces returns the unique set of namespace names across all config objects.
+func (i *IstioConfigList) Namespaces() []string {
+	seen := make(map[string]struct{})
+	add := func(objs []client.Object) {
+		for _, o := range objs {
+			seen[o.GetNamespace()] = struct{}{}
+		}
+	}
+	add(asClientObjects(i.AuthorizationPolicies))
+	add(asClientObjects(i.DestinationRules))
+	add(asClientObjects(i.EnvoyFilters))
+	add(asClientObjects(i.Gateways))
+	add(asClientObjects(i.K8sGateways))
+	add(asClientObjects(i.K8sGRPCRoutes))
+	add(asClientObjects(i.K8sHTTPRoutes))
+	add(asClientObjects(i.K8sInferencePools))
+	add(asClientObjects(i.K8sReferenceGrants))
+	add(asClientObjects(i.K8sTCPRoutes))
+	add(asClientObjects(i.K8sTLSRoutes))
+	add(asClientObjects(i.PeerAuthentications))
+	add(asClientObjects(i.RequestAuthentications))
+	add(asClientObjects(i.ServiceEntries))
+	add(asClientObjects(i.Sidecars))
+	add(asClientObjects(i.Telemetries))
+	add(asClientObjects(i.TrafficExtensions))
+	add(asClientObjects(i.VirtualServices))
+	add(asClientObjects(i.WasmPlugins))
+	add(asClientObjects(i.WorkloadEntries))
+	add(asClientObjects(i.WorkloadGroups))
+
+	result := make([]string, 0, len(seen))
+	for ns := range seen {
+		result = append(result, ns)
+	}
+	return result
+}
+
+func asClientObjects[T client.Object](slice []T) []client.Object {
+	out := make([]client.Object, len(slice))
+	for i, o := range slice {
+		out[i] = o
+	}
+	return out
+}
+
 func (i IstioConfigList) MarshalJSON() ([]byte, error) {
 	// result map with keys and values
 	jsonMap := make(map[string]interface{})

--- a/models/istio_config_test.go
+++ b/models/istio_config_test.go
@@ -201,3 +201,28 @@ func TestMergeConfigs_TrafficExtensionsWithEmpty(t *testing.T) {
 	require.Len(t, merged.TrafficExtensions, 1)
 	assert.Equal(t, "filter-a", merged.TrafficExtensions[0].Name)
 }
+
+func TestNamespaces(t *testing.T) {
+	list := models.IstioConfigList{
+		VirtualServices: []*networking_v1.VirtualService{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "vs1", Namespace: "bookinfo"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "vs2", Namespace: "default"}},
+		},
+		DestinationRules: []*networking_v1.DestinationRule{
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "dr1", Namespace: "bookinfo"}},
+			{ObjectMeta: meta_v1.ObjectMeta{Name: "dr2", Namespace: "other-ns"}},
+		},
+	}
+
+	namespaces := list.Namespaces()
+	assert.Len(t, namespaces, 3)
+	assert.Contains(t, namespaces, "bookinfo")
+	assert.Contains(t, namespaces, "default")
+	assert.Contains(t, namespaces, "other-ns")
+}
+
+func TestNamespacesEmpty(t *testing.T) {
+	list := models.IstioConfigList{}
+	namespaces := list.Namespaces()
+	assert.Empty(t, namespaces)
+}


### PR DESCRIPTION
### Describe the change

PR #9304 introduced namespace filtering in the validation pipeline to scope Istio configs to namespaces managed by a control plane. However, the filtering was too aggressive: it silently dropped Istio config objects from namespaces that are not explicitly managed (i.e., no sidecar injection or Ambient labels). This caused false positives — for example, KIA1401 ("Route is pointing to a non-existent K8s Gateway") when an HTTPRoute in an Ambient namespace referenced a K8s Gateway in a non-injected namespace like istio-ingress.

The root cause was in three areas:

- filterIstioConfigByManagedNamespaces only kept configs from namespaces mapped to a control plane, discarding everything else. Fixed to also preserve configs from namespaces not managed by ANY control plane — these can contain valid Istio configs (Gateways, ServiceEntries, DestinationRules, etc.) that affect mesh traffic.

- filterVS/DR/SEExportToNamespaces had } else { continue } blocks that skipped objects from namespaces with no mesh config. Fixed by letting meshExportTo stay nil, which isExportedObjectIncluded correctly interprets as "exported to all namespaces" — matching Istio's default behavior.

- Service Entry appender (loadServiceEntryHosts) returned false early when no mesh config existed for a namespace, hiding ServiceEntry hosts from the traffic graph. Fixed with the same pattern — let the nil default flow through to IsExportedTo, which treats empty exportTo as "visible everywhere".

Multi-primary isolation is preserved: configs from namespaces managed by a different control plane still respect that CP's DefaultExportTo settings via the per-namespace export-to filters.

### Steps to test the PR

Apply this YAML
```
apiVersion: v1
kind: Namespace
metadata:
  name: istio-ingress
---
apiVersion: v1
kind: Namespace
metadata:
  name: app-ambient
  labels:
    istio.io/dataplane-mode: ambient
---
apiVersion: v1
kind: Namespace
metadata:
  name: app-non-ambient
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: gateway-internal
  namespace: istio-ingress
spec:
  gatewayClassName: istio
  listeners:
    - name: default
      hostname: "*.example.com"
      port: 80
      protocol: HTTP
      allowedRoutes:
        namespaces:
          from: All
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: app
  namespace: app-ambient
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: gateway-internal
      namespace: istio-ingress
  hostnames:
    - app.example.com
  rules:
    - backendRefs:
        - name: app
          port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: app
  namespace: app-non-ambient
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: gateway-internal
      namespace: istio-ingress
  hostnames:
    - app.example.com
  rules:
    - backendRefs:
        - name: app
          port: 80
```
Verify that both HTTPRoutes are Gateway are verified in Kiali validations and marked as green.



### Automation testing
New tests are added to verify the logic.

### Issue reference

Fixes #9937
