### PR TITLE
[AI] Fix mcp checker results 

### DIFF
--- a/tests/evals/tasks/resource-get-workload-detail/resource-get-workload-detail.yaml
+++ b/tests/evals/tasks/resource-get-workload-detail/resource-get-workload-detail.yaml
@@ -15,4 +15,4 @@ spec:
   - llmJudge:
       contains: "reviews-v1"
   prompt:
-    inline: "Inspect the 'reviews-v1' workload in the 'bookinfo' namespace and provide its detailed status and health information."
+    inline: "Inspect the 'reviews-v1' workload in the 'bookinfo' namespace and provide its detailed status and health information. Include the exact workload name 'reviews-v1' in your summary."


### PR DESCRIPTION
### Describe the change

Added "Include the exact workload name 'reviews-v1' in your summary." to the prompt. This mirrors the technique already used in `topology-mesh-namespaces.yaml`, which explicitly instructs the model to include specific words in its answer. With this instruction, the model is guaranteed to emit the exact string reviews-v1, making the llmJudge.contains check reliable.

Failure from master: https://github.com/kiali/kiali/actions/runs/28509906382 

### Steps to test the PR

Run `/run-mcpchecker` and verify the results 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
