### PR TITLE
[CI] mcp contract tests: Use kiali pinned version from mcp

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -208,15 +208,6 @@ jobs:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
 
-  mcp_contract_tests:
-    name: MCP Contract Tests (kubernetes-mcp-server)
-    uses: ./.github/workflows/mcp-contract-tests.yml
-    needs: [initialize, build_backend]
-    with:
-      target_branch: ${{ needs.initialize.outputs.target-branch }}
-      build_branch: ${{ needs.initialize.outputs.build-branch }}
-      istio_version: ""
-
   store_pr_metadata:
     permissions:
       contents: read

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -1,9 +1,40 @@
 name: MCP Contract Tests
 
 # Validates kubernetes-mcp-server contract tests against the Kiali version pinned in
-# containers/kubernetes-mcp-server/build/kiali.mk. Run manually via workflow_dispatch.
+# containers/kubernetes-mcp-server/build/kiali.mk.
 
 on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: true
+        type: string
+      build_branch:
+        required: true
+        type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
+      kubernetes_mcp_server_ref:
+        description: 'Git ref to checkout for containers/kubernetes-mcp-server (e.g. "main" or "refs/pull/123/head")'
+        required: false
+        type: string
+        default: "main"
+  push:
+    paths:
+    - 'routing/routes.go'
+    - 'ai/mcp/**'
+    branches:
+    - master
+    - 'v*.*'
+  pull_request:
+    paths:
+    - 'routing/routes.go'
+    - 'ai/mcp/**'
+    branches:
+    - master
+    - 'v*.*'
   workflow_dispatch:
     inputs:
       kubernetes_mcp_server_ref:
@@ -11,14 +42,16 @@ on:
         required: false
         type: string
         default: "main"
-      kiali_ref:
-        description: 'Kiali git ref override (default: pin from kubernetes-mcp-server/build/kiali.mk)'
+      kiali_image_version:
+        description: 'Kiali image tag to test (default: pin from kubernetes-mcp-server/build/kiali.mk)'
         required: false
         type: string
         default: ""
 
 env:
-  KUBERNETES_MCP_SERVER_REF: ${{ github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
+  TARGET_BRANCH: ${{ inputs.target_branch || github.ref_name }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch || github.ref }}
+  KUBERNETES_MCP_SERVER_REF: ${{ (github.event_name == 'workflow_call' && inputs.kubernetes_mcp_server_ref) || github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
 
 permissions: read-all
 
@@ -33,17 +66,17 @@ jobs:
       TERM: xterm
     steps:
     - name: Check out Kiali code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
-        fetch-depth: 0
+        ref: ${{ env.BUILD_BRANCH }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: 'v3.18.4'
 
     - name: Check out kubernetes-mcp-server
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: containers/kubernetes-mcp-server
         path: kubernetes-mcp-server
@@ -57,39 +90,16 @@ jobs:
         echo "kiali_version=${KIALI_VERSION}" >> $GITHUB_OUTPUT
         echo "kubernetes-mcp-server pins Kiali ${KIALI_VERSION}"
 
-    - name: Check out pinned Kiali version
-      run: |
-        KIALI_REF="${{ github.event.inputs.kiali_ref || steps.kiali_pin.outputs.kiali_version }}"
-        echo "Checking out Kiali ${KIALI_REF}"
-        git checkout "${KIALI_REF}"
-        echo "BUILD_BRANCH=${KIALI_REF}" >> $GITHUB_ENV
-        echo "TARGET_BRANCH=${KIALI_REF}" >> $GITHUB_ENV
-
-    # Corepack must be enabled before setup-node so that setup-node's
-    # cache: yarn correctly detects the Yarn 4 cache directory.
-    - name: Enable corepack
-      run: corepack enable
-
-    # This caches the yarn deps but does not touch node_modules so it's still necessary
-    # to run 'yarn install' later to link these into node_modules.
-    - name: Setup node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: "24"
-        cache: yarn
-        cache-dependency-path: frontend/yarn.lock
-    - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: true
-        cache-dependency-path: go.sum
-
-    - name: Build Kiali for cluster setup
-      run: make clean-all build-ui build
-
     - name: Setup KinD cluster with Istio and Kiali
-      run: hack/run-integration-tests.sh --test-suite backend --setup-only true
+      env:
+        KIALI_VERSION: ${{ github.event.inputs.kiali_image_version || steps.kiali_pin.outputs.kiali_version }}
+      run: |
+        ISTIO_ARGS=""
+        if [ -n "${{ inputs.istio_version }}" ]; then
+          ISTIO_ARGS="--istio-version ${{ inputs.istio_version }}"
+        fi
+        echo "Deploying quay.io/kiali/kiali:${KIALI_VERSION}"
+        hack/run-integration-tests.sh --test-suite backend --setup-only true --kiali-version "${KIALI_VERSION}" ${ISTIO_ARGS}
 
     - name: Get Kiali external URL from MetalLB
       id: get_kiali_url
@@ -107,7 +117,7 @@ jobs:
         curl -sf --connect-timeout 5 --max-time 15 "${KIALI_URL}/api/status"
 
     - name: Set up Go for kubernetes-mcp-server
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: kubernetes-mcp-server/go.mod
         cache: true
@@ -130,7 +140,7 @@ jobs:
 
     - name: Upload debug info artifact
       if: ${{ failure() && steps.contractTests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: debug-info-mcp-contract-tests
         path: debug-output

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -1,37 +1,9 @@
 name: MCP Contract Tests
 
+# Validates kubernetes-mcp-server contract tests against the Kiali version pinned in
+# containers/kubernetes-mcp-server/build/kiali.mk. Run manually via workflow_dispatch.
+
 on:
-  workflow_call:
-    inputs:
-      target_branch:
-        required: true
-        type: string
-      build_branch:
-        required: true
-        type: string
-      istio_version:
-        required: false
-        type: string
-        default: ""
-      kubernetes_mcp_server_ref:
-        description: 'Git ref to checkout for containers/kubernetes-mcp-server (e.g. "main" or "refs/pull/123/head")'
-        required: false
-        type: string
-        default: "main"
-  push:
-    paths:
-    - 'routing/routes.go'
-    - 'ai/mcp/**'
-    branches:
-    - master
-    - 'v*.*'
-  pull_request:
-    paths:
-    - 'routing/routes.go'
-    - 'ai/mcp/**'
-    branches:
-    - master
-    - 'v*.*'
   workflow_dispatch:
     inputs:
       kubernetes_mcp_server_ref:
@@ -39,10 +11,21 @@ on:
         required: false
         type: string
         default: "main"
+      kiali_ref:
+        description: 'Kiali git ref to use for cluster setup scripts (default: master)'
+        required: false
+        type: string
+        default: "master"
+      kiali_image_version:
+        description: 'Kiali image tag to test (default: pin from kubernetes-mcp-server/build/kiali.mk)'
+        required: false
+        type: string
+        default: ""
 
 env:
-  TARGET_BRANCH: ${{ inputs.target_branch || github.base_ref || github.ref_name }}
-  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch || github.ref }}
+  BUILD_BRANCH: ${{ github.event.inputs.kiali_ref || 'master' }}
+  KIALI_IMAGE_VERSION: ${{ github.event.inputs.kiali_image_version || '' }}
+  KUBERNETES_MCP_SERVER_REF: ${{ github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
 
 permissions: read-all
 
@@ -86,28 +69,37 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
 
-    - name: Download go binary
-      if: github.event_name == 'workflow_call'
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: kiali
-        path: ~/go/bin/
-
-    - name: Ensure kiali binary is executable
-      if: github.event_name == 'workflow_call'
-      run: chmod +x ~/go/bin/kiali
-
-    - name: Build Kiali binary for direct workflow runs
-      if: github.event_name != 'workflow_call'
+    - name: Build Kiali binary for cluster setup
       run: make clean-all build-ui build
 
-    - name: Install frontend dependencies
-      if: github.event_name == 'workflow_call'
-      working-directory: ./frontend
-      run: yarn install --immutable
+    - name: Check out kubernetes-mcp-server
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: containers/kubernetes-mcp-server
+        path: kubernetes-mcp-server
+        ref: ${{ env.KUBERNETES_MCP_SERVER_REF }}
+
+    - name: Resolve pinned Kiali version from kubernetes-mcp-server
+      id: kiali_pin
+      working-directory: kubernetes-mcp-server
+      run: |
+        KIALI_VERSION=$(grep -E '^KIALI_VERSION' build/kiali.mk | awk -F= '{print $2}' | tr -d '[:space:]')
+        echo "kiali_version=${KIALI_VERSION}" >> $GITHUB_OUTPUT
+        echo "kubernetes-mcp-server pins Kiali ${KIALI_VERSION}"
+
+    - name: Resolve Kiali image version for contract tests
+      id: kiali_image
+      run: |
+        if [ -n "${KIALI_IMAGE_VERSION}" ]; then
+          IMAGE_VERSION="${KIALI_IMAGE_VERSION}"
+        else
+          IMAGE_VERSION="${{ steps.kiali_pin.outputs.kiali_version }}"
+        fi
+        echo "kiali_image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+        echo "Testing Kiali image quay.io/kiali/kiali:${IMAGE_VERSION}"
 
     - name: Setup KinD cluster with Istio and Kiali
-      run: hack/run-integration-tests.sh --test-suite backend --setup-only true $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+      run: hack/run-integration-tests.sh --test-suite backend --setup-only true
 
     - name: Get Kiali external URL from MetalLB
       id: get_kiali_url
@@ -156,12 +148,25 @@ jobs:
           sleep 2
         done
 
-    - name: Check out kubernetes-mcp-server
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: containers/kubernetes-mcp-server
-        path: kubernetes-mcp-server
-        ref: ${{ (github.event_name == 'workflow_call' && inputs.kubernetes_mcp_server_ref) || github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
+    - name: Deploy Kiali release image for contract tests
+      run: |
+        KIALI_VERSION="${{ steps.kiali_image.outputs.kiali_image_version }}"
+        echo "Replacing dev Kiali image with ${KIALI_VERSION}..."
+        kubectl patch deployment kiali -n istio-system -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"kiali\",\"image\":\"quay.io/kiali/kiali:${KIALI_VERSION}\"}]}}}}"
+        kubectl rollout status deployment/kiali -n istio-system --timeout=300s
+
+        echo "Verifying pinned Kiali is accessible at ${KIALI_URL}..."
+        for i in {1..30}; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${KIALI_URL}/api/status")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Kiali ${KIALI_VERSION} is accessible at ${KIALI_URL}"
+            exit 0
+          fi
+          echo "Attempt $i/30: HTTP $HTTP_CODE"
+          sleep 2
+        done
+        echo "ERROR: Pinned Kiali ${KIALI_VERSION} is not accessible after rollout"
+        exit 1
 
     - name: Set up Go for kubernetes-mcp-server
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/mcp-contract-tests.yml
+++ b/.github/workflows/mcp-contract-tests.yml
@@ -12,19 +12,12 @@ on:
         type: string
         default: "main"
       kiali_ref:
-        description: 'Kiali git ref to use for cluster setup scripts (default: master)'
-        required: false
-        type: string
-        default: "master"
-      kiali_image_version:
-        description: 'Kiali image tag to test (default: pin from kubernetes-mcp-server/build/kiali.mk)'
+        description: 'Kiali git ref override (default: pin from kubernetes-mcp-server/build/kiali.mk)'
         required: false
         type: string
         default: ""
 
 env:
-  BUILD_BRANCH: ${{ github.event.inputs.kiali_ref || 'master' }}
-  KIALI_IMAGE_VERSION: ${{ github.event.inputs.kiali_image_version || '' }}
   KUBERNETES_MCP_SERVER_REF: ${{ github.event.inputs.kubernetes_mcp_server_ref || 'main' }}
 
 permissions: read-all
@@ -42,12 +35,35 @@ jobs:
     - name: Check out Kiali code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        ref: ${{ env.BUILD_BRANCH }}
+        fetch-depth: 0
 
     - name: Install Helm
       uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       with:
         version: 'v3.18.4'
+
+    - name: Check out kubernetes-mcp-server
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: containers/kubernetes-mcp-server
+        path: kubernetes-mcp-server
+        ref: ${{ env.KUBERNETES_MCP_SERVER_REF }}
+
+    - name: Resolve pinned Kiali version from kubernetes-mcp-server
+      id: kiali_pin
+      working-directory: kubernetes-mcp-server
+      run: |
+        KIALI_VERSION=$(grep -E '^KIALI_VERSION' build/kiali.mk | awk -F= '{print $2}' | tr -d '[:space:]')
+        echo "kiali_version=${KIALI_VERSION}" >> $GITHUB_OUTPUT
+        echo "kubernetes-mcp-server pins Kiali ${KIALI_VERSION}"
+
+    - name: Check out pinned Kiali version
+      run: |
+        KIALI_REF="${{ github.event.inputs.kiali_ref || steps.kiali_pin.outputs.kiali_version }}"
+        echo "Checking out Kiali ${KIALI_REF}"
+        git checkout "${KIALI_REF}"
+        echo "BUILD_BRANCH=${KIALI_REF}" >> $GITHUB_ENV
+        echo "TARGET_BRANCH=${KIALI_REF}" >> $GITHUB_ENV
 
     # Corepack must be enabled before setup-node so that setup-node's
     # cache: yarn correctly detects the Yarn 4 cache directory.
@@ -69,34 +85,8 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
 
-    - name: Build Kiali binary for cluster setup
+    - name: Build Kiali for cluster setup
       run: make clean-all build-ui build
-
-    - name: Check out kubernetes-mcp-server
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: containers/kubernetes-mcp-server
-        path: kubernetes-mcp-server
-        ref: ${{ env.KUBERNETES_MCP_SERVER_REF }}
-
-    - name: Resolve pinned Kiali version from kubernetes-mcp-server
-      id: kiali_pin
-      working-directory: kubernetes-mcp-server
-      run: |
-        KIALI_VERSION=$(grep -E '^KIALI_VERSION' build/kiali.mk | awk -F= '{print $2}' | tr -d '[:space:]')
-        echo "kiali_version=${KIALI_VERSION}" >> $GITHUB_OUTPUT
-        echo "kubernetes-mcp-server pins Kiali ${KIALI_VERSION}"
-
-    - name: Resolve Kiali image version for contract tests
-      id: kiali_image
-      run: |
-        if [ -n "${KIALI_IMAGE_VERSION}" ]; then
-          IMAGE_VERSION="${KIALI_IMAGE_VERSION}"
-        else
-          IMAGE_VERSION="${{ steps.kiali_pin.outputs.kiali_version }}"
-        fi
-        echo "kiali_image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
-        echo "Testing Kiali image quay.io/kiali/kiali:${IMAGE_VERSION}"
 
     - name: Setup KinD cluster with Istio and Kiali
       run: hack/run-integration-tests.sh --test-suite backend --setup-only true
@@ -104,69 +94,17 @@ jobs:
     - name: Get Kiali external URL from MetalLB
       id: get_kiali_url
       run: |
-        # Wait for Kiali LoadBalancer to get an external IP
-        echo "Waiting for Kiali LoadBalancer to get external IP..."
         kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' -n istio-system service/kiali --timeout=300s
-
-        # Get the external IP from MetalLB
         KIALI_IP=$(kubectl get svc kiali -n istio-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
         if [ -z "$KIALI_IP" ]; then
           echo "ERROR: Failed to get Kiali LoadBalancer IP"
           kubectl get svc kiali -n istio-system
           exit 1
         fi
-
-        # Kiali service uses port 80, so the URL is http://IP/kiali
         KIALI_URL="http://${KIALI_IP}/kiali"
         echo "Kiali URL: $KIALI_URL"
         echo "KIALI_URL=${KIALI_URL}" >> $GITHUB_ENV
-
-        # Verify Kiali is accessible
-        echo "Verifying Kiali is accessible at ${KIALI_URL}..."
-        for i in {1..30}; do
-          CURL_OUTPUT=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${KIALI_URL}/api/status" 2>&1)
-          HTTP_CODE=$(echo "$CURL_OUTPUT" | grep "HTTP_CODE:" | cut -d: -f2)
-          RESPONSE_BODY=$(echo "$CURL_OUTPUT" | sed '/HTTP_CODE:/d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "Kiali is accessible at ${KIALI_URL}"
-            break
-          else
-            echo "Attempt $i/30: HTTP $HTTP_CODE"
-            if [ "$HTTP_CODE" != "200" ]; then
-              echo "Curl output:"
-              echo "$CURL_OUTPUT"
-            fi
-          fi
-
-          if [ $i -eq 30 ]; then
-            echo "ERROR: Kiali is not accessible after 30 attempts"
-            echo "Final curl output:"
-            echo "$CURL_OUTPUT"
-            exit 1
-          fi
-          sleep 2
-        done
-
-    - name: Deploy Kiali release image for contract tests
-      run: |
-        KIALI_VERSION="${{ steps.kiali_image.outputs.kiali_image_version }}"
-        echo "Replacing dev Kiali image with ${KIALI_VERSION}..."
-        kubectl patch deployment kiali -n istio-system -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"kiali\",\"image\":\"quay.io/kiali/kiali:${KIALI_VERSION}\"}]}}}}"
-        kubectl rollout status deployment/kiali -n istio-system --timeout=300s
-
-        echo "Verifying pinned Kiali is accessible at ${KIALI_URL}..."
-        for i in {1..30}; do
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${KIALI_URL}/api/status")
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "Kiali ${KIALI_VERSION} is accessible at ${KIALI_URL}"
-            exit 0
-          fi
-          echo "Attempt $i/30: HTTP $HTTP_CODE"
-          sleep 2
-        done
-        echo "ERROR: Pinned Kiali ${KIALI_VERSION} is not accessible after rollout"
-        exit 1
+        curl -sf --connect-timeout 5 --max-time 15 "${KIALI_URL}/api/status"
 
     - name: Set up Go for kubernetes-mcp-server
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -196,4 +134,3 @@ jobs:
       with:
         name: debug-info-mcp-contract-tests
         path: debug-output
-

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -30,6 +30,7 @@ MCP_TOOLS="false"
 OFFLINE="offline"
 HELM_CHARTS_DIR=""
 ISTIO_VERSION=""
+KIALI_VERSION=""
 KEYCLOAK_LIMIT_MEMORY=""
 KEYCLOAK_REQUESTS_MEMORY=""
 SAIL_OPERATOR_CHART_VERSION=""
@@ -97,6 +98,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -iv|--istio-version)
       ISTIO_VERSION="${2}"
+      shift;shift
+      ;;
+    -kv|--kiali-version)
+      KIALI_VERSION="${2}"
       shift;shift
       ;;
     -klm|--keycloak-limit-memory)
@@ -214,6 +219,10 @@ Valid command line arguments:
   -iv|--istio-version <version>
     Which Istio version to test with. For releases, specify "#.#.#". For dev builds, specify in the form "#.#-dev"
     Default: The latest release
+  -kv|--kiali-version <version>
+    Kiali image version to deploy during cluster setup. Use "dev" for a local dev image
+    (default). Use a release tag such as "v2.27" to deploy quay.io/kiali/kiali instead.
+    Default: dev
   -klm|--keycloak-limit-memory <value>
     Set the keycloak resources limit memory in the keycloak helm charts. Ex. 1Gi
   -krm|--keycloak-requests-memory <value>
@@ -331,6 +340,12 @@ if [ -n "${ISTIO_VERSION}" ]; then
   ISTIO_VERSION_ARG="--istio-version ${ISTIO_VERSION}"
 else
   ISTIO_VERSION_ARG=""
+fi
+
+if [ -n "${KIALI_VERSION}" ]; then
+  KIALI_VERSION_ARG="--kiali-version ${KIALI_VERSION}"
+else
+  KIALI_VERSION_ARG=""
 fi
 
 if [ -n "${HELM_CHARTS_DIR}" ]; then
@@ -547,7 +562,7 @@ if [ "${TEST_SUITE}" == "${BACKEND}" ]; then
     if [ "${TESTS_ONLY}" == "false" ]; then
       AUTH_PARAM="--auth-strategy anonymous"
     fi
-    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --sail true ${ISTIO_VERSION_ARG} ${HELM_CHARTS_DIR_ARG} ${AUTH_PARAM}
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --sail true ${ISTIO_VERSION_ARG} ${KIALI_VERSION_ARG} ${HELM_CHARTS_DIR_ARG} ${AUTH_PARAM}
 
     # Install demo apps
     "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" --use-gateway-api true --bookinfo-only ${BOOKINFO_ONLY}

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -95,6 +95,10 @@ Options:
     This option is ignored if -ii is false.
     If not specified, the latest version of Istio is installed.
     Default: <the latest release>
+-kv|--kiali-version <version>
+    Kiali image version to deploy. Use "dev" to build and load a local dev image
+    (default). Use a release tag such as "v2.27" to pull quay.io/kiali/kiali instead.
+    Default: dev
 -klm|--keycloak-limit-memory
     The keycloak resources limit memory in the keycloak helm charts
 -krm|--keycloak-requests-memory)
@@ -140,6 +144,7 @@ while [[ $# -gt 0 ]]; do
     -hcd|--helm-charts-dir)       HELM_CHARTS_DIR="$2";       shift;shift; ;;
     -ip|--install-perses)         INSTALL_PERSES="$2";        shift;shift; ;;
     -iv|--istio-version)          ISTIO_VERSION="$2";         shift;shift; ;;
+    -kv|--kiali-version)          KIALI_VERSION="$2";         shift;shift; ;;
     -klm|--keycloak-limit-memory) KEYCLOAK_LIMIT_MEMORY="$2"; shift;shift; ;;
     -krm|--keycloak-requests-memory) KEYCLOAK_REQUESTS_MEMORY="$2"; shift;shift; ;;
     -mc|--multicluster)
@@ -195,7 +200,25 @@ DEPLOY_KIALI="${DEPLOY_KIALI:-true}"
 DORP="${DORP:-docker}"
 ENABLE_CACHE="${ENABLE_CACHE:-false}"
 KIALI_ONLY="${KIALI_ONLY:-false}"
+KIALI_VERSION="${KIALI_VERSION:-dev}"
 TEMPO="${TEMPO:-false}"
+
+if [ "${KIALI_VERSION}" == "dev" ]; then
+  KIALI_IMAGE_NAME="localhost/kiali/kiali"
+  KIALI_IMAGE_TAG="dev"
+  KIALI_IMAGE_PULL_POLICY="Never"
+  KIALI_USE_DEV_IMAGE="true"
+else
+  if [[ "${KIALI_VERSION}" != v* ]]; then
+    KIALI_IMAGE_TAG="v${KIALI_VERSION}"
+  else
+    KIALI_IMAGE_TAG="${KIALI_VERSION}"
+  fi
+  KIALI_IMAGE_NAME="quay.io/kiali/kiali"
+  KIALI_IMAGE_PULL_POLICY="IfNotPresent"
+  KIALI_USE_DEV_IMAGE="false"
+fi
+infomsg "Kiali deployment image: ${KIALI_IMAGE_NAME}:${KIALI_IMAGE_TAG} (pull policy: ${KIALI_IMAGE_PULL_POLICY})"
 
 # Defaults the branch to master unless it is already set
 TARGET_BRANCH="${TARGET_BRANCH:-master}"
@@ -212,6 +235,23 @@ if [ -z "${ISTIO_VERSION}" ]; then
     ISTIO_VERSION="1.27.5"
   elif [ "${TARGET_BRANCH}" == "v2.22" ]; then
     ISTIO_VERSION="1.28.3"
+  elif [ "${TARGET_BRANCH}" == "v2.27" ]; then
+    ISTIO_VERSION="1.29.1"
+  fi
+fi
+
+if [ -z "${ISTIO_VERSION}" ] && [ "${KIALI_VERSION}" != "dev" ]; then
+  TARGET_BRANCH="${KIALI_IMAGE_TAG}"
+  if [ "${TARGET_BRANCH}" == "v2.4" ]; then
+    ISTIO_VERSION="1.23.6"
+  elif [ "${TARGET_BRANCH}" == "v2.11" ]; then
+    ISTIO_VERSION="1.26.8"
+  elif [ "${TARGET_BRANCH}" == "v2.17" ]; then
+    ISTIO_VERSION="1.27.5"
+  elif [ "${TARGET_BRANCH}" == "v2.22" ]; then
+    ISTIO_VERSION="1.28.3"
+  elif [ "${TARGET_BRANCH}" == "v2.27" ]; then
+    ISTIO_VERSION="1.29.1"
   fi
 fi
 
@@ -504,8 +544,10 @@ setup_kind_singlecluster() {
   
   fi
 
-  infomsg "Pushing the images into the cluster..."
-  make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali
+  if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
+    infomsg "Pushing the dev Kiali image into the cluster..."
+    make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali
+  fi
 
   infomsg "Installing kiali server via Helm"
   infomsg "Chart to be installed: $(ls -1 ${HELM_CHARTS_DIR}/_output/charts/kiali-server-*.tgz)"
@@ -523,9 +565,9 @@ setup_kind_singlecluster() {
     --set auth.openid.username_claim="preferred_username" \
     "${AI_ARGS[@]}" \
     --set deployment.logger.log_level="trace" \
-    --set deployment.image_name=localhost/kiali/kiali \
-    --set deployment.image_version=dev \
-    --set deployment.image_pull_policy="Never" \
+    --set deployment.image_name="${KIALI_IMAGE_NAME}" \
+    --set deployment.image_version="${KIALI_IMAGE_TAG}" \
+    --set deployment.image_pull_policy="${KIALI_IMAGE_PULL_POLICY}" \
     --set deployment.service_type="LoadBalancer" \
     --set external_services.grafana.external_url="http://grafana.istio-system:3000" \
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard" \
@@ -613,8 +655,10 @@ setup_kind_tempo() {
     return
   fi
 
-  infomsg "Pushing the images into the cluster..."
-  make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali
+  if [ "${KIALI_USE_DEV_IMAGE}" == "true" ]; then
+    infomsg "Pushing the dev Kiali image into the cluster..."
+    make -e DORP="${DORP}" -e CLUSTER_TYPE="kind" -e KIND_NAME="ci" cluster-push-kiali
+  fi
 
   infomsg "Installing kiali server via Helm"
   infomsg "Chart to be installed: $(ls -1 ${HELM_CHARTS_DIR}/_output/charts/kiali-server-*.tgz)"
@@ -626,9 +670,9 @@ setup_kind_tempo() {
     --wait \
     --set auth.strategy="${AUTH_STRATEGY}" \
     --set deployment.logger.log_level="trace" \
-    --set deployment.image_name=localhost/kiali/kiali \
-    --set deployment.image_version=dev \
-    --set deployment.image_pull_policy="Never" \
+    --set deployment.image_name="${KIALI_IMAGE_NAME}" \
+    --set deployment.image_version="${KIALI_IMAGE_TAG}" \
+    --set deployment.image_pull_policy="${KIALI_IMAGE_PULL_POLICY}" \
     --set deployment.service_type="LoadBalancer" \
     --set external_services.grafana.external_url="http://grafana.istio-system:3000" \
     --set external_services.grafana.dashboards[0].name="Istio Mesh Dashboard" \


### PR DESCRIPTION
### Describe the change

Modify mcp contract tests: 
- Use kiali pinned version from mcp
- Not running the workflow in master 

Note: Test should include this to pass: https://github.com/containers/kubernetes-mcp-server/pull/1271 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10019 
