### PR TITLE
Fall back to svc.cluster.local when istio_identity_domain is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1465,6 +1465,11 @@ func Set(conf *Config) {
 	}
 
 	conf.AddHealthDefault()
+
+	if conf.ExternalServices.Istio.IstioIdentityDomain == "" {
+		conf.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	}
+
 	configuration = *conf
 
 	// Only close the previous credential manager if we actually swapped it out.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -230,6 +230,28 @@ func TestSetCreatesNewCredentialManagerAndClosesOld(t *testing.T) {
 	}
 }
 
+func TestSetDefaultsEmptyIstioIdentityDomain(t *testing.T) {
+	original := Get()
+	defer Set(original)
+
+	conf := NewConfig()
+	conf.ExternalServices.Istio.IstioIdentityDomain = ""
+	Set(conf)
+
+	assert.Equal(t, "svc.cluster.local", Get().ExternalServices.Istio.IstioIdentityDomain)
+}
+
+func TestSetPreservesExplicitIstioIdentityDomain(t *testing.T) {
+	original := Get()
+	defer Set(original)
+
+	conf := NewConfig()
+	conf.ExternalServices.Istio.IstioIdentityDomain = "svc.my-custom.domain"
+	Set(conf)
+
+	assert.Equal(t, "svc.my-custom.domain", Get().ExternalServices.Istio.IstioIdentityDomain)
+}
+
 func createTestSecretFile(t *testing.T, parentDir string, name string, content string) {
 	childDir := fmt.Sprintf("%s/%s", parentDir, name)
 	filename := fmt.Sprintf("%s/value.txt", childDir)

--- a/tests/integration/utils/kiali/instance.go
+++ b/tests/integration/utils/kiali/instance.go
@@ -220,6 +220,18 @@ func sanitizeConfigForCR(configYAML string) (string, error) {
 		}
 	}
 
+	// Fix Go duration strings in health_config.compute that don't match
+	// the CRD enum format (e.g., "5m0s" -> "5m", "1h0m0s" -> "1h")
+	if healthConfig, ok := data["health_config"].(map[string]any); ok {
+		if compute, ok := healthConfig["compute"].(map[string]any); ok {
+			for _, field := range []string{"duration", "refresh_interval", "timeout"} {
+				if val, ok := compute[field].(string); ok {
+					compute[field] = normalizeGoDuration(val)
+				}
+			}
+		}
+	}
+
 	// Remove runtime-only fields that were never in any CRD schema version
 	// These fields are server runtime state, not configuration
 	delete(data, "in_cluster") // Never in CRD schema (deprecated/internal field)
@@ -233,6 +245,31 @@ func sanitizeConfigForCR(configYAML string) (string, error) {
 	}
 
 	return string(cleanedJSON), nil
+}
+
+// normalizeGoDuration converts Go's time.Duration.String() format to a
+// human-friendly format that matches CRD enum values.
+// For example: "5m0s" -> "5m", "1h0m0s" -> "1h", "10m0s" -> "10m".
+// Values that are already in the target format or can't be parsed are
+// returned unchanged.
+func normalizeGoDuration(s string) string {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return s
+	}
+
+	switch {
+	case d%(24*time.Hour) == 0:
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	case d%time.Hour == 0:
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	case d%time.Minute == 0:
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	case d%time.Second == 0:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	default:
+		return s
+	}
 }
 
 // UpdateConfig will update the Kiali instance with the new config. It will ensure


### PR DESCRIPTION
## Summary

- When the v2.27 operator deploys a v2.22 Kiali server, the CRD schema default for `istio_identity_domain` (changed from `"svc.cluster.local"` to `""` in the v2.27 operator) is injected by the Kubernetes API server before the operator reads the CR. This overrides the Ansible role default, causing the v2.22 server to receive an empty identity domain.
- The v2.22 server lacks the auto-detection logic added in v2.27 (`config.ResolveIdentityDomain()`), so it uses the empty string as-is. This breaks service account principal matching in authorization policy validations (and FQDN host matching in other subsystems), producing malformed SA names like `/ns/bookinfo/sa/bookinfo-details` instead of `cluster.local/ns/bookinfo/sa/bookinfo-details`.
- Adds a fallback in `config.Set()` so that an empty `IstioIdentityDomain` is resolved to `"svc.cluster.local"`, making the v2.22 server resilient to the newer CRD default.

## Test plan

- [x] New unit tests verify the fallback (`TestSetDefaultsEmptyIstioIdentityDomain`) and that explicit values are preserved (`TestSetPreservesExplicitIstioIdentityDomain`)
- [ ] Verify `TestAuthPolicyPrincipalsError` integration test passes when v2.22 server is deployed by v2.27 operator


Made with [Cursor](https://cursor.com)