### PR TITLE
Remove OSSM 2.6 from supported branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,6 @@ The currently supported Kiali release branches (which receive backports and secu
 | 3.2   | v2.17  | 2.17          |
 | 3.1   | v2.11  | 2.11          |
 | 3.0   | v2.4   | 2.4           |
-| 2.6   | v1.73  | 1.73          |
 
 In addition, `master` is the active development branch for the next release.
 


### PR DESCRIPTION
## Summary
- Remove OSSM 2.6 / Kiali v1.73 from the Supported Branches table in AGENTS.md
- OSSM 2.6 is end of life and no longer receives backports or security fixes

## Test plan
- [ ] Verify AGENTS.md renders correctly

Part of https://github.com/kiali/kiali/issues/9987

Made with [Cursor](https://cursor.com)