### PR TITLE
[v2.4] Upgrade tar to 7.5.19 to fix CVE-2026-59873 and CVE-2026-59874

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17302,15 +17302,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of #10022 to v2.4.

Upgrades the transitive `tar` (node-tar) dependency from 7.5.13 to 7.5.19 in `frontend/yarn.lock`.

This fixes two denial-of-service vulnerabilities:
- **CVE-2026-59874**: DoS via malformed tar archive header (fixed in 7.5.18)
- **CVE-2026-59873**: DoS via crafted gzip bomb (fixed in 7.5.19)

Made with [Cursor](https://cursor.com)