### PR TITLE
[AI] Add Istio list evaluation test

### DIFF
--- a/tests/evals/tasks/istio-list-comprehensive/cleanup.sh
+++ b/tests/evals/tasks/istio-list-comprehensive/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete all resources created by this test
+kubectl delete virtualservices,destinationrules,gateways,serviceentries \
+  -n bookinfo \
+  -l gevals.kiali.io/test=gevals-testing \
+  --ignore-not-found=true
+
+echo "Cleaned up comprehensive istio configuration test resources"

--- a/tests/evals/tasks/istio-list-comprehensive/istio-list-comprehensive.yaml
+++ b/tests/evals/tasks/istio-list-comprehensive/istio-list-comprehensive.yaml
@@ -1,0 +1,33 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kiali
+  name: "List Comprehensive Istio Configuration"
+  category: "Configuration Management"
+  description: "Lists multiple Istio resources across different types to validate token efficiency with larger datasets. This test validates that the grouped output format provides better token efficiency at scale."
+  difficulty: easy
+spec:
+  cleanup:
+  - script:
+      file: ./cleanup.sh
+      timeout: 120s
+  prompt:
+    inline: |
+      List all Istio configuration resources in the 'bookinfo' namespace.
+      Provide a summary of how many VirtualServices, DestinationRules, Gateways, and ServiceEntries you found.
+      Also report if any of these resources have validation errors.
+  requires:
+  - extension: kubernetes
+    as: k8s
+  setup:
+  - script:
+      file: ./setup.sh
+      timeout: 120s
+  verify:
+  - llmJudge:
+      contains: "VirtualService"
+  - llmJudge:
+      contains: "DestinationRule"
+  - llmJudge:
+      contains: "Gateway"

--- a/tests/evals/tasks/istio-list-comprehensive/setup.sh
+++ b/tests/evals/tasks/istio-list-comprehensive/setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create multiple VirtualServices (10)
+for i in {1..10}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: service-${i}-vs
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - "service-${i}.bookinfo.svc.cluster.local"
+  http:
+  - route:
+    - destination:
+        host: service-${i}
+        port:
+          number: 8080
+EOF
+done
+
+# Create multiple DestinationRules (10)
+for i in {1..10}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: service-${i}-dr
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  host: service-${i}.bookinfo.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 50
+        http2MaxRequests: 100
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+EOF
+done
+
+# Create multiple Gateways (5)
+for i in {1..5}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: gateway-${i}
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "service-${i}.example.com"
+EOF
+done
+
+# Create multiple ServiceEntries (5)
+for i in {1..5}; do
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: external-service-${i}
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - external-${i}.example.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+EOF
+done
+
+# Create one VirtualService with intentional validation error
+cat <<'EOF' | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: invalid-vs
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  hosts:
+  - "invalid-service"
+  gateways:
+  - non-existent-gateway
+  http:
+  - route:
+    - destination:
+        host: invalid-service
+        subset: non-existent-subset
+EOF
+
+echo "Created 10 VirtualServices, 10 DestinationRules, 5 Gateways, and 5 ServiceEntries in bookinfo namespace"


### PR DESCRIPTION
This test creates a larger set of Istio resources to validate token efficiency of the grouped output format at scale:
- 10 VirtualServices
- 10 DestinationRules
- 5 Gateways
- 5 ServiceEntries
- 1 VirtualService with validation errors (for testing invalid detection)

Total: 31 Istio resources vs 1-3 in existing tests.

This will establish a baseline that demonstrates the token savings of the grouped namespace→GVK→{valid,invalid} format compared to the flat array format when listing many resources.

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/issues/9945 
Needs to be done on a separate PR to create a baseline to compare. 
