### PR TITLE
[v2.4] Fix multicluster CI by using local helm chart for remote cluster RBAC

### DIFF
--- a/hack/istio/multicluster/deploy-kiali.sh
+++ b/hack/istio/multicluster/deploy-kiali.sh
@@ -136,7 +136,7 @@ deploy_kiali() {
         remote_url_flag="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
       fi
       echo "Preparing remote cluster secret for single Kiali install in multicluster mode."
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag} -vo false ${openshift_flags} -rcns ${ISTIO_NAMESPACE}
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag} -vo false ${openshift_flags} -rcns ${ISTIO_NAMESPACE} -kshc ${KIALI_SERVER_HELM_CHARTS}
     else
       echo "Preparing remote cluster secrets for both Kiali installs."
       local remote_url_flag1=""
@@ -145,8 +145,8 @@ deploy_kiali() {
         remote_url_flag1="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER2_NAME}-control-plane --context ${CLUSTER2_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
         remote_url_flag2="--remote-cluster-url https://$(${CLIENT_EXE} get nodes ${CLUSTER1_NAME}-control-plane --context ${CLUSTER1_CONTEXT} -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'):6443"
       fi
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag1} -vo false ${openshift_flags}
-      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER1_NAME} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} ${remote_url_flag2} -vo false ${openshift_flags}
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER2_NAME} -kcc ${CLUSTER1_CONTEXT} -rcc ${CLUSTER2_CONTEXT} ${remote_url_flag1} -vo false ${openshift_flags} -kshc ${KIALI_SERVER_HELM_CHARTS}
+      ${SCRIPT_DIR}/kiali-prepare-remote-cluster.sh -c ${CLIENT_EXE} --remote-cluster-name ${CLUSTER1_NAME} -kcc ${CLUSTER2_CONTEXT} -rcc ${CLUSTER1_CONTEXT} ${remote_url_flag2} -vo false ${openshift_flags} -kshc ${KIALI_SERVER_HELM_CHARTS}
     fi
   fi
 

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -24,6 +24,7 @@ DEFAULT_CLIENT_EXE="kubectl"
 DEFAULT_DELETE="false"
 DEFAULT_DRY_RUN="false"
 DEFAULT_HELM="helm"
+DEFAULT_HELM_CHARTS="kiali-server"
 DEFAULT_KIALI_CLUSTER_CONTEXT="east"
 DEFAULT_KIALI_CLUSTER_NAMESPACE="istio-system"
 DEFAULT_KIALI_VERSION="latest"
@@ -45,6 +46,7 @@ DEFAULT_EXEC_AUTH_JSON=""
 : ${KIALI_CLUSTER_CONTEXT:=${DEFAULT_KIALI_CLUSTER_CONTEXT}}
 : ${KIALI_CLUSTER_NAMESPACE:=${DEFAULT_KIALI_CLUSTER_NAMESPACE}}
 : ${KIALI_RESOURCE_NAME:=${DEFAULT_RESOURCE_NAME}}
+: ${KIALI_SERVER_HELM_CHARTS:=${DEFAULT_HELM_CHARTS}}
 : ${KIALI_VERSION:=${DEFAULT_KIALI_VERSION}}
 : ${PROCESS_KIALI_SECRET:=${DEFAULT_PROCESS_KIALI_SECRET}}
 : ${PROCESS_REMOTE_RESOURCES:=${DEFAULT_PROCESS_REMOTE_RESOURCES}}
@@ -109,6 +111,11 @@ create_resources_in_remote_cluster() {
     local helm_version_arg="--version ${KIALI_VERSION}"
   fi
 
+  local helm_repo_arg="--repo https://kiali.org/helm-charts"
+  if [ -f "${KIALI_SERVER_HELM_CHARTS}" ]; then
+    helm_repo_arg=""
+  fi
+
   local helm_template_output="$(${HELM} template            \
       ${helm_version_arg:-}                                 \
       --namespace ${REMOTE_CLUSTER_NAMESPACE}               \
@@ -118,9 +125,9 @@ create_resources_in_remote_cluster() {
       --set deployment.cluster_wide_access=true             \
       --set deployment.view_only_mode=${VIEW_ONLY}          \
       --set auth.strategy=anonymous                         \
-      --repo https://kiali.org/helm-charts                  \
+      ${helm_repo_arg}                                      \
       kiali-server                                          \
-      kiali-server)"
+      ${KIALI_SERVER_HELM_CHARTS})"
 
   if [ "${DRY_RUN}" == "true" ]; then
     echo "${helm_template_output}"
@@ -382,6 +389,10 @@ while [ $# -gt 0 ]; do
       KIALI_RESOURCE_NAME="$2"
       shift;shift
       ;;
+    -kshc|--kiali-server-helm-charts)
+      KIALI_SERVER_HELM_CHARTS="$2"
+      shift;shift
+      ;;
     -kv|--kiali-version)
       KIALI_VERSION="$2"
       shift;shift
@@ -480,6 +491,8 @@ Valid command line arguments:
                                   Default: "${DEFAULT_KIALI_CLUSTER_NAMESPACE}"
   -krn|--kiali-resource-name: used to name all the resources on the remote cluster.
                               Default: "${DEFAULT_RESOURCE_NAME}"
+  -kshc|--kiali-server-helm-charts <path>: If specified, must be the path to a Kiali server helm charts tarball. If not
+                                           specified, the latest published helm charts is used.
   -kv|--kiali-version: The version of Kiali that is installed. This is used to
                        determine what the role should look like. Pass in
                        "latest" to specify the latest version of Kiali.
@@ -552,6 +565,7 @@ info HELM=${HELM}
 info KIALI_CLUSTER_CONTEXT=${KIALI_CLUSTER_CONTEXT}
 info KIALI_CLUSTER_NAMESPACE=${KIALI_CLUSTER_NAMESPACE}
 info KIALI_RESOURCE_NAME=${KIALI_RESOURCE_NAME}
+info KIALI_SERVER_HELM_CHARTS=${KIALI_SERVER_HELM_CHARTS}
 info KIALI_VERSION=${KIALI_VERSION}
 info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}


### PR DESCRIPTION
## Summary

- Pass `-kshc ${KIALI_SERVER_HELM_CHARTS}` to all `kiali-prepare-remote-cluster.sh` invocations in `deploy-kiali.sh`, ensuring remote cluster RBAC resources are created from the v2.4 helm chart instead of the latest published one.

## Root Cause

The `kiali-prepare-remote-cluster.sh` calls in `deploy-kiali.sh` were missing the `-kshc` flag. Without it, the script falls back to fetching the **latest** chart from `https://kiali.org/helm-charts`. Since [helm-charts@03286a2](https://github.com/kiali/helm-charts/commit/03286a2) (June 12, 2026) removed `endpoints` from the kiali-server ClusterRole on master, the remote cluster service account no longer gets permission to list `Endpoints`.

The v2.4 Kiali binary still uses the `Endpoints` informer (`kubernetes/cache/kube_cache.go`), so the cache informer fails on the remote cluster, causing Kiali to crash-loop and the CI to time out waiting for pods to be ready.

**Affected CI jobs:**
- `Run frontend multicluster multi-primary integration tests`
- `Run backend multicluster external-controlplane integration tests`

**Failing run:** https://github.com/kiali/kiali/actions/runs/29073392411

**Why other branches are not affected:** v2.11+ no longer use the `Endpoints` informer (the `kubernetes/cache/` directory was refactored away), so they don't need `endpoints` in the ClusterRole.

## Test plan

- [ ] CI multicluster multi-primary integration tests pass
- [ ] CI backend external-controlplane integration tests pass

Made with [Cursor](https://cursor.com)