### PR TITLE
[UX] Improve Istio Config side panel UX

### DIFF
--- a/frontend/cypress/integration/common/istio_config.ts
+++ b/frontend/cypress/integration/common/istio_config.ts
@@ -750,6 +750,15 @@ Then(
   }
 );
 
+When('user clicks on the {string} VirtualService of the {string} namespace', (name: string, namespace: string) => {
+  cy.get(`[data-test="VirtualItem_Ns${namespace}_VirtualService_${name}"]`).find(linkSelector()).first().click();
+  ensureKialiFinishedLoading();
+});
+
+Then('the user sees the validation message {string} grouped with count {int}', (code: string, count: number) => {
+  cy.contains(`${code}`).parent().should('contain.text', `(${count})`);
+});
+
 // KIA0104 and similar scenarios delete VirtualService/bookinfo; re-apply sample networking once when
 // istio_config.feature finishes (step defs are global, so gate on basename — not wizard_istio_config.feature).
 AfterAll(() => {

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -398,6 +398,23 @@ Feature: Kiali Istio Config page
   @crd-validation
   @bookinfo-app
   @sleep-app
+  Scenario: Duplicate validation codes are grouped on the detail page
+    Given there is a "bar" VirtualService in the "sleep" namespace with a "bar-route" http-route to host "sleep" and subset "v1"
+    And the route of the VirtualService has weight 50
+    And the http-route of the VirtualService also has a destination to host "sleep" and subset "v1" with weight 50
+    And a "bar" DestinationRule in the "sleep" namespace for "sleep" host
+    And the DestinationRule has a "v1" subset for "version=v1" labels
+    When the user refreshes the page
+    And user selects the "sleep" namespace
+    Then the "bar" "VirtualService" of the "sleep" namespace should have a "warning"
+    When user clicks on the "bar" VirtualService of the "sleep" namespace
+    Then the user sees the validation message "KIA1105" grouped with count 2
+    And there is not a "bar" "DestinationRule" in the "sleep" namespace
+    And there is not a "bar" "VirtualService" in the "sleep" namespace
+
+  @crd-validation
+  @bookinfo-app
+  @sleep-app
   Scenario: KIA1106 validation
     Given there is a "foo" VirtualService in the "sleep" namespace with a "foo-route" http-route to host "sleep"
     And the VirtualService applies to "sleep" hosts

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigHelp.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigHelp.tsx
@@ -1,6 +1,6 @@
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
 import * as React from 'react';
-import { HelpMessage } from 'types/IstioObjects';
+import type { HelpMessage } from 'types/IstioObjects';
 
 interface IstioConfigHelpProps {
   helpMessages?: HelpMessage[];
@@ -8,7 +8,7 @@ interface IstioConfigHelpProps {
 }
 
 export class IstioConfigHelp extends React.Component<IstioConfigHelpProps> {
-  render() {
+  render(): React.ReactNode {
     const helpMessage = this.props.helpMessages?.find(helpMessage =>
       this.props.selectedLine?.includes(helpMessage.objectField.substring(helpMessage.objectField.lastIndexOf('.') + 1))
     );
@@ -35,7 +35,7 @@ export class IstioConfigHelp extends React.Component<IstioConfigHelpProps> {
         )}
         {!helpMessage && (
           <StackItem>
-            <p>Help information will appear when editing on important fields for this configuration.</p>
+            <p>Select a highlighted field in the editor to see contextual help.</p>
           </StackItem>
         )}
       </Stack>

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -4,13 +4,13 @@ import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { LocalTime } from 'components/Time/LocalTime';
 import * as React from 'react';
 import type { IstioConfigDetails } from 'types/IstioConfigDetails';
+import { ValidationTypes } from 'types/IstioObjects';
 import type {
   HelpMessage,
   ObjectReference,
   ObjectValidation,
   ServiceReference,
   ValidationMessage,
-  ValidationTypes,
   WorkloadReference
 } from 'types/IstioObjects';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -43,7 +43,7 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
 
   const configurationHasWarnings = (): boolean | undefined => {
     return props.istioValidations?.checks.some(check => {
-      return (check.severity as ValidationTypes) === ('warning' as ValidationTypes);
+      return check.severity === ValidationTypes.Warning;
     });
   };
 

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioConfigOverview.tsx
@@ -1,13 +1,10 @@
-import { Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Stack, StackItem, TooltipPosition } from '@patternfly/react-core';
 import { Labels } from 'components/Label/Labels';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { LocalTime } from 'components/Time/LocalTime';
-import { ValidationObjectSummary } from 'components/Validations/ValidationObjectSummary';
-import { GVKToBadge } from 'components/VirtualList/Config';
-import { KialiIcon } from 'config/KialiIcon';
 import * as React from 'react';
-import { IstioConfigDetails } from 'types/IstioConfigDetails';
-import {
+import type { IstioConfigDetails } from 'types/IstioConfigDetails';
+import type {
   HelpMessage,
   ObjectReference,
   ObjectValidation,
@@ -17,18 +14,12 @@ import {
   WorkloadReference
 } from 'types/IstioObjects';
 import { kialiStyle } from 'styles/StyleUtils';
-import {
-  getGVKTypeString,
-  getIstioObject,
-  getIstioObjectGVK,
-  getReconciliationCondition
-} from 'utils/IstioConfigUtils';
+import { getIstioObject } from 'utils/IstioConfigUtils';
 import { IstioConfigHelp } from './IstioConfigHelp';
 import { IstioConfigReferences } from './IstioConfigReferences';
 import { IstioConfigValidationReferences } from './IstioConfigValidationReferences';
 import { IstioStatusMessageList } from './IstioStatusMessageList';
 import { isMultiCluster } from '../../../config';
-import { infoStyle } from 'styles/IconStyle';
 
 interface IstioConfigOverviewProps {
   helpMessages?: HelpMessage[];
@@ -42,22 +33,9 @@ interface IstioConfigOverviewProps {
   workloadReferences: WorkloadReference[];
 }
 
-const iconStyle = kialiStyle({
-  display: 'inline-block'
-});
-
-const healthIconStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
-
-const resourceListStyle = kialiStyle({
-  $nest: {
-    '& > ul > li > span': {
-      float: 'left',
-      width: '125px',
-      fontWeight: 700
-    }
-  }
+const metadataStyle = kialiStyle({
+  color: 'var(--pf-t--global--color--subtle)',
+  fontSize: 'var(--pf-t--global--font--size--sm)'
 });
 
 export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: IstioConfigOverviewProps) => {
@@ -65,9 +43,10 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
 
   const configurationHasWarnings = (): boolean | undefined => {
     return props.istioValidations?.checks.some(check => {
-      return check.severity === ValidationTypes.Warning;
+      return (check.severity as ValidationTypes) === ('warning' as ValidationTypes);
     });
   };
+
   const hasReferences = (): boolean => {
     return (
       props.objectReferences.length > 0 || props.serviceReferences.length > 0 || props.workloadReferences.length > 0
@@ -76,87 +55,23 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
 
   const istioObject = getIstioObject(props.istioObjectDetails);
 
-  const resourceProperties = (
-    <div key="properties-list" className={resourceListStyle}>
-      <ul style={{ listStyleType: 'none' }}>
-        {istioObject && istioObject.metadata.creationTimestamp && (
-          <li>
-            <span>Created</span>
-
-            <div style={{ display: 'inline-block' }}>
-              <LocalTime time={istioObject.metadata.creationTimestamp} />
-            </div>
-          </li>
-        )}
-
-        {istioObject && istioObject.metadata.resourceVersion && (
-          <li>
-            <span>Version</span>
-            {istioObject.metadata.resourceVersion}
-          </li>
-        )}
-      </ul>
-    </div>
-  );
-
   return (
     <Stack hasGutter={true}>
-      <StackItem>
-        <Title headingLevel="h3" size={TitleSizes.xl}>
-          Overview
-        </Title>
-      </StackItem>
+      {isMultiCluster && (
+        <StackItem>
+          <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {cluster}
+        </StackItem>
+      )}
 
-      <StackItem>
-        {isMultiCluster && (
-          <div key="cluster-icon">
-            <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} /> {cluster}
-          </div>
-        )}
-
-        {istioObject && istioObject.kind && (
-          <>
-            <div className={iconStyle}>
-              <PFBadge
-                badge={GVKToBadge[getGVKTypeString(getIstioObjectGVK(istioObject.apiVersion, istioObject.kind))]}
-                position={TooltipPosition.top}
-              />
-            </div>
-
-            {istioObject?.metadata.name}
-
-            <Tooltip
-              position={TooltipPosition.right}
-              content={<div style={{ textAlign: 'left' }}>{resourceProperties}</div>}
-            >
-              <KialiIcon.Info className={infoStyle} />
-            </Tooltip>
-
-            {props.istioValidations &&
-              (!props.statusMessages || props.statusMessages.length === 0) &&
-              (!props.istioValidations.checks || props.istioValidations.checks.length === 0) && (
-                <span className={healthIconStyle}>
-                  <ValidationObjectSummary
-                    id="config-validation"
-                    validations={[props.istioValidations]}
-                    reconciledCondition={getReconciliationCondition(props.istioObjectDetails)}
-                  />
-                </span>
-              )}
-          </>
-        )}
-      </StackItem>
+      {istioObject?.metadata.creationTimestamp && (
+        <StackItem className={metadataStyle}>
+          Created <LocalTime time={istioObject.metadata.creationTimestamp} />
+        </StackItem>
+      )}
 
       {istioObject?.metadata.labels && (
         <StackItem>
           <Labels tooltipMessage="Labels defined on this resource" labels={istioObject?.metadata.labels}></Labels>
-        </StackItem>
-      )}
-
-      {((props.statusMessages && props.statusMessages.length > 0) ||
-        (props.istioValidations && props.istioValidations.checks && props.istioValidations.checks.length > 0)) && (
-        <StackItem>
-          <IstioStatusMessageList messages={props.statusMessages} checks={props.istioValidations?.checks} />
         </StackItem>
       )}
 
@@ -176,6 +91,13 @@ export const IstioConfigOverview: React.FC<IstioConfigOverviewProps> = (props: I
             isValid={!props.istioValidations || props.istioValidations?.valid}
             cluster={cluster}
           />
+        </StackItem>
+      )}
+
+      {((props.statusMessages && props.statusMessages.length > 0) ||
+        (props.istioValidations && props.istioValidations.checks && props.istioValidations.checks.length > 0)) && (
+        <StackItem>
+          <IstioStatusMessageList messages={props.statusMessages} checks={props.istioValidations?.checks} />
         </StackItem>
       )}
 

--- a/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { Flex, FlexItem, Stack, StackItem, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { IstioLevelToSeverity, ObjectCheck, ValidationMessage, ValidationTypes } from 'types/IstioObjects';
+import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
+import { IstioLevelToSeverity } from 'types/IstioObjects';
+import type { ObjectCheck, ValidationMessage, ValidationTypes } from 'types/IstioObjects';
 import { Validation } from 'components/Validations/Validation';
-import { KialiIcon } from 'config/KialiIcon';
+import { kialiStyle } from 'styles/StyleUtils';
+import { PFSpacer } from 'styles/PfSpacer';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 interface IstioStatusMessageListProps {
@@ -10,8 +12,42 @@ interface IstioStatusMessageListProps {
   messages?: ValidationMessage[];
 }
 
+interface GroupedCheck {
+  code?: string;
+  count: number;
+  message: string;
+  severity: string;
+}
+
+const messageStyle = kialiStyle({
+  paddingBottom: PFSpacer.sm
+});
+
+const groupChecks = (checks: ObjectCheck[]): GroupedCheck[] => {
+  const grouped = new Map<string, GroupedCheck>();
+
+  for (const check of checks) {
+    const key = `${check.code ?? ''}_${check.severity}`;
+
+    if (grouped.has(key)) {
+      grouped.get(key)!.count++;
+    } else {
+      grouped.set(key, {
+        code: check.code,
+        count: 1,
+        message: check.message,
+        severity: check.severity
+      });
+    }
+  }
+
+  return Array.from(grouped.values());
+};
+
 export const IstioStatusMessageList: React.FC<IstioStatusMessageListProps> = ({ checks, messages }) => {
   const { t } = useKialiTranslation();
+
+  const groupedChecks = React.useMemo(() => groupChecks(checks ?? []), [checks]);
 
   return (
     <Stack>
@@ -25,45 +61,26 @@ export const IstioStatusMessageList: React.FC<IstioStatusMessageListProps> = ({ 
         const severity: ValidationTypes = IstioLevelToSeverity[msg.level || 'UNKNOWN'];
 
         return (
-          <StackItem key={`msg-${i}`}>
-            <Flex>
-              <FlexItem>
-                <Validation severity={severity} />
-              </FlexItem>
-              <FlexItem>
-                <a href={msg.documentationUrl} target="_blank" rel="noopener noreferrer">
-                  {msg.type.code}
-                </a>
-              </FlexItem>
-              <FlexItem>
-                <Tooltip content={msg.description} position={TooltipPosition.right}>
-                  <KialiIcon.Info />
-                </Tooltip>
-              </FlexItem>
-            </Flex>
+          <StackItem key={`msg-${i}`} className={messageStyle}>
+            <Validation severity={severity} />{' '}
+            <a href={msg.documentationUrl} target="_blank" rel="noopener noreferrer">
+              {msg.type.code}
+            </a>
+            {msg.description && ` ${msg.description}`}
           </StackItem>
         );
       })}
 
-      <Stack>
-        {(checks ?? []).map((check, index) => {
-          const severity: ValidationTypes = IstioLevelToSeverity[check.severity.toUpperCase() || 'UNKNOWN'];
+      {groupedChecks.map((group, index) => {
+        const severity: ValidationTypes = IstioLevelToSeverity[group.severity.toUpperCase() || 'UNKNOWN'];
 
-          return (
-            <StackItem key={`valid_msg-${index}`}>
-              <Flex>
-                <FlexItem>
-                  <Validation severity={severity} />
-                </FlexItem>
-                <FlexItem>{check.code}</FlexItem>
-                <Tooltip content={check.message} position={TooltipPosition.right}>
-                  <KialiIcon.Info />
-                </Tooltip>
-              </Flex>
-            </StackItem>
-          );
-        })}
-      </Stack>
+        return (
+          <StackItem key={`valid_msg-${index}`} className={messageStyle}>
+            <Validation severity={severity} /> {group.code} {group.message}
+            {group.count > 1 && ` (${group.count})`}
+          </StackItem>
+        );
+      })}
     </Stack>
   );
 };


### PR DESCRIPTION
### Describe the change

Improves the Istio Config details side panel to reduce "user data mining" — presenting information explicitly instead of requiring hover/click to discover it. Per the UX recommendations in #9912:

- **Validation messages shown inline**: Replaced the `Code + info icon (tooltip with message)` pattern with `Code + message` displayed directly on the same line.
- **Duplicate validations grouped**: When the same validation code fires multiple times on one resource, only one entry is shown with a count in parentheses (e.g. `KIA1105 This host subset combination is already referenced... (2)`).
- **Removed redundant identity**: The "Overview" heading, resource type badge, and resource name were duplicates of the page header — removed from the side panel.
- **Inline Created timestamp**: Replaced the info icon tooltip (which showed Created time + resourceVersion) with a visible `Created <time>` line. Dropped resourceVersion (already visible in YAML).
- **Removed validation summary icon**: The green checkmark shown when no issues exist was redundant — the absence of the Configuration Analysis section already communicates "no issues".
- **Moved References before Configuration Analysis**: Both Validation References and Config References now appear before the validation messages for a more stable layout.
- **Improved Help empty state**: Changed from "Help information will appear when editing on important fields..." to "Select a highlighted field in the editor to see contextual help." — more actionable.

### Steps to test the PR

1. Navigate to any Istio Config detail page (e.g. a VirtualService or Gateway)
2. Verify the side panel shows: Created timestamp, Labels, References, then Configuration Analysis (if issues exist), then Help
3. Verify no "Overview" title, no badge+name duplication, no info icon tooltip, no green checkmark icon
4. For validation grouping: create a VirtualService with duplicate route destinations to the same host+subset — verify the detail page shows the KIA1105 code + message with `(2)` count

### Automation testing

Added a new `@crd-validation` Cypress scenario in `istio_config.feature`:
- **"Duplicate validation codes are grouped on the detail page"**: Creates a VirtualService triggering KIA1105 twice, navigates to the detail page, and asserts the grouped message with count `(2)` is visible.

New step definitions in `istio_config.ts`:
- `user clicks on the {string} VirtualService of the {string} namespace` — navigates from list to detail
- `the user sees the validation message {string} grouped with count {int}` — asserts grouped code + count

### Issue reference

Fixes #9912

Made with [Cursor](https://cursor.com)