### PR TITLE
[v2.27] Improve graph trace overlay visibility

### DIFF
--- a/frontend/src/pages/Graph/styles/styleEdge.tsx
+++ b/frontend/src/pages/Graph/styles/styleEdge.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { DefaultEdge, Edge, observer, ScaleDetailsLevel, WithSelectionProps } from '@patternfly/react-topology';
+import { DefaultEdge, observer, ScaleDetailsLevel } from '@patternfly/react-topology';
+import type { Edge, WithSelectionProps } from '@patternfly/react-topology';
 import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import { useIconFontReady } from 'hooks/useIconFontReady';
@@ -16,8 +17,8 @@ import { AnimationEdge } from '../TrafficAnimation/AnimationEdge';
 //   support [lock] icons on edge tags
 
 const ColorFind = PFColors.Gold400;
-const ColorSpan = PFColors.Purple200;
-const OverlayOpacity = 0.3;
+const ColorSpan = PFColors.Purple500;
+const OverlayOpacity = 0.35;
 const OverlayWidth = 30;
 
 type StyleEdgeProps = {
@@ -34,7 +35,7 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
   const detailsLevel = useDetailsLevel();
   const iconFontReady = useIconFontReady();
 
-  let cssClasses: string[] = [];
+  const cssClasses: string[] = [];
 
   const onMouseEnter = (): void => {
     data.onHover?.(element, true);
@@ -116,9 +117,9 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
     cssClasses.push(findClass);
   }
 
-  // Set the path style when unhighlighted (opacity)
+  // Set the path style when unhighlighted (opacity), but keep trace-overlay edges visible
   let opacity = 1;
-  if (data.isUnhighlighted) {
+  if (data.isUnhighlighted && !data.hasSpans) {
     opacity = 0.1;
   }
 

--- a/frontend/src/pages/Graph/styles/styleNode.tsx
+++ b/frontend/src/pages/Graph/styles/styleNode.tsx
@@ -1,14 +1,12 @@
 import {
   DefaultNode,
   getShapeComponent,
-  Node,
   NodeShape,
   observer,
   ScaleDetailsLevel,
-  ShapeProps,
-  useHover,
-  WithSelectionProps
+  useHover
 } from '@patternfly/react-topology';
+import type { Node, ShapeProps, WithSelectionProps } from '@patternfly/react-topology';
 import { useDetailsLevel } from '@patternfly/react-topology';
 import * as React from 'react';
 import { KeyIcon, TopologyIcon } from '@patternfly/react-icons';
@@ -92,8 +90,8 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
 
   const ColorFind = PFColors.Gold400;
   const ColorFocus = PFColors.Blue200;
-  const ColorSpan = PFColors.Purple200;
-  const OverlayOpacity = 0.3;
+  const ColorSpan = PFColors.Purple500;
+  const OverlayOpacity = 0.35;
   const OverlayWidth = 40;
 
   const findOverlayStyle = kialiStyle({
@@ -113,9 +111,9 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
     strokeOpacity: OverlayOpacity
   });
 
-  // Set the path style when unhighlighted (opacity)
+  // Set the path style when unhighlighted (opacity), but keep trace-overlay nodes visible
   let opacity = 1;
-  if (data.isUnhighlighted) {
+  if (data.isUnhighlighted && !data.hasSpans) {
     opacity = 0.1;
   }
 


### PR DESCRIPTION
## Summary

Backport of #10007 to v2.27.

- Use a darker purple (`Purple500` instead of `Purple200`) and slightly higher opacity (`0.35` instead of `0.3`) for the trace overlay on both nodes and edges, making it clearly visible.
- Skip the unhighlight dimming for nodes and edges with trace spans so the trace path remains visible when surrounding elements are dimmed.
- Fix pre-existing lint issues in the changed files (type-only imports, `const` for non-reassigned array).

Fixes #10006

## Test plan

- [ ] Enable a trace overlay on the traffic graph and verify it is clearly visible on nodes and edges
- [ ] With a trace overlay active, hover or select an element and verify the trace-highlighted nodes/edges remain visible while other elements dim
- [ ] Verify the find (gold) and focus (blue) overlays still render correctly