### PR TITLE
[Ambient] Exclude waypoint and gateway workloads from KIA1317

### DIFF
--- a/business/checkers/ambient/ambient_workload_checker.go
+++ b/business/checkers/ambient/ambient_workload_checker.go
@@ -124,6 +124,9 @@ func (awc AmbientWorkloadChecker) hasSidecarInAmbientNamespace() bool {
 }
 
 func (awc AmbientWorkloadChecker) hasAuthPolicyAndNoWaypoint() bool {
+	if awc.workload.IsWaypoint() || awc.workload.IsGateway() {
+		return false
+	}
 	for _, ap := range awc.authorizationPolicies {
 		if ap.Namespace == awc.workload.Namespace && len(awc.workload.WaypointWorkloads) == 0 {
 			return true

--- a/business/checkers/ambient/ambient_workload_checker_test.go
+++ b/business/checkers/ambient/ambient_workload_checker_test.go
@@ -273,6 +273,34 @@ func TestWorkloadZeroReplicasInAmbientNamespace(t *testing.T) {
 	assert.True(valid)
 }
 
+func TestWaypointWithAuthPolicyDoesNotTriggerKIA1317(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	waypointLabels := map[string]string{
+		config.WaypointLabel: config.WaypointLabelValue,
+	}
+
+	workload := data.CreateWorkload(ns1, "waypoint", waypointLabels)
+	workload.IsAmbient = true
+	workload.WaypointWorkloads = make([]models.WorkloadReferenceInfo, 0)
+	workload.Pods = models.Pods{data.CreatePod("waypoint-pod", waypointLabels, true, false, false)}
+
+	vals, valid := NewAmbientWorkloadChecker(
+		conf.KubernetesConfig.ClusterName,
+		conf,
+		workload,
+		ns1,
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		[]*security_v1.AuthorizationPolicy{data.CreateEmptyAuthorizationPolicy("test", ns1)},
+	).Check()
+
+	assert.Empty(vals)
+	assert.True(valid)
+}
+
 func TestWaypointZeroReplicas(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -296,10 +324,37 @@ func TestWaypointZeroReplicas(t *testing.T) {
 		workload,
 		ns1,
 		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}, IsAmbient: true}},
-		[]*security_v1.AuthorizationPolicy{},
+		[]*security_v1.AuthorizationPolicy{data.CreateEmptyAuthorizationPolicy("test", ns1)},
 	).Check()
 
 	// Should not have any validation errors because waypoints are always ambient
+	assert.Empty(vals)
+	assert.True(valid)
+}
+
+func TestGatewayWithAuthPolicyDoesNotTriggerKIA1317(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	gatewayLabels := map[string]string{
+		"istio": "ingressgateway",
+	}
+
+	workload := data.CreateWorkload(ns1, "istio-ingressgateway", gatewayLabels)
+	workload.WaypointWorkloads = make([]models.WorkloadReferenceInfo, 0)
+	workload.Pods = models.Pods{data.CreatePod("gateway-pod", gatewayLabels, false, true, false)}
+
+	vals, valid := NewAmbientWorkloadChecker(
+		conf.KubernetesConfig.ClusterName,
+		conf,
+		workload,
+		ns1,
+		models.Namespaces{models.Namespace{Name: ns1, Labels: map[string]string{}}},
+		[]*security_v1.AuthorizationPolicy{data.CreateEmptyAuthorizationPolicy("test", ns1)},
+	).Check()
+
 	assert.Empty(vals)
 	assert.True(valid)
 }


### PR DESCRIPTION
### Describe the change

KIA1317 warns when a workload's namespace has AuthorizationPolicies but the workload has no resolved waypoint. Waypoint proxy workloads and gateway workloads were incorrectly receiving this warning because they are L7 infra themselves and do not consume a waypoint.

This change skips KIA1317 for workloads identified as waypoint proxies (`IsWaypoint()`) or gateways (`IsGateway()`), matching the exclusion pattern already used for waypoint/gateway services in the port mapping checker.

### Steps to test the PR

1. Deploy an ambient mesh with bookinfo and an AuthorizationPolicy in the bookinfo namespace.
2. Deploy a waypoint proxy for the namespace.
3. Open the waypoint workload details page in Kiali.
4. Confirm KIA1317 is not shown on the waypoint workload.
5. Optionally verify a regular bookinfo workload without a waypoint still shows KIA1317.

### Automation testing

Unit tests in `business/checkers/ambient/ambient_workload_checker_test.go`:

- `TestWaypointWithAuthPolicyDoesNotTriggerKIA1317` — waypoint with namespace auth policy does not trigger KIA1317
- `TestGatewayWithAuthPolicyDoesNotTriggerKIA1317` — ingress gateway with namespace auth policy does not trigger KIA1317
- `TestWaypointZeroReplicas` — extended to include an auth policy and confirm no KIA1317
- `TestWorkloadHasAuthPolicyAndNoWaypoint` — unchanged; regular workloads still trigger KIA1317

Run:

```bash
make -e GO_TEST_FLAGS='-run "TestWorkloadHasAuthPolicyAndNoWaypoint|TestWaypoint|TestGateway"' test
```

### Issue reference

Fixes #9986

Made with [Cursor](https://cursor.com)