### PR TITLE
[AI] Enhance MCP Server with Istio Ambient Mesh capabilities

### DIFF
--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
+	networking_v1_api "istio.io/api/networking/v1"
 	security_v1_api "istio.io/api/security/v1"
+	telemetry_v1_api "istio.io/api/telemetry/v1"
+	extensions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+	telemetry_v1 "istio.io/client-go/pkg/apis/telemetry/v1"
 
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
@@ -14,6 +20,12 @@ import (
 
 // PolicyAnalysisResponse is the output of the analyze_ambient_policies tool
 type PolicyAnalysisResponse struct {
+	Namespaces []NamespaceAnalysis `json:"namespaces"`
+	Summary    string              `json:"summary,omitempty"`
+}
+
+// NamespaceAnalysis contains the analysis for a single namespace
+type NamespaceAnalysis struct {
 	NamespaceStatus NamespaceAmbientStatus `json:"namespace_status"`
 	Policies        []AnalyzedPolicy       `json:"policies"`
 	Recommendations []string               `json:"recommendations,omitempty"`
@@ -29,33 +41,109 @@ type NamespaceAmbientStatus struct {
 	WaypointName string `json:"waypoint_name,omitempty"`
 }
 
-// AnalyzedPolicy contains the classification and warnings for a single AuthorizationPolicy
+// AnalyzedPolicy contains the classification and warnings for a single Istio configuration
 type AnalyzedPolicy struct {
-	Layer   string `json:"layer"` // "L4" or "L7"
-	Name    string `json:"name"`
-	Reason  string `json:"reason"`
-	Rules   int    `json:"rules_count"`
-	Warning string `json:"warning,omitempty"`
+	ConfigType string `json:"config_type"` // e.g., "AuthorizationPolicy", "VirtualService", etc.
+	Layer      string `json:"layer"`       // "L4" or "L7"
+	Name       string `json:"name"`
+	Reason     string `json:"reason"`
+	Rules      int    `json:"rules_count"`
+	Warning    string `json:"warning,omitempty"`
 }
 
 func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
 	ctx := kialiInterface.Request.Context()
-	namespace := mcputil.GetStringArg(args, "namespace")
 	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
 
-	if namespace == "" {
-		return "namespace parameter is required", http.StatusBadRequest
+	// Get namespaces to analyze (either single, multiple, or all Ambient namespaces)
+	var namespacesToAnalyze []string
+
+	// Check for single namespace
+	if namespace := mcputil.GetStringArg(args, "namespace"); namespace != "" {
+		namespacesToAnalyze = []string{namespace}
 	}
 
-	// Validate namespace access
-	if errMsg, statusCode := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
-		return errMsg, statusCode
+	// Check for multiple namespaces
+	if namespacesArg, ok := args["namespaces"].([]interface{}); ok && len(namespacesArg) > 0 {
+		if len(namespacesToAnalyze) > 0 {
+			return "cannot specify both 'namespace' and 'namespaces' parameters", http.StatusBadRequest
+		}
+		for _, ns := range namespacesArg {
+			if nsStr, ok := ns.(string); ok && nsStr != "" {
+				namespacesToAnalyze = append(namespacesToAnalyze, nsStr)
+			}
+		}
 	}
 
+	// If no namespaces specified, analyze all Ambient namespaces
+	if len(namespacesToAnalyze) == 0 {
+		allNamespaces, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespaces(ctx, clusterName)
+		if err != nil {
+			return fmt.Sprintf("failed to get namespaces: %v", err), http.StatusInternalServerError
+		}
+
+		// Filter to only Ambient namespaces
+		for _, ns := range allNamespaces {
+			if ns.IsAmbient {
+				namespacesToAnalyze = append(namespacesToAnalyze, ns.Name)
+			}
+		}
+
+		if len(namespacesToAnalyze) == 0 {
+			return PolicyAnalysisResponse{
+				Namespaces: []NamespaceAnalysis{},
+				Summary:    "No Ambient namespaces found in the cluster",
+			}, http.StatusOK
+		}
+	}
+
+	// Analyze each namespace
+	namespaceResults := make([]NamespaceAnalysis, 0, len(namespacesToAnalyze))
+	totalL4 := 0
+	totalL7 := 0
+	totalL7WithoutWaypoint := 0
+
+	for _, namespace := range namespacesToAnalyze {
+		// Validate namespace access
+		if errMsg, statusCode := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
+			return fmt.Sprintf("namespace '%s': %s", namespace, errMsg), statusCode
+		}
+
+		result := analyzeNamespace(ctx, kialiInterface, namespace, clusterName)
+		namespaceResults = append(namespaceResults, result)
+
+		// Count L4/L7 across all namespaces
+		for _, policy := range result.Policies {
+			if policy.Layer == "L7" {
+				totalL7++
+				if policy.Warning != "" {
+					totalL7WithoutWaypoint++
+				}
+			} else {
+				totalL4++
+			}
+		}
+	}
+
+	// Generate overall summary
+	overallSummary := generateOverallSummary(len(namespacesToAnalyze), totalL4, totalL7, totalL7WithoutWaypoint)
+
+	return PolicyAnalysisResponse{
+		Namespaces: namespaceResults,
+		Summary:    overallSummary,
+	}, http.StatusOK
+}
+
+// analyzeNamespace performs the analysis for a single namespace
+func analyzeNamespace(ctx context.Context, kialiInterface *mcputil.KialiInterface, namespace, clusterName string) NamespaceAnalysis {
 	// Get namespace details to check if it's Ambient
 	namespaceInfo, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespace(ctx, namespace, clusterName)
 	if err != nil {
-		return fmt.Sprintf("failed to get namespace info: %v", err), http.StatusInternalServerError
+		// Return an error result
+		return NamespaceAnalysis{
+			NamespaceStatus: NamespaceAmbientStatus{Name: namespace, Cluster: clusterName},
+			Summary:         fmt.Sprintf("Error: failed to get namespace info: %v", err),
+		}
 	}
 
 	// Check if namespace has waypoint
@@ -69,33 +157,77 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		WaypointName: waypointName,
 	}
 
-	// Get AuthorizationPolicies
+	// Get all relevant Istio configs for Ambient analysis
 	criteria := business.IstioConfigCriteria{
-		IncludeAuthorizationPolicies: true,
+		IncludeAuthorizationPolicies:  true,
+		IncludePeerAuthentications:    true,
+		IncludeRequestAuthentications: true,
+		IncludeVirtualServices:        true,
+		IncludeDestinationRules:       true,
+		IncludeWasmPlugins:            true,
+		IncludeTelemetry:              true,
 	}
 	istioConfigs, err := kialiInterface.BusinessLayer.IstioConfig.GetIstioConfigListForNamespace(ctx, clusterName, namespace, criteria)
 	if err != nil {
-		return fmt.Sprintf("failed to get AuthorizationPolicies: %v", err), http.StatusInternalServerError
+		return NamespaceAnalysis{
+			NamespaceStatus: nsStatus,
+			Summary:         fmt.Sprintf("Error: failed to get Istio configs: %v", err),
+		}
 	}
 
-	// Analyze policies
+	// Analyze all config types
 	analyzedPolicies := make([]AnalyzedPolicy, 0)
 	l4Count := 0
 	l7Count := 0
 	l7WithoutWaypointCount := 0
 
+	// Analyze AuthorizationPolicies
 	for _, ap := range istioConfigs.AuthorizationPolicies {
 		analyzed := analyzeAuthorizationPolicy(ap, nsStatus)
 		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
 
-		if analyzed.Layer == "L7" {
-			l7Count++
-			if analyzed.Warning != "" {
-				l7WithoutWaypointCount++
-			}
-		} else {
-			l4Count++
-		}
+	// Analyze PeerAuthentications
+	for _, pa := range istioConfigs.PeerAuthentications {
+		analyzed := analyzePeerAuthentication(pa, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
+
+	// Analyze RequestAuthentications (always L7)
+	for _, ra := range istioConfigs.RequestAuthentications {
+		analyzed := analyzeRequestAuthentication(ra, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
+
+	// Analyze VirtualServices (always L7)
+	for _, vs := range istioConfigs.VirtualServices {
+		analyzed := analyzeVirtualService(vs, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
+
+	// Analyze DestinationRules
+	for _, dr := range istioConfigs.DestinationRules {
+		analyzed := analyzeDestinationRule(dr, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
+
+	// Analyze WasmPlugins (always L7)
+	for _, wp := range istioConfigs.WasmPlugins {
+		analyzed := analyzeWasmPlugin(wp, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
+	}
+
+	// Analyze Telemetry
+	for _, tel := range istioConfigs.Telemetries {
+		analyzed := analyzeTelemetry(tel, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+		updateCounts(&l4Count, &l7Count, &l7WithoutWaypointCount, analyzed)
 	}
 
 	// Generate summary
@@ -104,12 +236,12 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	// Generate recommendations
 	recommendations := generateRecommendations(nsStatus, l7Count, l7WithoutWaypointCount)
 
-	return PolicyAnalysisResponse{
-		Summary:         summary,
+	return NamespaceAnalysis{
 		NamespaceStatus: nsStatus,
 		Policies:        analyzedPolicies,
 		Recommendations: recommendations,
-	}, http.StatusOK
+		Summary:         summary,
+	}
 }
 
 // checkNamespaceWaypoint checks if the namespace has a waypoint proxy configured.
@@ -124,23 +256,32 @@ func checkNamespaceWaypoint(ctx context.Context, businessLayer *business.Layer, 
 	return false, ""
 }
 
+// updateCounts updates the L4/L7 counters based on analyzed policy
+func updateCounts(l4Count, l7Count, l7WithoutWaypoint *int, analyzed AnalyzedPolicy) {
+	if analyzed.Layer == "L7" {
+		*l7Count++
+		if analyzed.Warning != "" {
+			*l7WithoutWaypoint++
+		}
+	} else {
+		*l4Count++
+	}
+}
+
 // analyzeAuthorizationPolicy classifies a policy as L4 or L7
 func analyzeAuthorizationPolicy(ap *security_v1.AuthorizationPolicy, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
 	isL7, reason := isL7Policy(&ap.Spec)
 
 	analyzed := AnalyzedPolicy{
-		Name:  ap.Name,
-		Rules: len(ap.Spec.Rules),
+		ConfigType: "AuthorizationPolicy",
+		Name:       ap.Name,
+		Rules:      len(ap.Spec.Rules),
 	}
 
 	if isL7 {
 		analyzed.Layer = "L7"
 		analyzed.Reason = reason
-
-		// Generate warning if namespace is Ambient but has no waypoint
-		if nsStatus.IsAmbient && !nsStatus.HasWaypoint {
-			analyzed.Warning = fmt.Sprintf("Namespace '%s' is in Ambient mode but has NO waypoint. This L7 policy will NOT be enforced.", nsStatus.Name)
-		}
+		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This L7 policy will NOT be enforced.")
 	} else {
 		analyzed.Layer = "L4"
 		analyzed.Reason = "Only uses L4 fields (source/destination principals, IPs, ports, namespaces)"
@@ -191,7 +332,17 @@ func isL7Policy(spec *security_v1_api.AuthorizationPolicy) (bool, string) {
 	return false, ""
 }
 
-// isL7Condition checks if a 'when' condition key requires L7 processing
+// ambientNoWaypointWarning returns a warning when an L7 config is in an Ambient namespace
+// without a waypoint. Returns empty string if no warning is needed.
+func ambientNoWaypointWarning(nsStatus NamespaceAmbientStatus, consequence string) string {
+	if nsStatus.IsAmbient && !nsStatus.HasWaypoint {
+		return fmt.Sprintf("Namespace '%s' is in Ambient mode but has NO waypoint. %s", nsStatus.Name, consequence)
+	}
+	return ""
+}
+
+// isL7Condition checks if a 'when' condition key requires L7 processing.
+// Note: destination.port is L4 (evaluated by ztunnel), not listed here.
 func isL7Condition(key string) bool {
 	l7Prefixes := []string{
 		"request.headers",
@@ -199,11 +350,10 @@ func isL7Condition(key string) bool {
 		"request.auth.principal",
 		"request.auth.audiences",
 		"request.auth.presenter",
-		"destination.port",
 	}
 
 	for _, prefix := range l7Prefixes {
-		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+		if strings.HasPrefix(key, prefix) {
 			return true
 		}
 	}
@@ -216,22 +366,22 @@ func generateSummary(l4Count, l7Count, l7WithoutWaypoint int, nsStatus Namespace
 	total := l4Count + l7Count
 
 	if total == 0 {
-		return fmt.Sprintf("No AuthorizationPolicies found in namespace '%s'", nsStatus.Name)
+		return fmt.Sprintf("No Istio configurations found in namespace '%s'", nsStatus.Name)
 	}
 
 	if !nsStatus.IsAmbient {
-		return fmt.Sprintf("Found %d policies (%d L4, %d L7). Namespace is NOT in Ambient mode - policies enforced by sidecars.", total, l4Count, l7Count)
+		return fmt.Sprintf("Found %d configs (%d L4, %d L7). Namespace is NOT in Ambient mode - configs enforced by sidecars.", total, l4Count, l7Count)
 	}
 
 	if l7WithoutWaypoint > 0 {
-		return fmt.Sprintf("Found %d policies (%d L4, %d L7). WARNING: %d L7 policies require a waypoint but namespace has NONE - these will NOT be enforced!", total, l4Count, l7Count, l7WithoutWaypoint)
+		return fmt.Sprintf("Found %d configs (%d L4, %d L7). WARNING: %d L7 configs require a waypoint but namespace has NONE - these will NOT work!", total, l4Count, l7Count, l7WithoutWaypoint)
 	}
 
 	if l7Count > 0 && nsStatus.HasWaypoint {
-		return fmt.Sprintf("Found %d policies (%d L4, %d L7). All L7 policies will be enforced by waypoint '%s'.", total, l4Count, l7Count, nsStatus.WaypointName)
+		return fmt.Sprintf("Found %d configs (%d L4, %d L7). All L7 configs will be processed by waypoint '%s'.", total, l4Count, l7Count, nsStatus.WaypointName)
 	}
 
-	return fmt.Sprintf("Found %d L4 policies. All will be enforced by ztunnel.", l4Count)
+	return fmt.Sprintf("Found %d L4 configs. All will be processed by ztunnel.", l4Count)
 }
 
 // generateRecommendations provides actionable next steps
@@ -246,20 +396,251 @@ func generateRecommendations(nsStatus NamespaceAmbientStatus, l7Count, l7Without
 
 	if l7WithoutWaypoint > 0 {
 		recommendations = append(recommendations,
-			fmt.Sprintf("Deploy a waypoint proxy in namespace '%s' to enforce L7 policies. Use 'istioctl waypoint apply' or create a Gateway resource.", nsStatus.Name),
-			"After deploying the waypoint, verify policies are enforced by checking metrics or testing the protected endpoints.",
+			fmt.Sprintf("Deploy a waypoint proxy in namespace '%s' to enable L7 configs. Use 'istioctl waypoint apply' or create a Gateway resource.", nsStatus.Name),
+			"After deploying the waypoint, verify configs are working by checking metrics or testing the affected services.",
 		)
 	}
 
 	if l7Count == 0 && nsStatus.HasWaypoint {
 		recommendations = append(recommendations,
-			"All policies are L4-only. Consider removing the waypoint proxy to reduce resource usage if L7 features are not needed.",
+			"All configs are L4-only. Consider removing the waypoint proxy to reduce resource usage if L7 features are not needed.",
 		)
 	}
 
 	if len(recommendations) == 0 {
-		recommendations = append(recommendations, "No issues found. All policies are correctly configured for Ambient mode.")
+		recommendations = append(recommendations, "No issues found. All configurations are correctly set up for Ambient mode.")
 	}
 
 	return recommendations
+}
+
+// analyzePeerAuthentication classifies a PeerAuthentication as L4
+// PeerAuthentication is processed by ztunnel for mTLS configuration
+func analyzePeerAuthentication(pa *security_v1.PeerAuthentication, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	analyzed := AnalyzedPolicy{
+		ConfigType: "PeerAuthentication",
+		Name:       pa.Name,
+		Layer:      "L4",
+		Reason:     "PeerAuthentication configures mTLS at L4 (processed by ztunnel)",
+		Rules:      1, // PeerAuth doesn't have "rules" but we set 1 for consistency
+	}
+	return analyzed
+}
+
+// analyzeRequestAuthentication classifies a RequestAuthentication as L7
+// JWT validation requires HTTP header parsing, only waypoint can do this
+func analyzeRequestAuthentication(ra *security_v1.RequestAuthentication, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	return AnalyzedPolicy{
+		ConfigType: "RequestAuthentication",
+		Name:       ra.Name,
+		Layer:      "L7",
+		Reason:     "RequestAuthentication validates JWT tokens (requires HTTP header parsing)",
+		Rules:      len(ra.Spec.JwtRules),
+		Warning:    ambientNoWaypointWarning(nsStatus, "This RequestAuthentication will NOT work."),
+	}
+}
+
+// analyzeVirtualService classifies a VirtualService as L7 (HTTP/TLS routes) or L4 (TCP-only routes)
+func analyzeVirtualService(vs *networking_v1.VirtualService, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	analyzed := AnalyzedPolicy{
+		ConfigType: "VirtualService",
+		Name:       vs.Name,
+		Rules:      countVirtualServiceRules(&vs.Spec),
+	}
+
+	// HTTP or TLS routes require waypoint (L7); TCP-only routes are L4
+	if len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0 {
+		analyzed.Layer = "L7"
+		analyzed.Reason = "VirtualService provides HTTP/TLS routing (traffic splitting, retries, timeouts, rewrites)"
+		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This VirtualService will NOT work.")
+	} else {
+		analyzed.Layer = "L4"
+		analyzed.Reason = "VirtualService only defines TCP routes (L4 load balancing, no HTTP features)"
+	}
+
+	return analyzed
+}
+
+// countVirtualServiceRules counts HTTP and TLS routes
+func countVirtualServiceRules(spec *networking_v1_api.VirtualService) int {
+	count := 0
+	for _, http := range spec.Http {
+		if http != nil {
+			count++
+		}
+	}
+	for _, tls := range spec.Tls {
+		if tls != nil {
+			count++
+		}
+	}
+	for _, tcp := range spec.Tcp {
+		if tcp != nil {
+			count++
+		}
+	}
+	return count
+}
+
+// analyzeDestinationRule classifies a DestinationRule as L4 or L7
+// Basic TLS settings are L4, but HTTP-specific features are L7
+func analyzeDestinationRule(dr *networking_v1.DestinationRule, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	isL7, reason := isL7DestinationRule(&dr.Spec)
+
+	analyzed := AnalyzedPolicy{
+		ConfigType: "DestinationRule",
+		Name:       dr.Name,
+		Rules:      1,
+	}
+
+	if isL7 {
+		analyzed.Layer = "L7"
+		analyzed.Reason = reason
+		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This DestinationRule's L7 features will NOT work.")
+	} else {
+		analyzed.Layer = "L4"
+		analyzed.Reason = "Only uses L4 features (basic TLS configuration)"
+	}
+
+	return analyzed
+}
+
+// isL7DestinationRule checks if a DestinationRule uses L7 features
+func isL7DestinationRule(spec *networking_v1_api.DestinationRule) (bool, string) {
+	// Check for HTTP-specific traffic policy
+	if spec.TrafficPolicy != nil {
+		tp := spec.TrafficPolicy
+
+		// Load balancer with consistent hash on HTTP headers/cookies
+		if tp.LoadBalancer != nil && tp.LoadBalancer.GetConsistentHash() != nil {
+			ch := tp.LoadBalancer.GetConsistentHash()
+			if ch.GetHttpHeaderName() != "" || ch.GetHttpCookie() != nil {
+				return true, "Uses HTTP-based load balancing (consistent hash on headers/cookies)"
+			}
+		}
+
+		// Connection pool settings for HTTP
+		if tp.ConnectionPool != nil && tp.ConnectionPool.Http != nil {
+			return true, "Uses HTTP connection pool settings"
+		}
+
+		// Circuit breaker with HTTP-specific settings
+		if tp.OutlierDetection != nil {
+			return true, "Uses circuit breaking/outlier detection (requires HTTP metrics)"
+		}
+	}
+
+	// Check subsets for HTTP-specific traffic policies
+	for _, subset := range spec.Subsets {
+		if subset.TrafficPolicy != nil {
+			tp := subset.TrafficPolicy
+
+			if tp.LoadBalancer != nil && tp.LoadBalancer.GetConsistentHash() != nil {
+				ch := tp.LoadBalancer.GetConsistentHash()
+				if ch.GetHttpHeaderName() != "" || ch.GetHttpCookie() != nil {
+					return true, "Uses HTTP-based load balancing in subset"
+				}
+			}
+
+			if tp.ConnectionPool != nil && tp.ConnectionPool.Http != nil {
+				return true, "Uses HTTP connection pool settings in subset"
+			}
+
+			if tp.OutlierDetection != nil {
+				return true, "Uses circuit breaking in subset"
+			}
+		}
+	}
+
+	// If only basic TLS or simple load balancing, it's L4
+	return false, ""
+}
+
+// analyzeWasmPlugin classifies a WasmPlugin as L7
+// WasmPlugins run in the HTTP filter chain
+func analyzeWasmPlugin(wp *extensions_v1alpha1.WasmPlugin, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	return AnalyzedPolicy{
+		ConfigType: "WasmPlugin",
+		Name:       wp.Name,
+		Layer:      "L7",
+		Reason:     "WasmPlugin processes HTTP requests (runs in waypoint's Envoy filter chain)",
+		Rules:      1,
+		Warning:    ambientNoWaypointWarning(nsStatus, "This WasmPlugin will NOT be loaded."),
+	}
+}
+
+// analyzeTelemetry classifies Telemetry as L4 or L7 depending on metrics type
+func analyzeTelemetry(tel *telemetry_v1.Telemetry, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	isL7, reason := isL7Telemetry(&tel.Spec)
+
+	analyzed := AnalyzedPolicy{
+		ConfigType: "Telemetry",
+		Name:       tel.Name,
+		Rules:      countTelemetryRules(&tel.Spec),
+	}
+
+	if isL7 {
+		analyzed.Layer = "L7"
+		analyzed.Reason = reason
+		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "L7 telemetry features will NOT work.")
+	} else {
+		analyzed.Layer = "L4"
+		analyzed.Reason = reason
+	}
+
+	return analyzed
+}
+
+// isL7Telemetry checks if Telemetry config requires L7 processing
+func isL7Telemetry(spec *telemetry_v1_api.Telemetry) (bool, string) {
+	// Check tracing - distributed tracing requires HTTP context propagation
+	if spec.Tracing != nil && len(spec.Tracing) > 0 {
+		return true, "Configures distributed tracing (requires HTTP header propagation)"
+	}
+
+	// Check access logging - typically includes HTTP-specific fields
+	if spec.AccessLogging != nil && len(spec.AccessLogging) > 0 {
+		return true, "Configures access logging (typically includes HTTP details)"
+	}
+
+	// Check for metrics overrides - if metrics are being customized, likely L7
+	for _, metric := range spec.Metrics {
+		if metric != nil && len(metric.Overrides) > 0 {
+			return true, "Collects customized HTTP metrics (request count, duration, status codes)"
+		}
+	}
+
+	// Basic TCP metrics only (connection counts, bytes transferred)
+	return false, "Only collects L4 metrics (TCP connections, bytes transferred)"
+}
+
+// countTelemetryRules counts telemetry configuration items
+func countTelemetryRules(spec *telemetry_v1_api.Telemetry) int {
+	count := 0
+	count += len(spec.Metrics)
+	count += len(spec.Tracing)
+	count += len(spec.AccessLogging)
+	return count
+}
+
+// generateOverallSummary creates a summary across multiple namespaces
+func generateOverallSummary(namespaceCount, totalL4, totalL7, totalL7WithoutWaypoint int) string {
+	if namespaceCount == 1 {
+		// For single namespace, the namespace-specific summary is sufficient
+		return ""
+	}
+
+	totalConfigs := totalL4 + totalL7
+
+	if totalConfigs == 0 {
+		return fmt.Sprintf("Analyzed %d namespaces. No Istio configurations found.", namespaceCount)
+	}
+
+	if totalL7WithoutWaypoint > 0 {
+		return fmt.Sprintf("Analyzed %d namespaces with %d total configs (%d L4, %d L7). WARNING: %d L7 configs are in namespaces without waypoints and will NOT work!",
+			namespaceCount, totalConfigs, totalL4, totalL7, totalL7WithoutWaypoint)
+	}
+
+	return fmt.Sprintf("Analyzed %d namespaces with %d total configs (%d L4, %d L7). All L7 configs are in namespaces with waypoints.",
+		namespaceCount, totalConfigs, totalL4, totalL7)
 }

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -594,12 +594,12 @@ func analyzeTelemetry(tel *telemetry_v1.Telemetry, nsStatus NamespaceAmbientStat
 // isL7Telemetry checks if Telemetry config requires L7 processing
 func isL7Telemetry(spec *telemetry_v1_api.Telemetry) (bool, string) {
 	// Check tracing - distributed tracing requires HTTP context propagation
-	if spec.Tracing != nil && len(spec.Tracing) > 0 {
+	if len(spec.Tracing) > 0 {
 		return true, "Configures distributed tracing (requires HTTP header propagation)"
 	}
 
 	// Check access logging - typically includes HTTP-specific fields
-	if spec.AccessLogging != nil && len(spec.AccessLogging) > 0 {
+	if len(spec.AccessLogging) > 0 {
 		return true, "Configures access logging (typically includes HTTP details)"
 	}
 

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -14,28 +14,28 @@ import (
 
 // PolicyAnalysisResponse is the output of the analyze_ambient_policies tool
 type PolicyAnalysisResponse struct {
-	Summary         string                 `json:"summary"`
 	NamespaceStatus NamespaceAmbientStatus `json:"namespace_status"`
 	Policies        []AnalyzedPolicy       `json:"policies"`
 	Recommendations []string               `json:"recommendations,omitempty"`
+	Summary         string                 `json:"summary"`
 }
 
 // NamespaceAmbientStatus describes the Ambient configuration of the namespace
 type NamespaceAmbientStatus struct {
-	Name         string `json:"name"`
 	Cluster      string `json:"cluster"`
-	IsAmbient    bool   `json:"is_ambient"`
 	HasWaypoint  bool   `json:"has_waypoint"`
+	IsAmbient    bool   `json:"is_ambient"`
+	Name         string `json:"name"`
 	WaypointName string `json:"waypoint_name,omitempty"`
 }
 
 // AnalyzedPolicy contains the classification and warnings for a single AuthorizationPolicy
 type AnalyzedPolicy struct {
-	Name    string `json:"name"`
 	Layer   string `json:"layer"` // "L4" or "L7"
+	Name    string `json:"name"`
 	Reason  string `json:"reason"`
-	Warning string `json:"warning,omitempty"`
 	Rules   int    `json:"rules_count"`
+	Warning string `json:"warning,omitempty"`
 }
 
 func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -112,25 +112,15 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}, http.StatusOK
 }
 
-// checkNamespaceWaypoint checks if the namespace has a waypoint proxy configured
+// checkNamespaceWaypoint checks if the namespace has a waypoint proxy configured.
+// It uses GetWaypoints (cached) instead of GetWorkloadList to avoid loading all workload details.
 func checkNamespaceWaypoint(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (bool, string) {
-	// Get workloads in the namespace to find waypoint proxies
-	criteria := business.WorkloadCriteria{
-		Namespace: namespace,
-		Cluster:   cluster,
-	}
-	workloads, err := businessLayer.Workload.GetWorkloadList(ctx, criteria)
-	if err != nil {
-		return false, ""
-	}
-
-	// Look for waypoint workloads
-	for _, wl := range workloads.Workloads {
-		if wl.IsWaypoint {
+	waypoints := businessLayer.Workload.GetWaypoints(ctx)
+	for _, wl := range waypoints {
+		if wl.Namespace == namespace && wl.Cluster == cluster {
 			return true, wl.Name
 		}
 	}
-
 	return false, ""
 }
 

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -85,7 +85,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	l7WithoutWaypointCount := 0
 
 	for _, ap := range istioConfigs.AuthorizationPolicies {
-		analyzed := analyzeAuthorizationPolicy(*ap, nsStatus)
+		analyzed := analyzeAuthorizationPolicy(ap, nsStatus)
 		analyzedPolicies = append(analyzedPolicies, analyzed)
 
 		if analyzed.Layer == "L7" {
@@ -125,7 +125,7 @@ func checkNamespaceWaypoint(ctx context.Context, businessLayer *business.Layer, 
 }
 
 // analyzeAuthorizationPolicy classifies a policy as L4 or L7
-func analyzeAuthorizationPolicy(ap security_v1.AuthorizationPolicy, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+func analyzeAuthorizationPolicy(ap *security_v1.AuthorizationPolicy, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
 	isL7, reason := isL7Policy(&ap.Spec)
 
 	analyzed := AnalyzedPolicy{

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -467,13 +467,13 @@ func analyzeVirtualService(vs *networking_v1.VirtualService, nsStatus NamespaceA
 		Rules:      countVirtualServiceRules(&vs.Spec),
 	}
 
-	isHTTPortTLS := len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0
+	hasHTTPOrTLS := len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0
 
-	if isHTTPortTLS && appliesToMeshTraffic(vs.Spec.Gateways) {
+	if hasHTTPOrTLS && appliesToMeshTraffic(vs.Spec.Gateways) {
 		analyzed.Layer = "L7"
 		analyzed.Reason = "VirtualService provides HTTP/TLS routing for mesh traffic (requires waypoint)"
 		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This VirtualService will NOT work.")
-	} else if isHTTPortTLS {
+	} else if hasHTTPOrTLS {
 		analyzed.Layer = "L7"
 		analyzed.Reason = "VirtualService provides HTTP/TLS routing via ingress/egress Gateway (no waypoint needed)"
 	} else {

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -1,0 +1,275 @@
+package analyze_ambient_policies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	security_v1_api "istio.io/api/security/v1"
+	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+
+	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/business"
+)
+
+// PolicyAnalysisResponse is the output of the analyze_ambient_policies tool
+type PolicyAnalysisResponse struct {
+	Summary         string                 `json:"summary"`
+	NamespaceStatus NamespaceAmbientStatus `json:"namespace_status"`
+	Policies        []AnalyzedPolicy       `json:"policies"`
+	Recommendations []string               `json:"recommendations,omitempty"`
+}
+
+// NamespaceAmbientStatus describes the Ambient configuration of the namespace
+type NamespaceAmbientStatus struct {
+	Name         string `json:"name"`
+	Cluster      string `json:"cluster"`
+	IsAmbient    bool   `json:"is_ambient"`
+	HasWaypoint  bool   `json:"has_waypoint"`
+	WaypointName string `json:"waypoint_name,omitempty"`
+}
+
+// AnalyzedPolicy contains the classification and warnings for a single AuthorizationPolicy
+type AnalyzedPolicy struct {
+	Name    string `json:"name"`
+	Layer   string `json:"layer"` // "L4" or "L7"
+	Reason  string `json:"reason"`
+	Warning string `json:"warning,omitempty"`
+	Rules   int    `json:"rules_count"`
+}
+
+func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
+	ctx := kialiInterface.Request.Context()
+	namespace := mcputil.GetStringArg(args, "namespace")
+	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
+
+	if namespace == "" {
+		return "namespace parameter is required", http.StatusBadRequest
+	}
+
+	// Validate namespace access
+	if errMsg, statusCode := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
+		return errMsg, statusCode
+	}
+
+	// Get namespace details to check if it's Ambient
+	namespaceInfo, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespace(ctx, namespace, clusterName)
+	if err != nil {
+		return fmt.Sprintf("failed to get namespace info: %v", err), http.StatusInternalServerError
+	}
+
+	// Check if namespace has waypoint
+	hasWaypoint, waypointName := checkNamespaceWaypoint(ctx, kialiInterface.BusinessLayer, namespace, clusterName)
+
+	nsStatus := NamespaceAmbientStatus{
+		Name:         namespace,
+		Cluster:      clusterName,
+		IsAmbient:    namespaceInfo.IsAmbient,
+		HasWaypoint:  hasWaypoint,
+		WaypointName: waypointName,
+	}
+
+	// Get AuthorizationPolicies
+	criteria := business.IstioConfigCriteria{
+		IncludeAuthorizationPolicies: true,
+	}
+	istioConfigs, err := kialiInterface.BusinessLayer.IstioConfig.GetIstioConfigListForNamespace(ctx, clusterName, namespace, criteria)
+	if err != nil {
+		return fmt.Sprintf("failed to get AuthorizationPolicies: %v", err), http.StatusInternalServerError
+	}
+
+	// Analyze policies
+	analyzedPolicies := make([]AnalyzedPolicy, 0)
+	l4Count := 0
+	l7Count := 0
+	l7WithoutWaypointCount := 0
+
+	for _, ap := range istioConfigs.AuthorizationPolicies {
+		analyzed := analyzeAuthorizationPolicy(*ap, nsStatus)
+		analyzedPolicies = append(analyzedPolicies, analyzed)
+
+		if analyzed.Layer == "L7" {
+			l7Count++
+			if analyzed.Warning != "" {
+				l7WithoutWaypointCount++
+			}
+		} else {
+			l4Count++
+		}
+	}
+
+	// Generate summary
+	summary := generateSummary(l4Count, l7Count, l7WithoutWaypointCount, nsStatus)
+
+	// Generate recommendations
+	recommendations := generateRecommendations(nsStatus, l7Count, l7WithoutWaypointCount)
+
+	return PolicyAnalysisResponse{
+		Summary:         summary,
+		NamespaceStatus: nsStatus,
+		Policies:        analyzedPolicies,
+		Recommendations: recommendations,
+	}, http.StatusOK
+}
+
+// checkNamespaceWaypoint checks if the namespace has a waypoint proxy configured
+func checkNamespaceWaypoint(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (bool, string) {
+	// Get workloads in the namespace to find waypoint proxies
+	criteria := business.WorkloadCriteria{
+		Namespace: namespace,
+		Cluster:   cluster,
+	}
+	workloads, err := businessLayer.Workload.GetWorkloadList(ctx, criteria)
+	if err != nil {
+		return false, ""
+	}
+
+	// Look for waypoint workloads
+	for _, wl := range workloads.Workloads {
+		if wl.IsWaypoint {
+			return true, wl.Name
+		}
+	}
+
+	return false, ""
+}
+
+// analyzeAuthorizationPolicy classifies a policy as L4 or L7
+func analyzeAuthorizationPolicy(ap security_v1.AuthorizationPolicy, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
+	isL7, reason := isL7Policy(&ap.Spec)
+
+	analyzed := AnalyzedPolicy{
+		Name:  ap.Name,
+		Rules: len(ap.Spec.Rules),
+	}
+
+	if isL7 {
+		analyzed.Layer = "L7"
+		analyzed.Reason = reason
+
+		// Generate warning if namespace is Ambient but has no waypoint
+		if nsStatus.IsAmbient && !nsStatus.HasWaypoint {
+			analyzed.Warning = fmt.Sprintf("Namespace '%s' is in Ambient mode but has NO waypoint. This L7 policy will NOT be enforced.", nsStatus.Name)
+		}
+	} else {
+		analyzed.Layer = "L4"
+		analyzed.Reason = "Only uses L4 fields (source/destination principals, IPs, ports, namespaces)"
+	}
+
+	return analyzed
+}
+
+// isL7Policy determines if an AuthorizationPolicy requires L7 (waypoint) enforcement
+func isL7Policy(spec *security_v1_api.AuthorizationPolicy) (bool, string) {
+	if spec == nil || len(spec.Rules) == 0 {
+		return false, ""
+	}
+
+	// Check for L7-specific fields in rules
+	for _, rule := range spec.Rules {
+		// Check 'when' conditions for L7 fields
+		for _, condition := range rule.When {
+			if isL7Condition(condition.Key) {
+				return true, fmt.Sprintf("Uses L7 condition: %s", condition.Key)
+			}
+		}
+
+		// Check 'to' operations for HTTP-specific fields
+		for _, to := range rule.To {
+			if to.Operation != nil {
+				if len(to.Operation.Methods) > 0 {
+					return true, "Uses HTTP methods field"
+				}
+				if len(to.Operation.Paths) > 0 {
+					return true, "Uses HTTP paths field"
+				}
+				if len(to.Operation.Hosts) > 0 {
+					return true, "Uses HTTP hosts field"
+				}
+			}
+		}
+
+		// Check 'from' for request principals (JWT-based, requires L7)
+		for _, from := range rule.From {
+			if from.Source != nil && len(from.Source.RequestPrincipals) > 0 {
+				return true, "Uses request principals (JWT)"
+			}
+		}
+	}
+
+	// If none of the above L7 indicators are found, it's L4
+	return false, ""
+}
+
+// isL7Condition checks if a 'when' condition key requires L7 processing
+func isL7Condition(key string) bool {
+	l7Prefixes := []string{
+		"request.headers",
+		"request.auth.claims",
+		"request.auth.principal",
+		"request.auth.audiences",
+		"request.auth.presenter",
+		"destination.port",
+	}
+
+	for _, prefix := range l7Prefixes {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			return true
+		}
+	}
+
+	return false
+}
+
+// generateSummary creates a human-readable summary
+func generateSummary(l4Count, l7Count, l7WithoutWaypoint int, nsStatus NamespaceAmbientStatus) string {
+	total := l4Count + l7Count
+
+	if total == 0 {
+		return fmt.Sprintf("No AuthorizationPolicies found in namespace '%s'", nsStatus.Name)
+	}
+
+	if !nsStatus.IsAmbient {
+		return fmt.Sprintf("Found %d policies (%d L4, %d L7). Namespace is NOT in Ambient mode - policies enforced by sidecars.", total, l4Count, l7Count)
+	}
+
+	if l7WithoutWaypoint > 0 {
+		return fmt.Sprintf("Found %d policies (%d L4, %d L7). WARNING: %d L7 policies require a waypoint but namespace has NONE - these will NOT be enforced!", total, l4Count, l7Count, l7WithoutWaypoint)
+	}
+
+	if l7Count > 0 && nsStatus.HasWaypoint {
+		return fmt.Sprintf("Found %d policies (%d L4, %d L7). All L7 policies will be enforced by waypoint '%s'.", total, l4Count, l7Count, nsStatus.WaypointName)
+	}
+
+	return fmt.Sprintf("Found %d L4 policies. All will be enforced by ztunnel.", l4Count)
+}
+
+// generateRecommendations provides actionable next steps
+func generateRecommendations(nsStatus NamespaceAmbientStatus, l7Count, l7WithoutWaypoint int) []string {
+	recommendations := make([]string, 0)
+
+	if !nsStatus.IsAmbient {
+		return []string{
+			fmt.Sprintf("Namespace '%s' is not in Ambient mode. Enable Ambient by labeling the namespace with 'istio.io/dataplane-mode=ambient'.", nsStatus.Name),
+		}
+	}
+
+	if l7WithoutWaypoint > 0 {
+		recommendations = append(recommendations,
+			fmt.Sprintf("Deploy a waypoint proxy in namespace '%s' to enforce L7 policies. Use 'istioctl waypoint apply' or create a Gateway resource.", nsStatus.Name),
+			"After deploying the waypoint, verify policies are enforced by checking metrics or testing the protected endpoints.",
+		)
+	}
+
+	if l7Count == 0 && nsStatus.HasWaypoint {
+		recommendations = append(recommendations,
+			"All policies are L4-only. Consider removing the waypoint proxy to reduce resource usage if L7 features are not needed.",
+		)
+	}
+
+	if len(recommendations) == 0 {
+		recommendations = append(recommendations, "No issues found. All policies are correctly configured for Ambient mode.")
+	}
+
+	return recommendations
+}

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies.go
@@ -13,9 +13,11 @@ import (
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	telemetry_v1 "istio.io/client-go/pkg/apis/telemetry/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/models"
 )
 
 // PolicyAnalysisResponse is the output of the analyze_ambient_policies tool
@@ -97,19 +99,25 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		}
 	}
 
-	// Analyze each namespace
+	// Analyze each namespace, recording per-namespace errors instead of aborting the whole request.
 	namespaceResults := make([]NamespaceAnalysis, 0, len(namespacesToAnalyze))
 	totalL4 := 0
 	totalL7 := 0
 	totalL7WithoutWaypoint := 0
 
 	for _, namespace := range namespacesToAnalyze {
-		// Validate namespace access
-		if errMsg, statusCode := mcputil.ValidateNamespaceAccess(ctx, kialiInterface.BusinessLayer, namespace, clusterName); errMsg != "" {
-			return fmt.Sprintf("namespace '%s': %s", namespace, errMsg), statusCode
+		// Fetch and validate namespace access in one call to avoid a double lookup.
+		nsInfo, errMsg := getValidatedNamespace(ctx, kialiInterface.BusinessLayer, namespace, clusterName)
+		if errMsg != "" {
+			// Record the error per-namespace instead of aborting the entire batch.
+			namespaceResults = append(namespaceResults, NamespaceAnalysis{
+				NamespaceStatus: NamespaceAmbientStatus{Name: namespace, Cluster: clusterName},
+				Summary:         fmt.Sprintf("Error: %s", errMsg),
+			})
+			continue
 		}
 
-		result := analyzeNamespace(ctx, kialiInterface, namespace, clusterName)
+		result := analyzeNamespace(ctx, kialiInterface, nsInfo, clusterName)
 		namespaceResults = append(namespaceResults, result)
 
 		// Count L4/L7 across all namespaces
@@ -134,17 +142,26 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}, http.StatusOK
 }
 
-// analyzeNamespace performs the analysis for a single namespace
-func analyzeNamespace(ctx context.Context, kialiInterface *mcputil.KialiInterface, namespace, clusterName string) NamespaceAnalysis {
-	// Get namespace details to check if it's Ambient
-	namespaceInfo, err := kialiInterface.BusinessLayer.Namespace.GetClusterNamespace(ctx, namespace, clusterName)
+// getValidatedNamespace fetches the namespace and validates access in a single API call.
+// Returns the namespace info and an empty error string on success, or nil and a message on failure.
+func getValidatedNamespace(ctx context.Context, businessLayer *business.Layer, namespace, cluster string) (*models.Namespace, string) {
+	nsInfo, err := businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster)
 	if err != nil {
-		// Return an error result
-		return NamespaceAnalysis{
-			NamespaceStatus: NamespaceAmbientStatus{Name: namespace, Cluster: clusterName},
-			Summary:         fmt.Sprintf("Error: failed to get namespace info: %v", err),
+		switch {
+		case business.IsAccessibleError(err), k8serrors.IsForbidden(err), k8serrors.IsUnauthorized(err):
+			return nil, fmt.Sprintf("namespace %q is not accessible in cluster %q", namespace, cluster)
+		case k8serrors.IsNotFound(err):
+			return nil, fmt.Sprintf("namespace %q does not exist in cluster %q", namespace, cluster)
+		default:
+			return nil, fmt.Sprintf("failed to get namespace %q in cluster %q: %v", namespace, cluster, err)
 		}
 	}
+	return nsInfo, ""
+}
+
+// analyzeNamespace performs the analysis for a single namespace using an already-fetched namespace object.
+func analyzeNamespace(ctx context.Context, kialiInterface *mcputil.KialiInterface, namespaceInfo *models.Namespace, clusterName string) NamespaceAnalysis {
+	namespace := namespaceInfo.Name
 
 	// Check if namespace has waypoint
 	hasWaypoint, waypointName := checkNamespaceWaypoint(ctx, kialiInterface.BusinessLayer, namespace, clusterName)
@@ -440,7 +457,9 @@ func analyzeRequestAuthentication(ra *security_v1.RequestAuthentication, nsStatu
 	}
 }
 
-// analyzeVirtualService classifies a VirtualService as L7 (HTTP/TLS routes) or L4 (TCP-only routes)
+// analyzeVirtualService classifies a VirtualService as L7 (HTTP/TLS routes) or L4 (TCP-only routes).
+// A waypoint warning is only emitted when the VS applies to mesh (east-west) traffic. VirtualServices
+// targeting only named ingress/egress Gateways are processed by those Gateways, not by a waypoint.
 func analyzeVirtualService(vs *networking_v1.VirtualService, nsStatus NamespaceAmbientStatus) AnalyzedPolicy {
 	analyzed := AnalyzedPolicy{
 		ConfigType: "VirtualService",
@@ -448,17 +467,36 @@ func analyzeVirtualService(vs *networking_v1.VirtualService, nsStatus NamespaceA
 		Rules:      countVirtualServiceRules(&vs.Spec),
 	}
 
-	// HTTP or TLS routes require waypoint (L7); TCP-only routes are L4
-	if len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0 {
+	isHTTPortTLS := len(vs.Spec.Http) > 0 || len(vs.Spec.Tls) > 0
+
+	if isHTTPortTLS && appliesToMeshTraffic(vs.Spec.Gateways) {
 		analyzed.Layer = "L7"
-		analyzed.Reason = "VirtualService provides HTTP/TLS routing (traffic splitting, retries, timeouts, rewrites)"
+		analyzed.Reason = "VirtualService provides HTTP/TLS routing for mesh traffic (requires waypoint)"
 		analyzed.Warning = ambientNoWaypointWarning(nsStatus, "This VirtualService will NOT work.")
+	} else if isHTTPortTLS {
+		analyzed.Layer = "L7"
+		analyzed.Reason = "VirtualService provides HTTP/TLS routing via ingress/egress Gateway (no waypoint needed)"
 	} else {
 		analyzed.Layer = "L4"
 		analyzed.Reason = "VirtualService only defines TCP routes (L4 load balancing, no HTTP features)"
 	}
 
 	return analyzed
+}
+
+// appliesToMeshTraffic reports whether a VirtualService targets in-mesh (east-west) traffic.
+// A VS applies to mesh traffic when spec.gateways is empty (default) or contains the reserved
+// value "mesh". VSes that only reference named ingress/egress Gateways do not need a waypoint.
+func appliesToMeshTraffic(gateways []string) bool {
+	if len(gateways) == 0 {
+		return true // default: applies to mesh
+	}
+	for _, gw := range gateways {
+		if gw == "mesh" {
+			return true
+		}
+	}
+	return false
 }
 
 // countVirtualServiceRules counts HTTP and TLS routes

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
@@ -1,0 +1,212 @@
+package analyze_ambient_policies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	security_v1_api "istio.io/api/security/v1"
+)
+
+func TestIsL7Policy_HTTPMethods(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				To: []*security_v1_api.Rule_To{
+					{
+						Operation: &security_v1_api.Operation{
+							Methods: []string{"GET", "POST"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.True(t, isL7, "Policy with HTTP methods should be L7")
+	assert.Equal(t, "Uses HTTP methods field", reason)
+}
+
+func TestIsL7Policy_HTTPPaths(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				To: []*security_v1_api.Rule_To{
+					{
+						Operation: &security_v1_api.Operation{
+							Paths: []string{"/api/*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.True(t, isL7, "Policy with HTTP paths should be L7")
+	assert.Equal(t, "Uses HTTP paths field", reason)
+}
+
+func TestIsL7Policy_RequestHeaders(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				When: []*security_v1_api.Condition{
+					{
+						Key:    "request.headers[x-custom]",
+						Values: []string{"value"},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.True(t, isL7, "Policy with request.headers should be L7")
+	assert.Contains(t, reason, "request.headers")
+}
+
+func TestIsL7Policy_JWTClaims(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				When: []*security_v1_api.Condition{
+					{
+						Key:    "request.auth.claims[iss]",
+						Values: []string{"https://issuer.example.com"},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.True(t, isL7, "Policy with JWT claims should be L7")
+	assert.Contains(t, reason, "request.auth.claims")
+}
+
+func TestIsL7Policy_RequestPrincipals(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				From: []*security_v1_api.Rule_From{
+					{
+						Source: &security_v1_api.Source{
+							RequestPrincipals: []string{"cluster.local/ns/default/sa/myapp"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.True(t, isL7, "Policy with request principals should be L7")
+	assert.Equal(t, "Uses request principals (JWT)", reason)
+}
+
+func TestIsL7Policy_L4Only(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{
+			{
+				From: []*security_v1_api.Rule_From{
+					{
+						Source: &security_v1_api.Source{
+							Principals: []string{"cluster.local/ns/default/sa/myapp"},
+							Namespaces: []string{"default"},
+						},
+					},
+				},
+				To: []*security_v1_api.Rule_To{
+					{
+						Operation: &security_v1_api.Operation{
+							Ports: []string{"8080"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.False(t, isL7, "Policy with only L4 fields should NOT be L7")
+	assert.Empty(t, reason)
+}
+
+func TestIsL7Policy_EmptyPolicy(t *testing.T) {
+	spec := &security_v1_api.AuthorizationPolicy{
+		Rules: []*security_v1_api.Rule{},
+	}
+
+	isL7, reason := isL7Policy(spec)
+	assert.False(t, isL7, "Empty policy should not be L7")
+	assert.Empty(t, reason)
+}
+
+func TestIsL7Policy_NilPolicy(t *testing.T) {
+	isL7, reason := isL7Policy(nil)
+	assert.False(t, isL7, "Nil policy should not be L7")
+	assert.Empty(t, reason)
+}
+
+func TestGenerateSummary_NoAmbient(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{
+		Name:      "test-ns",
+		IsAmbient: false,
+	}
+
+	summary := generateSummary(2, 3, 0, nsStatus)
+	assert.Contains(t, summary, "NOT in Ambient mode")
+	assert.Contains(t, summary, "sidecars")
+}
+
+func TestGenerateSummary_AmbientWithWaypoint(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{
+		Name:         "test-ns",
+		IsAmbient:    true,
+		HasWaypoint:  true,
+		WaypointName: "waypoint-proxy",
+	}
+
+	summary := generateSummary(1, 2, 0, nsStatus)
+	assert.Contains(t, summary, "waypoint-proxy")
+	assert.NotContains(t, summary, "WARNING")
+}
+
+func TestGenerateSummary_AmbientWithoutWaypoint(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{
+		Name:        "test-ns",
+		IsAmbient:   true,
+		HasWaypoint: false,
+	}
+
+	summary := generateSummary(1, 2, 2, nsStatus)
+	assert.Contains(t, summary, "WARNING")
+	assert.Contains(t, summary, "will NOT be enforced")
+}
+
+func TestGenerateRecommendations_NeedWaypoint(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{
+		Name:        "test-ns",
+		IsAmbient:   true,
+		HasWaypoint: false,
+	}
+
+	recommendations := generateRecommendations(nsStatus, 2, 2)
+	assert.NotEmpty(t, recommendations)
+	assert.Contains(t, recommendations[0], "Deploy a waypoint")
+	assert.Contains(t, recommendations[0], "istioctl waypoint apply")
+}
+
+func TestGenerateRecommendations_NoIssues(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{
+		Name:         "test-ns",
+		IsAmbient:    true,
+		HasWaypoint:  true,
+		WaypointName: "waypoint-proxy",
+	}
+
+	recommendations := generateRecommendations(nsStatus, 2, 0)
+	assert.NotEmpty(t, recommendations)
+	assert.Contains(t, recommendations[0], "No issues found")
+}

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	networking_v1_api "istio.io/api/networking/v1"
 	security_v1_api "istio.io/api/security/v1"
+	telemetry_v1_api "istio.io/api/telemetry/v1"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsL7Policy_HTTPMethods(t *testing.T) {
@@ -182,7 +186,7 @@ func TestGenerateSummary_AmbientWithoutWaypoint(t *testing.T) {
 
 	summary := generateSummary(1, 2, 2, nsStatus)
 	assert.Contains(t, summary, "WARNING")
-	assert.Contains(t, summary, "will NOT be enforced")
+	assert.Contains(t, summary, "will NOT work!")
 }
 
 func TestGenerateRecommendations_NeedWaypoint(t *testing.T) {
@@ -209,4 +213,185 @@ func TestGenerateRecommendations_NoIssues(t *testing.T) {
 	recommendations := generateRecommendations(nsStatus, 2, 0)
 	assert.NotEmpty(t, recommendations)
 	assert.Contains(t, recommendations[0], "No issues found")
+}
+
+// --- isL7Condition tests ---
+
+func TestIsL7Condition_DestinationPortIsL4(t *testing.T) {
+	assert.False(t, isL7Condition("destination.port"), "destination.port should be L4 (processed by ztunnel)")
+}
+
+func TestIsL7Condition_RequestHeaders(t *testing.T) {
+	assert.True(t, isL7Condition("request.headers[x-forwarded-for]"))
+}
+
+func TestIsL7Condition_RequestAuthClaims(t *testing.T) {
+	assert.True(t, isL7Condition("request.auth.claims[iss]"))
+}
+
+// --- isL7DestinationRule tests ---
+
+func TestIsL7DestinationRule_HTTPConnectionPool(t *testing.T) {
+	spec := &networking_v1_api.DestinationRule{
+		TrafficPolicy: &networking_v1_api.TrafficPolicy{
+			ConnectionPool: &networking_v1_api.ConnectionPoolSettings{
+				Http: &networking_v1_api.ConnectionPoolSettings_HTTPSettings{
+					Http1MaxPendingRequests: 1024,
+				},
+			},
+		},
+	}
+	isL7, reason := isL7DestinationRule(spec)
+	assert.True(t, isL7)
+	assert.Contains(t, reason, "HTTP connection pool")
+}
+
+func TestIsL7DestinationRule_HTTPConsistentHash(t *testing.T) {
+	spec := &networking_v1_api.DestinationRule{
+		TrafficPolicy: &networking_v1_api.TrafficPolicy{
+			LoadBalancer: &networking_v1_api.LoadBalancerSettings{
+				LbPolicy: &networking_v1_api.LoadBalancerSettings_ConsistentHash{
+					ConsistentHash: &networking_v1_api.LoadBalancerSettings_ConsistentHashLB{
+						HashKey: &networking_v1_api.LoadBalancerSettings_ConsistentHashLB_HttpHeaderName{
+							HttpHeaderName: "x-user",
+						},
+					},
+				},
+			},
+		},
+	}
+	isL7, reason := isL7DestinationRule(spec)
+	assert.True(t, isL7)
+	assert.Contains(t, reason, "HTTP-based load balancing")
+}
+
+func TestIsL7DestinationRule_L4Only(t *testing.T) {
+	spec := &networking_v1_api.DestinationRule{
+		TrafficPolicy: &networking_v1_api.TrafficPolicy{
+			Tls: &networking_v1_api.ClientTLSSettings{
+				Mode: networking_v1_api.ClientTLSSettings_ISTIO_MUTUAL,
+			},
+		},
+	}
+	isL7, _ := isL7DestinationRule(spec)
+	assert.False(t, isL7, "DestinationRule with only TLS settings should be L4")
+}
+
+func TestIsL7DestinationRule_Empty(t *testing.T) {
+	spec := &networking_v1_api.DestinationRule{}
+	isL7, _ := isL7DestinationRule(spec)
+	assert.False(t, isL7)
+}
+
+// --- isL7Telemetry tests ---
+
+func TestIsL7Telemetry_Tracing(t *testing.T) {
+	spec := &telemetry_v1_api.Telemetry{
+		Tracing: []*telemetry_v1_api.Tracing{
+			{DisableSpanReporting: nil},
+		},
+	}
+	isL7, reason := isL7Telemetry(spec)
+	assert.True(t, isL7)
+	assert.Contains(t, reason, "tracing")
+}
+
+func TestIsL7Telemetry_AccessLogging(t *testing.T) {
+	spec := &telemetry_v1_api.Telemetry{
+		AccessLogging: []*telemetry_v1_api.AccessLogging{
+			{},
+		},
+	}
+	isL7, reason := isL7Telemetry(spec)
+	assert.True(t, isL7)
+	assert.Contains(t, reason, "access logging")
+}
+
+func TestIsL7Telemetry_MetricOverrides(t *testing.T) {
+	spec := &telemetry_v1_api.Telemetry{
+		Metrics: []*telemetry_v1_api.Metrics{
+			{
+				Overrides: []*telemetry_v1_api.MetricsOverrides{
+					{},
+				},
+			},
+		},
+	}
+	isL7, reason := isL7Telemetry(spec)
+	assert.True(t, isL7)
+	assert.Contains(t, reason, "HTTP metrics")
+}
+
+func TestIsL7Telemetry_L4Only(t *testing.T) {
+	spec := &telemetry_v1_api.Telemetry{}
+	isL7, reason := isL7Telemetry(spec)
+	assert.False(t, isL7)
+	assert.Contains(t, reason, "L4 metrics")
+}
+
+// --- analyzeVirtualService tests ---
+
+func TestAnalyzeVirtualService_HTTPRoutes_IsL7(t *testing.T) {
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vs"},
+		Spec: networking_v1_api.VirtualService{
+			Http: []*networking_v1_api.HTTPRoute{
+				{Name: "route-1"},
+			},
+		},
+	}
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: true, WaypointName: "waypoint"}
+	result := analyzeVirtualService(vs, nsStatus)
+	assert.Equal(t, "L7", result.Layer)
+	assert.Empty(t, result.Warning, "No warning expected when waypoint exists")
+}
+
+func TestAnalyzeVirtualService_TCPOnly_IsL4(t *testing.T) {
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "tcp-vs"},
+		Spec: networking_v1_api.VirtualService{
+			Tcp: []*networking_v1_api.TCPRoute{
+				{},
+			},
+		},
+	}
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
+	result := analyzeVirtualService(vs, nsStatus)
+	assert.Equal(t, "L4", result.Layer, "TCP-only VirtualService should be L4")
+	assert.Empty(t, result.Warning, "No warning for L4 config without waypoint")
+}
+
+func TestAnalyzeVirtualService_HTTPNoWaypoint_HasWarning(t *testing.T) {
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vs"},
+		Spec: networking_v1_api.VirtualService{
+			Http: []*networking_v1_api.HTTPRoute{
+				{Name: "route-1"},
+			},
+		},
+	}
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
+	result := analyzeVirtualService(vs, nsStatus)
+	assert.Equal(t, "L7", result.Layer)
+	assert.NotEmpty(t, result.Warning)
+	assert.Contains(t, result.Warning, "NO waypoint")
+}
+
+// --- ambientNoWaypointWarning tests ---
+
+func TestAmbientNoWaypointWarning_NotAmbient(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: false}
+	assert.Empty(t, ambientNoWaypointWarning(nsStatus, "consequence"))
+}
+
+func TestAmbientNoWaypointWarning_AmbientWithWaypoint(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: true}
+	assert.Empty(t, ambientNoWaypointWarning(nsStatus, "consequence"))
+}
+
+func TestAmbientNoWaypointWarning_AmbientNoWaypoint(t *testing.T) {
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
+	warning := ambientNoWaypointWarning(nsStatus, "Things will break.")
+	assert.Contains(t, warning, "NO waypoint")
+	assert.Contains(t, warning, "Things will break.")
 }

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
@@ -368,6 +368,7 @@ func TestAnalyzeVirtualService_HTTPNoWaypoint_HasWarning(t *testing.T) {
 			Http: []*networking_v1_api.HTTPRoute{
 				{Name: "route-1"},
 			},
+			// No gateways → applies to mesh traffic → needs waypoint
 		},
 	}
 	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
@@ -375,6 +376,56 @@ func TestAnalyzeVirtualService_HTTPNoWaypoint_HasWarning(t *testing.T) {
 	assert.Equal(t, "L7", result.Layer)
 	assert.NotEmpty(t, result.Warning)
 	assert.Contains(t, result.Warning, "NO waypoint")
+}
+
+func TestAnalyzeVirtualService_IngressGatewayOnly_NoWarning(t *testing.T) {
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress-vs"},
+		Spec: networking_v1_api.VirtualService{
+			Gateways: []string{"my-ingress-gateway"},
+			Http: []*networking_v1_api.HTTPRoute{
+				{Name: "route-1"},
+			},
+		},
+	}
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
+	result := analyzeVirtualService(vs, nsStatus)
+	assert.Equal(t, "L7", result.Layer)
+	assert.Empty(t, result.Warning, "VS targeting ingress Gateway should NOT warn about missing waypoint")
+	assert.Contains(t, result.Reason, "ingress/egress Gateway")
+}
+
+func TestAnalyzeVirtualService_MeshAndGateway_HasWarning(t *testing.T) {
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "mesh-and-ingress-vs"},
+		Spec: networking_v1_api.VirtualService{
+			Gateways: []string{"mesh", "my-ingress-gateway"},
+			Http: []*networking_v1_api.HTTPRoute{
+				{Name: "route-1"},
+			},
+		},
+	}
+	nsStatus := NamespaceAmbientStatus{Name: "test-ns", IsAmbient: true, HasWaypoint: false}
+	result := analyzeVirtualService(vs, nsStatus)
+	assert.Equal(t, "L7", result.Layer)
+	assert.NotEmpty(t, result.Warning, "VS targeting both mesh and Gateway still needs waypoint for mesh traffic")
+}
+
+// --- appliesToMeshTraffic tests ---
+
+func TestAppliesToMeshTraffic_Empty(t *testing.T) {
+	assert.True(t, appliesToMeshTraffic(nil), "empty gateways defaults to mesh")
+	assert.True(t, appliesToMeshTraffic([]string{}))
+}
+
+func TestAppliesToMeshTraffic_ExplicitMesh(t *testing.T) {
+	assert.True(t, appliesToMeshTraffic([]string{"mesh"}))
+	assert.True(t, appliesToMeshTraffic([]string{"mesh", "my-gateway"}))
+}
+
+func TestAppliesToMeshTraffic_IngressOnly(t *testing.T) {
+	assert.False(t, appliesToMeshTraffic([]string{"my-ingress-gateway"}))
+	assert.False(t, appliesToMeshTraffic([]string{"ingress-gw", "egress-gw"}))
 }
 
 // --- ambientNoWaypointWarning tests ---

--- a/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
+++ b/ai/mcp/analyze_ambient_policies/analyze_ambient_policies_test.go
@@ -1,14 +1,23 @@
 package analyze_ambient_policies
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networking_v1_api "istio.io/api/networking/v1"
 	security_v1_api "istio.io/api/security/v1"
 	telemetry_v1_api "istio.io/api/telemetry/v1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes/kubetest"
 )
 
 func TestIsL7Policy_HTTPMethods(t *testing.T) {
@@ -445,4 +454,74 @@ func TestAmbientNoWaypointWarning_AmbientNoWaypoint(t *testing.T) {
 	warning := ambientNoWaypointWarning(nsStatus, "Things will break.")
 	assert.Contains(t, warning, "NO waypoint")
 	assert.Contains(t, warning, "Things will break.")
+}
+
+func setupExecuteTest(t *testing.T, objs ...runtime.Object) (*mcputil.KialiInterface, *config.Config) {
+	t.Helper()
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(objs...)
+	layer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+	r := httptest.NewRequest(http.MethodPost, "/api/chat/mcp/analyze_ambient_policies", nil)
+	r.Header.Set("Kiali-User", "test-user")
+	return &mcputil.KialiInterface{
+		Request:       r,
+		BusinessLayer: layer,
+		Conf:          conf,
+	}, conf
+}
+
+func TestExecute_BothNamespaceAndNamespaces_ReturnsBadRequest(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{
+		"namespace":  "ambient-ns",
+		"namespaces": []interface{}{"ambient-ns"},
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, result.(string), "cannot specify both")
+}
+
+func TestExecute_AutoDiscoverAmbientNamespaces(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+		kubetest.FakeNamespace("default"),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{})
+	assert.Equal(t, http.StatusOK, status)
+
+	resp, ok := result.(PolicyAnalysisResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Namespaces, 1)
+	assert.Equal(t, "ambient-ns", resp.Namespaces[0].NamespaceStatus.Name)
+}
+
+func TestExecute_InvalidNamespace_RecordsPerNamespaceError(t *testing.T) {
+	ki, _ := setupExecuteTest(t,
+		kubetest.FakeNamespaceWithLabels("ambient-ns", map[string]string{
+			config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		}),
+	)
+
+	result, status := Execute(ki, map[string]interface{}{
+		"namespaces": []interface{}{"ambient-ns", "missing-ns"},
+	})
+	assert.Equal(t, http.StatusOK, status)
+
+	resp, ok := result.(PolicyAnalysisResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Namespaces, 2)
+	assert.Equal(t, "ambient-ns", resp.Namespaces[0].NamespaceStatus.Name)
+	assert.NotContains(t, resp.Namespaces[0].Summary, "Error:")
+	assert.Equal(t, "missing-ns", resp.Namespaces[1].NamespaceStatus.Name)
+	assert.Contains(t, resp.Namespaces[1].Summary, "Error:")
 }

--- a/ai/mcp/get_mesh_status/get_mesh_status.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
+	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/mesh"
 	meshApi "github.com/kiali/kiali/mesh/api"
@@ -49,7 +50,7 @@ func Execute(ki *mcputil.KialiInterface, args map[string]interface{}) (interface
 		return "unexpected mesh status response type", http.StatusInternalServerError
 	}
 
-	summary := transformToSummary(meshConfig)
+	summary := transformToSummary(meshConfig, ki.KialiCache)
 	if !hasAccessibleControlPlane(summary) {
 		return "No accessible control plane data found for this token. Cannot retrieve mesh status.", http.StatusForbidden
 	}
@@ -62,11 +63,11 @@ func hasAccessibleControlPlane(summary MeshSummaryFormatted) bool {
 	return len(summary.Components.ControlPlane.Nodes) > 0
 }
 
-func transformToSummary(cfg meshCommon.Config) MeshSummaryFormatted {
+func transformToSummary(cfg meshCommon.Config, kialiCache cache.KialiCache) MeshSummaryFormatted {
 	nodesByID := buildNodeIndex(cfg)
 
 	return MeshSummaryFormatted{
-		Components:        extractComponents(cfg),
+		Components:        extractComponents(cfg, kialiCache),
 		ConnectivityGraph: extractConnectivity(cfg, nodesByID),
 		CriticalAlerts:    extractCriticalAlerts(cfg),
 		Environment:       extractEnvironment(cfg),
@@ -130,12 +131,15 @@ func extractTrustDomain(nd *meshCommon.NodeData) string {
 	return ""
 }
 
-func extractComponents(cfg meshCommon.Config) MeshSummaryComponents {
+func extractComponents(cfg meshCommon.Config, kialiCache cache.KialiCache) MeshSummaryComponents {
 	var cp MeshSummaryControlPlane
 	obs := MeshSummaryObservabilityStack{}
 	monitoredNS := make([]MeshSummaryMonitoredNamespace, 0)
 
 	worstCPStatus := kubernetes.ComponentHealthy
+
+	// Track clusters that have Ambient enabled
+	ambientClusters := make(map[string]bool)
 
 	for _, n := range cfg.Elements.Nodes {
 		if n.Data == nil {
@@ -176,7 +180,15 @@ func extractComponents(cfg meshCommon.Config) MeshSummaryComponents {
 			obs.Perses = health
 
 		case mesh.InfraTypeDataPlane:
-			monitoredNS = append(monitoredNS, extractDataPlaneNamespaces(n.Data)...)
+			nsData := extractDataPlaneNamespaces(n.Data)
+			monitoredNS = append(monitoredNS, nsData...)
+			// Check if any namespace in this cluster has Ambient enabled
+			for _, ns := range nsData {
+				if ns.IsAmbient {
+					ambientClusters[n.Data.Cluster] = true
+					break
+				}
+			}
 		}
 	}
 
@@ -186,9 +198,15 @@ func extractComponents(cfg meshCommon.Config) MeshSummaryComponents {
 		cp.Status = worstCPStatus
 	}
 
+	// Extract ztunnel information for Ambient-enabled clusters
+	var ztunnel *MeshSummaryZtunnel
+	if len(ambientClusters) > 0 && kialiCache != nil {
+		ztunnel = extractZtunnelStatus(kialiCache, ambientClusters)
+	}
+
 	return MeshSummaryComponents{
 		ControlPlane:       cp,
-		DataPlane:          MeshSummaryDataPlane{MonitoredNamespaces: monitoredNS},
+		DataPlane:          MeshSummaryDataPlane{MonitoredNamespaces: monitoredNS, Ztunnel: ztunnel},
 		ObservabilityStack: obs,
 	}
 }
@@ -488,4 +506,61 @@ func mergeStatus(a, b string) string {
 		return b
 	}
 	return a
+}
+
+// extractZtunnelStatus collects ztunnel DaemonSet and pod information across Ambient-enabled clusters
+func extractZtunnelStatus(kialiCache cache.KialiCache, ambientClusters map[string]bool) *MeshSummaryZtunnel {
+	var allPods []MeshSummaryZtunnelPod
+	var totalDesired, totalReady int32
+
+	for cluster := range ambientClusters {
+		if !kialiCache.IsAmbientEnabled(cluster) {
+			continue
+		}
+
+		// Get DaemonSet status
+		daemonsets := kialiCache.GetZtunnelDaemonset(cluster)
+		for _, ds := range daemonsets {
+			totalDesired += ds.Status.DesiredNumberScheduled
+			totalReady += ds.Status.NumberReady
+		}
+
+		// Get pod details
+		pods := kialiCache.GetZtunnelPods(cluster)
+		for _, pod := range pods {
+			ready := false
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == "Ready" && cond.Status == "True" {
+					ready = true
+					break
+				}
+			}
+			allPods = append(allPods, MeshSummaryZtunnelPod{
+				Name:  pod.Name,
+				Node:  pod.Spec.NodeName,
+				Phase: string(pod.Status.Phase),
+				Ready: ready,
+			})
+		}
+	}
+
+	if totalDesired == 0 {
+		return nil
+	}
+
+	status := "HEALTHY"
+	if totalReady == 0 {
+		status = "UNHEALTHY"
+	} else if totalReady < totalDesired {
+		status = "DEGRADED"
+	}
+
+	return &MeshSummaryZtunnel{
+		DaemonSet: MeshSummaryZtunnelDaemonSet{
+			DesiredPods: totalDesired,
+			ReadyPods:   totalReady,
+			Status:      status,
+		},
+		Pods: allPods,
+	}
 }

--- a/ai/mcp/get_mesh_status/get_mesh_status.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status.go
@@ -515,10 +515,6 @@ func extractZtunnelStatus(kialiCache cache.KialiCache, ambientClusters map[strin
 	var totalDesired, totalReady int32
 
 	for cluster := range ambientClusters {
-		if !kialiCache.IsAmbientEnabled(cluster) {
-			continue
-		}
-
 		// Get DaemonSet status
 		daemonsets := kialiCache.GetZtunnelDaemonset(cluster)
 		for _, ds := range daemonsets {

--- a/ai/mcp/get_mesh_status/get_mesh_status.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kiali/kiali/ai/mcputil"
@@ -530,7 +531,7 @@ func extractZtunnelStatus(kialiCache cache.KialiCache, ambientClusters map[strin
 		for _, pod := range pods {
 			ready := false
 			for _, cond := range pod.Status.Conditions {
-				if cond.Type == "Ready" && cond.Status == "True" {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
 					ready = true
 					break
 				}

--- a/ai/mcp/get_mesh_status/get_mesh_status_test.go
+++ b/ai/mcp/get_mesh_status/get_mesh_status_test.go
@@ -66,7 +66,7 @@ func sampleMeshConfig() meshCommon.Config {
 }
 
 func TestTransformToSummary_Environment(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	assert.Equal(t, "cluster.local", summary.Environment.TrustDomain)
 	assert.Equal(t, "1.28.0", summary.Environment.IstioVersion)
@@ -75,7 +75,7 @@ func TestTransformToSummary_Environment(t *testing.T) {
 }
 
 func TestTransformToSummary_ControlPlane(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	require.Len(t, summary.Components.ControlPlane.Nodes, 1)
 	assert.Equal(t, kubernetes.ComponentHealthy, summary.Components.ControlPlane.Status)
@@ -89,7 +89,7 @@ func TestTransformToSummary_ControlPlane(t *testing.T) {
 }
 
 func TestHasAccessibleControlPlane_TrueWithIstiodNode(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 	assert.True(t, hasAccessibleControlPlane(summary))
 }
 
@@ -103,13 +103,13 @@ func TestHasAccessibleControlPlane_FalseWithoutControlPlaneNodes(t *testing.T) {
 		},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 	assert.False(t, hasAccessibleControlPlane(summary))
 	assert.Equal(t, "UNKNOWN", summary.Components.ControlPlane.Status)
 }
 
 func TestTransformToSummary_ObservabilityStack(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	obs := summary.Components.ObservabilityStack
 	assert.Equal(t, kubernetes.ComponentHealthy, obs.Prometheus)
@@ -121,7 +121,7 @@ func TestTransformToSummary_ObservabilityStack(t *testing.T) {
 }
 
 func TestTransformToSummary_DataPlane(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	expected := []MeshSummaryMonitoredNamespace{
 		{Cluster: "cluster-1", IsAmbient: true, Name: "bookinfo"},
@@ -131,7 +131,7 @@ func TestTransformToSummary_DataPlane(t *testing.T) {
 }
 
 func TestTransformToSummary_Connectivity(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	require.Len(t, summary.ConnectivityGraph, 4)
 
@@ -158,7 +158,7 @@ func TestTransformToSummary_Connectivity(t *testing.T) {
 }
 
 func TestTransformToSummary_CriticalAlerts(t *testing.T) {
-	summary := transformToSummary(sampleMeshConfig())
+	summary := transformToSummary(sampleMeshConfig(), nil)
 
 	require.Len(t, summary.CriticalAlerts, 2)
 
@@ -183,7 +183,7 @@ func TestTransformToSummary_NoNodes_HandlesGracefully(t *testing.T) {
 		Elements:  meshCommon.Elements{},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	assert.Equal(t, "UNKNOWN", summary.Components.ControlPlane.Status)
 	assert.Empty(t, summary.Components.ControlPlane.Nodes)
@@ -200,7 +200,7 @@ func TestTransformToSummary_TempoTraceStore(t *testing.T) {
 		},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	assert.Equal(t, kubernetes.ComponentHealthy, summary.Components.ObservabilityStack.Tempo)
 	assert.Empty(t, summary.Components.ObservabilityStack.Jaeger)
@@ -216,7 +216,7 @@ func TestTransformToSummary_UnhealthyControlPlane_OverallStatus(t *testing.T) {
 		},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	assert.Equal(t, kubernetes.ComponentUnhealthy, summary.Components.ControlPlane.Status)
 	require.Len(t, summary.Components.ControlPlane.Nodes, 2)
@@ -261,7 +261,7 @@ func TestTransformToSummary_MultiClusterDataPlane(t *testing.T) {
 		},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	expected := []MeshSummaryMonitoredNamespace{
 		{Cluster: "east", IsAmbient: true, Name: "bookinfo"},
@@ -286,7 +286,7 @@ func TestTransformToSummary_DuplicateEdges(t *testing.T) {
 		},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	require.Len(t, summary.ConnectivityGraph, 1, "duplicate edges should be deduplicated")
 	assert.Equal(t, "istio-system/istiod", summary.ConnectivityGraph[0].From)
@@ -560,7 +560,7 @@ func TestTransformToSummary_DataPlane_EmptyNotNull(t *testing.T) {
 		Elements:  meshCommon.Elements{},
 		Timestamp: time.Now().Unix(),
 	}
-	summary := transformToSummary(cfg)
+	summary := transformToSummary(cfg, nil)
 
 	require.NotNil(t, summary.Components.DataPlane.MonitoredNamespaces, "monitored_namespaces should be empty slice, not nil")
 	assert.Empty(t, summary.Components.DataPlane.MonitoredNamespaces)

--- a/ai/mcp/get_mesh_status/types.go
+++ b/ai/mcp/get_mesh_status/types.go
@@ -46,6 +46,25 @@ type MeshSummaryObservabilityStack struct {
 
 type MeshSummaryDataPlane struct {
 	MonitoredNamespaces []MeshSummaryMonitoredNamespace `json:"monitored_namespaces"`
+	Ztunnel             *MeshSummaryZtunnel             `json:"ztunnel,omitempty"`
+}
+
+type MeshSummaryZtunnel struct {
+	DaemonSet MeshSummaryZtunnelDaemonSet `json:"daemonset"`
+	Pods      []MeshSummaryZtunnelPod     `json:"pods"`
+}
+
+type MeshSummaryZtunnelDaemonSet struct {
+	DesiredPods int32  `json:"desired_pods"`
+	ReadyPods   int32  `json:"ready_pods"`
+	Status      string `json:"status"`
+}
+
+type MeshSummaryZtunnelPod struct {
+	Name  string `json:"name"`
+	Node  string `json:"node"`
+	Phase string `json:"phase"`
+	Ready bool   `json:"ready"`
 }
 
 type MeshSummaryMonitoredNamespace struct {

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -29,10 +29,11 @@ var validGraphTypes = map[string]bool{
 
 // MeshGraphArgs are the optional parameters accepted by the mesh graph tool.
 type MeshGraphArgs struct {
-	Namespaces   []string `json:"namespaces,omitempty"`
-	RateInterval string   `json:"rateInterval,omitempty"`
-	GraphType    string   `json:"graphType,omitempty"`
-	ClusterName  string   `json:"clusterName,omitempty"`
+	Namespaces     []string `json:"namespaces,omitempty"`
+	RateInterval   string   `json:"rateInterval,omitempty"`
+	GraphType      string   `json:"graphType,omitempty"`
+	ClusterName    string   `json:"clusterName,omitempty"`
+	AmbientTraffic string   `json:"ambientTraffic,omitempty"`
 }
 
 // GetMeshGraphResponse encapsulates the mesh graph tool response.
@@ -51,9 +52,23 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	toolArgs.RateInterval = mcputil.GetStringOrDefault(args, mcputil.DefaultRateInterval, "rateInterval")
 	toolArgs.GraphType = mcputil.GetStringOrDefault(args, mcputil.DefaultGraphType, "graphType")
 	toolArgs.ClusterName = mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
+	toolArgs.AmbientTraffic = mcputil.GetStringArg(args, "ambientTraffic")
 
 	if !validGraphTypes[toolArgs.GraphType] {
 		return fmt.Sprintf("invalid graphType %q: must be one of app, service, versionedApp, workload", toolArgs.GraphType), http.StatusBadRequest
+	}
+
+	// Validate ambientTraffic parameter
+	if toolArgs.AmbientTraffic != "" {
+		validAmbientValues := map[string]bool{
+			"none":     true,
+			"total":    true,
+			"waypoint": true,
+			"ztunnel":  true,
+		}
+		if !validAmbientValues[toolArgs.AmbientTraffic] {
+			return fmt.Sprintf("invalid ambientTraffic %q: must be one of none, total, waypoint, ztunnel", toolArgs.AmbientTraffic), http.StatusBadRequest
+		}
 	}
 
 	// Parse namespaces argument (comma-separated string)
@@ -169,6 +184,9 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		}
 		if toolArgs.RateInterval != "" {
 			q.Set("duration", toolArgs.RateInterval)
+		}
+		if toolArgs.AmbientTraffic != "" {
+			q.Set("ambientTraffic", toolArgs.AmbientTraffic)
 		}
 		graphReq.URL.RawQuery = q.Encode()
 		graphOpts := graph.NewOptions(graphReq, kialiInterface.BusinessLayer, kialiInterface.Conf)

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -29,11 +29,11 @@ var validGraphTypes = map[string]bool{
 
 // MeshGraphArgs are the optional parameters accepted by the mesh graph tool.
 type MeshGraphArgs struct {
+	AmbientTraffic string   `json:"ambientTraffic,omitempty"`
+	ClusterName    string   `json:"clusterName,omitempty"`
+	GraphType      string   `json:"graphType,omitempty"`
 	Namespaces     []string `json:"namespaces,omitempty"`
 	RateInterval   string   `json:"rateInterval,omitempty"`
-	GraphType      string   `json:"graphType,omitempty"`
-	ClusterName    string   `json:"clusterName,omitempty"`
-	AmbientTraffic string   `json:"ambientTraffic,omitempty"`
 }
 
 // GetMeshGraphResponse encapsulates the mesh graph tool response.

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -27,6 +27,13 @@ var validGraphTypes = map[string]bool{
 	graph.GraphTypeWorkload:     true,
 }
 
+var validAmbientTrafficValues = map[string]bool{
+	graph.AmbientTrafficNone:     true,
+	graph.AmbientTrafficTotal:    true,
+	graph.AmbientTrafficWaypoint: true,
+	graph.AmbientTrafficZtunnel:  true,
+}
+
 // MeshGraphArgs are the optional parameters accepted by the mesh graph tool.
 type MeshGraphArgs struct {
 	AmbientTraffic string   `json:"ambientTraffic,omitempty"`
@@ -59,22 +66,14 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}
 
 	// Validate ambientTraffic parameter using the canonical constants from the graph package
-	if toolArgs.AmbientTraffic != "" {
-		validAmbientValues := map[string]bool{
-			graph.AmbientTrafficNone:     true,
-			graph.AmbientTrafficTotal:    true,
-			graph.AmbientTrafficWaypoint: true,
-			graph.AmbientTrafficZtunnel:  true,
-		}
-		if !validAmbientValues[toolArgs.AmbientTraffic] {
-			return fmt.Sprintf("invalid ambientTraffic %q: must be one of %s, %s, %s, %s",
-				toolArgs.AmbientTraffic,
-				graph.AmbientTrafficNone,
-				graph.AmbientTrafficTotal,
-				graph.AmbientTrafficWaypoint,
-				graph.AmbientTrafficZtunnel,
-			), http.StatusBadRequest
-		}
+	if toolArgs.AmbientTraffic != "" && !validAmbientTrafficValues[toolArgs.AmbientTraffic] {
+		return fmt.Sprintf("invalid ambientTraffic %q: must be one of %s, %s, %s, %s",
+			toolArgs.AmbientTraffic,
+			graph.AmbientTrafficNone,
+			graph.AmbientTrafficTotal,
+			graph.AmbientTrafficWaypoint,
+			graph.AmbientTrafficZtunnel,
+		), http.StatusBadRequest
 	}
 
 	// Parse namespaces argument (comma-separated string)

--- a/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
+++ b/ai/mcp/get_mesh_traffic_graph/get_mesh_traffic_graph.go
@@ -58,16 +58,22 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		return fmt.Sprintf("invalid graphType %q: must be one of app, service, versionedApp, workload", toolArgs.GraphType), http.StatusBadRequest
 	}
 
-	// Validate ambientTraffic parameter
+	// Validate ambientTraffic parameter using the canonical constants from the graph package
 	if toolArgs.AmbientTraffic != "" {
 		validAmbientValues := map[string]bool{
-			"none":     true,
-			"total":    true,
-			"waypoint": true,
-			"ztunnel":  true,
+			graph.AmbientTrafficNone:     true,
+			graph.AmbientTrafficTotal:    true,
+			graph.AmbientTrafficWaypoint: true,
+			graph.AmbientTrafficZtunnel:  true,
 		}
 		if !validAmbientValues[toolArgs.AmbientTraffic] {
-			return fmt.Sprintf("invalid ambientTraffic %q: must be one of none, total, waypoint, ztunnel", toolArgs.AmbientTraffic), http.StatusBadRequest
+			return fmt.Sprintf("invalid ambientTraffic %q: must be one of %s, %s, %s, %s",
+				toolArgs.AmbientTraffic,
+				graph.AmbientTrafficNone,
+				graph.AmbientTrafficTotal,
+				graph.AmbientTrafficWaypoint,
+				graph.AmbientTrafficZtunnel,
+			), http.StatusBadRequest
 		}
 	}
 

--- a/ai/mcp/list_or_get_resources/ambient_test.go
+++ b/ai/mcp/list_or_get_resources/ambient_test.go
@@ -1,0 +1,105 @@
+package list_or_get_resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+)
+
+func TestExtractAmbientNetworking_WorkloadNotInDump(t *testing.T) {
+	wl := &models.Workload{
+		WorkloadListItem: models.WorkloadListItem{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+	}
+
+	dump := &kubernetes.ZtunnelConfigDump{
+		Workloads: []kubernetes.Workload{
+			{
+				WorkloadName: "other-workload",
+				Namespace:    "test-ns",
+			},
+		},
+	}
+
+	result := extractAmbientNetworking(wl, dump)
+	assert.NotNil(t, result)
+	assert.False(t, result.Captured, "Workload not in dump should not be captured")
+}
+
+func TestExtractAmbientNetworking_WorkloadCaptured(t *testing.T) {
+	wl := &models.Workload{
+		WorkloadListItem: models.WorkloadListItem{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+	}
+
+	dump := &kubernetes.ZtunnelConfigDump{
+		Workloads: []kubernetes.Workload{
+			{
+				WorkloadName: "test-workload",
+				Namespace:    "test-ns",
+				Protocol:     "HBONE",
+				NetworkMode:  "Standard",
+				Status:       "Healthy",
+				Node:         "worker-1",
+				TrustDomain:  "cluster.local",
+				Services:     []string{"svc1", "svc2"},
+			},
+		},
+		Services: []kubernetes.Service{
+			{
+				Name:      "svc1",
+				Namespace: "test-ns",
+				Vips:      []string{"10.96.0.1"},
+				Waypoint: kubernetes.Waypoint{
+					Destination: "test-ns/waypoint",
+				},
+			},
+			{
+				Name:      "svc2",
+				Namespace: "test-ns",
+				Vips:      []string{"10.96.0.2"},
+			},
+		},
+	}
+
+	result := extractAmbientNetworking(wl, dump)
+	assert.NotNil(t, result)
+	assert.True(t, result.Captured)
+	assert.Equal(t, "HBONE", result.Protocol)
+	assert.Equal(t, "Standard", result.NetworkMode)
+	assert.Equal(t, "Healthy", result.Status)
+	assert.Equal(t, "worker-1", result.Node)
+	assert.Equal(t, "cluster.local", result.TrustDomain)
+	assert.Len(t, result.CapturedServices, 2)
+	assert.Equal(t, "svc1", result.CapturedServices[0].Name)
+	assert.Equal(t, "test-ns/waypoint", result.CapturedServices[0].Waypoint)
+	assert.Equal(t, []string{"10.96.0.1"}, result.CapturedServices[0].Vips)
+}
+
+func TestExtractAmbientNetworking_NilDump(t *testing.T) {
+	wl := &models.Workload{
+		WorkloadListItem: models.WorkloadListItem{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+	}
+
+	result := extractAmbientNetworking(wl, nil)
+	assert.Nil(t, result)
+}
+
+func TestContainsString(t *testing.T) {
+	slice := []string{"foo", "bar", "baz"}
+
+	assert.True(t, containsString(slice, "foo"))
+	assert.True(t, containsString(slice, "bar"))
+	assert.False(t, containsString(slice, "qux"))
+	assert.False(t, containsString([]string{}, "foo"))
+}

--- a/ai/mcp/list_or_get_resources/ambient_test.go
+++ b/ai/mcp/list_or_get_resources/ambient_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -93,4 +94,52 @@ func TestExtractAmbientNetworking_NilDump(t *testing.T) {
 
 	result := extractAmbientNetworking(wl, nil)
 	assert.Nil(t, result)
+}
+
+func TestExtractAmbientNetworking_FQDNServiceRefs(t *testing.T) {
+	wl := &models.Workload{
+		WorkloadListItem: models.WorkloadListItem{
+			Name:      "details-v1",
+			Namespace: "bookinfo",
+		},
+	}
+
+	dump := &kubernetes.ZtunnelConfigDump{
+		Workloads: []kubernetes.Workload{
+			{
+				WorkloadName: "details-v1",
+				Namespace:    "bookinfo",
+				Protocol:     "HBONE",
+				Services: []string{
+					"bookinfo/details.bookinfo.svc.cluster.local",
+				},
+			},
+		},
+		Services: []kubernetes.Service{
+			{
+				Hostname:  "details.bookinfo.svc.cluster.local",
+				Name:      "details",
+				Namespace: "bookinfo",
+				Vips:      []string{"10.96.0.1"},
+			},
+		},
+	}
+
+	result := extractAmbientNetworking(wl, dump)
+	require.NotNil(t, result)
+	assert.True(t, result.Captured)
+	require.Len(t, result.CapturedServices, 1)
+	assert.Equal(t, "details", result.CapturedServices[0].Name)
+}
+
+func TestZtunnelReferencesService(t *testing.T) {
+	svc := &kubernetes.Service{
+		Hostname:  "details.bookinfo.svc.cluster.local",
+		Name:      "details",
+		Namespace: "bookinfo",
+	}
+
+	assert.True(t, ztunnelReferencesService([]string{"bookinfo/details.bookinfo.svc.cluster.local"}, svc))
+	assert.True(t, ztunnelReferencesService([]string{"details"}, svc))
+	assert.False(t, ztunnelReferencesService([]string{"bookinfo/reviews.bookinfo.svc.cluster.local"}, svc))
 }

--- a/ai/mcp/list_or_get_resources/ambient_test.go
+++ b/ai/mcp/list_or_get_resources/ambient_test.go
@@ -94,12 +94,3 @@ func TestExtractAmbientNetworking_NilDump(t *testing.T) {
 	result := extractAmbientNetworking(wl, nil)
 	assert.Nil(t, result)
 }
-
-func TestContainsString(t *testing.T) {
-	slice := []string{"foo", "bar", "baz"}
-
-	assert.True(t, containsString(slice, "foo"))
-	assert.True(t, containsString(slice, "bar"))
-	assert.False(t, containsString(slice, "qux"))
-	assert.False(t, containsString([]string{}, "foo"))
-}

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -209,19 +209,18 @@ func recoverFromPanic(res *interface{}, status *int, resourceType, name, namespa
 
 // ResourceDetailArgs are the optional parameters accepted by the resource detail tool.
 type ResourceDetailArgs struct {
-	ResourceType   string    `json:"resource_type,omitempty"`
-	Namespaces     []string  `json:"namespaces,omitempty"`
-	ResourceName   string    `json:"resource_name,omitempty"`
-	ClusterName    string    `json:"cluster_name,omitempty"`
-	RateInterval   string    `json:"rate_interval,omitempty"`
-	QueryTime      time.Time `json:"query_time,omitempty"`
-	IncludeZtunnel bool      `json:"include_ztunnel,omitempty"`
+	ClusterName  string    `json:"cluster_name,omitempty"`
+	Namespaces   []string  `json:"namespaces,omitempty"`
+	QueryTime    time.Time `json:"query_time,omitempty"`
+	RateInterval string    `json:"rate_interval,omitempty"`
+	ResourceName string    `json:"resource_name,omitempty"`
+	ResourceType string    `json:"resource_type,omitempty"`
 }
 
 func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
 	// Extract parameters
 	resourceType := mcputil.GetStringArg(args, "resource_type", "resourceType")
-	namespaces := mcputil.GetStringArg(args, "namespaces")
+	namespaces := mcputil.GetStringArg(args, "namespaces", "namespace")
 	resourceName := mcputil.GetStringArg(args, "resource_name", "resourceName")
 	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
 	rateInterval := mcputil.GetStringOrDefault(args, DefaultRateInterval, "rateInterval")
@@ -294,16 +293,13 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		}
 	}
 
-	includeZtunnel := mcputil.GetBoolArg(args, "includeZtunnel")
-
 	resourceArgs := ResourceDetailArgs{
-		ResourceType:   resourceType,
-		Namespaces:     namespacesSlice,
-		ResourceName:   resourceName,
-		ClusterName:    clusterName,
-		RateInterval:   rateInterval,
-		QueryTime:      queryTime,
-		IncludeZtunnel: includeZtunnel,
+		ClusterName:  clusterName,
+		Namespaces:   namespacesSlice,
+		QueryTime:    queryTime,
+		RateInterval: rateInterval,
+		ResourceName: resourceName,
+		ResourceType: resourceType,
 	}
 	var resp interface{}
 	var status int
@@ -396,16 +392,27 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, kial
 			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
 
-		// Get ztunnel dump if requested and workload is in Ambient mode
+		// For Ambient workloads, automatically fetch ztunnel networking details.
+		// GetZtunnelDump expects a ztunnel DaemonSet pod name; since models.Pod lacks
+		// NodeName we iterate all ztunnel pods until we find the one whose dump contains
+		// this workload. Results are cached after the first fetch.
 		var ztunnelDump *kubernetes.ZtunnelConfigDump
-		if resourceArgs.IncludeZtunnel && workloadDetails.IsAmbient && len(workloadDetails.Pods) > 0 {
-			// Use the first pod to get the ztunnel dump
-			pod := workloadDetails.Pods[0]
-			ztunnelDump = kialiCache.GetZtunnelDump(
-				criteria.Cluster,
-				criteria.Namespace,
-				pod.Name,
-			)
+		if workloadDetails.IsAmbient {
+			for _, ztunnelPod := range kialiCache.GetZtunnelPods(criteria.Cluster) {
+				dump := kialiCache.GetZtunnelDump(criteria.Cluster, ztunnelPod.Namespace, ztunnelPod.Name)
+				if dump == nil {
+					continue
+				}
+				for i := range dump.Workloads {
+					if dump.Workloads[i].WorkloadName == workloadDetails.Name && dump.Workloads[i].Namespace == workloadDetails.Namespace {
+						ztunnelDump = dump
+						break
+					}
+				}
+				if ztunnelDump != nil {
+					break
+				}
+			}
 		}
 
 		// Get waypoint captured services if this workload is a waypoint

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -397,7 +397,7 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, kial
 		// NodeName we iterate all ztunnel pods until we find the one whose dump contains
 		// this workload. Results are cached after the first fetch.
 		var ztunnelDump *kubernetes.ZtunnelConfigDump
-		if workloadDetails.IsAmbient {
+		if workloadDetails.IsAmbient && kialiCache != nil {
 			for _, ztunnelPod := range kialiCache.GetZtunnelPods(criteria.Cluster) {
 				dump := kialiCache.GetZtunnelDump(criteria.Cluster, ztunnelPod.Namespace, ztunnelPod.Name)
 				if dump == nil {

--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -209,12 +209,13 @@ func recoverFromPanic(res *interface{}, status *int, resourceType, name, namespa
 
 // ResourceDetailArgs are the optional parameters accepted by the resource detail tool.
 type ResourceDetailArgs struct {
-	ResourceType string    `json:"resource_type,omitempty"`
-	Namespaces   []string  `json:"namespaces,omitempty"`
-	ResourceName string    `json:"resource_name,omitempty"`
-	ClusterName  string    `json:"cluster_name,omitempty"`
-	RateInterval string    `json:"rate_interval,omitempty"`
-	QueryTime    time.Time `json:"query_time,omitempty"`
+	ResourceType   string    `json:"resource_type,omitempty"`
+	Namespaces     []string  `json:"namespaces,omitempty"`
+	ResourceName   string    `json:"resource_name,omitempty"`
+	ClusterName    string    `json:"cluster_name,omitempty"`
+	RateInterval   string    `json:"rate_interval,omitempty"`
+	QueryTime      time.Time `json:"query_time,omitempty"`
+	IncludeZtunnel bool      `json:"include_ztunnel,omitempty"`
 }
 
 func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
@@ -293,13 +294,16 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		}
 	}
 
+	includeZtunnel := mcputil.GetBoolArg(args, "includeZtunnel")
+
 	resourceArgs := ResourceDetailArgs{
-		ResourceType: resourceType,
-		Namespaces:   namespacesSlice,
-		ResourceName: resourceName,
-		ClusterName:  clusterName,
-		RateInterval: rateInterval,
-		QueryTime:    queryTime,
+		ResourceType:   resourceType,
+		Namespaces:     namespacesSlice,
+		ResourceName:   resourceName,
+		ClusterName:    clusterName,
+		RateInterval:   rateInterval,
+		QueryTime:      queryTime,
+		IncludeZtunnel: includeZtunnel,
 	}
 	var resp interface{}
 	var status int
@@ -309,7 +313,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}
 	if resourceName != "" && len(namespacesSlice) == 1 {
 		log.Debugf("Getting resource details type: %s for resource name: %s and namespace: %s", resourceType, resourceName, namespacesSlice[0])
-		resp, status, err = getResourceDetails(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, resourceArgs, namespacesSlice[0])
+		resp, status, err = getResourceDetails(kialiInterface.Request.Context(), kialiInterface.BusinessLayer, kialiInterface.KialiCache, resourceArgs, namespacesSlice[0])
 		if err != nil {
 			return err.Error(), status
 		}
@@ -343,7 +347,7 @@ func calculateRateInterval(
 	return interval, nil
 }
 
-func getResourceDetails(ctx context.Context, businessLayer *business.Layer, resourceArgs ResourceDetailArgs, namespace string) (resp interface{}, status int, err error) {
+func getResourceDetails(ctx context.Context, businessLayer *business.Layer, kialiCache cache.KialiCache, resourceArgs ResourceDetailArgs, namespace string) (resp interface{}, status int, err error) {
 	defer recoverFromPanic(&resp, &status, resourceArgs.ResourceType, resourceArgs.ResourceName, namespace)
 
 	istioConfigValidations := models.IstioValidations{}
@@ -391,7 +395,31 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, reso
 		if err != nil {
 			return classifyError(err, "workload", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}
-		return TransformWorkloadDetail(workloadDetails), http.StatusOK, nil
+
+		// Get ztunnel dump if requested and workload is in Ambient mode
+		var ztunnelDump *kubernetes.ZtunnelConfigDump
+		if resourceArgs.IncludeZtunnel && workloadDetails.IsAmbient && len(workloadDetails.Pods) > 0 {
+			// Use the first pod to get the ztunnel dump
+			pod := workloadDetails.Pods[0]
+			ztunnelDump = kialiCache.GetZtunnelDump(
+				criteria.Cluster,
+				criteria.Namespace,
+				pod.Name,
+			)
+		}
+
+		// Get waypoint captured services if this workload is a waypoint
+		var waypointServices []models.ServiceReferenceInfo
+		if workloadDetails.WorkloadListItem.IsWaypoint {
+			waypointServices = businessLayer.Svc.ListWaypointServices(
+				ctx,
+				workloadDetails.Name,
+				workloadDetails.Namespace,
+				criteria.Cluster,
+			)
+		}
+
+		return TransformWorkloadDetail(workloadDetails, ztunnelDump, waypointServices), http.StatusOK, nil
 	case "app":
 		criteria := business.AppCriteria{
 			Namespace: namespace, AppName: resourceArgs.ResourceName,

--- a/ai/mcp/list_or_get_resources/output_types.go
+++ b/ai/mcp/list_or_get_resources/output_types.go
@@ -157,11 +157,38 @@ type PodInfo struct {
 }
 
 type WorkloadDetailResponse struct {
-	AssociatedServices []string          `json:"associated_services"`
-	Istio              WorkloadIstioInfo `json:"istio"`
-	Pods               []PodInfo         `json:"pods"`
-	Status             WorkloadStatus    `json:"status"`
-	Workload           WorkloadInfo      `json:"workload"`
+	AssociatedServices []string               `json:"associated_services"`
+	Istio              WorkloadIstioInfo      `json:"istio"`
+	Pods               []PodInfo              `json:"pods"`
+	Status             WorkloadStatus         `json:"status"`
+	Workload           WorkloadInfo           `json:"workload"`
+	AmbientNetworking  *AmbientNetworkingInfo `json:"ambientNetworking,omitempty"`
+	WaypointServices   []WaypointServiceInfo  `json:"waypointServices,omitempty"`
+}
+
+// WaypointServiceInfo contains information about services captured by a waypoint proxy
+type WaypointServiceInfo struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// AmbientNetworkingInfo contains ztunnel-specific networking details for Ambient workloads
+type AmbientNetworkingInfo struct {
+	Captured         bool                 `json:"captured"`
+	Protocol         string               `json:"protocol,omitempty"`    // "HBONE", "TCP"
+	NetworkMode      string               `json:"networkMode,omitempty"` // "Standard", "HostNetwork"
+	Status           string               `json:"status,omitempty"`      // "Healthy", "Unhealthy"
+	Node             string               `json:"node,omitempty"`        // Kubernetes node name
+	TrustDomain      string               `json:"trustDomain,omitempty"` // "cluster.local"
+	CapturedServices []ZtunnelServiceInfo `json:"capturedServices,omitempty"`
+}
+
+// ZtunnelServiceInfo contains service-level ztunnel configuration
+type ZtunnelServiceInfo struct {
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Vips      []string `json:"vips"`
+	Waypoint  string   `json:"waypoint,omitempty"` // "namespace/workload"
 }
 
 type AppWorkloadInfo struct {

--- a/ai/mcp/list_or_get_resources/output_types.go
+++ b/ai/mcp/list_or_get_resources/output_types.go
@@ -157,12 +157,12 @@ type PodInfo struct {
 }
 
 type WorkloadDetailResponse struct {
+	AmbientNetworking  *AmbientNetworkingInfo `json:"ambientNetworking,omitempty"`
 	AssociatedServices []string               `json:"associated_services"`
 	Istio              WorkloadIstioInfo      `json:"istio"`
 	Pods               []PodInfo              `json:"pods"`
 	Status             WorkloadStatus         `json:"status"`
 	Workload           WorkloadInfo           `json:"workload"`
-	AmbientNetworking  *AmbientNetworkingInfo `json:"ambientNetworking,omitempty"`
 	WaypointServices   []WaypointServiceInfo  `json:"waypointServices,omitempty"`
 }
 
@@ -175,12 +175,12 @@ type WaypointServiceInfo struct {
 // AmbientNetworkingInfo contains ztunnel-specific networking details for Ambient workloads
 type AmbientNetworkingInfo struct {
 	Captured         bool                 `json:"captured"`
-	Protocol         string               `json:"protocol,omitempty"`    // "HBONE", "TCP"
-	NetworkMode      string               `json:"networkMode,omitempty"` // "Standard", "HostNetwork"
-	Status           string               `json:"status,omitempty"`      // "Healthy", "Unhealthy"
-	Node             string               `json:"node,omitempty"`        // Kubernetes node name
-	TrustDomain      string               `json:"trustDomain,omitempty"` // "cluster.local"
 	CapturedServices []ZtunnelServiceInfo `json:"capturedServices,omitempty"`
+	NetworkMode      string               `json:"networkMode,omitempty"` // "Standard", "HostNetwork"
+	Node             string               `json:"node,omitempty"`        // Kubernetes node name
+	Protocol         string               `json:"protocol,omitempty"`    // "HBONE", "TCP"
+	Status           string               `json:"status,omitempty"`      // "Healthy", "Unhealthy"
+	TrustDomain      string               `json:"trustDomain,omitempty"` // "cluster.local"
 }
 
 // ZtunnelServiceInfo contains service-level ztunnel configuration

--- a/ai/mcp/list_or_get_resources/output_types.go
+++ b/ai/mcp/list_or_get_resources/output_types.go
@@ -162,8 +162,8 @@ type WorkloadDetailResponse struct {
 	Istio              WorkloadIstioInfo      `json:"istio"`
 	Pods               []PodInfo              `json:"pods"`
 	Status             WorkloadStatus         `json:"status"`
-	Workload           WorkloadInfo           `json:"workload"`
 	WaypointServices   []WaypointServiceInfo  `json:"waypointServices,omitempty"`
+	Workload           WorkloadInfo           `json:"workload"`
 }
 
 // WaypointServiceInfo contains information about services captured by a waypoint proxy

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
 
@@ -264,7 +265,7 @@ func TransformServiceDetail(sd *models.ServiceDetails) ServiceDetailResponse {
 	}
 }
 
-func TransformWorkloadDetail(wl *models.Workload) WorkloadDetailResponse {
+func TransformWorkloadDetail(wl *models.Workload, ztunnelDump *kubernetes.ZtunnelConfigDump, waypointServices []models.ServiceReferenceInfo) WorkloadDetailResponse {
 	healthStr := "NA"
 	if wl.Health.Status != nil {
 		healthStr = string(wl.Health.Status.Status)
@@ -367,6 +368,23 @@ func TransformWorkloadDetail(wl *models.Workload) WorkloadDetailResponse {
 	inboundRate := computeSuccessRate(wl.Health.Requests.Inbound)
 	outboundRate := computeSuccessRate(wl.Health.Requests.Outbound)
 
+	var ambientNetworking *AmbientNetworkingInfo
+	if ztunnelDump != nil {
+		ambientNetworking = extractAmbientNetworking(wl, ztunnelDump)
+	}
+
+	// Transform waypoint services if present
+	var waypointSvcs []WaypointServiceInfo
+	if len(waypointServices) > 0 {
+		waypointSvcs = make([]WaypointServiceInfo, 0, len(waypointServices))
+		for _, svc := range waypointServices {
+			waypointSvcs = append(waypointSvcs, WaypointServiceInfo{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+			})
+		}
+	}
+
 	return WorkloadDetailResponse{
 		AssociatedServices: svcNames,
 		Istio: WorkloadIstioInfo{
@@ -402,6 +420,8 @@ func TransformWorkloadDetail(wl *models.Workload) WorkloadDetailResponse {
 			Namespace:      wl.Namespace,
 			ServiceAccount: sa,
 		},
+		AmbientNetworking: ambientNetworking,
+		WaypointServices:  waypointSvcs,
 	}
 }
 
@@ -766,4 +786,65 @@ func labelsToString(labels map[string]string) string {
 		pairs = append(pairs, fmt.Sprintf("%s=%s", k, labels[k]))
 	}
 	return strings.Join(pairs, ", ")
+}
+
+// extractAmbientNetworking extracts ztunnel-specific networking information for an Ambient workload
+func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfigDump) *AmbientNetworkingInfo {
+	if dump == nil {
+		return nil
+	}
+
+	// Find this workload in the ztunnel dump
+	var ztunnelWorkload *kubernetes.Workload
+	for i := range dump.Workloads {
+		zw := &dump.Workloads[i]
+		if zw.WorkloadName == wl.Name && zw.Namespace == wl.Namespace {
+			ztunnelWorkload = zw
+			break
+		}
+	}
+
+	// If workload not found in ztunnel dump, it's not captured
+	if ztunnelWorkload == nil {
+		return &AmbientNetworkingInfo{Captured: false}
+	}
+
+	// Extract captured services
+	var capturedServices []ZtunnelServiceInfo
+	for i := range dump.Services {
+		svc := &dump.Services[i]
+		// Check if this service references the workload
+		if containsString(ztunnelWorkload.Services, svc.Name) {
+			waypointDest := ""
+			if svc.Waypoint.Destination != "" {
+				waypointDest = svc.Waypoint.Destination
+			}
+			capturedServices = append(capturedServices, ZtunnelServiceInfo{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Vips:      svc.Vips,
+				Waypoint:  waypointDest,
+			})
+		}
+	}
+
+	return &AmbientNetworkingInfo{
+		Captured:         true,
+		Protocol:         ztunnelWorkload.Protocol,
+		NetworkMode:      ztunnelWorkload.NetworkMode,
+		Status:           ztunnelWorkload.Status,
+		Node:             ztunnelWorkload.Node,
+		TrustDomain:      ztunnelWorkload.TrustDomain,
+		CapturedServices: capturedServices,
+	}
+}
+
+// containsString checks if a string slice contains a specific string
+func containsString(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -2,7 +2,6 @@ package list_or_get_resources
 
 import (
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
@@ -814,8 +813,8 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 	var capturedServices []ZtunnelServiceInfo
 	for i := range dump.Services {
 		svc := &dump.Services[i]
-		// Check if this service references the workload
-		if slices.Contains(ztunnelWorkload.Services, svc.Name) {
+		// ztunnel workload service refs use "namespace/hostname" (see kubernetes/testdata/ztunnel-config.json).
+		if ztunnelReferencesService(ztunnelWorkload.Services, svc) {
 			waypointDest := ""
 			if svc.Waypoint.Destination != "" {
 				waypointDest = svc.Waypoint.Destination
@@ -838,4 +837,25 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 		TrustDomain:      ztunnelWorkload.TrustDomain,
 		CapturedServices: capturedServices,
 	}
+}
+
+// ztunnelReferencesService reports whether a ztunnel workload service entry references the given service.
+// Workload.Services entries use "namespace/hostname" (e.g. "bookinfo/details.bookinfo.svc.cluster.local").
+func ztunnelReferencesService(workloadServices []string, svc *kubernetes.Service) bool {
+	if len(workloadServices) == 0 {
+		return false
+	}
+	fqdnRef := ""
+	if svc.Hostname != "" {
+		fqdnRef = fmt.Sprintf("%s/%s", svc.Namespace, svc.Hostname)
+	}
+	for _, ref := range workloadServices {
+		if ref == svc.Name || ref == svc.Hostname {
+			return true
+		}
+		if fqdnRef != "" && ref == fqdnRef {
+			return true
+		}
+	}
+	return false
 }

--- a/ai/mcp/list_or_get_resources/transforms.go
+++ b/ai/mcp/list_or_get_resources/transforms.go
@@ -2,6 +2,7 @@ package list_or_get_resources
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -814,7 +815,7 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 	for i := range dump.Services {
 		svc := &dump.Services[i]
 		// Check if this service references the workload
-		if containsString(ztunnelWorkload.Services, svc.Name) {
+		if slices.Contains(ztunnelWorkload.Services, svc.Name) {
 			waypointDest := ""
 			if svc.Waypoint.Destination != "" {
 				waypointDest = svc.Waypoint.Destination
@@ -837,14 +838,4 @@ func extractAmbientNetworking(wl *models.Workload, dump *kubernetes.ZtunnelConfi
 		TrustDomain:      ztunnelWorkload.TrustDomain,
 		CapturedServices: capturedServices,
 	}
-}
-
-// containsString checks if a string slice contains a specific string
-func containsString(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }

--- a/ai/mcp/list_or_get_resources/transforms_test.go
+++ b/ai/mcp/list_or_get_resources/transforms_test.go
@@ -257,7 +257,7 @@ func TestTransformWorkloadDetail_InjectionDisabled(t *testing.T) {
 	wl.Namespace = "bookinfo"
 	wl.WorkloadGVK = schema.GroupVersionKind{Kind: "Deployment"}
 
-	result := TransformWorkloadDetail(wl)
+	result := TransformWorkloadDetail(wl, nil, nil)
 	require.NotNil(t, result.Istio.IstioInjectionAnnotation)
 	assert.False(t, *result.Istio.IstioInjectionAnnotation)
 	assert.False(t, result.Istio.IstioSidecar)
@@ -306,7 +306,7 @@ func TestTransformWorkloadDetail(t *testing.T) {
 		},
 	}
 
-	result := TransformWorkloadDetail(wl)
+	result := TransformWorkloadDetail(wl, nil, nil)
 
 	assert.Equal(t, "details-v1", result.Workload.Name)
 	assert.Equal(t, "Deployment", result.Workload.Kind)
@@ -511,7 +511,7 @@ func TestTransformWorkloadDetail_AmbientMode(t *testing.T) {
 	wl.Namespace = "default"
 	wl.IsAmbient = true
 
-	result := TransformWorkloadDetail(wl)
+	result := TransformWorkloadDetail(wl, nil, nil)
 	assert.Equal(t, "Ambient", result.Istio.Mode)
 }
 
@@ -520,7 +520,7 @@ func TestTransformWorkloadDetail_NoIstio(t *testing.T) {
 	wl.Name = "test-wl"
 	wl.Namespace = "default"
 
-	result := TransformWorkloadDetail(wl)
+	result := TransformWorkloadDetail(wl, nil, nil)
 	assert.Equal(t, "None", result.Istio.Mode)
 	assert.Equal(t, "", result.Istio.ProxyVersion)
 	assert.Nil(t, result.Istio.SyncStatus)

--- a/ai/mcp/mcp_tools.go
+++ b/ai/mcp/mcp_tools.go
@@ -14,6 +14,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/kiali/kiali/ai/mcp/analyze_ambient_policies"
 	"github.com/kiali/kiali/ai/mcp/get_action_ui"
 	"github.com/kiali/kiali/ai/mcp/get_logs"
 	"github.com/kiali/kiali/ai/mcp/get_mesh_status"
@@ -62,6 +63,13 @@ var TraceToolNames = map[string]struct{}{
 	"get_trace_details": {},
 }
 
+// AmbientToolNames are MCP tools that are 100% specific to Istio Ambient Mesh.
+// They must not be offered or executed when ambient mesh is not enabled in any cluster.
+// Tools that work without Ambient but provide enhanced data when available should NOT be listed here.
+var AmbientToolNames = map[string]struct{}{
+	"analyze_ambient_policies": {}, // L4/L7 policy analysis - Ambient-specific
+}
+
 func IsMetricTool(name string) bool {
 	_, ok := MetricToolNames[name]
 	return ok
@@ -69,6 +77,11 @@ func IsMetricTool(name string) bool {
 
 func IsTraceTool(name string) bool {
 	_, ok := TraceToolNames[name]
+	return ok
+}
+
+func IsAmbientTool(name string) bool {
+	_, ok := AmbientToolNames[name]
 	return ok
 }
 
@@ -167,6 +180,8 @@ func (t ToolDef) GetDefinition() map[string]interface{} {
 
 func (t ToolDef) Call(kialiInterface *mcputil.KialiInterface, args map[string]interface{}) (interface{}, int) {
 	switch t.Name {
+	case "analyze_ambient_policies":
+		return analyze_ambient_policies.Execute(kialiInterface, args)
 	case "get_mesh_traffic_graph":
 		return get_mesh_traffic_graph.Execute(kialiInterface, args)
 	case "list_or_get_resources":

--- a/ai/mcp/tools/analyze_ambient_policies.yaml
+++ b/ai/mcp/tools/analyze_ambient_policies.yaml
@@ -1,13 +1,17 @@
 - name: "analyze_ambient_policies"
-  description: "Analyzes AuthorizationPolicies in an Ambient Mesh namespace to determine if they will work correctly. Classifies policies as L4 (ztunnel-enforced) or L7 (waypoint-required) and warns about L7 policies in namespaces without waypoints. Use this when diagnosing policy enforcement issues in Ambient mode."
+  description: "Analyzes all Istio configurations in Ambient Mesh namespaces to determine if they will work correctly. Classifies each config as L4 (ztunnel-enforced) or L7 (waypoint-required). Analyzes: AuthorizationPolicies, PeerAuthentications, RequestAuthentications, VirtualServices, DestinationRules, WasmPlugins, and Telemetry. Warns about L7 configs in namespaces without waypoints. If no namespace is specified, analyzes ALL Ambient namespaces automatically. Use this when diagnosing config enforcement issues in Ambient mode or when planning waypoint deployment."
   toolset: [default, mcp]
   input_schema:
     type: "object"
-    required: ["namespace"]
     properties:
       namespace:
         type: "string"
-        description: "Namespace to analyze AuthorizationPolicies in."
+        description: "Optional: Single namespace to analyze. If omitted (along with namespaces), will analyze all Ambient namespaces."
+      namespaces:
+        type: "array"
+        items:
+          type: "string"
+        description: "Optional: Multiple specific namespaces to analyze in one call. Cannot be used with namespace parameter."
       clusterName:
         type: "string"
         description: "Optional cluster name. If not provided, will use the default cluster name in the Kiali KubeConfig."

--- a/ai/mcp/tools/analyze_ambient_policies.yaml
+++ b/ai/mcp/tools/analyze_ambient_policies.yaml
@@ -1,0 +1,13 @@
+- name: "analyze_ambient_policies"
+  description: "Analyzes AuthorizationPolicies in an Ambient Mesh namespace to determine if they will work correctly. Classifies policies as L4 (ztunnel-enforced) or L7 (waypoint-required) and warns about L7 policies in namespaces without waypoints. Use this when diagnosing policy enforcement issues in Ambient mode."
+  toolset: [default, mcp]
+  input_schema:
+    type: "object"
+    required: ["namespace"]
+    properties:
+      namespace:
+        type: "string"
+        description: "Namespace to analyze AuthorizationPolicies in."
+      clusterName:
+        type: "string"
+        description: "Optional cluster name. If not provided, will use the default cluster name in the Kiali KubeConfig."

--- a/ai/mcp/tools/get_mesh_traffic_graph.yaml
+++ b/ai/mcp/tools/get_mesh_traffic_graph.yaml
@@ -15,3 +15,7 @@
       clusterName:
         type: "string"
         description: "Optional cluster name to include in the graph. Default is the cluster name in the Kiali configuration (KubeConfig)."
+      ambientTraffic:
+        type: "string"
+        description: "Optional. Filter Ambient Mesh traffic. 'none' excludes all ambient traffic, 'total' includes all (default), 'waypoint' shows only waypoint-reported traffic, 'ztunnel' shows only ztunnel-reported traffic. Only applicable when Ambient Mesh is enabled."
+        enum: ["none", "total", "waypoint", "ztunnel"]

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -7,7 +7,7 @@
     properties:
       resourceType:
         type: "string"
-        description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them."
+        description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically."
         enum: ["service", "workload", "app", "namespace", "argoapp"]
       namespaces:
         type: "string"
@@ -18,6 +18,3 @@
       clusterName:
         type: "string"
         description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."
-      includeZtunnel:
-        type: "boolean"
-        description: "Optional. Include ztunnel networking details for Ambient workloads (protocol, network mode, captured services, waypoint configuration). Only applicable when resourceType is 'workload' and resourceName is specified. Requires Ambient Mesh enabled. Default: false."

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -5,16 +5,19 @@
     type: "object"
     required: ["resourceType"]
     properties:
+      clusterName:
+        type: "string"
+        description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."
+      namespace:
+        type: "string"
+        description: "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value."
+      namespaces:
+        type: "string"
+        description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value."
+      resourceName:
+        type: "string"
+        description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource."
       resourceType:
         type: "string"
         description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically."
         enum: ["service", "workload", "app", "namespace", "argoapp"]
-      namespaces:
-        type: "string"
-        description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces."
-      resourceName:
-        type: "string"
-        description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource."
-      clusterName:
-        type: "string"
-        description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."

--- a/ai/mcp/tools/list_or_get_resources.yaml
+++ b/ai/mcp/tools/list_or_get_resources.yaml
@@ -18,3 +18,6 @@
       clusterName:
         type: "string"
         description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig."
+      includeZtunnel:
+        type: "boolean"
+        description: "Optional. Include ztunnel networking details for Ambient workloads (protocol, network mode, captured services, waypoint configuration). Only applicable when resourceType is 'workload' and resourceName is specified. Requires Ambient Mesh enabled. Default: false."

--- a/ai/mcputil/args.go
+++ b/ai/mcputil/args.go
@@ -135,9 +135,3 @@ func GetStringOrDefault(args map[string]interface{}, defaultValue string, keys .
 	}
 	return defaultValue
 }
-
-// GetBoolArg returns the boolean value for the first present key in args.
-// Alias for AsBoolFromArgs for consistency with GetStringArg, GetTimeArg.
-func GetBoolArg(args map[string]interface{}, keys ...string) bool {
-	return AsBoolFromArgs(args, keys...)
-}

--- a/ai/mcputil/args.go
+++ b/ai/mcputil/args.go
@@ -135,3 +135,9 @@ func GetStringOrDefault(args map[string]interface{}, defaultValue string, keys .
 	}
 	return defaultValue
 }
+
+// GetBoolArg returns the boolean value for the first present key in args.
+// Alias for AsBoolFromArgs for consistency with GetStringArg, GetTimeArg.
+func GetBoolArg(args map[string]interface{}, keys ...string) bool {
+	return AsBoolFromArgs(args, keys...)
+}

--- a/ai/prompts/catalog.go
+++ b/ai/prompts/catalog.go
@@ -111,5 +111,56 @@ func Catalog() []Prompt {
 			Query:       "Analyze the current workload and report degraded status, traffic anomalies, sidecar issues, and the next troubleshooting steps.",
 			Title:       "Workload Troubleshooting",
 		},
+
+		// Ambient Mesh prompts
+		{
+			Category:    "mesh",
+			Description: "Check if Ambient Mesh is enabled and get ztunnel DaemonSet status across clusters",
+			Name:        "ambient-mesh-status",
+			Query:       "Check if Ambient Mesh is enabled in my clusters. Show ztunnel DaemonSet status, pod health per node, and which namespaces are in Ambient mode.",
+			Title:       "Ambient Mesh Status",
+		},
+		{
+			Category:    "namespaces",
+			Description: "List namespaces with their Ambient mode status and identify which ones need waypoints",
+			Name:        "ambient-namespace-overview",
+			Query:       "List all namespaces with their Ambient status. Identify which namespaces are in Ambient mode, which have waypoints deployed, and which may need waypoints for L7 policies.",
+			Title:       "Ambient Namespace Overview",
+		},
+		{
+			Category:    "namespace-details",
+			Description: "Analyze AuthorizationPolicies in this namespace for Ambient compatibility (L4 vs L7)",
+			Name:        "ambient-policy-analysis",
+			Query:       "Analyze the AuthorizationPolicies in the current namespace for Ambient Mesh compatibility. Show which policies are L4 (ztunnel-enforced) vs L7 (waypoint-required), and warn if L7 policies exist without a waypoint.",
+			Title:       "Ambient Policy Analysis",
+		},
+		{
+			Category:    "workload-details",
+			Description: "Show ztunnel networking details for this Ambient workload (protocol, captured services, waypoint)",
+			Name:        "ambient-workload-networking",
+			Query:       "Show detailed Ambient networking information for the current workload. Include ztunnel capture status, protocol (HBONE/TCP), network mode, captured services with VIPs, and waypoint configuration.",
+			Title:       "Ambient Workload Networking",
+		},
+		{
+			Category:    "workload-details",
+			Description: "For waypoint proxies, show which services they are capturing and enforcing policies for",
+			Name:        "waypoint-captured-services",
+			Query:       "If this workload is a waypoint proxy, show which services it is capturing and enforcing L7 policies for. Include service names and namespaces.",
+			Title:       "Waypoint Captured Services",
+		},
+		{
+			Category:    "graph",
+			Description: "Show traffic topology filtered to Ambient Mesh waypoint-reported traffic only",
+			Name:        "ambient-waypoint-traffic",
+			Query:       "Show the traffic topology for the selected namespaces, filtered to show only waypoint-reported traffic. This helps visualize L7 traffic flow in Ambient mode.",
+			Title:       "Ambient Waypoint Traffic",
+		},
+		{
+			Category:    "istio",
+			Description: "Review AuthorizationPolicies across namespaces for Ambient compatibility issues",
+			Name:        "ambient-policy-audit",
+			Query:       "Audit AuthorizationPolicies across all Ambient namespaces. Report L7 policies in namespaces without waypoints, and recommend where waypoints should be deployed.",
+			Title:       "Ambient Policy Audit",
+		},
 	}
 }

--- a/ai/prompts/catalog.go
+++ b/ai/prompts/catalog.go
@@ -4,7 +4,7 @@ package prompts
 type Prompt struct {
 	Category    string `json:"category"`
 	Description string `json:"description"`
-	IsAmbient   bool   `json:"isAmbient,omitempty"`
+	IsAmbient   bool   `json:"isAmbient"`
 	Name        string `json:"name"`
 	Query       string `json:"query"`
 	Title       string `json:"title"`

--- a/ai/prompts/catalog.go
+++ b/ai/prompts/catalog.go
@@ -127,16 +127,16 @@ func Catalog() []Prompt {
 			Description: "List namespaces with their Ambient mode status and identify which ones need waypoints",
 			IsAmbient:   true,
 			Name:        "ambient-namespace-overview",
-			Query:       "List all namespaces with their Ambient status. Identify which namespaces are in Ambient mode, which have waypoints deployed, and which may need waypoints for L7 policies.",
+			Query:       "List all namespaces with their Ambient status. Identify which namespaces are in Ambient mode, which have waypoints deployed, and analyze all Istio configs across Ambient namespaces to determine which need waypoints for L7 features.",
 			Title:       "Ambient Namespace Overview",
 		},
 		{
 			Category:    "namespace-details",
-			Description: "Analyze AuthorizationPolicies in this namespace for Ambient compatibility (L4 vs L7)",
+			Description: "Analyze all Istio configs in this namespace for Ambient compatibility (L4 vs L7)",
 			IsAmbient:   true,
-			Name:        "ambient-policy-analysis",
-			Query:       "Analyze the AuthorizationPolicies in the current namespace for Ambient Mesh compatibility. Show which policies are L4 (ztunnel-enforced) vs L7 (waypoint-required), and warn if L7 policies exist without a waypoint.",
-			Title:       "Ambient Policy Analysis",
+			Name:        "ambient-config-analysis",
+			Query:       "Analyze all Istio configurations in the current namespace for Ambient Mesh compatibility. Show which configs are L4 (ztunnel-processed) vs L7 (waypoint-required) including AuthorizationPolicies, VirtualServices, DestinationRules, RequestAuthentications, PeerAuthentications, WasmPlugins, and Telemetry. Warn if L7 configs exist without a waypoint.",
+			Title:       "Ambient Config Analysis",
 		},
 		{
 			Category:    "workload-details",
@@ -164,11 +164,11 @@ func Catalog() []Prompt {
 		},
 		{
 			Category:    "istio",
-			Description: "Review AuthorizationPolicies across namespaces for Ambient compatibility issues",
+			Description: "Review all Istio configs across namespaces for Ambient compatibility issues",
 			IsAmbient:   true,
-			Name:        "ambient-policy-audit",
-			Query:       "Audit AuthorizationPolicies across all Ambient namespaces. Report L7 policies in namespaces without waypoints, and recommend where waypoints should be deployed.",
-			Title:       "Ambient Policy Audit",
+			Name:        "ambient-config-audit",
+			Query:       "Audit all Istio configurations across all Ambient namespaces. Report L7 configs (AuthorizationPolicies, VirtualServices, RequestAuthentications, DestinationRules, WasmPlugins, Telemetry) in namespaces without waypoints, and recommend where waypoints should be deployed.",
+			Title:       "Ambient Config Audit",
 		},
 	}
 }

--- a/ai/prompts/catalog.go
+++ b/ai/prompts/catalog.go
@@ -4,6 +4,7 @@ package prompts
 type Prompt struct {
 	Category    string `json:"category"`
 	Description string `json:"description"`
+	IsAmbient   bool   `json:"isAmbient,omitempty"`
 	Name        string `json:"name"`
 	Query       string `json:"query"`
 	Title       string `json:"title"`
@@ -112,10 +113,11 @@ func Catalog() []Prompt {
 			Title:       "Workload Troubleshooting",
 		},
 
-		// Ambient Mesh prompts
+		// Ambient Mesh prompts — only shown when Ambient Mesh is enabled in at least one cluster
 		{
 			Category:    "mesh",
 			Description: "Check if Ambient Mesh is enabled and get ztunnel DaemonSet status across clusters",
+			IsAmbient:   true,
 			Name:        "ambient-mesh-status",
 			Query:       "Check if Ambient Mesh is enabled in my clusters. Show ztunnel DaemonSet status, pod health per node, and which namespaces are in Ambient mode.",
 			Title:       "Ambient Mesh Status",
@@ -123,6 +125,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "namespaces",
 			Description: "List namespaces with their Ambient mode status and identify which ones need waypoints",
+			IsAmbient:   true,
 			Name:        "ambient-namespace-overview",
 			Query:       "List all namespaces with their Ambient status. Identify which namespaces are in Ambient mode, which have waypoints deployed, and which may need waypoints for L7 policies.",
 			Title:       "Ambient Namespace Overview",
@@ -130,6 +133,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "namespace-details",
 			Description: "Analyze AuthorizationPolicies in this namespace for Ambient compatibility (L4 vs L7)",
+			IsAmbient:   true,
 			Name:        "ambient-policy-analysis",
 			Query:       "Analyze the AuthorizationPolicies in the current namespace for Ambient Mesh compatibility. Show which policies are L4 (ztunnel-enforced) vs L7 (waypoint-required), and warn if L7 policies exist without a waypoint.",
 			Title:       "Ambient Policy Analysis",
@@ -137,6 +141,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "workload-details",
 			Description: "Show ztunnel networking details for this Ambient workload (protocol, captured services, waypoint)",
+			IsAmbient:   true,
 			Name:        "ambient-workload-networking",
 			Query:       "Show detailed Ambient networking information for the current workload. Include ztunnel capture status, protocol (HBONE/TCP), network mode, captured services with VIPs, and waypoint configuration.",
 			Title:       "Ambient Workload Networking",
@@ -144,6 +149,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "workload-details",
 			Description: "For waypoint proxies, show which services they are capturing and enforcing policies for",
+			IsAmbient:   true,
 			Name:        "waypoint-captured-services",
 			Query:       "If this workload is a waypoint proxy, show which services it is capturing and enforcing L7 policies for. Include service names and namespaces.",
 			Title:       "Waypoint Captured Services",
@@ -151,6 +157,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "graph",
 			Description: "Show traffic topology filtered to Ambient Mesh waypoint-reported traffic only",
+			IsAmbient:   true,
 			Name:        "ambient-waypoint-traffic",
 			Query:       "Show the traffic topology for the selected namespaces, filtered to show only waypoint-reported traffic. This helps visualize L7 traffic flow in Ambient mode.",
 			Title:       "Ambient Waypoint Traffic",
@@ -158,6 +165,7 @@ func Catalog() []Prompt {
 		{
 			Category:    "istio",
 			Description: "Review AuthorizationPolicies across namespaces for Ambient compatibility issues",
+			IsAmbient:   true,
 			Name:        "ambient-policy-audit",
 			Query:       "Audit AuthorizationPolicies across all Ambient namespaces. Report L7 policies in namespaces without waypoints, and recommend where waypoints should be deployed.",
 			Title:       "Ambient Policy Audit",

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -397,22 +397,26 @@ func TestConvertToolToAnthropic_FromToolDefinition_ListOrGetResources(t *testing
 			Description: param.NewOpt("Fetches a list of resources OR retrieves detailed data for a specific resource. If 'resourceName' is omitted, it returns a list. If 'resourceName' is provided, it returns details for that specific resource."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
-					"resourceType": map[string]interface{}{
+					"clusterName": map[string]interface{}{
 						"type":        "string",
-						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
-						"enum":        []interface{}{"service", "workload", "app", "namespace", "argoapp"},
+						"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+					},
+					"namespace": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
 					},
 					"namespaces": map[string]interface{}{
 						"type":        "string",
-						"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
+						"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
 					},
 					"resourceName": map[string]interface{}{
 						"type":        "string",
 						"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
 					},
-					"clusterName": map[string]interface{}{
+					"resourceType": map[string]interface{}{
 						"type":        "string",
-						"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
+						"enum":        []interface{}{"service", "workload", "app", "namespace", "argoapp"},
 					},
 				},
 				Required: []string{"resourceType"},

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -237,6 +237,11 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetMeshGraph(t *testing.T) {
 			Description: param.NewOpt("Returns service-to-service traffic topology, dependencies, and network metrics (throughput, response time, mTLS) for the specified namespaces. Use this to diagnose routing issues, latency, or find upstream/downstream dependencies."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
+					"ambientTraffic": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional. Filter Ambient Mesh traffic. 'none' excludes all ambient traffic, 'total' includes all (default), 'waypoint' shows only waypoint-reported traffic, 'ztunnel' shows only ztunnel-reported traffic. Only applicable when Ambient Mesh is enabled.",
+						"enum":        []interface{}{"none", "total", "waypoint", "ztunnel"},
+					},
 					"namespaces": map[string]interface{}{
 						"type":        "string",
 						"description": "Comma-separated list of namespaces to map",
@@ -394,7 +399,7 @@ func TestConvertToolToAnthropic_FromToolDefinition_ListOrGetResources(t *testing
 				Properties: map[string]interface{}{
 					"resourceType": map[string]interface{}{
 						"type":        "string",
-						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
+						"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
 						"enum":        []interface{}{"service", "workload", "app", "namespace", "argoapp"},
 					},
 					"namespaces": map[string]interface{}{

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -193,6 +193,11 @@ func TestConvertToolToGoogle_FromToolDefinition_GetMeshGraph(t *testing.T) {
 	expected := &genai.Schema{
 		Type: genai.TypeObject,
 		Properties: map[string]*genai.Schema{
+			"ambientTraffic": {
+				Type:        genai.TypeString,
+				Description: "Optional. Filter Ambient Mesh traffic. 'none' excludes all ambient traffic, 'total' includes all (default), 'waypoint' shows only waypoint-reported traffic, 'ztunnel' shows only ztunnel-reported traffic. Only applicable when Ambient Mesh is enabled.",
+				Enum:        []string{"none", "total", "waypoint", "ztunnel"},
+			},
 			"namespaces": {
 				Type:        genai.TypeString,
 				Description: "Comma-separated list of namespaces to map",
@@ -326,7 +331,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 		Properties: map[string]*genai.Schema{
 			"resourceType": {
 				Type:        genai.TypeString,
-				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
+				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
 				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
 			},
 			"namespaces": {

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -329,22 +329,26 @@ func TestConvertToolToGoogle_FromToolDefinition_ListOrGetResources(t *testing.T)
 	expected := &genai.Schema{
 		Type: genai.TypeObject,
 		Properties: map[string]*genai.Schema{
-			"resourceType": {
+			"clusterName": {
 				Type:        genai.TypeString,
-				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
-				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
+				Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+			},
+			"namespace": {
+				Type:        genai.TypeString,
+				Description: "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
 			},
 			"namespaces": {
 				Type:        genai.TypeString,
-				Description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
+				Description: "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
 			},
 			"resourceName": {
 				Type:        genai.TypeString,
 				Description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
 			},
-			"clusterName": {
+			"resourceType": {
 				Type:        genai.TypeString,
-				Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+				Description: "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
+				Enum:        []string{"service", "workload", "app", "namespace", "argoapp"},
 			},
 		},
 		Required: []string{"resourceType"},

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -258,6 +258,16 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetMeshGraph(t *testing.T) {
 						"namespaces",
 					},
 					"properties": map[string]interface{}{
+						"ambientTraffic": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional. Filter Ambient Mesh traffic. 'none' excludes all ambient traffic, 'total' includes all (default), 'waypoint' shows only waypoint-reported traffic, 'ztunnel' shows only ztunnel-reported traffic. Only applicable when Ambient Mesh is enabled.",
+							"enum": []interface{}{
+								"none",
+								"total",
+								"waypoint",
+								"ztunnel",
+							},
+						},
 						"namespaces": map[string]interface{}{
 							"type":        "string",
 							"description": "Comma-separated list of namespaces to map",
@@ -438,7 +448,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 					"properties": map[string]interface{}{
 						"resourceType": map[string]interface{}{
 							"type":        "string",
-							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them.",
+							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
 							"enum": []interface{}{
 								"service",
 								"workload",

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -446,6 +446,22 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 						"resourceType",
 					},
 					"properties": map[string]interface{}{
+						"clusterName": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
+						},
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional alias for 'namespaces' when querying a single namespace (e.g., 'bookinfo'). Cannot be combined with a comma-separated 'namespaces' value.",
+						},
+						"namespaces": map[string]interface{}{
+							"type":        "string",
+							"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces. The singular alias 'namespace' is also accepted for a single namespace value.",
+						},
+						"resourceName": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
+						},
 						"resourceType": map[string]interface{}{
 							"type":        "string",
 							"description": "The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io). ArgoCD Applications have no Kiali UI page so always use this tool (not get_action_ui) for them. When resourceType is 'workload' and the workload is in Ambient mode, ztunnel networking details are included automatically.",
@@ -456,18 +472,6 @@ func TestConvertToolToOpenAI_FromToolDefinition_ListOrGetResources(t *testing.T)
 								"namespace",
 								"argoapp",
 							},
-						},
-						"namespaces": map[string]interface{}{
-							"type":        "string",
-							"description": "Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.",
-						},
-						"resourceName": map[string]interface{}{
-							"type":        "string",
-							"description": "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
-						},
-						"clusterName": map[string]interface{}{
-							"type":        "string",
-							"description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig.",
 						},
 					},
 				},

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -135,24 +135,34 @@ func ChatMCP(
 	}
 }
 
-func ChatPrompts(conf *config.Config) http.HandlerFunc {
+func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !conf.ChatAI.Enabled {
 			RespondWithError(w, http.StatusServiceUnavailable, "ChatAI is not enabled")
 			return
 		}
+
+		// Determine whether Ambient Mesh is enabled in any accessible cluster
+		saClients := clientFactory.GetSAClients()
+		accessibleClusters := make([]string, 0, len(saClients))
+		for clusterName := range saClients {
+			accessibleClusters = append(accessibleClusters, clusterName)
+		}
+		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters)
+
 		category := r.URL.Query().Get("category")
 		catalog := prompts.Catalog()
-		if category != "" {
-			filtered := make([]prompts.Prompt, 0, len(catalog))
-			for _, p := range catalog {
-				if p.Category == category {
-					filtered = append(filtered, p)
-				}
+		filtered := make([]prompts.Prompt, 0, len(catalog))
+		for _, p := range catalog {
+			if p.IsAmbient && !ambientEnabled {
+				continue
 			}
-			catalog = filtered
+			if category != "" && p.Category != category {
+				continue
+			}
+			filtered = append(filtered, p)
 		}
-		RespondWithJSON(w, http.StatusOK, catalog)
+		RespondWithJSON(w, http.StatusOK, filtered)
 	}
 }
 

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -112,6 +112,20 @@ func ChatMCP(
 			RespondWithError(w, http.StatusInternalServerError, "AI initialization error: "+err.Error())
 			return
 		}
+		// Gate Ambient-specific tools when Ambient Mesh is not enabled in any cluster
+		if mcp.IsAmbientTool(toolName) {
+			// Get accessible clusters from SA clients
+			saClients := clientFactory.GetSAClients()
+			accessibleClusters := make([]string, 0, len(saClients))
+			for clusterName := range saClients {
+				accessibleClusters = append(accessibleClusters, clusterName)
+			}
+			if !kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters) {
+				RespondWithError(w, http.StatusNotFound,
+					fmt.Sprintf("Tool '%s' is not available when Ambient Mesh is not enabled in any cluster", toolName))
+				return
+			}
+		}
 		mcpResult, code := tool.Call(kialiInterface, args)
 		if code != http.StatusOK {
 			RespondWithError(w, code, fmt.Sprintf("Tool %s returned error: %v", toolName, mcpResult))

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -107,14 +107,8 @@ func ChatMCP(
 			RespondWithError(w, http.StatusNotFound, "metrics are unavailable because Prometheus is disabled")
 			return
 		}
-		kialiInterface, err := GetKialiInterface(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, perses, discovery)
-		if err != nil {
-			RespondWithError(w, http.StatusInternalServerError, "AI initialization error: "+err.Error())
-			return
-		}
-		// Gate Ambient-specific tools when Ambient Mesh is not enabled in any cluster
+		// Gate Ambient-specific tools before building the full interface, matching the tracing/metrics pattern above.
 		if mcp.IsAmbientTool(toolName) {
-			// Get accessible clusters from SA clients
 			saClients := clientFactory.GetSAClients()
 			accessibleClusters := make([]string, 0, len(saClients))
 			for clusterName := range saClients {
@@ -125,6 +119,11 @@ func ChatMCP(
 					fmt.Sprintf("Tool '%s' is not available when Ambient Mesh is not enabled in any cluster", toolName))
 				return
 			}
+		}
+		kialiInterface, err := GetKialiInterface(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, perses, discovery)
+		if err != nil {
+			RespondWithError(w, http.StatusInternalServerError, "AI initialization error: "+err.Error())
+			return
 		}
 		mcpResult, code := tool.Call(kialiInterface, args)
 		if code != http.StatusOK {

--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -109,12 +109,7 @@ func ChatMCP(
 		}
 		// Gate Ambient-specific tools before building the full interface, matching the tracing/metrics pattern above.
 		if mcp.IsAmbientTool(toolName) {
-			saClients := clientFactory.GetSAClients()
-			accessibleClusters := make([]string, 0, len(saClients))
-			for clusterName := range saClients {
-				accessibleClusters = append(accessibleClusters, clusterName)
-			}
-			if !kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters) {
+			if !kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusterNames(clientFactory)) {
 				RespondWithError(w, http.StatusNotFound,
 					fmt.Sprintf("Tool '%s' is not available when Ambient Mesh is not enabled in any cluster", toolName))
 				return
@@ -134,6 +129,16 @@ func ChatMCP(
 	}
 }
 
+// accessibleClusterNames returns cluster names reachable via the client factory's service-account clients.
+func accessibleClusterNames(clientFactory kubernetes.ClientFactory) []string {
+	saClients := clientFactory.GetSAClients()
+	names := make([]string, 0, len(saClients))
+	for clusterName := range saClients {
+		names = append(names, clusterName)
+	}
+	return names
+}
+
 func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory kubernetes.ClientFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !conf.ChatAI.Enabled {
@@ -141,13 +146,7 @@ func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory
 			return
 		}
 
-		// Determine whether Ambient Mesh is enabled in any accessible cluster
-		saClients := clientFactory.GetSAClients()
-		accessibleClusters := make([]string, 0, len(saClients))
-		for clusterName := range saClients {
-			accessibleClusters = append(accessibleClusters, clusterName)
-		}
-		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusters)
+		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusterNames(clientFactory))
 
 		category := r.URL.Query().Get("category")
 		catalog := prompts.Catalog()

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -1115,7 +1115,7 @@ func TestChatPrompts_ReturnsAllPrompts(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var prompts []map[string]string
+	var prompts []map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&prompts)
 	require.NoError(t, err)
 	assert.Greater(t, len(prompts), 0, "should return at least one prompt")
@@ -1145,7 +1145,7 @@ func TestChatPrompts_FilterByCategory(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var prompts []map[string]string
+	var prompts []map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&prompts)
 	require.NoError(t, err)
 	assert.Greater(t, len(prompts), 0, "should return prompts for overview category")

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -1101,8 +1101,10 @@ func TestDeleteConversations_SessionScoping(t *testing.T) {
 func TestChatPrompts_ReturnsAllPrompts(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ChatAI.Enabled = true
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, kubetest.NewFakeK8sClient())
+	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 
-	handler := ChatPrompts(conf)
+	handler := ChatPrompts(conf, kialiCache, cf)
 
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -1129,8 +1131,10 @@ func TestChatPrompts_ReturnsAllPrompts(t *testing.T) {
 func TestChatPrompts_FilterByCategory(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ChatAI.Enabled = true
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, kubetest.NewFakeK8sClient())
+	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 
-	handler := ChatPrompts(conf)
+	handler := ChatPrompts(conf, kialiCache, cf)
 
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -1154,8 +1158,10 @@ func TestChatPrompts_FilterByCategory(t *testing.T) {
 func TestChatPrompts_FilterByCategory_NoResults(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ChatAI.Enabled = true
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, kubetest.NewFakeK8sClient())
+	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 
-	handler := ChatPrompts(conf)
+	handler := ChatPrompts(conf, kialiCache, cf)
 
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
@@ -1175,8 +1181,10 @@ func TestChatPrompts_FilterByCategory_NoResults(t *testing.T) {
 func TestChatPrompts_DisabledWhenChatAIOff(t *testing.T) {
 	conf := config.NewConfig()
 	conf.ChatAI.Enabled = false
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, kubetest.NewFakeK8sClient())
+	kialiCache := cache.NewTestingCacheWithFactory(t, cf, *conf)
 
-	handler := ChatPrompts(conf)
+	handler := ChatPrompts(conf, kialiCache, cf)
 
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1873,7 +1873,7 @@ func NewRoutes(
 			log.ChatAILogName,
 			"GET",
 			"/api/chat/prompts",
-			handlers.ChatPrompts(conf),
+			handlers.ChatPrompts(conf, kialiCache, clientFactory),
 			true,
 		},
 		// swagger:route POST /chat/{provider}/{model}/ai chat aiChatAI

--- a/tests/integration/mcp_tools/analyze_ambient_policies_test.go
+++ b/tests/integration/mcp_tools/analyze_ambient_policies_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAnalyzeAmbientPolicies_MissingNamespace(t *testing.T) {
+func TestAnalyzeAmbientPolicies_NoNamespace(t *testing.T) {
 	resp, err := CallMCPToolEmptyBody("analyze_ambient_policies")
 	require.NoError(t, err)
-	// Without Ambient the tool is gated at 404; with Ambient but no namespace it is 400.
+	// Without Ambient the tool is gated at 404.
+	// With Ambient enabled and no namespace specified, the tool auto-discovers all Ambient
+	// namespaces and returns 200 OK (even if none are found).
 	assert.True(t,
-		resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound,
-		"Expected 400 (missing namespace) or 404 (Ambient not enabled), got %d", resp.StatusCode)
+		resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound,
+		"Expected 200 (auto-discovery) or 404 (Ambient not enabled), got %d", resp.StatusCode)
 }
 
 func TestAnalyzeAmbientPolicies_WithNamespace(t *testing.T) {
@@ -30,12 +32,23 @@ func TestAnalyzeAmbientPolicies_WithNamespace(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, resp.Parsed)
 
-	_, hasSummary := resp.Parsed["summary"]
-	assert.True(t, hasSummary, "Response should contain 'summary'")
+	// Top-level response contains a "namespaces" array; per-namespace details live inside it.
+	namespacesRaw, hasNamespaces := resp.Parsed["namespaces"]
+	assert.True(t, hasNamespaces, "Response should contain 'namespaces'")
 
-	_, hasNsStatus := resp.Parsed["namespace_status"]
-	assert.True(t, hasNsStatus, "Response should contain 'namespace_status'")
+	namespaces, ok := namespacesRaw.([]interface{})
+	require.True(t, ok, "'namespaces' should be an array")
+	require.NotEmpty(t, namespaces, "'namespaces' array should have at least one entry")
 
-	_, hasPolicies := resp.Parsed["policies"]
-	assert.True(t, hasPolicies, "Response should contain 'policies'")
+	nsEntry, ok := namespaces[0].(map[string]interface{})
+	require.True(t, ok, "first namespace entry should be an object")
+
+	_, hasNsStatus := nsEntry["namespace_status"]
+	assert.True(t, hasNsStatus, "Namespace entry should contain 'namespace_status'")
+
+	_, hasPolicies := nsEntry["policies"]
+	assert.True(t, hasPolicies, "Namespace entry should contain 'policies'")
+
+	_, hasSummary := nsEntry["summary"]
+	assert.True(t, hasSummary, "Namespace entry should contain 'summary'")
 }

--- a/tests/integration/mcp_tools/analyze_ambient_policies_test.go
+++ b/tests/integration/mcp_tools/analyze_ambient_policies_test.go
@@ -1,0 +1,41 @@
+package mcp_tools
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeAmbientPolicies_MissingNamespace(t *testing.T) {
+	resp, err := CallMCPToolEmptyBody("analyze_ambient_policies")
+	require.NoError(t, err)
+	// Without Ambient the tool is gated at 404; with Ambient but no namespace it is 400.
+	assert.True(t,
+		resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound,
+		"Expected 400 (missing namespace) or 404 (Ambient not enabled), got %d", resp.StatusCode)
+}
+
+func TestAnalyzeAmbientPolicies_WithNamespace(t *testing.T) {
+	resp, err := CallMCPTool("analyze_ambient_policies", map[string]interface{}{
+		"namespace": "bookinfo",
+	})
+	require.NoError(t, err)
+
+	if resp.StatusCode == http.StatusNotFound {
+		t.Skip("Ambient Mesh is not enabled in this cluster — skipping analyze_ambient_policies test")
+	}
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, resp.Parsed)
+
+	_, hasSummary := resp.Parsed["summary"]
+	assert.True(t, hasSummary, "Response should contain 'summary'")
+
+	_, hasNsStatus := resp.Parsed["namespace_status"]
+	assert.True(t, hasNsStatus, "Response should contain 'namespace_status'")
+
+	_, hasPolicies := resp.Parsed["policies"]
+	assert.True(t, hasPolicies, "Response should contain 'policies'")
+}

--- a/tests/integration/mcp_tools/tools_coverage_test.go
+++ b/tests/integration/mcp_tools/tools_coverage_test.go
@@ -107,6 +107,13 @@ func TestAllMCPEndpointsExist(t *testing.T) {
 				}
 				return
 			}
+			if mcp.IsAmbientTool(toolName) {
+				// Ambient-specific tools return 404 when Ambient Mesh is not enabled in any cluster.
+				// A 400 means Ambient is enabled but required args are missing — the tool is reachable.
+				assert.NotEqual(t, 500, resp.StatusCode,
+					"Ambient tool /api/chat/mcp/%s returned an unexpected server error", toolName)
+				return
+			}
 			assert.NotEqual(t, 404, resp.StatusCode,
 				"Tool endpoint /api/chat/mcp/%s returned 404 — not registered", toolName)
 		})


### PR DESCRIPTION
### Describe the change

Adds Ambient mesh capabilities to the MCP server: 
- New tool `analyze_ambient_policies` to provide information about L4 and L7 policies
- Add ztunnel and waypoint data to the workloads information
- Add ztunnel status in the `get_mesh_status` tool
- Add Ambient traffic data in the graph
- Add specific Ambient  prompts 

<img width="1807" height="880" alt="image" src="https://github.com/user-attachments/assets/6538c628-6ddf-446d-9830-b04fc732f587" />

<img width="502" height="954" alt="image" src="https://github.com/user-attachments/assets/ccd09015-797e-4324-9c67-1f0a522a442d" />


### Steps to test the PR

- Install Ambient Mesh and verify the new tools are working as expected. They can be tested using the new prompts. 
- Verify compatibility with the mcp server 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes #9977 
