### PR TITLE
[AI] Guide multi-cluster tool usage via system prompts

### DIFF
--- a/ai/types/prompt.go
+++ b/ai/types/prompt.go
@@ -26,7 +26,13 @@ ALWAYS use this context to ground your answers, understand what the user is look
    - Simply tell the user: "I have prepared the configuration in the attachment. You can review and apply it there."
 
 ### MULTI-CLUSTER
-When Kiali manages multiple clusters, always include clusterName in tool calls when the user context specifies a cluster or when the user refers to one explicitly. If the cluster name is unknown, call list_clusters first to get the available cluster names, then re-invoke the requested tool.
+Kiali mesh clusters are identified only by the 'name' field from list_clusters (e.g. "east", "west"). This is the only valid value for the clusterName tool parameter.
+When Kiali manages multiple clusters:
+1. If UI context already includes a cluster (e.g. "in cluster west"), use that name as clusterName.
+2. If the user mentions a cluster and the name is unclear, call list_clusters first.
+3. Match the user's words to a 'name' from that list. Do not invent cluster names or pass values that are not listed.
+4. If there is no unambiguous match, ask the user to choose from the listed cluster names (e.g. "Which cluster do you mean? Available: east (home), west").
+5. If only one accessible cluster exists, omit clusterName (defaults to home).
 
 ### ACTION HANDLING
 You have tools that automatically navigate the user's UI ('get_action_ui') or surface documentation widgets ('get_referenced_docs'). When you call these tools, the system handles the UI updates automatically. Simply answer the user naturally (e.g., "I've pulled up the traffic graph for you" or "Here is the documentation on PeerAuthentication"). Do not wait for or analyze the system response from these UI tools.
@@ -59,6 +65,15 @@ For every issue, follow this structure:
 ### ISTIO CONFIGURATION RULES (CRITICAL)
 1. **Traffic Splitting:** Always create/update BOTH a DestinationRule (subsets) AND a VirtualService (weights) together.
 2. **Read-Only Application:** Use 'manage_istio_config' with confirmed: false. Never apply changes directly. Tell the user: "I have prepared the configuration in the attachment. You can review and apply it there."
+
+### MULTI-CLUSTER
+Kiali mesh clusters are identified only by the 'name' field from list_clusters (e.g. "east", "west"). This is the only valid value for the clusterName tool parameter.
+When troubleshooting multi-cluster issues:
+1. If UI context already includes a cluster (e.g. "in cluster west"), use that name as clusterName.
+2. If the user mentions a cluster and the name is unclear, call list_clusters first.
+3. Match the user's words to a 'name' from that list. Do not invent cluster names or pass values that are not listed.
+4. If there is no unambiguous match, ask the user to choose from the listed cluster names (e.g. "Which cluster do you mean? Available: east (home), west").
+5. If only one accessible cluster exists, omit clusterName (defaults to home).
 
 ### ACTION HANDLING
 You have tools that automatically navigate the user's UI ('get_action_ui') or surface documentation widgets ('get_referenced_docs'). Call them proactively during troubleshooting to guide the user to the relevant Kiali view. Simply answer naturally; do not wait for or analyze the system response from these UI tools.

--- a/ai/types/prompt.go
+++ b/ai/types/prompt.go
@@ -27,6 +27,7 @@ ALWAYS use this context to ground your answers, understand what the user is look
 
 ### MULTI-CLUSTER
 Kiali mesh clusters are identified only by the 'name' field from list_clusters (e.g. "east", "west"). This is the only valid value for the clusterName tool parameter.
+**CRITICAL:** If the user mentions a cluster by kubeconfig context name (e.g. "kind-east", "minikube", "gke_project_region_cluster"), you MUST call list_clusters first. The clusterName parameter must use the 'name' field from that response — never kubeconfig context names, even if they appear in the user's message or UI context.
 When Kiali manages multiple clusters:
 1. If UI context already includes a cluster (e.g. "in cluster west"), use that name as clusterName.
 2. If the user mentions a cluster and the name is unclear, call list_clusters first.

--- a/ai/types/prompt.go
+++ b/ai/types/prompt.go
@@ -68,6 +68,7 @@ For every issue, follow this structure:
 
 ### MULTI-CLUSTER
 Kiali mesh clusters are identified only by the 'name' field from list_clusters (e.g. "east", "west"). This is the only valid value for the clusterName tool parameter.
+**CRITICAL:** If the user mentions a cluster by kubeconfig context name (e.g. "kind-east", "minikube", "gke_project_region_cluster"), you MUST call list_clusters first. The clusterName parameter must use the 'name' field from that response — never kubeconfig context names, even if they appear in the user's message or UI context.
 When troubleshooting multi-cluster issues:
 1. If UI context already includes a cluster (e.g. "in cluster west"), use that name as clusterName.
 2. If the user mentions a cluster and the name is unclear, call list_clusters first.


### PR DESCRIPTION
### Describe the change

Improves multi-cluster guidance in the Kiali AI Assistant system prompts (ask and troubleshoot modes).

Models were passing invalid values as `clusterName` (for example kubeconfig context names like `kind-west`) instead of Kiali's mesh cluster names (for example `west`). Kiali does not know kubeconfig context names, so exposing or mapping them in the API is not a reliable solution.

This PR adds explicit MULTI-CLUSTER instructions telling the model to:
- Use only the `name` field from `list_clusters` as `clusterName`
- Prefer cluster from UI context when available
- Call `list_clusters` when the user's cluster reference is unclear
- Ask the user to pick from listed clusters when there is no unambiguous match

### Steps to test the PR

1. Start Kiali in multi-cluster mode:
   ```bash
   kiali -c hack/ci-yaml/ci-test-config-no-cache.yaml run \
     --context kind-east --remote-cluster-contexts kind-west \
     --cluster-name-overrides kind-east=east,kind-west=west --no-browser
   ```
2. Open the Kiali AI chatbot in a new session.
3. Ask: `can you give me the metrics for workload productpage-v1 in bookinfo namespace for cluster kind-west?`
4. Expected: the model calls `list_clusters`, resolves `west`, and invokes tools with `clusterName=west` (not `kind-west`).
5. Repeat in troubleshoot mode with a similar multi-cluster question.

### Automation testing

No new tests added. Prompt-only change in `ai/types/prompt.go`.

### Issue reference

Ref #9895