### PR TITLE
[AI] Make maxToolIterations configurable

### DIFF
--- a/ai/providers/anthropic/anthropic.go
+++ b/ai/providers/anthropic/anthropic.go
@@ -149,7 +149,7 @@ func (p *AnthropicProvider) SendChat(onChunk func(chunk string), r *http.Request
 		return true, ""
 	}
 
-	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn)
+	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn, p.conf.ChatAI.MaxToolIterations)
 	if aborted {
 		return types.TokenUsage{}
 	}

--- a/ai/providers/chat_loop.go
+++ b/ai/providers/chat_loop.go
@@ -46,6 +46,10 @@ type PrepareNextTurnFunc func(
 //     compose a coherent partial-failure response (MCP protocol convention).
 //  4. Calls prepareNextTurn to apply results to the provider's state.
 //
+// maxToolIterations caps the number of tool-call iterations (LLM call + tool
+// execution round) before the loop is force-aborted. It comes from
+// config.ChatAI.MaxToolIterations.
+//
 // Returns (responseContent, actions, docs, aborted).  aborted=true means an
 // error was already streamed to onChunk and the caller should return immediately.
 func RunChatLoop(
@@ -55,11 +59,11 @@ func RunChatLoop(
 	onChunk func(string),
 	streamTurn StreamTurnFunc,
 	prepareNextTurn PrepareNextTurnFunc,
+	maxToolIterations int,
 ) (responseContent string, actions []get_action_ui.Action, docs []types.ReferencedDoc, aborted bool) {
 	actions = []get_action_ui.Action{}
 	docs = []types.ReferencedDoc{}
 
-	const maxToolIterations = 5
 	for iter := 0; iter < maxToolIterations; iter++ {
 		text, toolCalls, err := streamTurn(ctx, onChunk)
 		if err != nil {

--- a/ai/providers/chat_loop_test.go
+++ b/ai/providers/chat_loop_test.go
@@ -90,7 +90,7 @@ func TestRunChatLoop_NoToolCalls(t *testing.T) {
 	var chunks []string
 	content, actions, docs, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, nopPrepare(t),
+		collectChunks(&chunks), streamTurn, nopPrepare(t), 5,
 	)
 
 	assert.False(t, aborted)
@@ -113,7 +113,7 @@ func TestRunChatLoop_ParseMarkdownApplied(t *testing.T) {
 
 	content, _, _, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(new([]string)), streamTurn, nopPrepare(t),
+		collectChunks(new([]string)), streamTurn, nopPrepare(t), 5,
 	)
 
 	assert.False(t, aborted)
@@ -133,7 +133,7 @@ func TestRunChatLoop_StreamTurnError(t *testing.T) {
 	var chunks []string
 	content, _, _, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, nopPrepare(t),
+		collectChunks(&chunks), streamTurn, nopPrepare(t), 5,
 	)
 
 	assert.True(t, aborted)
@@ -160,7 +160,7 @@ func TestRunChatLoop_ContextCanceled(t *testing.T) {
 	var chunks []string
 	_, _, _, aborted := RunChatLoop(
 		dummyProvider{}, ctx, ki,
-		collectChunks(&chunks), streamTurn, nopPrepare(t),
+		collectChunks(&chunks), streamTurn, nopPrepare(t), 5,
 	)
 
 	assert.True(t, aborted)
@@ -198,7 +198,7 @@ func TestRunChatLoop_ToolResultError(t *testing.T) {
 	var chunks []string
 	content, _, _, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, prepare,
+		collectChunks(&chunks), streamTurn, prepare, 5,
 	)
 
 	assert.False(t, aborted, "loop must not abort on a tool error")
@@ -241,7 +241,7 @@ func TestRunChatLoop_PartialToolFailure(t *testing.T) {
 	var chunks []string
 	content, _, _, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, prepare,
+		collectChunks(&chunks), streamTurn, prepare, 5,
 	)
 
 	assert.False(t, aborted, "partial tool failure must not abort the loop")
@@ -290,7 +290,7 @@ func TestRunChatLoop_PrepareNextTurnFalseStopsLoop(t *testing.T) {
 
 	content, _, docs, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(new([]string)), streamTurn, prepare,
+		collectChunks(new([]string)), streamTurn, prepare, 5,
 	)
 
 	assert.False(t, aborted)
@@ -331,7 +331,7 @@ func TestRunChatLoop_PrepareNextTurnTrueContinuesLoop(t *testing.T) {
 
 	content, _, docs, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(new([]string)), streamTurn, prepare,
+		collectChunks(new([]string)), streamTurn, prepare, 5,
 	)
 
 	assert.False(t, aborted)
@@ -343,29 +343,33 @@ func TestRunChatLoop_PrepareNextTurnTrueContinuesLoop(t *testing.T) {
 
 // TestRunChatLoop_MaxToolIterationsAborts verifies that the loop is
 // force-aborted with an error event when tool calls are returned on every
-// iteration up to the maximum.
+// iteration up to the maximum, and that a custom maxToolIterations value is
+// respected.
 func TestRunChatLoop_MaxToolIterationsAborts(t *testing.T) {
 	require.NoError(t, mcp.LoadTools())
-	ki := newTestKialiInterface(t)
 
-	streamCalls := 0
-	streamTurn := func(_ context.Context, _ func(string)) (string, []types.StreamToolCallData, error) {
-		streamCalls++
-		// Always return a tool call so the loop never exits naturally.
-		return "", []types.StreamToolCallData{referencedDocsCall(fmt.Sprintf("tc-%d", streamCalls))}, nil
+	for _, maxIter := range []int{5, 3} {
+		maxIter := maxIter
+		t.Run(fmt.Sprintf("maxToolIterations=%d", maxIter), func(t *testing.T) {
+			ki := newTestKialiInterface(t)
+
+			streamCalls := 0
+			streamTurn := func(_ context.Context, _ func(string)) (string, []types.StreamToolCallData, error) {
+				streamCalls++
+				return "", []types.StreamToolCallData{referencedDocsCall(fmt.Sprintf("tc-%d", streamCalls))}, nil
+			}
+
+			var chunks []string
+			_, _, _, aborted := RunChatLoop(
+				dummyProvider{}, context.Background(), ki,
+				collectChunks(&chunks), streamTurn, alwaysContinuePrepare(), maxIter,
+			)
+
+			assert.True(t, aborted, "loop must abort after reaching maxToolIterations")
+			assert.True(t, hasErrorEvent(chunks), "a max-iterations error event must be emitted")
+			assert.Equal(t, maxIter, streamCalls, "streamTurn must be called exactly maxToolIterations times")
+		})
 	}
-
-	var chunks []string
-	_, _, _, aborted := RunChatLoop(
-		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, alwaysContinuePrepare(),
-	)
-
-	assert.True(t, aborted, "loop must abort after reaching maxToolIterations")
-	assert.True(t, hasErrorEvent(chunks), "a max-iterations error event must be emitted")
-	// 5 iterations: tools execute on 0..3 (iter 4 aborts before executing)
-	// streamTurn is called on each of the 5 iterations.
-	assert.Equal(t, 5, streamCalls)
 }
 
 // TestRunChatLoop_DocsAccumulatedAcrossIterations verifies that referenced
@@ -395,7 +399,7 @@ func TestRunChatLoop_DocsAccumulatedAcrossIterations(t *testing.T) {
 
 	_, _, docs, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(new([]string)), streamTurn, prepare,
+		collectChunks(new([]string)), streamTurn, prepare, 5,
 	)
 
 	assert.False(t, aborted)
@@ -423,7 +427,7 @@ func TestRunChatLoop_ContextCanceledAfterToolExecution(t *testing.T) {
 	var chunks []string
 	_, _, _, aborted := RunChatLoop(
 		dummyProvider{}, ctx, ki,
-		collectChunks(&chunks), streamTurn, alwaysStopPrepare(""),
+		collectChunks(&chunks), streamTurn, alwaysStopPrepare(""), 5,
 	)
 
 	assert.True(t, aborted)
@@ -448,7 +452,7 @@ func TestRunChatLoop_SSEChunksAreValidJSON(t *testing.T) {
 	var chunks []string
 	RunChatLoop( //nolint:errcheck
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(&chunks), streamTurn, alwaysStopPrepare(""),
+		collectChunks(&chunks), streamTurn, alwaysStopPrepare(""), 5,
 	)
 
 	require.NotEmpty(t, chunks)
@@ -476,7 +480,7 @@ func TestRunChatLoop_EmptyTextIsNotAccumulated(t *testing.T) {
 
 	content, _, _, aborted := RunChatLoop(
 		dummyProvider{}, context.Background(), ki,
-		collectChunks(new([]string)), streamTurn, alwaysContinuePrepare(),
+		collectChunks(new([]string)), streamTurn, alwaysContinuePrepare(), 5,
 	)
 
 	assert.False(t, aborted)

--- a/ai/providers/google/google.go
+++ b/ai/providers/google/google.go
@@ -224,7 +224,7 @@ func (p *GoogleAIProvider) SendChat(onChunk func(chunk string), r *http.Request,
 		return false, extraText
 	}
 
-	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn)
+	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn, p.conf.ChatAI.MaxToolIterations)
 	if aborted {
 		return types.TokenUsage{}
 	}

--- a/ai/providers/openai/openai.go
+++ b/ai/providers/openai/openai.go
@@ -176,7 +176,7 @@ func (p *OpenAIProvider) SendChat(onChunk func(chunk string), r *http.Request, r
 		return true, ""
 	}
 
-	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn)
+	responseContent, actions, referencedDocs, aborted := providers.RunChatLoop(p, ctx, kialiInterface, onChunk, streamTurn, prepareNextTurn, p.conf.ChatAI.MaxToolIterations)
 	if aborted {
 		return types.TokenUsage{}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -850,11 +850,12 @@ type ProviderConfig struct {
 
 // ChatAIConfig defines configuration for the ChatAI subsystem
 type ChatAIConfig struct {
-	DefaultProvider string           `yaml:"default_provider,omitempty" json:"default_provider,omitempty"`
-	Enabled         bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	Providers       []ProviderConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
-	StoreConfig     AiStoreConfig    `yaml:"store_config,omitempty" json:"store_config,omitempty"`
-	Tools           ToolFilterConfig `yaml:"tools,omitempty" json:"tools,omitempty"`
+	DefaultProvider   string           `yaml:"default_provider,omitempty" json:"default_provider,omitempty"`
+	Enabled           bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	MaxToolIterations int              `yaml:"max_tool_iterations,omitempty" json:"max_tool_iterations,omitempty"`
+	Providers         []ProviderConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
+	StoreConfig       AiStoreConfig    `yaml:"store_config,omitempty" json:"store_config,omitempty"`
+	Tools             ToolFilterConfig `yaml:"tools,omitempty" json:"tools,omitempty"`
 }
 
 // Clustering defines configuration around multi-cluster functionality.
@@ -1048,9 +1049,10 @@ func NewConfig() (c *Config) {
 			},
 		},
 		ChatAI: ChatAIConfig{
-			Enabled:         false,
-			DefaultProvider: "",
-			Providers:       []ProviderConfig{},
+			Enabled:           false,
+			DefaultProvider:   "",
+			MaxToolIterations: 5,
+			Providers:         []ProviderConfig{},
 			StoreConfig: AiStoreConfig{
 				Enabled:                 true,
 				InactivityTimeout:       "30m",
@@ -1379,6 +1381,10 @@ func (conf *Config) AddHealthDefault() {
 func (conf *Config) ValidateAI() error {
 	if !conf.ChatAI.Enabled {
 		return nil
+	}
+
+	if conf.ChatAI.MaxToolIterations < 1 || conf.ChatAI.MaxToolIterations > 20 {
+		return fmt.Errorf("chat_ai.max_tool_iterations must be between 1 and 20, got %d", conf.ChatAI.MaxToolIterations)
 	}
 
 	if err := normalizeAndValidateToolFilter("chat_ai.tools", &conf.ChatAI.Tools); err != nil {


### PR DESCRIPTION
### Describe the change

Add max_tool_iterations for chat_ai.

- Helm charts: https://github.com/kiali/helm-charts/pull/424 
- Operator PR: https://github.com/kiali/kiali-operator/pull/1074

### Steps to test the PR

- Modify `chat_ai.max_tool_iterations` to any number <1 and > 20 and verify it doesn't start. 
- Change `chat_ai.max_tool_iterations` to 1 and make some queries, verify at some point it reaches the limit: 
<img width="526" height="837" alt="image" src="https://github.com/user-attachments/assets/5991ae54-4c8d-4ba1-9fd2-ac17e19954ad" />


### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #9974 
