### PR TITLE
Remove v1.73 branch references

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -6,14 +6,14 @@ on:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
   workflow_call:
     inputs:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
 
 jobs:

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -6,7 +6,7 @@ on:
       tag_branches:
         description: Branches to tag (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
 
 permissions: read-all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1541,7 +1541,7 @@ Tests are in `kiali-operator/molecule/`. Each subdirectory is a test scenario (e
 ### Never Modify These Files
 
 **Versioned Operator Roles:**
-- `kiali-operator/roles/v1.73/`, `roles/v2.4/`, etc. - Only modify the `default` role
+- `kiali-operator/roles/v2.4/`, `roles/v2.11/`, etc. - Only modify the `default` role
 
 **Old CSV Versions:**
 - `kiali-operator/manifests/*/[version]/` - Only modify the LATEST version

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -87,7 +87,7 @@ podman run -it \
   -e CYPRESS_USERNAME="kubeadmin" \
   -e CYPRESS_AUTH_PROVIDER="kube:admin" \
   -e TEST_GROUP="@smoke" \
-  quay.io/kiali/kiali-cypress-tests:v1.73
+  quay.io/kiali/kiali-cypress-tests:latest
 ```
 
 ## Structure

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -204,9 +204,7 @@ TARGET_BRANCH="${TARGET_BRANCH:-master}"
 # When using Sail, install-istio-via-sail.sh will pin the Sail chart and map unsupported patch versions
 # (e.g. 1.26.8) to a CRD-supported value (e.g. v1.26-latest).
 if [ -z "${ISTIO_VERSION}" ]; then
-  if [ "${TARGET_BRANCH}" == "v1.73" ]; then
-    ISTIO_VERSION="1.18.7"
-  elif [ "${TARGET_BRANCH}" == "v2.4" ]; then
+  if [ "${TARGET_BRANCH}" == "v2.4" ]; then
     ISTIO_VERSION="1.23.6"
   elif [ "${TARGET_BRANCH}" == "v2.11" ]; then
     ISTIO_VERSION="1.26.8"

--- a/hack/setup-minikube-in-ci.sh
+++ b/hack/setup-minikube-in-ci.sh
@@ -102,18 +102,6 @@ DORP="${DORP:-docker}"
 # Defaults the branch to master unless it is already set
 TARGET_BRANCH="${TARGET_BRANCH:-master}"
 
-# If a specific version of Istio hasn't been provided, try and guess the right one
-# based on the Kiali branch being tested (TARGET_BRANCH) and the compatibility matrices:
-# https://kiali.io/docs/installation/installation-guide/prerequisites/
-# https://istio.io/latest/docs/releases/supported-releases/
-if [ -z "${ISTIO_VERSION}" ]; then
-  if [ "${TARGET_BRANCH}" == "v1.65" ]; then
-    ISTIO_VERSION="1.16.0"
-  elif [ "${TARGET_BRANCH}" == "v1.73" ]; then
-    ISTIO_VERSION="1.18.0"
-  fi
-fi
-
 if [ -z "${HELM_CHARTS_DIR}" ]; then
   HELM_CHARTS_DIR="$(mktemp -d)"
 


### PR DESCRIPTION
## Summary
- Remove all `v1.73` references from CI workflows, setup scripts, and documentation since this branch is no longer supported.
- Updates default branch lists in release workflows (`bump-release-version.yml`, `tag-release-creator.yml`).
- Removes `v1.73` Istio version mappings from `setup-kind-in-ci.sh` and the legacy minikube Istio block from `setup-minikube-in-ci.sh`.
- Updates stale `v1.73` references in `frontend/cypress/README.md` and `AGENTS.md`.

## Test plan
- [ ] Verify CI workflows still trigger correctly for remaining branches (`v2.4`, `v2.11`, `v2.17`, `v2.22`)
- [ ] Verify KinD CI setup script resolves Istio versions for supported branches

Part of https://github.com/kiali/kiali/issues/9987

Made with [Cursor](https://cursor.com)