### PR TITLE
Fall back to svc.cluster.local when istio_identity_domain is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1006,6 +1006,11 @@ func Set(conf *Config) {
 	rwMutex.Lock()
 	defer rwMutex.Unlock()
 	conf.AddHealthDefault()
+
+	if conf.ExternalServices.Istio.IstioIdentityDomain == "" {
+		conf.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	}
+
 	configuration = *conf
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -312,6 +312,28 @@ func TestRaces(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSetDefaultsEmptyIstioIdentityDomain(t *testing.T) {
+	original := Get()
+	defer Set(original)
+
+	conf := NewConfig()
+	conf.ExternalServices.Istio.IstioIdentityDomain = ""
+	Set(conf)
+
+	assert.Equal(t, "svc.cluster.local", Get().ExternalServices.Istio.IstioIdentityDomain)
+}
+
+func TestSetPreservesExplicitIstioIdentityDomain(t *testing.T) {
+	original := Get()
+	defer Set(original)
+
+	conf := NewConfig()
+	conf.ExternalServices.Istio.IstioIdentityDomain = "svc.my-custom.domain"
+	Set(conf)
+
+	assert.Equal(t, "svc.my-custom.domain", Get().ExternalServices.Istio.IstioIdentityDomain)
+}
+
 func TestAllNamespacesAccessible(t *testing.T) {
 	// cluster wide access flag is the only one that matters
 	cases := map[string]struct {


### PR DESCRIPTION
## Summary

- Backport to v2.4 of the fix from https://github.com/kiali/kiali/pull/9996
- When the v2.27 operator deploys a v2.4 Kiali server, the CRD schema default for `istio_identity_domain` (changed from `"svc.cluster.local"` to `""` in the v2.27 operator) is injected by the Kubernetes API server before the operator reads the CR. This overrides the Ansible role default, causing the v2.4 server to receive an empty identity domain.
- The v2.4 server lacks the auto-detection logic added in v2.27, so it uses the empty string as-is, breaking service account principal matching in validations and FQDN host matching across multiple subsystems.
- Adds a fallback in `config.Set()` so that an empty `IstioIdentityDomain` is resolved to `"svc.cluster.local"`.

## Test plan

- [x] New unit tests verify the fallback and that explicit values are preserved


Made with [Cursor](https://cursor.com)