### PR TITLE
[CI] Perses link fix (backport #9930 to v2.22)

### DIFF
--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -5,6 +5,8 @@ config:
   provisioning:
     interval: 1m
 volumes:
+- name: plugins
+  emptyDir: {}
 - name: provisioning
   projected:
     sources:
@@ -15,6 +17,8 @@ volumes:
     - configMap:
         name: perses-provisioning
 volumeMounts:
+- name: plugins
+  mountPath: /etc/perses/plugins
 - name: provisioning
   mountPath: /etc/perses/provisioning
   readOnly: true

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -376,6 +376,7 @@ setup_kind_singlecluster() {
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
     ${HELM} install perses perses/perses -n istio-system -f "${SCRIPT_DIR}"/istio/perses/values.yaml
+
           PERSES_ARGS=(
         "--set" "external_services.perses.enabled=true"
         "--set" "external_services.perses.internal_url=http://perses.istio-system:8080"


### PR DESCRIPTION
## Summary

Backport of #9930 to v2.22.

- Perses v0.53.1 needs to extract plugin archives into `/etc/perses/plugins/` at startup, but that path was read-only in the container
- Without the plugins loaded, variable and datasource schemas are not initialized, so dashboard provisioning is rejected and the Perses link Cypress test fails
- Adds an `emptyDir` volume mounted at `/etc/perses/plugins` so Perses can write there

Fixes the recurring `#perses_link_0` Cypress failure seen in CI for v2.22 PRs.

## Test plan

- [ ] CI Cypress Perses link test passes


Made with [Cursor](https://cursor.com)