### PR TITLE
[AI] manage_istio_config_read: reduce LLM token

### DIFF
--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -56,12 +56,10 @@ type istioListItem struct {
 
 // KindValidationResult summarises resources for a single GVK within a namespace.
 // The map key in IstioListResult is "group/version/kind".
-// Valid is present (true) only when every resource passes Kiali validation.
-// Invalid lists only the names that failed; omitted when all resources are valid.
+// Valid and Invalid are mutually exclusive subsets; both omitted when empty.
 type KindValidationResult struct {
-	Names   []string `json:"names"`
-	Valid   *bool    `json:"valid,omitempty"`
-	Invalid []string `json:"invalid,omitempty"`
+	Valid   []string `json:"valid,omitempty"`   // Resources passing validation
+	Invalid []string `json:"invalid,omitempty"` // Resources failing validation
 }
 
 // IstioListResult is the grouped output returned by the list action.
@@ -368,7 +366,7 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		return items[i].Name < items[j].Name
 	})
 
-	// Group into namespace → "group/version/kind" → {names, valid, invalid}.
+	// Group into namespace → "group/version/kind" → {valid, invalid}.
 	// Because items are pre-sorted the name slices are already in alphabetical order.
 	namespaces := make(map[string]map[string]KindValidationResult)
 	for _, item := range items {
@@ -377,21 +375,12 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 			namespaces[item.Namespace] = make(map[string]KindValidationResult)
 		}
 		kvr := namespaces[item.Namespace][gvkKey]
-		kvr.Names = append(kvr.Names, item.Name)
-		if !item.Valid {
+		if item.Valid {
+			kvr.Valid = append(kvr.Valid, item.Name)
+		} else {
 			kvr.Invalid = append(kvr.Invalid, item.Name)
 		}
 		namespaces[item.Namespace][gvkKey] = kvr
-	}
-	// Set valid:true only on groups where no resource failed validation.
-	validTrue := true
-	for ns, kinds := range namespaces {
-		for key, kvr := range kinds {
-			if len(kvr.Invalid) == 0 {
-				kvr.Valid = &validTrue
-				namespaces[ns][key] = kvr
-			}
-		}
 	}
 
 	return IstioListResult{Cluster: cluster, Namespaces: namespaces}, http.StatusOK

--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -43,30 +43,41 @@ var istioConfigCriteria = business.IstioConfigCriteria{
 	IncludeTelemetry:              true,
 }
 
-type IstioListItem struct {
-	Name       string            `json:"name"`
-	Namespace  string            `json:"namespace"`
-	Group      string            `json:"group"`
-	Version    string            `json:"version"`
-	Kind       string            `json:"kind"`
-	Validation ValidationSummary `json:"validation"`
+// istioListItem is an internal flat representation used while collecting
+// resources before they are grouped into the final output structure.
+type istioListItem struct {
+	Name      string
+	Namespace string
+	Group     string
+	Version   string
+	Kind      string
+	Valid     bool
 }
 
-// IstioListResult wraps the list output in a JSON object so the MCP
-// structuredContent requirement (must be a JSON object/record) is satisfied.
+// KindValidationResult holds resource names grouped by validation status for a
+// single GVK within a namespace. The map key in IstioListResult is
+// "group/version/kind" (e.g. "networking.istio.io/v1/VirtualService").
+type KindValidationResult struct {
+	Valid   []string `json:"valid"`
+	Invalid []string `json:"invalid"`
+}
+
+// IstioListResult is the grouped output returned by the list action.
+// Resources are nested as: namespace → "group/version/kind" → {valid, invalid}.
+// This eliminates per-item repetition of namespace, group, version, and kind keys.
 type IstioListResult struct {
-	Cluster string          `json:"cluster"`
-	Items   []IstioListItem `json:"items"`
+	Cluster    string                                     `json:"cluster"`
+	Namespaces map[string]map[string]KindValidationResult `json:"namespaces"`
 }
 
-type ValidationSummary struct {
-	Valid  bool                     `json:"valid"`
-	Checks []ValidationCheckSummary `json:"checks,omitempty"`
+type validationSummary struct {
+	Valid  bool
+	Checks []validationCheckSummary
 }
 
-type ValidationCheckSummary struct {
-	Severity string `json:"severity"`
-	Message  string `json:"message"`
+type validationCheckSummary struct {
+	Severity string
+	Message  string
 }
 
 func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *business.Layer, conf *config.Config) (interface{}, int) {
@@ -220,296 +231,159 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		istioValidations = models.IstioValidations{}
 	}
 
-	items := make([]IstioListItem, 0, len(virtualServices)+len(destinationRules)+len(gateways))
+	items := make([]istioListItem, 0, len(virtualServices)+len(destinationRules)+len(gateways))
+
+	appendItem := func(name, ns string, gvk schema.GroupVersionKind, obj runtime.Object) {
+		v := validationSummaryForRuntimeObject(obj, gvk, istioValidations, cluster)
+		items = append(items, istioListItem{
+			Name:      name,
+			Namespace: ns,
+			Group:     gvk.Group,
+			Version:   gvk.Version,
+			Kind:      gvk.Kind,
+			Valid:     v.Valid,
+		})
+	}
 
 	for _, vs := range virtualServices {
-		if vs == nil {
-			continue
+		if vs != nil {
+			appendItem(vs.Name, vs.Namespace, kubernetes.VirtualServices, vs)
 		}
-		items = append(items, IstioListItem{
-			Name:       vs.Name,
-			Namespace:  vs.Namespace,
-			Group:      kubernetes.VirtualServices.Group,
-			Version:    kubernetes.VirtualServices.Version,
-			Kind:       kubernetes.VirtualServices.Kind,
-			Validation: validationSummaryForRuntimeObject(vs, kubernetes.VirtualServices, istioValidations, cluster),
-		})
 	}
 	for _, dr := range destinationRules {
-		if dr == nil {
-			continue
+		if dr != nil {
+			appendItem(dr.Name, dr.Namespace, kubernetes.DestinationRules, dr)
 		}
-		items = append(items, IstioListItem{
-			Name:       dr.Name,
-			Namespace:  dr.Namespace,
-			Group:      kubernetes.DestinationRules.Group,
-			Version:    kubernetes.DestinationRules.Version,
-			Kind:       kubernetes.DestinationRules.Kind,
-			Validation: validationSummaryForRuntimeObject(dr, kubernetes.DestinationRules, istioValidations, cluster),
-		})
 	}
 	for _, gw := range gateways {
-		if gw == nil {
-			continue
+		if gw != nil {
+			appendItem(gw.Name, gw.Namespace, kubernetes.Gateways, gw)
 		}
-		items = append(items, IstioListItem{
-			Name:       gw.Name,
-			Namespace:  gw.Namespace,
-			Group:      kubernetes.Gateways.Group,
-			Version:    kubernetes.Gateways.Version,
-			Kind:       kubernetes.Gateways.Kind,
-			Validation: validationSummaryForRuntimeObject(gw, kubernetes.Gateways, istioValidations, cluster),
-		})
 	}
 
 	// Remaining supported types (not affected by service_name filtering).
 	for _, se := range serviceEntries {
-		if se == nil {
-			continue
+		if se != nil {
+			appendItem(se.Name, se.Namespace, kubernetes.ServiceEntries, se)
 		}
-		items = append(items, IstioListItem{
-			Name:       se.Name,
-			Namespace:  se.Namespace,
-			Group:      kubernetes.ServiceEntries.Group,
-			Version:    kubernetes.ServiceEntries.Version,
-			Kind:       kubernetes.ServiceEntries.Kind,
-			Validation: validationSummaryForRuntimeObject(se, kubernetes.ServiceEntries, istioValidations, cluster),
-		})
 	}
 	for _, sc := range sidecars {
-		if sc == nil {
-			continue
+		if sc != nil {
+			appendItem(sc.Name, sc.Namespace, kubernetes.Sidecars, sc)
 		}
-		items = append(items, IstioListItem{
-			Name:       sc.Name,
-			Namespace:  sc.Namespace,
-			Group:      kubernetes.Sidecars.Group,
-			Version:    kubernetes.Sidecars.Version,
-			Kind:       kubernetes.Sidecars.Kind,
-			Validation: validationSummaryForRuntimeObject(sc, kubernetes.Sidecars, istioValidations, cluster),
-		})
 	}
 	for _, ef := range envoyFilters {
-		if ef == nil {
-			continue
+		if ef != nil {
+			appendItem(ef.Name, ef.Namespace, kubernetes.EnvoyFilters, ef)
 		}
-		items = append(items, IstioListItem{
-			Name:       ef.Name,
-			Namespace:  ef.Namespace,
-			Group:      kubernetes.EnvoyFilters.Group,
-			Version:    kubernetes.EnvoyFilters.Version,
-			Kind:       kubernetes.EnvoyFilters.Kind,
-			Validation: validationSummaryForRuntimeObject(ef, kubernetes.EnvoyFilters, istioValidations, cluster),
-		})
 	}
 	for _, we := range workloadEntries {
-		if we == nil {
-			continue
+		if we != nil {
+			appendItem(we.Name, we.Namespace, kubernetes.WorkloadEntries, we)
 		}
-		items = append(items, IstioListItem{
-			Name:       we.Name,
-			Namespace:  we.Namespace,
-			Group:      kubernetes.WorkloadEntries.Group,
-			Version:    kubernetes.WorkloadEntries.Version,
-			Kind:       kubernetes.WorkloadEntries.Kind,
-			Validation: validationSummaryForRuntimeObject(we, kubernetes.WorkloadEntries, istioValidations, cluster),
-		})
 	}
 	for _, wg := range workloadGroups {
-		if wg == nil {
-			continue
+		if wg != nil {
+			appendItem(wg.Name, wg.Namespace, kubernetes.WorkloadGroups, wg)
 		}
-		items = append(items, IstioListItem{
-			Name:       wg.Name,
-			Namespace:  wg.Namespace,
-			Group:      kubernetes.WorkloadGroups.Group,
-			Version:    kubernetes.WorkloadGroups.Version,
-			Kind:       kubernetes.WorkloadGroups.Kind,
-			Validation: validationSummaryForRuntimeObject(wg, kubernetes.WorkloadGroups, istioValidations, cluster),
-		})
 	}
 	for _, te := range trafficExtensions {
-		if te == nil {
-			continue
+		if te != nil {
+			appendItem(te.Name, te.Namespace, kubernetes.TrafficExtensions, te)
 		}
-		items = append(items, IstioListItem{
-			Name:       te.Name,
-			Namespace:  te.Namespace,
-			Group:      kubernetes.TrafficExtensions.Group,
-			Version:    kubernetes.TrafficExtensions.Version,
-			Kind:       kubernetes.TrafficExtensions.Kind,
-			Validation: validationSummaryForRuntimeObject(te, kubernetes.TrafficExtensions, istioValidations, cluster),
-		})
 	}
 	for _, wp := range wasmPlugins {
-		if wp == nil {
-			continue
+		if wp != nil {
+			appendItem(wp.Name, wp.Namespace, kubernetes.WasmPlugins, wp)
 		}
-		items = append(items, IstioListItem{
-			Name:       wp.Name,
-			Namespace:  wp.Namespace,
-			Group:      kubernetes.WasmPlugins.Group,
-			Version:    kubernetes.WasmPlugins.Version,
-			Kind:       kubernetes.WasmPlugins.Kind,
-			Validation: validationSummaryForRuntimeObject(wp, kubernetes.WasmPlugins, istioValidations, cluster),
-		})
 	}
 	for _, tl := range telemetries {
-		if tl == nil {
-			continue
+		if tl != nil {
+			appendItem(tl.Name, tl.Namespace, kubernetes.Telemetries, tl)
 		}
-		items = append(items, IstioListItem{
-			Name:       tl.Name,
-			Namespace:  tl.Namespace,
-			Group:      kubernetes.Telemetries.Group,
-			Version:    kubernetes.Telemetries.Version,
-			Kind:       kubernetes.Telemetries.Kind,
-			Validation: validationSummaryForRuntimeObject(tl, kubernetes.Telemetries, istioValidations, cluster),
-		})
 	}
 	for _, ap := range authorizationPolicies {
-		if ap == nil {
-			continue
+		if ap != nil {
+			appendItem(ap.Name, ap.Namespace, kubernetes.AuthorizationPolicies, ap)
 		}
-		items = append(items, IstioListItem{
-			Name:       ap.Name,
-			Namespace:  ap.Namespace,
-			Group:      kubernetes.AuthorizationPolicies.Group,
-			Version:    kubernetes.AuthorizationPolicies.Version,
-			Kind:       kubernetes.AuthorizationPolicies.Kind,
-			Validation: validationSummaryForRuntimeObject(ap, kubernetes.AuthorizationPolicies, istioValidations, cluster),
-		})
 	}
 	for _, pa := range peerAuthentications {
-		if pa == nil {
-			continue
+		if pa != nil {
+			appendItem(pa.Name, pa.Namespace, kubernetes.PeerAuthentications, pa)
 		}
-		items = append(items, IstioListItem{
-			Name:       pa.Name,
-			Namespace:  pa.Namespace,
-			Group:      kubernetes.PeerAuthentications.Group,
-			Version:    kubernetes.PeerAuthentications.Version,
-			Kind:       kubernetes.PeerAuthentications.Kind,
-			Validation: validationSummaryForRuntimeObject(pa, kubernetes.PeerAuthentications, istioValidations, cluster),
-		})
 	}
 	for _, ra := range requestAuthentications {
-		if ra == nil {
-			continue
+		if ra != nil {
+			appendItem(ra.Name, ra.Namespace, kubernetes.RequestAuthentications, ra)
 		}
-		items = append(items, IstioListItem{
-			Name:       ra.Name,
-			Namespace:  ra.Namespace,
-			Group:      kubernetes.RequestAuthentications.Group,
-			Version:    kubernetes.RequestAuthentications.Version,
-			Kind:       kubernetes.RequestAuthentications.Kind,
-			Validation: validationSummaryForRuntimeObject(ra, kubernetes.RequestAuthentications, istioValidations, cluster),
-		})
 	}
-
 	for _, kgw := range k8sGateways {
-		if kgw == nil {
-			continue
+		if kgw != nil {
+			appendItem(kgw.Name, kgw.Namespace, kubernetes.K8sGateways, kgw)
 		}
-		items = append(items, IstioListItem{
-			Name:       kgw.Name,
-			Namespace:  kgw.Namespace,
-			Group:      kubernetes.K8sGateways.Group,
-			Version:    kubernetes.K8sGateways.Version,
-			Kind:       kubernetes.K8sGateways.Kind,
-			Validation: validationSummaryForRuntimeObject(kgw, kubernetes.K8sGateways, istioValidations, cluster),
-		})
 	}
 	for _, hr := range k8sHTTPRoutes {
-		if hr == nil {
-			continue
+		if hr != nil {
+			appendItem(hr.Name, hr.Namespace, kubernetes.K8sHTTPRoutes, hr)
 		}
-		items = append(items, IstioListItem{
-			Name:       hr.Name,
-			Namespace:  hr.Namespace,
-			Group:      kubernetes.K8sHTTPRoutes.Group,
-			Version:    kubernetes.K8sHTTPRoutes.Version,
-			Kind:       kubernetes.K8sHTTPRoutes.Kind,
-			Validation: validationSummaryForRuntimeObject(hr, kubernetes.K8sHTTPRoutes, istioValidations, cluster),
-		})
 	}
 	for _, gr := range k8sGRPCRoutes {
-		if gr == nil {
-			continue
+		if gr != nil {
+			appendItem(gr.Name, gr.Namespace, kubernetes.K8sGRPCRoutes, gr)
 		}
-		items = append(items, IstioListItem{
-			Name:       gr.Name,
-			Namespace:  gr.Namespace,
-			Group:      kubernetes.K8sGRPCRoutes.Group,
-			Version:    kubernetes.K8sGRPCRoutes.Version,
-			Kind:       kubernetes.K8sGRPCRoutes.Kind,
-			Validation: validationSummaryForRuntimeObject(gr, kubernetes.K8sGRPCRoutes, istioValidations, cluster),
-		})
 	}
 	for _, tr := range k8sTCPRoutes {
-		if tr == nil {
-			continue
+		if tr != nil {
+			appendItem(tr.Name, tr.Namespace, kubernetes.K8sTCPRoutes, tr)
 		}
-		items = append(items, IstioListItem{
-			Name:       tr.Name,
-			Namespace:  tr.Namespace,
-			Group:      kubernetes.K8sTCPRoutes.Group,
-			Version:    kubernetes.K8sTCPRoutes.Version,
-			Kind:       kubernetes.K8sTCPRoutes.Kind,
-			Validation: validationSummaryForRuntimeObject(tr, kubernetes.K8sTCPRoutes, istioValidations, cluster),
-		})
 	}
 	for _, tlr := range k8sTLSRoutes {
-		if tlr == nil {
-			continue
+		if tlr != nil {
+			appendItem(tlr.Name, tlr.Namespace, kubernetes.K8sTLSRoutes, tlr)
 		}
-		items = append(items, IstioListItem{
-			Name:       tlr.Name,
-			Namespace:  tlr.Namespace,
-			Group:      kubernetes.K8sTLSRoutes.Group,
-			Version:    kubernetes.K8sTLSRoutes.Version,
-			Kind:       kubernetes.K8sTLSRoutes.Kind,
-			Validation: validationSummaryForRuntimeObject(tlr, kubernetes.K8sTLSRoutes, istioValidations, cluster),
-		})
 	}
 	for _, rg := range k8sReferenceGrants {
-		if rg == nil {
-			continue
+		if rg != nil {
+			appendItem(rg.Name, rg.Namespace, kubernetes.K8sReferenceGrants, rg)
 		}
-		items = append(items, IstioListItem{
-			Name:       rg.Name,
-			Namespace:  rg.Namespace,
-			Group:      kubernetes.K8sReferenceGrants.Group,
-			Version:    kubernetes.K8sReferenceGrants.Version,
-			Kind:       kubernetes.K8sReferenceGrants.Kind,
-			Validation: validationSummaryForRuntimeObject(rg, kubernetes.K8sReferenceGrants, istioValidations, cluster),
-		})
 	}
 	for _, ip := range k8sInferencePools {
-		if ip == nil {
-			continue
+		if ip != nil {
+			appendItem(ip.Name, ip.Namespace, kubernetes.K8sInferencePools, ip)
 		}
-		items = append(items, IstioListItem{
-			Name:       ip.Name,
-			Namespace:  ip.Namespace,
-			Group:      kubernetes.K8sInferencePools.Group,
-			Version:    kubernetes.K8sInferencePools.Version,
-			Kind:       kubernetes.K8sInferencePools.Kind,
-			Validation: validationSummaryForRuntimeObject(ip, kubernetes.K8sInferencePools, istioValidations, cluster),
-		})
 	}
 
+	// Sort for deterministic output: namespace → group/kind → name.
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].Namespace != items[j].Namespace {
 			return items[i].Namespace < items[j].Namespace
 		}
-		if items[i].Kind != items[j].Kind {
-			return items[i].Kind < items[j].Kind
+		gvkI := items[i].Group + "/" + items[i].Kind
+		gvkJ := items[j].Group + "/" + items[j].Kind
+		if gvkI != gvkJ {
+			return gvkI < gvkJ
 		}
 		return items[i].Name < items[j].Name
 	})
 
-	return IstioListResult{Cluster: cluster, Items: items}, http.StatusOK
+	// Group into namespace → "group/version/kind" → {valid, invalid} names.
+	// Because items are pre-sorted the name slices are already in alphabetical order.
+	namespaces := make(map[string]map[string]KindValidationResult)
+	for _, item := range items {
+		gvkKey := item.Group + "/" + item.Version + "/" + item.Kind
+		if namespaces[item.Namespace] == nil {
+			namespaces[item.Namespace] = make(map[string]KindValidationResult)
+		}
+		kvr := namespaces[item.Namespace][gvkKey]
+		if item.Valid {
+			kvr.Valid = append(kvr.Valid, item.Name)
+		} else {
+			kvr.Invalid = append(kvr.Invalid, item.Name)
+		}
+		namespaces[item.Namespace][gvkKey] = kvr
+	}
+
+	return IstioListResult{Cluster: cluster, Namespaces: namespaces}, http.StatusOK
 }
 
 // matchesServiceHost checks if a host specification matches the service name.
@@ -544,7 +418,7 @@ func matchesServiceHost(host, serviceName string) bool {
 	return false
 }
 
-func validationSummaryForRuntimeObject(obj runtime.Object, fallbackGVK schema.GroupVersionKind, validations models.IstioValidations, cluster string) ValidationSummary {
+func validationSummaryForRuntimeObject(obj runtime.Object, fallbackGVK schema.GroupVersionKind, validations models.IstioValidations, cluster string) validationSummary {
 	typeAcc, _ := meta.TypeAccessor(obj)
 	objAcc, _ := meta.Accessor(obj)
 
@@ -569,7 +443,7 @@ func validationSummaryForRuntimeObject(obj runtime.Object, fallbackGVK schema.Gr
 	}
 
 	// Default: valid when we don't find a validation entry.
-	out := ValidationSummary{Valid: true}
+	out := validationSummary{Valid: true}
 	if apiVersion == "" || kind == "" || name == "" {
 		return out
 	}
@@ -592,7 +466,7 @@ func validationSummaryForRuntimeObject(obj runtime.Object, fallbackGVK schema.Gr
 	}
 
 	out.Valid = v.Valid
-	checks := make([]ValidationCheckSummary, 0, len(v.Checks))
+	checks := make([]validationCheckSummary, 0, len(v.Checks))
 	for _, c := range v.Checks {
 		if c == nil {
 			continue
@@ -601,7 +475,7 @@ func validationSummaryForRuntimeObject(obj runtime.Object, fallbackGVK schema.Gr
 		if sev != "error" && sev != "warning" {
 			continue
 		}
-		checks = append(checks, ValidationCheckSummary{
+		checks = append(checks, validationCheckSummary{
 			Severity: sev,
 			Message:  c.Message,
 		})

--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -54,12 +54,14 @@ type istioListItem struct {
 	Valid     bool
 }
 
-// KindValidationResult holds resource names grouped by validation status for a
-// single GVK within a namespace. The map key in IstioListResult is
-// "group/version/kind" (e.g. "networking.istio.io/v1/VirtualService").
+// KindValidationResult summarises resources for a single GVK within a namespace.
+// The map key in IstioListResult is "group/version/kind".
+// Valid is present (true) only when every resource passes Kiali validation.
+// Invalid lists only the names that failed; omitted when all resources are valid.
 type KindValidationResult struct {
-	Valid   []string `json:"valid"`
-	Invalid []string `json:"invalid"`
+	Names   []string `json:"names"`
+	Valid   *bool    `json:"valid,omitempty"`
+	Invalid []string `json:"invalid,omitempty"`
 }
 
 // IstioListResult is the grouped output returned by the list action.
@@ -366,7 +368,7 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		return items[i].Name < items[j].Name
 	})
 
-	// Group into namespace → "group/version/kind" → {valid, invalid} names.
+	// Group into namespace → "group/version/kind" → {names, valid, invalid}.
 	// Because items are pre-sorted the name slices are already in alphabetical order.
 	namespaces := make(map[string]map[string]KindValidationResult)
 	for _, item := range items {
@@ -375,12 +377,21 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 			namespaces[item.Namespace] = make(map[string]KindValidationResult)
 		}
 		kvr := namespaces[item.Namespace][gvkKey]
-		if item.Valid {
-			kvr.Valid = append(kvr.Valid, item.Name)
-		} else {
+		kvr.Names = append(kvr.Names, item.Name)
+		if !item.Valid {
 			kvr.Invalid = append(kvr.Invalid, item.Name)
 		}
 		namespaces[item.Namespace][gvkKey] = kvr
+	}
+	// Set valid:true only on groups where no resource failed validation.
+	validTrue := true
+	for ns, kinds := range namespaces {
+		for key, kvr := range kinds {
+			if len(kvr.Invalid) == 0 {
+				kvr.Valid = &validTrue
+				namespaces[ns][key] = kvr
+			}
+		}
 	}
 
 	return IstioListResult{Cluster: cluster, Namespaces: namespaces}, http.StatusOK

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -94,14 +94,10 @@ func TestIstioList_ReturnsGroupedOutput(t *testing.T) {
 	require.Contains(t, bookinfo, vsKey)
 	require.Contains(t, bookinfo, drKey)
 
-	// Default validation (no validation store in unit tests) → valid:true, no invalid field.
-	assert.Equal(t, []string{"reviews"}, bookinfo[vsKey].Names)
-	require.NotNil(t, bookinfo[vsKey].Valid)
-	assert.True(t, *bookinfo[vsKey].Valid)
+	// Default validation (no validation store in unit tests) → all in valid array, invalid empty.
+	assert.Equal(t, []string{"reviews"}, bookinfo[vsKey].Valid)
 	assert.Empty(t, bookinfo[vsKey].Invalid)
-	assert.Equal(t, []string{"reviews"}, bookinfo[drKey].Names)
-	require.NotNil(t, bookinfo[drKey].Valid)
-	assert.True(t, *bookinfo[drKey].Valid)
+	assert.Equal(t, []string{"reviews"}, bookinfo[drKey].Valid)
 	assert.Empty(t, bookinfo[drKey].Invalid)
 }
 
@@ -160,7 +156,10 @@ func TestIstioList_FilterByService(t *testing.T) {
 	names := map[string]struct{}{}
 	for _, kinds := range result.Namespaces {
 		for _, kvr := range kinds {
-			for _, n := range kvr.Names {
+			for _, n := range kvr.Valid {
+				names[n] = struct{}{}
+			}
+			for _, n := range kvr.Invalid {
 				names[n] = struct{}{}
 			}
 		}

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -44,7 +44,7 @@ func TestMatchesServiceHost(t *testing.T) {
 	}
 }
 
-func TestIstioList_ReturnsCompactYAML(t *testing.T) {
+func TestIstioList_ReturnsGroupedOutput(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KubernetesConfig.ClusterName = "east"
 	config.Set(conf)
@@ -83,19 +83,22 @@ func TestIstioList_ReturnsCompactYAML(t *testing.T) {
 	result, ok := res.(IstioListResult)
 	require.True(t, ok, "expected IstioListResult output, got %T", res)
 	require.Equal(t, "east", result.Cluster)
-	require.Len(t, result.Items, 2)
 
-	// Validate items are present and compact
-	assert.Equal(t, "bookinfo", result.Items[0].Namespace)
-	assert.NotEmpty(t, result.Items[0].Name)
-	assert.NotEmpty(t, result.Items[0].Group)
-	assert.NotEmpty(t, result.Items[0].Version)
-	assert.NotEmpty(t, result.Items[0].Kind)
+	// Both resources are in the bookinfo namespace.
+	bookinfo, ok := result.Namespaces["bookinfo"]
+	require.True(t, ok, "expected bookinfo namespace in result")
 
-	// Default validation when validations cannot be found (e.g., in unit tests)
-	for _, item := range result.Items {
-		assert.True(t, item.Validation.Valid)
-	}
+	// VirtualService and DestinationRule should each appear under their own GVK key.
+	vsKey := "networking.istio.io/v1/VirtualService"
+	drKey := "networking.istio.io/v1/DestinationRule"
+	require.Contains(t, bookinfo, vsKey)
+	require.Contains(t, bookinfo, drKey)
+
+	// Default validation (no validation store in unit tests) → valid.
+	assert.Equal(t, []string{"reviews"}, bookinfo[vsKey].Valid)
+	assert.Empty(t, bookinfo[vsKey].Invalid)
+	assert.Equal(t, []string{"reviews"}, bookinfo[drKey].Valid)
+	assert.Empty(t, bookinfo[drKey].Invalid)
 }
 
 func TestIstioList_FilterByService(t *testing.T) {
@@ -149,18 +152,26 @@ func TestIstioList_FilterByService(t *testing.T) {
 	result, ok := res.(IstioListResult)
 	require.True(t, ok, "expected IstioListResult output, got %T", res)
 
+	// Collect all names across all namespaces and GVK groups.
 	names := map[string]struct{}{}
-	for _, item := range result.Items {
-		names[item.Name] = struct{}{}
+	for _, kinds := range result.Namespaces {
+		for _, kvr := range kinds {
+			for _, n := range kvr.Valid {
+				names[n] = struct{}{}
+			}
+			for _, n := range kvr.Invalid {
+				names[n] = struct{}{}
+			}
+		}
 	}
 
-	// Should contain reviews-related configs
+	// Should contain reviews-related configs.
 	_, hasReviewsVS := names["reviews-vs"]
 	_, hasReviewsDR := names["reviews-dr"]
 	assert.True(t, hasReviewsVS)
 	assert.True(t, hasReviewsDR)
 
-	// Should NOT contain ratings-related configs
+	// Should NOT contain ratings-related configs.
 	_, hasRatingsVS := names["ratings-vs"]
 	_, hasRatingsDR := names["ratings-dr"]
 	assert.False(t, hasRatingsVS)
@@ -274,5 +285,5 @@ func TestIstioList_IncludesTrafficExtensions(t *testing.T) {
 	result, ok := res.(IstioListResult)
 	require.True(t, ok)
 	assert.Equal(t, "east", result.Cluster)
-	assert.Empty(t, result.Items)
+	assert.Empty(t, result.Namespaces)
 }

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -94,10 +94,14 @@ func TestIstioList_ReturnsGroupedOutput(t *testing.T) {
 	require.Contains(t, bookinfo, vsKey)
 	require.Contains(t, bookinfo, drKey)
 
-	// Default validation (no validation store in unit tests) → valid.
-	assert.Equal(t, []string{"reviews"}, bookinfo[vsKey].Valid)
+	// Default validation (no validation store in unit tests) → valid:true, no invalid field.
+	assert.Equal(t, []string{"reviews"}, bookinfo[vsKey].Names)
+	require.NotNil(t, bookinfo[vsKey].Valid)
+	assert.True(t, *bookinfo[vsKey].Valid)
 	assert.Empty(t, bookinfo[vsKey].Invalid)
-	assert.Equal(t, []string{"reviews"}, bookinfo[drKey].Valid)
+	assert.Equal(t, []string{"reviews"}, bookinfo[drKey].Names)
+	require.NotNil(t, bookinfo[drKey].Valid)
+	assert.True(t, *bookinfo[drKey].Valid)
 	assert.Empty(t, bookinfo[drKey].Invalid)
 }
 
@@ -156,10 +160,7 @@ func TestIstioList_FilterByService(t *testing.T) {
 	names := map[string]struct{}{}
 	for _, kinds := range result.Namespaces {
 		for _, kvr := range kinds {
-			for _, n := range kvr.Valid {
-				names[n] = struct{}{}
-			}
-			for _, n := range kvr.Invalid {
+			for _, n := range kvr.Names {
 				names[n] = struct{}{}
 			}
 		}

--- a/ai/mcp/manage_istio_config/manage_istio_config.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -521,6 +522,67 @@ func validateManagedIstioGroupAndKind(group, kind string) error {
 	}
 }
 
+// readableGroupKinds lists all API groups and their kinds that manage_istio_config_read supports.
+// This is a superset of the write tool (which only covers networking/security.istio.io).
+var readableGroupKinds = map[string]map[string]struct{}{
+	"networking.istio.io": {
+		"VirtualService":  {},
+		"DestinationRule": {},
+		"Gateway":         {},
+		"ServiceEntry":    {},
+		"Sidecar":         {},
+		"WorkloadEntry":   {},
+		"WorkloadGroup":   {},
+		"EnvoyFilter":     {},
+	},
+	"security.istio.io": {
+		"AuthorizationPolicy":   {},
+		"PeerAuthentication":    {},
+		"RequestAuthentication": {},
+	},
+	"gateway.networking.k8s.io": {
+		"Gateway":        {},
+		"HTTPRoute":      {},
+		"GRPCRoute":      {},
+		"TCPRoute":       {},
+		"TLSRoute":       {},
+		"ReferenceGrant": {},
+	},
+	"inference.networking.k8s.io": {
+		"InferencePool": {},
+	},
+	"extensions.istio.io": {
+		"WasmPlugin":       {},
+		"TrafficExtension": {},
+	},
+	"telemetry.istio.io": {
+		"Telemetry": {},
+	},
+}
+
+// validateReadableGroupAndKind checks that the group/kind combination is supported
+// by the read-only tool.
+func validateReadableGroupAndKind(group, kind string) error {
+	g := strings.TrimSpace(group)
+	k := strings.TrimSpace(kind)
+	kinds, ok := readableGroupKinds[g]
+	if !ok {
+		return fmt.Errorf("invalid group %q: not a supported Istio or Gateway API group", g)
+	}
+	if k == "" {
+		return fmt.Errorf("kind is required for group %q", g)
+	}
+	if _, ok := kinds[k]; !ok {
+		validKinds := make([]string, 0, len(kinds))
+		for k := range kinds {
+			validKinds = append(validKinds, k)
+		}
+		sort.Strings(validKinds)
+		return fmt.Errorf("invalid kind %q for group %q: must be one of %s", k, g, strings.Join(validKinds, ", "))
+	}
+	return nil
+}
+
 // validateReadOnlyIstioConfigInput validates args for read-only actions (list, get).
 func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 	action := mcputil.GetStringArg(args, "action")
@@ -531,10 +593,18 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 	object := mcputil.GetStringArg(args, "object")
 	switch action {
 	case "list":
-		if strings.TrimSpace(group) != "" || strings.TrimSpace(kind) != "" {
-			return validateManagedIstioGroupAndKind(group, kind)
+		hasGroup := strings.TrimSpace(group) != ""
+		hasKind := strings.TrimSpace(kind) != ""
+		if !hasGroup && !hasKind {
+			return nil
 		}
-		return nil
+		if hasKind && !hasGroup {
+			return fmt.Errorf("group is required when kind is specified for action %q", action)
+		}
+		if hasGroup && !hasKind {
+			return fmt.Errorf("kind is required when group is specified for action %q", action)
+		}
+		return validateReadableGroupAndKind(group, kind)
 	case "get":
 		if namespace == "" {
 			return fmt.Errorf("namespace is required for action %q", action)
@@ -551,7 +621,7 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 		if object == "" {
 			return fmt.Errorf("name is required for action %q", action)
 		}
-		return validateManagedIstioGroupAndKind(group, kind)
+		return validateReadableGroupAndKind(group, kind)
 	default:
 		return fmt.Errorf("invalid action %q: must be one of list, get", action)
 	}

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -597,7 +597,7 @@ func TestExecuteReadOnly_ListSuccess(t *testing.T) {
 	total := 0
 	for _, kinds := range result.Namespaces {
 		for _, kvr := range kinds {
-			total += len(kvr.Names)
+			total += len(kvr.Valid) + len(kvr.Invalid)
 		}
 	}
 	assert.GreaterOrEqual(t, total, 2)

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -573,7 +573,7 @@ func TestExecuteReadOnly_ListSuccess(t *testing.T) {
 	total := 0
 	for _, kinds := range result.Namespaces {
 		for _, kvr := range kinds {
-			total += len(kvr.Valid) + len(kvr.Invalid)
+			total += len(kvr.Names)
 		}
 	}
 	assert.GreaterOrEqual(t, total, 2)

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -245,13 +245,16 @@ func TestValidateReadOnlyIstioConfigInput(t *testing.T) {
 			wantErr: "invalid action",
 		},
 		{
-			name: "valid get",
+			name: "valid get networking",
 			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "networking.istio.io", "version": "v1", "kind": "VirtualService", "object": "x"},
 		},
 		{
-			name:    "get invalid kind for networking",
-			args:    map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "networking.istio.io", "version": "v1", "kind": "WasmPlugin", "object": "x"},
-			wantErr: "invalid kind",
+			name: "valid get gateway API",
+			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "gateway.networking.k8s.io", "version": "v1", "kind": "HTTPRoute", "object": "bookinfo"},
+		},
+		{
+			name: "valid get extensions",
+			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "extensions.istio.io", "version": "v1alpha1", "kind": "WasmPlugin", "object": "x"},
 		},
 		{
 			name:    "list filter kind without group",
@@ -264,22 +267,43 @@ func TestValidateReadOnlyIstioConfigInput(t *testing.T) {
 			wantErr: "kind is required",
 		},
 		{
-			name:    "list filter invalid group",
-			args:    map[string]interface{}{"action": "list", "group": "gateway.networking.k8s.io", "kind": "Gateway"},
-			wantErr: "invalid group",
+			name: "list filter gateway API group is now valid",
+			args: map[string]interface{}{"action": "list", "group": "gateway.networking.k8s.io", "kind": "Gateway"},
 		},
 		{
-			name:    "list filter invalid kind for networking",
-			args:    map[string]interface{}{"action": "list", "group": "networking.istio.io", "kind": "WasmPlugin"},
-			wantErr: "invalid kind",
-		},
-		{
-			name: "list filter valid networking",
+			name: "list filter networking",
 			args: map[string]interface{}{"action": "list", "group": "networking.istio.io", "kind": "Sidecar"},
 		},
 		{
-			name: "list filter valid security",
+			name: "list filter security",
 			args: map[string]interface{}{"action": "list", "group": "security.istio.io", "kind": "PeerAuthentication"},
+		},
+		{
+			name: "list filter extensions",
+			args: map[string]interface{}{"action": "list", "group": "extensions.istio.io", "kind": "WasmPlugin"},
+		},
+		{
+			name:    "list filter unknown group",
+			args:    map[string]interface{}{"action": "list", "group": "unknown.example.com", "kind": "Foo"},
+			wantErr: "not a supported Istio or Gateway API group",
+		},
+		{
+			name:    "get unknown group",
+			args:    map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "unknown.example.com", "version": "v1", "kind": "Foo", "object": "x"},
+			wantErr: "not a supported Istio or Gateway API group",
+		},
+		{
+			name:    "get invalid kind for valid group",
+			args:    map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "networking.istio.io", "version": "v1", "kind": "UnknownKind", "object": "x"},
+			wantErr: "invalid kind",
+		},
+		{
+			name: "get telemetry",
+			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "telemetry.istio.io", "version": "v1", "kind": "Telemetry", "object": "x"},
+		},
+		{
+			name: "get inference pool",
+			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "inference.networking.k8s.io", "version": "v1alpha2", "kind": "InferencePool", "object": "x"},
 		},
 	}
 
@@ -699,11 +723,11 @@ func TestExecuteReadOnly_UnmanagedGVK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
-	assert.Contains(t, resStr, "invalid group")
+	// Now caught at input validation level: unknown group is rejected before reaching business layer.
+	assert.Contains(t, resStr, "not a supported Istio or Gateway API group")
 }
 
-// manage_istio_config only allows networking.istio.io and security.istio.io; Gateway API
-// groups are rejected before GetIstioAPI (no v1beta1 hint path for this tool).
+// gateway.networking.k8s.io with v1beta1 is not managed; the hint to use v1 should appear.
 func TestExecuteReadOnly_GatewayAPIv1beta1Hint(t *testing.T) {
 	businessLayer, conf := setupTest(t)
 	r := reqWithAuth()
@@ -721,7 +745,7 @@ func TestExecuteReadOnly_GatewayAPIv1beta1Hint(t *testing.T) {
 	assert.Equal(t, http.StatusOK, status)
 	resStr, ok := res.(string)
 	require.True(t, ok)
-	assert.Contains(t, resStr, "invalid group")
+	assert.Contains(t, resStr, "v1")
 }
 
 func TestExecute_DeleteNonExistentResource(t *testing.T) {

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -569,7 +569,14 @@ func TestExecuteReadOnly_ListSuccess(t *testing.T) {
 
 	result, ok := res.(IstioListResult)
 	require.True(t, ok, "expected IstioListResult, got %T", res)
-	assert.GreaterOrEqual(t, len(result.Items), 2)
+	// Count total resources across all namespaces and GVK groups.
+	total := 0
+	for _, kinds := range result.Namespaces {
+		for _, kvr := range kinds {
+			total += len(kvr.Valid) + len(kvr.Invalid)
+		}
+	}
+	assert.GreaterOrEqual(t, total, 2)
 }
 
 func TestExecuteReadOnly_GetSuccess(t *testing.T) {

--- a/ai/mcp/tools/manage_istio_config_read.yaml
+++ b/ai/mcp/tools/manage_istio_config_read.yaml
@@ -17,8 +17,7 @@
         description: "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required."
       group:
         type: "string"
-        description: "API group of the Istio object. Required for 'get' action."
-        enum: ["networking.istio.io", "security.istio.io"]
+        description: "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action."
       version:
         type: "string"
         description: "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters."

--- a/ai/mcp/tools/manage_istio_config_read.yaml
+++ b/ai/mcp/tools/manage_istio_config_read.yaml
@@ -1,5 +1,5 @@
 - name: "manage_istio_config_read"
-  description: "Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config."
+  description: "Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."
   toolset: [default, mcp]
   input_schema:
     type: "object"
@@ -21,7 +21,7 @@
         enum: ["networking.istio.io", "security.istio.io"]
       version:
         type: "string"
-        description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action."
+        description: "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters."
       kind:
         type: "string"
         description: "Kind of the Istio object. Required for 'get' action."

--- a/ai/mcp/tools/manage_istio_config_read.yaml
+++ b/ai/mcp/tools/manage_istio_config_read.yaml
@@ -1,5 +1,5 @@
 - name: "manage_istio_config_read"
-  description: "Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."
+  description: "Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config."
   toolset: [default, mcp]
   input_schema:
     type: "object"

--- a/ai/mcp/tools/manage_istio_config_read.yaml
+++ b/ai/mcp/tools/manage_istio_config_read.yaml
@@ -1,5 +1,5 @@
 - name: "manage_istio_config_read"
-  description: "Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."
+  description: "Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."
   toolset: [default, mcp]
   input_schema:
     type: "object"
@@ -11,16 +11,16 @@
         enum: ["list", "get"]
       clusterName:
         type: "string"
-        description: "Cluster containing the Istio object, if not provided, will use the cluster name in the Kiali configuration (KubeConfig)"
+        description: "Target cluster. Defaults to Kiali config cluster."
       namespace:
         type: "string"
-        description: "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required."
+        description: "Namespace. Optional for 'list' (defaults to all). Required for 'get'."
       group:
         type: "string"
-        description: "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action."
+        description: "API group (e.g. 'networking.istio.io'). Required for 'get'."
       version:
         type: "string"
-        description: "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters."
+        description: "API version (e.g. 'v1'). Required for 'get'."
       kind:
         type: "string"
         description: "Kind of the Istio object. Required for 'get' action."
@@ -30,4 +30,4 @@
         description: "Name of the Istio object. Required for 'get' action."
       serviceName:
         type: "string"
-        description: "Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action."
+        description: "Filter configs by service (VirtualServices, DestinationRules, Gateways). 'list' only."

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -578,7 +578,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 	expected := anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        "manage_istio_config_read",
-			Description: param.NewOpt("Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config."),
+			Description: param.NewOpt("Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
 					"action": map[string]interface{}{
@@ -601,7 +601,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 					},
 					"version": map[string]interface{}{
 						"type":        "string",
-						"description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+						"description": "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
 					},
 					"kind": map[string]interface{}{
 						"type":        "string",

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -596,8 +596,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 					},
 					"group": map[string]interface{}{
 						"type":        "string",
-						"description": "API group of the Istio object. Required for 'get' action.",
-						"enum":        []interface{}{"networking.istio.io", "security.istio.io"},
+						"description": "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
 					},
 					"version": map[string]interface{}{
 						"type":        "string",

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -578,7 +578,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 	expected := anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        "manage_istio_config_read",
-			Description: param.NewOpt("Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."),
+			Description: param.NewOpt("Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
 					"action": map[string]interface{}{
@@ -588,19 +588,19 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 					},
 					"clusterName": map[string]interface{}{
 						"type":        "string",
-						"description": "Cluster containing the Istio object, if not provided, will use the cluster name in the Kiali configuration (KubeConfig)",
+						"description": "Target cluster. Defaults to Kiali config cluster.",
 					},
 					"namespace": map[string]interface{}{
 						"type":        "string",
-						"description": "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required.",
+						"description": "Namespace. Optional for 'list' (defaults to all). Required for 'get'.",
 					},
 					"group": map[string]interface{}{
 						"type":        "string",
-						"description": "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
+						"description": "API group (e.g. 'networking.istio.io'). Required for 'get'.",
 					},
 					"version": map[string]interface{}{
 						"type":        "string",
-						"description": "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
+						"description": "API version (e.g. 'v1'). Required for 'get'.",
 					},
 					"kind": map[string]interface{}{
 						"type":        "string",
@@ -617,7 +617,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 					},
 					"serviceName": map[string]interface{}{
 						"type":        "string",
-						"description": "Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action.",
+						"description": "Filter configs by service (VirtualServices, DestinationRules, Gateways). 'list' only.",
 					},
 				},
 				Required: []string{"action"},

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -578,7 +578,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ManageIstioConfigRead(t *test
 	expected := anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        "manage_istio_config_read",
-			Description: param.NewOpt("Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."),
+			Description: param.NewOpt("Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
 					"action": map[string]interface{}{

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -488,19 +488,19 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfigRead(t *testing
 			},
 			"clusterName": {
 				Type:        genai.TypeString,
-				Description: "Cluster containing the Istio object, if not provided, will use the cluster name in the Kiali configuration (KubeConfig)",
+				Description: "Target cluster. Defaults to Kiali config cluster.",
 			},
 			"namespace": {
 				Type:        genai.TypeString,
-				Description: "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required.",
+				Description: "Namespace. Optional for 'list' (defaults to all). Required for 'get'.",
 			},
 			"group": {
 				Type:        genai.TypeString,
-				Description: "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
+				Description: "API group (e.g. 'networking.istio.io'). Required for 'get'.",
 			},
 			"version": {
 				Type:        genai.TypeString,
-				Description: "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
+				Description: "API version (e.g. 'v1'). Required for 'get'.",
 			},
 			"kind": {
 				Type:        genai.TypeString,
@@ -517,7 +517,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfigRead(t *testing
 			},
 			"serviceName": {
 				Type:        genai.TypeString,
-				Description: "Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action.",
+				Description: "Filter configs by service (VirtualServices, DestinationRules, Gateways). 'list' only.",
 			},
 		},
 		Required: []string{"action"},

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -496,8 +496,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfigRead(t *testing
 			},
 			"group": {
 				Type:        genai.TypeString,
-				Description: "API group of the Istio object. Required for 'get' action.",
-				Enum:        []string{"networking.istio.io", "security.istio.io"},
+				Description: "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
 			},
 			"version": {
 				Type:        genai.TypeString,

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -501,7 +501,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfigRead(t *testing
 			},
 			"version": {
 				Type:        genai.TypeString,
-				Description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+				Description: "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
 			},
 			"kind": {
 				Type:        genai.TypeString,

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -662,7 +662,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 		OfFunction: &openai.ChatCompletionFunctionToolParam{
 			Function: openai.FunctionDefinitionParam{
 				Name:        "manage_istio_config_read",
-				Description: openai.String("Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."),
+				Description: openai.String("Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"required": []interface{}{
@@ -679,19 +679,19 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 						},
 						"clusterName": map[string]interface{}{
 							"type":        "string",
-							"description": "Cluster containing the Istio object, if not provided, will use the cluster name in the Kiali configuration (KubeConfig)",
+							"description": "Target cluster. Defaults to Kiali config cluster.",
 						},
 						"namespace": map[string]interface{}{
 							"type":        "string",
-							"description": "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required.",
+							"description": "Namespace. Optional for 'list' (defaults to all). Required for 'get'.",
 						},
 						"group": map[string]interface{}{
 							"type":        "string",
-							"description": "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
+							"description": "API group (e.g. 'networking.istio.io'). Required for 'get'.",
 						},
 						"version": map[string]interface{}{
 							"type":        "string",
-							"description": "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
+							"description": "API version (e.g. 'v1'). Required for 'get'.",
 						},
 						"kind": map[string]interface{}{
 							"type":        "string",
@@ -716,7 +716,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 						},
 						"serviceName": map[string]interface{}{
 							"type":        "string",
-							"description": "Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action.",
+							"description": "Filter configs by service (VirtualServices, DestinationRules, Gateways). 'list' only.",
 						},
 					},
 				},

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -687,11 +687,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 						},
 						"group": map[string]interface{}{
 							"type":        "string",
-							"description": "API group of the Istio object. Required for 'get' action.",
-							"enum": []interface{}{
-								"networking.istio.io",
-								"security.istio.io",
-							},
+							"description": "API group (e.g. 'networking.istio.io', 'security.istio.io', 'gateway.networking.k8s.io'). Required for 'get' action.",
 						},
 						"version": map[string]interface{}{
 							"type":        "string",

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -662,7 +662,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 		OfFunction: &openai.ChatCompletionFunctionToolParam{
 			Function: openai.FunctionDefinitionParam{
 				Name:        "manage_istio_config_read",
-				Description: openai.String("Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config."),
+				Description: openai.String("Read-only Istio config: list or get objects. 'list' returns namespace→'{full-api-group}/{version}/{kind}'→{valid:[names],invalid:[names]}. The valid/invalid arrays ARE the validation result — do NOT call 'get' on each item just to check health; use the list directly. Only use 'get' to inspect a specific object's full YAML spec. Key parsing: the group is the entire string before the first '/' (e.g. key 'gateway.networking.k8s.io/v1/Gateway' → group='gateway.networking.k8s.io', version='v1', kind='Gateway'). For writes use manage_istio_config."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"required": []interface{}{
@@ -695,7 +695,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 						},
 						"version": map[string]interface{}{
 							"type":        "string",
-							"description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+							"description": "API version (e.g. 'v1'). Required for 'get' action. Read directly from the list key: the middle segment between the two '/' characters.",
 						},
 						"kind": map[string]interface{}{
 							"type":        "string",

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -662,7 +662,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 		OfFunction: &openai.ChatCompletionFunctionToolParam{
 			Function: openai.FunctionDefinitionParam{
 				Name:        "manage_istio_config_read",
-				Description: openai.String("Read Istio config. 'list' returns namespace→'group/version/kind'→{valid:[names],invalid:[names]}. 'get' returns full YAML for a specific object. Group/version/kind are parsed from list keys (e.g. 'gateway.networking.k8s.io/v1/Gateway'). For writes use manage_istio_config."),
+				Description: openai.String("Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"required": []interface{}{


### PR DESCRIPTION
### Describe the change

Reduce LLM token with the main changes: 

- Restructured Istio List Output format grouped by group/version/kind
- Optimized MCP tool schema reducing tool description
- Test updated

### Steps to test the PR

The verification can be done with the mcp checker and the comparison with the updated baseline. 
Not a huge token reduction, but it should be better when there are more istio configs in the cluster.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes #9945 
