### PR TITLE
Fix OSSMC NamespaceDetailsTab crash and harden namespace Cypress tests

### DIFF
--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -25,7 +25,8 @@ When('user graphs {string} namespaces', (namespaces: string) => {
 });
 
 When('user {string} display menu', (_action: string) => {
-  cy.get('button#display-settings').should('not.be.disabled').click();
+  ensureKialiFinishedLoading();
+  cy.get('button#display-settings').should('be.visible').and('not.be.disabled').click();
 });
 
 When('user enables {string} {string} edge labels', (radio: string, edgeLabel: string) => {

--- a/frontend/cypress/integration/common/namespace_actions.ts
+++ b/frontend/cypress/integration/common/namespace_actions.ts
@@ -1,0 +1,42 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
+
+/**
+ * Shared OSSMC-safe helpers for namespace detail actions that open the
+ * NamespaceTrafficPolicies confirmation modal (sidecar injection, ambient, etc.).
+ */
+export const visitNamespaceDetailPage = (namespace: string): void => {
+  if (Cypress.env('OSSMC')) {
+    cy.intercept('**/api/namespaces/graph*').as('namespaceMinigraph');
+  }
+  cy.visit({ url: `/console/namespaces/${namespace}?refresh=0` });
+  if (Cypress.env('OSSMC')) {
+    cy.wait('@namespaceMinigraph');
+  }
+  ensureKialiFinishedLoading();
+};
+
+export const openNamespaceActionsMenu = (): void => {
+  ensureKialiFinishedLoading();
+  // Avoid opening the minigraph menu while a confirm modal is still mounted.
+  cy.get('[role="dialog"]').should('not.exist');
+  if (Cypress.env('OSSMC')) {
+    cy.get('button#minigraph-toggle', { timeout: 40000 }).should('be.visible').click();
+  } else {
+    cy.getBySel('namespace-actions-toggle').should('be.visible').click();
+  }
+  cy.get('[role="menu"]').should('be.visible');
+};
+
+export const confirmNamespaceTrafficPolicyModal = (): void => {
+  cy.intercept('PATCH', '**/api/namespaces/**').as('namespacePatch');
+  cy.getBySel('confirm-create', { timeout: 10000 }).should('be.visible').should('not.be.disabled').click();
+  cy.wait('@namespacePatch');
+  cy.get('[role="dialog"]').should('not.exist');
+  ensureKialiFinishedLoading();
+};
+
+When('user navigates to the namespace detail page for {string}', function (namespace: string) {
+  this.targetNamespace = namespace;
+  visitNamespaceDetailPage(namespace);
+});

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -1,5 +1,6 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
+import { confirmNamespaceTrafficPolicyModal, openNamespaceActionsMenu } from './namespace_actions';
 
 // Most of these "Given" implementations are directly using the Kiali API
 // in order to reach a well known state in the environment before performing
@@ -284,54 +285,27 @@ When('I visit the overview page', () => {
   cy.contains('Inbound traffic', { matchCase: false }); // Make sure data finished loading, so avoid broken tests because of a re-render
 });
 
-When('user navigates to the namespace detail page for {string}', function (namespace: string) {
-  this.targetNamespace = namespace;
-  cy.visit({ url: `/console/namespaces/${namespace}?refresh=0` });
-  ensureKialiFinishedLoading();
-});
-
-function openNamespaceActionsMenu(): void {
-  if (Cypress.env('OSSMC')) {
-    cy.intercept('**/api/namespaces/graph*').as('namespaceMinigraph');
-    cy.wait('@namespaceMinigraph');
-    cy.waitForReact();
-    cy.get('button#minigraph-toggle').should('be.visible').click();
-  } else {
-    cy.getBySel('namespace-actions-toggle').should('be.visible').click();
-  }
-}
-
-function confirmAndWaitForNamespacePatch(): void {
-  cy.intercept('PATCH', '**/api/namespaces/**').as('namespacePatch');
-  cy.getBySel('confirm-create').should('be.visible').click();
-  cy.wait('@namespacePatch');
-  ensureKialiFinishedLoading();
-}
-
 When('I override the default automatic sidecar injection policy in the namespace to enabled', function () {
-  ensureKialiFinishedLoading();
   openNamespaceActionsMenu();
   cy.getBySel(`enable-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
-  confirmAndWaitForNamespacePatch();
+  confirmNamespaceTrafficPolicyModal();
 });
 
 When(
   'I change the override configuration for automatic sidecar injection policy in the namespace to {string} it',
   function (enabledOrDisabled: string) {
-    ensureKialiFinishedLoading();
     openNamespaceActionsMenu();
     cy.getBySel(`${enabledOrDisabled}-${this.targetNamespace}-namespace-sidecar-injection`)
       .should('be.visible')
       .click();
-    confirmAndWaitForNamespacePatch();
+    confirmNamespaceTrafficPolicyModal();
   }
 );
 
 When('I remove override configuration for sidecar injection in the namespace', function () {
-  ensureKialiFinishedLoading();
   openNamespaceActionsMenu();
   cy.getBySel(`remove-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
-  confirmAndWaitForNamespacePatch();
+  confirmNamespaceTrafficPolicyModal();
 });
 
 function switchWorkloadSidecarInjection(enableOrDisable: string): void {
@@ -339,12 +313,9 @@ function switchWorkloadSidecarInjection(enableOrDisable: string): void {
 
   // In OSSMC, the workload actions toggle does not exist. Workload actions are integrated in the minigraph menu
   if (Cypress.env('OSSMC')) {
-    cy.intercept(`**/api/**/workloads/**/graph*`).as('workloadMinigraph');
+    cy.intercept('**/api/**/workloads/**/graph*').as('workloadMinigraph');
     cy.wait('@workloadMinigraph');
-
-    cy.waitForReact();
-
-    cy.get('button#minigraph-toggle').should('be.visible').click();
+    cy.get('button#minigraph-toggle', { timeout: 40000 }).should('be.visible').click();
   } else {
     cy.get('button[data-test="workload-actions-toggle"]').should('be.visible').click();
   }

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,6 +1,7 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { ensureKialiFinishedLoading, openTab, waitForKialiApiReady } from './transition';
+import { openTab, waitForKialiApiReady } from './transition';
 import { getCellsForCol } from './table';
+import { confirmNamespaceTrafficPolicyModal, openNamespaceActionsMenu } from './namespace_actions';
 import { Pod } from 'types/IstioObjects';
 import { enableKialiFeature, USE_WAYPOINT_NAME_CONFIG } from './kiali-config';
 
@@ -695,17 +696,14 @@ Then('the user updates the log level to {string}', (level: string) => {
 });
 
 When('user opens the namespace actions menu', () => {
-  if (Cypress.env('OSSMC')) {
-    cy.get('button#minigraph-toggle', { timeout: 40000 }).should('be.visible').click();
-  } else {
-    cy.getBySel('namespace-actions-toggle').should('be.visible').click();
-  }
+  openNamespaceActionsMenu();
 });
 
 Then('the option {string} does not exist in namespace actions', (option: string) => {
   cy.get('[role="menu"]').should('be.visible');
   cy.get('[role="menu"]').contains(option).should('not.exist');
   cy.get('body').click(0, 0);
+  cy.get('[role="menu"]').should('not.exist');
 });
 
 When('user clicks on {string} in namespace actions', (option: string) => {
@@ -727,8 +725,7 @@ When('user clicks on {string} in namespace actions', (option: string) => {
         break;
     }
     cy.get(`[data-test="${selector}"]`).should('be.visible').click();
-    cy.get(`[data-test="confirm-create"]`, { timeout: 10000 }).should('be.visible').should('not.be.disabled').click();
-    ensureKialiFinishedLoading();
+    confirmNamespaceTrafficPolicyModal();
   });
 });
 

--- a/frontend/src/components/VirtualList/Renderers.tsx
+++ b/frontend/src/components/VirtualList/Renderers.tsx
@@ -4,26 +4,28 @@ import { Label as PFLabel, Tooltip, TooltipPosition } from '@patternfly/react-co
 import { getFiltersFromURL } from '../FilterList/FilterHelper';
 import { appLabelFilter, versionLabelFilter } from '../../pages/WorkloadList/FiltersAndSorts';
 import { MissingSidecar } from '../MissingSidecar/MissingSidecar';
-import { Renderer, Resource, SortResource, TResource, GVKToBadge } from './Config';
+import type { Renderer, Resource, SortResource, TResource } from './Config';
+import { GVKToBadge } from './Config';
 import { HealthIndicator } from '../Health/HealthIndicator';
 import { ValidationObjectSummary } from '../Validations/ValidationObjectSummary';
 import { ValidationServiceSummary } from '../Validations/ValidationServiceSummary';
-import { WorkloadListItem } from '../../types/Workload';
-import { IstioConfigItem } from '../../types/IstioConfigList';
-import { AppListItem } from '../../types/AppList';
-import { ServiceListItem } from '../../types/ServiceList';
-import { ActiveFilter } from '../../types/Filters';
+import type { WorkloadListItem } from '../../types/Workload';
+import type { IstioConfigItem } from '../../types/IstioConfigList';
+import type { AppListItem } from '../../types/AppList';
+import type { ServiceListItem } from '../../types/ServiceList';
+import type { ActiveFilter } from '../../types/Filters';
 import { renderAPILogo } from '../Logo/Logos';
-import { Health } from '../../types/Health';
-import { NamespaceInfo } from '../../types/NamespaceInfo';
+import type { Health } from '../../types/Health';
+import type { NamespaceInfo } from '../../types/NamespaceInfo';
 import { ValidationSummary } from '../Validations/ValidationSummary';
-import { StatefulFiltersRef } from '../Filters/StatefulFilters';
+import type { StatefulFiltersRef } from '../Filters/StatefulFilters';
 import { IstioObjectLink, GetIstioObjectUrl } from '../Link/IstioObjectLink';
 import { labelFilter } from 'components/Filters/CommonFilters';
 import { labelFilter as NsLabelFilter } from '../../pages/Namespaces/Filters';
 import { ValidationSummaryLink } from '../Link/ValidationSummaryLink';
-import { ValidationStatus } from '../../types/IstioObjects';
-import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import type { ValidationStatus } from '../../types/IstioObjects';
+import type { PFBadgeType } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { MissingLabel } from '../MissingLabel/MissingLabel';
 import { t } from 'utils/I18nUtils';
 import { getPagePath } from 'utils/NavigationUtils';
@@ -51,7 +53,7 @@ import { ControlPlaneBadge } from '../Badge/ControlPlaneBadge';
 import { DataPlaneBadge } from '../Badge/DataPlaneBadge';
 import { NotPartOfMeshBadge } from '../Badge/NotPartOfMeshBadge';
 import { getNamespaceDetailUrl, getNamespaceModeInfo, isDataPlaneNamespace } from 'utils/NamespaceUtils';
-import { isRevisionAvailable } from '../../pages/Namespaces/NamespaceRevisionUtils';
+import { isRevisionAvailable, getNamespaceRevisions } from '../../pages/Namespaces/NamespaceRevisionUtils';
 
 const revisionWarningIconStyle = kialiStyle({
   verticalAlign: 'middle'
@@ -523,30 +525,6 @@ export const nsMode: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
       </PFLabel>
     </Td>
   );
-};
-
-export const getNamespaceRevision = (ns: NamespaceInfo): string | undefined => {
-  let revision: string | undefined;
-  if (ns.labels) {
-    if (ns.labels[INJECTION_LABEL_REV]) {
-      revision = ns.labels[INJECTION_LABEL_REV];
-    }
-  }
-  if (!revision || revision === '') {
-    revision = ns.revision;
-  }
-  return revision;
-};
-
-export const getNamespaceRevisions = (ns: NamespaceInfo): string[] => {
-  const raw = getNamespaceRevision(ns);
-  if (!raw || raw === '') {
-    return [];
-  }
-  return raw
-    .split(',')
-    .map(r => r.trim())
-    .filter(r => r !== '');
 };
 
 export const nsRevision: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {

--- a/frontend/src/pages/NamespaceDetails/NamespaceDetailsOverview.tsx
+++ b/frontend/src/pages/NamespaceDetails/NamespaceDetailsOverview.tsx
@@ -18,9 +18,10 @@ import {
 } from '@patternfly/react-core';
 import { GraphDataSource } from 'services/GraphDataSource';
 import { MiniGraphCard } from 'pages/Graph/MiniGraphCard';
-import { DurationInSeconds } from 'types/Common';
-import { NamespaceInfo, NamespaceStatus } from 'types/NamespaceInfo';
-import { DEGRADED, FAILURE, HEALTHY, NA, NOT_READY, Status } from 'types/Health';
+import type { DurationInSeconds } from 'types/Common';
+import type { NamespaceInfo, NamespaceStatus } from 'types/NamespaceInfo';
+import type { Status } from 'types/Health';
+import { DEGRADED, FAILURE, HEALTHY, NA, NOT_READY } from 'types/Health';
 import { ControlPlaneBadge } from 'components/Badge/ControlPlaneBadge';
 import { DataPlaneBadge } from 'components/Badge/DataPlaneBadge';
 import { NotPartOfMeshBadge } from 'components/Badge/NotPartOfMeshBadge';
@@ -31,8 +32,7 @@ import { URLParam } from 'app/History';
 import { getNamespaceModeInfo, isDataPlaneNamespace } from 'utils/NamespaceUtils';
 import { ModeBadge } from '../../components/Badge/ModeBadge';
 import { t } from 'utils/I18nUtils';
-import { getNamespaceRevisions } from 'components/VirtualList/Renderers';
-import { isRevisionAvailable } from 'pages/Namespaces/NamespaceRevisionUtils';
+import { getNamespaceRevisions, isRevisionAvailable } from 'pages/Namespaces/NamespaceRevisionUtils';
 import { KialiIcon, createIcon } from 'config/KialiIcon';
 import { kialiStyle } from 'styles/StyleUtils';
 import { classes } from 'typestyle';
@@ -40,7 +40,7 @@ import { infoStyle } from 'styles/IconStyle';
 import { EditableAnnotationsCard } from 'components/Label/EditableAnnotationsCard';
 import { EditableLabelsCard } from 'components/Label/EditableLabelsCard';
 import { NamespaceHealthStatus } from 'pages/Namespaces/NamespaceHealthStatus';
-import { NamespaceAction } from 'pages/Namespaces/NamespaceActions';
+import type { NamespaceAction } from 'pages/Namespaces/NamespaceActions';
 import { FilterSelected } from 'components/Filters/StatefulFilters';
 import { navigateToFilteredList } from '../PageUtils';
 import { detailCardStackStyle, detailGridStyle, detailLeftColumnStyle, flexFillStyle } from 'styles/FlexStyles';
@@ -251,6 +251,26 @@ export class NamespaceDetailsOverview extends React.Component<Props> {
     }
   }
 
+  render(): React.ReactNode {
+    const { namespace } = this.props;
+    const miniGraphSpan = 8;
+
+    return (
+      <>
+        <div className={flexFillStyle} data-test={`namespace-detail-overview-${namespace}`}>
+          <Grid hasGutter={true} className={detailGridStyle}>
+            <GridItem span={4} className={detailLeftColumnStyle}>
+              <Stack className={detailCardStackStyle}>{this.renderLeftCard()}</Stack>
+            </GridItem>
+            <GridItem span={miniGraphSpan}>
+              <MiniGraphCard dataSource={this.graphDataSource} namespaceActions={this.props.namespaceActions} />
+            </GridItem>
+          </Grid>
+        </div>
+      </>
+    );
+  }
+
   private fetchGraph = (): void => {
     this.graphDataSource.fetchForNamespace(this.props.duration, this.props.namespace, this.props.nsInfo.cluster);
   };
@@ -411,26 +431,6 @@ export class NamespaceDetailsOverview extends React.Component<Props> {
             title={t('Annotations')}
           />
         </StackItem>
-      </>
-    );
-  }
-
-  render(): React.ReactNode {
-    const { namespace } = this.props;
-    const miniGraphSpan = 8;
-
-    return (
-      <>
-        <div className={flexFillStyle} data-test={`namespace-detail-overview-${namespace}`}>
-          <Grid hasGutter={true} className={detailGridStyle}>
-            <GridItem span={4} className={detailLeftColumnStyle}>
-              <Stack className={detailCardStackStyle}>{this.renderLeftCard()}</Stack>
-            </GridItem>
-            <GridItem span={miniGraphSpan}>
-              <MiniGraphCard dataSource={this.graphDataSource} namespaceActions={this.props.namespaceActions} />
-            </GridItem>
-          </Grid>
-        </div>
       </>
     );
   }

--- a/frontend/src/pages/Namespaces/NamespaceRevisionUtils.ts
+++ b/frontend/src/pages/Namespaces/NamespaceRevisionUtils.ts
@@ -1,4 +1,5 @@
 import { INJECTION_LABEL_REV } from 'config/ServerConfig';
+import type { NamespaceInfo } from 'types/NamespaceInfo';
 
 type NamespaceLike = {
   labels?: Record<string, string>;
@@ -20,4 +21,26 @@ export const isRevisionAvailable = (ns: NamespaceLike): boolean => {
     .map(r => r.trim())
     .filter(r => r !== '')
     .every(r => controlPlaneRevisions.has(r));
+};
+
+export const getNamespaceRevision = (ns: NamespaceInfo): string | undefined => {
+  let revision: string | undefined;
+  if (ns.labels?.[INJECTION_LABEL_REV]) {
+    revision = ns.labels[INJECTION_LABEL_REV];
+  }
+  if (!revision || revision === '') {
+    revision = ns.revision;
+  }
+  return revision;
+};
+
+export const getNamespaceRevisions = (ns: NamespaceInfo): string[] => {
+  const raw = getNamespaceRevision(ns);
+  if (!raw || raw === '') {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map(r => r.trim())
+    .filter(r => r !== '');
 };


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/9953

## Summary

Fixes an OSSMC UI crash that prevented the namespace Service Mesh tab from loading, and includes minor Cypress hardening for namespace-level traffic policy actions in kiosk mode.

## Crash scenario

When OpenShift Console lazy-loads the OSSMC `NamespaceDetailsTab` exposed module (registered in OSSMC #667, backed by the new namespace detail page from #9628), the browser console reports:

```
Failed to load module 'NamespaceDetailsTab' of plugin ossmconsole@…
ReferenceError: Cannot access 'istioConfig' before initialization
```

OpenShift Console then fails to render the tab. In minified builds this often appears downstream as React error #306 ("lazy element resolved to null"), which obscures the real failure.

The failing import chain under OSSMC webpack code-splitting is:

```
NamespaceDetailsTab (lazy chunk)
  → NamespaceDetailsPage
    → NamespaceDetailsOverview
      → components/VirtualList/Renderers
        → components/VirtualList/Config
          → Renderers.istioConfig   ← read at module init time
```

`Config.ts` has imported `Renderers` and referenced `Renderers.istioConfig` at module scope since the frontend was reorganized (~2022). `Renderers.tsx` imports from `Config.ts`. That circular dependency is usually harmless when modules load in a favorable order inside a single SPA bundle.

OSSMC is different: each exposed `$codeRef` module (including `NamespaceDetailsTab`) is built as a separate async webpack chunk. When that chunk is evaluated, `Config` runs before `Renderers` finishes initializing its exports, so `istioConfig` is still in the temporal dead zone.

The trigger was not the bundler change itself, but the combination of:

1. **#9628** — `NamespaceDetailsOverview` imported `getNamespaceRevisions` from `Renderers`, pulling the namespace detail page into the `Renderers` → `Config` cycle.
2. **OSSMC #667** — the namespace/project Service Mesh tab was wired to `NamespaceDetailsPage` as a lazy-loaded plugin module.

Standalone Kiali continued to work because its SPA bundle (CRA/webpack previously, Rsbuild now) evaluates modules in an order that avoids the TDZ on normal navigation.

## Fix

Move `getNamespaceRevision` and `getNamespaceRevisions` out of `VirtualList/Renderers.tsx` into `pages/Namespaces/NamespaceRevisionUtils.ts` (alongside the existing `isRevisionAvailable` helper).

- `NamespaceDetailsOverview` now imports revision helpers from `NamespaceRevisionUtils` instead of `Renderers`.
- `Renderers.tsx` imports the same helpers for the namespace list `nsRevision` column renderer.

This breaks the import chain for the namespace detail page without changing runtime behavior.

## Why the Rsbuild migration surfaced this

The Rsbuild migration (#9653) did **not** introduce the OSSMC crash. The underlying `Config` ↔ `Renderers` cycle predates it by years.

What Rsbuild did change was how the problem became visible during development:

- **Unit tests:** migrating from Jest to Rstest uses stricter ESM module semantics. Importing from `Renderers` in tests now hits the same TDZ unless `Config` is mocked — see the comment added in `Renderers.test.ts`:

  ```typescript
  // Break the Renderers ↔ Config circular dependency that causes a TDZ
  // error under ESM. Config.ts eagerly accesses Renderers at module scope,
  // but the test only needs types from Config, not runtime renderer refs.
  rstest.mock('../Config', () => ({}));
  ```

  Before Rsbuild, the Jest test imported `Config` directly without that mock and did not fail.

- **Standalone Kiali:** Rsbuild bundles the SPA differently from OSSMC's per-module webpack chunks. The namespace detail route in standalone Kiali does not hit the TDZ even after the Rsbuild switch — which is why the bug appeared OSSMC-specific until the unminified plugin error was captured.

So Rsbuild made the latent circular dependency easier to discover in tests, while the production OSSMC failure was triggered by the new namespace detail page being lazy-loaded as a separate plugin chunk.

## Cypress test improvements (minor)

The original PR also hardens OSSMC namespace action Cypress steps. These are secondary to the UI crash fix but worth keeping:

- New `namespace_actions.ts` shared helpers for namespace detail navigation, minigraph kebab menu, and `NamespaceTrafficPolicies` modal confirmation.
- Intercept minigraph **before** `cy.visit()` (avoids missing the graph request on OSSMC).
- Wait for confirm button enabled, PATCH completion, and dialog dismissal before chaining actions (important for multi-step waypoint namespace scenarios).
- Remove `cy.waitForReact()` calls; minor display-menu flake guard in `graph_display.ts`.

## Test plan

- [x] Manual OSSMC verification (CRC): namespace Service Mesh tab loads without console error; namespace actions work
- [x] CI passes on this PR (standalone Kiali Cypress suites, especially `@core-2` `sidecar_injection.feature` and `@ambient` `waypoint.feature`)
- [x] OSSMC CI: namespace scenarios in `sidecar_injection.feature` and `[Namespaces] Add to Ambient in the test-sidecar namespace` in `waypoint.feature`