### PR TITLE
Add opt-in OpenShift impersonation mode for multi-cluster auth

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -285,8 +285,8 @@ func (in *NamespaceService) GetKialiSAClusterNamespaces(ctx context.Context, clu
 		return nil, fmt.Errorf("cluster [%s] is not found or is not accessible for Kiali SA", cluster)
 	}
 
-	// Check cache first using the SA token
-	if cachedNs, found := in.kialiCache.GetNamespaces(cluster, saClient.GetToken()); found {
+	// Check cache first using the SA cache key
+	if cachedNs, found := in.kialiCache.GetNamespaces(cluster, saClient.GetCacheKey()); found {
 		return cachedNs, nil
 	}
 
@@ -317,7 +317,7 @@ func (in *NamespaceService) GetKialiSAClusterNamespaces(ctx context.Context, clu
 	// Apply discovery selector filtering
 	namespaces = istio.FilterNamespacesWithDiscoverySelectors(namespaces, istio.GetDiscoverySelectorsForCluster(ctx, in.discovery, cluster, in.conf))
 
-	in.kialiCache.SetNamespaces(saClient.GetToken(), namespaces)
+	in.kialiCache.SetNamespaces(saClient.GetCacheKey(), namespaces)
 
 	return namespaces, nil
 }

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -438,6 +438,8 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 
 	// When the user's effective identity is the same as the SA (e.g. anonymous auth
 	// where no impersonation is involved), the SA list is already the correct answer.
+	// Under impersonation, GetCacheKey() returns the impersonated username (never equal
+	// to the SA's bearer token), so the RBAC intersection below always runs.
 	if in.userClients[cluster].GetCacheKey() == in.kialiSAClients[cluster].GetToken() {
 		return nss, nil
 	}

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -95,7 +95,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 	clustersToCheck := make(map[string]kubernetes.ClientInterface)
 	namespaces := []models.Namespace{}
 	for cluster, client := range in.userClients {
-		cachedNamespaces, found := in.kialiCache.GetNamespaces(cluster, client.GetToken())
+		cachedNamespaces, found := in.kialiCache.GetNamespaces(cluster, client.GetCacheKey())
 		if !found {
 			clustersToCheck[cluster] = client
 		} else {
@@ -156,7 +156,7 @@ func (in *NamespaceService) GetNamespaces(ctx context.Context) ([]models.Namespa
 		namespacesPerCluster[ns.Cluster] = append(namespacesPerCluster[ns.Cluster], ns)
 	}
 	for cluster, ns := range namespacesPerCluster {
-		in.kialiCache.SetNamespaces(in.userClients[cluster].GetToken(), ns)
+		in.kialiCache.SetNamespaces(in.userClients[cluster].GetCacheKey(), ns)
 	}
 
 	return namespaces, nil
@@ -355,7 +355,7 @@ func (in *NamespaceService) GetClusterNamespace(ctx context.Context, namespace s
 	}
 
 	// Cache already has discovery selectors applied
-	if ns, found := in.kialiCache.GetNamespace(cluster, client.GetToken(), namespace); found {
+	if ns, found := in.kialiCache.GetNamespace(cluster, client.GetCacheKey(), namespace); found {
 		return &ns, nil
 	}
 
@@ -436,10 +436,9 @@ func (in *NamespaceService) getNamespacesUsingKialiSA(cluster string, labelSelec
 		return nil, err
 	}
 
-	// When the user token is the same as the SA token (e.g. anonymous auth)
-	// the SA list is already the correct answer — skip the redundant user
-	// LIST and intersection/filter.
-	if in.userClients[cluster].GetToken() == in.kialiSAClients[cluster].GetToken() {
+	// When the user's effective identity is the same as the SA (e.g. anonymous auth
+	// where no impersonation is involved), the SA list is already the correct answer.
+	if in.userClients[cluster].GetCacheKey() == in.kialiSAClients[cluster].GetToken() {
 		return nss, nil
 	}
 

--- a/business/namespaces_test.go
+++ b/business/namespaces_test.go
@@ -731,3 +731,91 @@ func TestMixedClustersNoError(t *testing.T) {
 	require.Equal("beta", namespaces[1].Name)
 	require.Equal("vanilla", namespaces[1].Cluster)
 }
+
+func TestGetNamespacesSameTokenDifferentImpersonation(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.KubernetesConfig.CacheTokenNamespaceDuration = 600000
+
+	// Both user clients share the same Token (SA token) but have different CacheKeys
+	// (simulating different impersonated users).
+	userA := kubetest.NewFakeK8sClient()
+	userA.Token = "shared-sa-token"
+	userA.CacheKey = "user-a@example.com"
+
+	userB := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "ns-b-only"}},
+	)
+	userB.Token = "shared-sa-token"
+	userB.CacheKey = "user-b@example.com"
+
+	saClient := kubetest.NewFakeK8sClient()
+	saClient.Token = "shared-sa-token"
+
+	saClients := map[string]kubernetes.ClientInterface{"east": saClient}
+
+	// Populate cache as user A with a narrow list.
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	kialiCache.SetNamespaces(
+		userA.GetCacheKey(),
+		[]models.Namespace{{Name: "ns-a-only", Cluster: "east"}},
+	)
+
+	// Now query as user B — should NOT get user A's cached entry.
+	userBClients := map[string]kubernetes.UserClientInterface{"east": userB}
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userBClients)
+
+	namespaces, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(err)
+
+	// User B should get their own namespaces (ns-b-only from the fake client),
+	// NOT user A's cached "ns-a-only".
+	for _, ns := range namespaces {
+		require.NotEqual("ns-a-only", ns.Name, "user B should not see user A's cached namespace")
+	}
+}
+
+func TestGetNamespacesImpersonationDoesNotSkipRBACIntersection(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.Deployment.ClusterWideAccess = true
+
+	// SA client can see all namespaces.
+	saClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "allowed"}},
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "forbidden"}},
+	)
+	saClient.Token = "shared-sa-token"
+
+	// User client (impersonated) can only see "allowed" via its own LIST.
+	// Same SA token but different CacheKey (impersonated username).
+	userClient := kubetest.NewFakeK8sClient(
+		&core_v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "allowed"}},
+	)
+	userClient.Token = "shared-sa-token"
+	userClient.CacheKey = "restricted-user@example.com"
+
+	saClients := map[string]kubernetes.ClientInterface{"east": saClient}
+	userClients := map[string]kubernetes.UserClientInterface{"east": userClient}
+
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+	nsservice := NewNamespaceService(kialiCache, conf, discovery, saClients, userClients)
+
+	namespaces, err := nsservice.GetNamespaces(context.TODO())
+	require.NoError(err)
+
+	// The user should only see "allowed" — the RBAC intersection must run
+	// because GetCacheKey() != GetToken() of the SA.
+	names := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		names = append(names, ns.Name)
+	}
+	require.Contains(names, "allowed")
+	require.NotContains(names, "forbidden", "impersonated user should not see namespaces beyond their RBAC")
+}

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -137,7 +137,7 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 		// When impersonation is enabled, only the home cluster needs OAuth config
 		// (for the initial user login). Remote clusters use SA + impersonation headers.
 		if conf.Auth.OpenShift.Impersonation.Enabled && cluster != conf.KubernetesConfig.ClusterName {
-			log.Infof("Skipping OAuth config for cluster [%s] — impersonation mode does not require per-cluster OAuth", cluster)
+			log.Debugf("Skipping OAuth config for cluster [%s] — impersonation mode does not require per-cluster OAuth", cluster)
 			continue
 		}
 

--- a/business/openshift_oauth.go
+++ b/business/openshift_oauth.go
@@ -134,6 +134,13 @@ func NewOpenshiftOAuthService(ctx context.Context, conf *config.Config, kialiSAC
 			continue
 		}
 
+		// When impersonation is enabled, only the home cluster needs OAuth config
+		// (for the initial user login). Remote clusters use SA + impersonation headers.
+		if conf.Auth.OpenShift.Impersonation.Enabled && cluster != conf.KubernetesConfig.ClusterName {
+			log.Infof("Skipping OAuth config for cluster [%s] — impersonation mode does not require per-cluster OAuth", cluster)
+			continue
+		}
+
 		log.Debugf("Getting OAuth config for cluster [%s]", cluster)
 		// Use CA info from kube config.
 		url := client.ClusterInfo().ClientConfig.Host + "/.well-known/oauth-authorization-server"

--- a/business/services.go
+++ b/business/services.go
@@ -704,7 +704,7 @@ func (in *SvcService) getCapturingWaypoints(svc *models.Service, all bool) ([]mo
 	}
 
 	// If we don't have a service override, look for a namespace-level waypoint
-	if ns, nsFound := in.kialiCache.GetNamespace(svc.Cluster, in.userClients[svc.Cluster].GetToken(), svc.Namespace); nsFound {
+	if ns, nsFound := in.kialiCache.GetNamespace(svc.Cluster, in.userClients[svc.Cluster].GetCacheKey(), svc.Namespace); nsFound {
 		waypointUse, waypointUseFound = ns.Labels[config.WaypointUseLabel]
 		waypointUseNamespace, waypointUseNamespaceFound = ns.Labels[config.WaypointUseNamespaceLabel]
 

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -2629,7 +2629,7 @@ func (in *WorkloadService) getCapturingWaypoints(ctx context.Context, workload m
 	if !ok {
 		return waypoints, false
 	}
-	if ns, nsFound := in.cache.GetNamespace(workload.Cluster, userClient.GetToken(), workload.Namespace); nsFound {
+	if ns, nsFound := in.cache.GetNamespace(workload.Cluster, userClient.GetCacheKey(), workload.Namespace); nsFound {
 		waypointUse, waypointUseFound = ns.Labels[config.WaypointUseLabel]
 		waypointUseNamespace, waypointUseNamespaceFound = ns.Labels[config.WaypointUseNamespaceLabel]
 
@@ -2737,7 +2737,7 @@ func (in *WorkloadService) listWaypointWorkloads(ctx context.Context, wpCluster,
 	}
 
 	// Get annotated workloads
-	namespaces, found := in.cache.GetNamespaces(wpCluster, userClient.GetToken())
+	namespaces, found := in.cache.GetNamespaces(wpCluster, userClient.GetCacheKey())
 	namespaceNames := sliceutil.Map(namespaces, func(ns models.Namespace) string {
 		return ns.Name
 	})

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -92,10 +92,10 @@ type KialiCache interface {
 	SetMesh(*models.Mesh)
 
 	// GetNamespace returns a namespace from the in memory cache if it exists.
-	GetNamespace(cluster string, token string, name string) (models.Namespace, bool)
+	GetNamespace(cluster string, cacheKey string, name string) (models.Namespace, bool)
 
-	// GetNamespaces returns all namespaces for the cluster/token from the in memory cache.
-	GetNamespaces(cluster string, token string) ([]models.Namespace, bool)
+	// GetNamespaces returns all namespaces for the cluster/cacheKey from the in memory cache.
+	GetNamespaces(cluster string, cacheKey string) ([]models.Namespace, bool)
 
 	GetWaypoints() (models.Workloads, bool)
 	SetWaypoints(models.Workloads)
@@ -135,11 +135,11 @@ type KialiCache interface {
 	SetClusters([]models.KubeCluster)
 
 	// SetNamespaces sets the in memory cache of namespaces.
-	// We cache all namespaces for cluster + token.
-	SetNamespaces(token string, namespaces []models.Namespace)
+	// We cache all namespaces for cluster + cacheKey.
+	SetNamespaces(cacheKey string, namespaces []models.Namespace)
 
-	// SetNamespace caches a specific namespace by cluster + token.
-	SetNamespace(token string, namespace models.Namespace)
+	// SetNamespace caches a specific namespace by cluster + cacheKey.
+	SetNamespace(cacheKey string, namespace models.Namespace)
 }
 
 type kialiCacheImpl struct {
@@ -178,12 +178,12 @@ type kialiCacheImpl struct {
 	// so using a store here but the only key should be kialiCacheMeshKey.
 	meshStore store.Store[string, *models.Mesh]
 
-	// Store the namespaces per token + cluster as a map[string]namespace where string is the namespace name
+	// Store the namespaces per cacheKey + cluster as a map[string]namespace where string is the namespace name
 	// so you can easily deref the namespace in GetNamespace and SetNamespace. The downside to this is that
 	// we need an additional lock for the namespace map that gets returned from the store to ensure it is threadsafe.
 	namespaceStore store.Store[namespacesKey, map[string]models.Namespace]
 
-	// Only necessary because we want to cache the namespaces per cluster and token as a map
+	// Only necessary because we want to cache the namespaces per cluster and cacheKey as a map
 	// and maps are not thread safe. We need an additional lock on top of the Store to ensure
 	// that the map returned from the store is threadsafe.
 	namespacesLock sync.RWMutex
@@ -725,19 +725,21 @@ func (c *kialiCacheImpl) SetWaypoints(waypoints models.Workloads) {
 }
 
 type namespacesKey struct {
-	cluster string
-	token   string
+	// cacheKey identifies the requester via GetCacheKey(). Under impersonation this
+	// is the impersonated username; otherwise it's the bearer token.
+	cacheKey string
+	cluster  string
 }
 
 func (n namespacesKey) String() string {
-	return fmt.Sprintf("cluster: %s\ttoken: xxx", n.cluster)
+	return fmt.Sprintf("cacheKey: xxx\tcluster: %s", n.cluster)
 }
 
-func (c *kialiCacheImpl) GetNamespace(cluster string, token string, namespace string) (models.Namespace, bool) {
+func (c *kialiCacheImpl) GetNamespace(cluster string, cacheKey string, namespace string) (models.Namespace, bool) {
 	c.namespacesLock.RLock()
 	defer c.namespacesLock.RUnlock()
 
-	key := namespacesKey{cluster: cluster, token: token}
+	key := namespacesKey{cacheKey: cacheKey, cluster: cluster}
 	namespaces, found := c.namespaceStore.Get(key)
 	if !found {
 		return models.Namespace{}, false
@@ -747,11 +749,11 @@ func (c *kialiCacheImpl) GetNamespace(cluster string, token string, namespace st
 	return ns, found
 }
 
-func (c *kialiCacheImpl) GetNamespaces(cluster string, token string) ([]models.Namespace, bool) {
+func (c *kialiCacheImpl) GetNamespaces(cluster string, cacheKey string) ([]models.Namespace, bool) {
 	c.namespacesLock.RLock()
 	defer c.namespacesLock.RUnlock()
 
-	key := namespacesKey{cluster: cluster, token: token}
+	key := namespacesKey{cacheKey: cacheKey, cluster: cluster}
 	namespaces, found := c.namespaceStore.Get(key)
 
 	return maps.Values(namespaces), found
@@ -768,7 +770,7 @@ func (c *kialiCacheImpl) RefreshTokenNamespaces(cluster string) {
 	}
 }
 
-func (c *kialiCacheImpl) SetNamespaces(token string, namespaces []models.Namespace) {
+func (c *kialiCacheImpl) SetNamespaces(cacheKey string, namespaces []models.Namespace) {
 	c.namespacesLock.Lock()
 	defer c.namespacesLock.Unlock()
 
@@ -778,7 +780,7 @@ func (c *kialiCacheImpl) SetNamespaces(token string, namespaces []models.Namespa
 	}
 
 	for cluster, clusterNamespaces := range namespacesByCluster {
-		key := namespacesKey{cluster: cluster, token: token}
+		key := namespacesKey{cacheKey: cacheKey, cluster: cluster}
 		ns := make(map[string]models.Namespace)
 		for _, namespace := range clusterNamespaces {
 			ns[namespace.Name] = namespace
@@ -787,11 +789,11 @@ func (c *kialiCacheImpl) SetNamespaces(token string, namespaces []models.Namespa
 	}
 }
 
-func (c *kialiCacheImpl) SetNamespace(token string, namespace models.Namespace) {
+func (c *kialiCacheImpl) SetNamespace(cacheKey string, namespace models.Namespace) {
 	c.namespacesLock.Lock()
 	defer c.namespacesLock.Unlock()
 
-	key := namespacesKey{cluster: namespace.Cluster, token: token}
+	key := namespacesKey{cacheKey: cacheKey, cluster: namespace.Cluster}
 	ns, found := c.namespaceStore.Get(key)
 	if !found {
 		ns = make(map[string]models.Namespace)

--- a/config/config.go
+++ b/config/config.go
@@ -601,7 +601,9 @@ type OpenShiftConfig struct {
 // When enabled, users authenticate once to the home cluster and Kiali uses its service
 // account credentials on all clusters with impersonation headers carrying the user's identity.
 type ImpersonationConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	AllowedGroups []string `yaml:"allowed_groups,omitempty"`
+	AllowedUsers  []string `yaml:"allowed_users,omitempty"`
+	Enabled       bool     `yaml:"enabled,omitempty"`
 }
 
 // DiscoveryOverrideConfig contains explicit OIDC endpoints to override auto-discovery
@@ -1053,7 +1055,7 @@ func NewConfig() (c *Config) {
 				UsernameClaim:         "sub",
 			},
 			OpenShift: OpenShiftConfig{
-				Impersonation:         ImpersonationConfig{Enabled: false},
+				Impersonation:         ImpersonationConfig{Enabled: false, AllowedGroups: []string{}, AllowedUsers: []string{}},
 				InsecureSkipVerifyTLS: false,
 			},
 		},
@@ -2154,6 +2156,27 @@ func Validate(conf *Config) error {
 	log.Infof("Using authentication strategy [%v]", auth.Strategy)
 	if auth.OpenShift.Impersonation.Enabled && auth.Strategy != AuthStrategyOpenshift {
 		return fmt.Errorf("impersonation is only supported with the openshift auth strategy, but auth.strategy is [%s]", auth.Strategy)
+	}
+	if auth.OpenShift.Impersonation.Enabled {
+		for _, u := range auth.OpenShift.Impersonation.AllowedUsers {
+			if u == "" {
+				return fmt.Errorf("auth.openshift.impersonation.allowed_users must not contain empty strings")
+			}
+			if strings.HasPrefix(u, "system:") {
+				return fmt.Errorf("auth.openshift.impersonation.allowed_users must not contain system: prefixed identities, found [%s]", u)
+			}
+		}
+		for _, g := range auth.OpenShift.Impersonation.AllowedGroups {
+			if g == "" {
+				return fmt.Errorf("auth.openshift.impersonation.allowed_groups must not contain empty strings")
+			}
+			if strings.HasPrefix(g, "system:") {
+				return fmt.Errorf("auth.openshift.impersonation.allowed_groups must not contain system: prefixed groups, found [%s]", g)
+			}
+		}
+		if len(auth.OpenShift.Impersonation.AllowedUsers) == 0 && len(auth.OpenShift.Impersonation.AllowedGroups) == 0 {
+			log.Warningf("Impersonation enabled without allowed_users/allowed_groups: the SA can impersonate any non-system identity. Suggest to configure allowlists for production deployments.")
+		}
 	}
 	if auth.Strategy == AuthStrategyOpenshift && auth.OpenShift.Impersonation.Enabled {
 		log.Infof("OpenShift impersonation mode is enabled")

--- a/config/config.go
+++ b/config/config.go
@@ -2152,6 +2152,9 @@ func Validate(conf *Config) error {
 	// log some messages to let the administrator know when credentials are configured certain ways
 	auth := conf.Auth
 	log.Infof("Using authentication strategy [%v]", auth.Strategy)
+	if auth.OpenShift.Impersonation.Enabled && auth.Strategy != AuthStrategyOpenshift {
+		return fmt.Errorf("impersonation is only supported with the openshift auth strategy, but auth.strategy is [%s]", auth.Strategy)
+	}
 	if auth.Strategy == AuthStrategyOpenshift && auth.OpenShift.Impersonation.Enabled {
 		log.Infof("OpenShift impersonation mode is enabled")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -592,8 +592,16 @@ type AuthConfig struct {
 
 // OpenShiftConfig contains specific configuration for authentication when on OpenShift
 type OpenShiftConfig struct {
-	CAFile                string `yaml:"ca_file,omitempty"`
-	InsecureSkipVerifyTLS bool   `yaml:"insecure_skip_verify_tls,omitempty"`
+	CAFile                string              `yaml:"ca_file,omitempty"`
+	Impersonation         ImpersonationConfig `yaml:"impersonation,omitempty"`
+	InsecureSkipVerifyTLS bool                `yaml:"insecure_skip_verify_tls,omitempty"`
+}
+
+// ImpersonationConfig configures Kubernetes API impersonation for multi-cluster access.
+// When enabled, users authenticate once to the home cluster and Kiali uses its service
+// account credentials on all clusters with impersonation headers carrying the user's identity.
+type ImpersonationConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 // DiscoveryOverrideConfig contains explicit OIDC endpoints to override auto-discovery
@@ -1045,6 +1053,7 @@ func NewConfig() (c *Config) {
 				UsernameClaim:         "sub",
 			},
 			OpenShift: OpenShiftConfig{
+				Impersonation:         ImpersonationConfig{Enabled: false},
 				InsecureSkipVerifyTLS: false,
 			},
 		},
@@ -2143,6 +2152,9 @@ func Validate(conf *Config) error {
 	// log some messages to let the administrator know when credentials are configured certain ways
 	auth := conf.Auth
 	log.Infof("Using authentication strategy [%v]", auth.Strategy)
+	if auth.Strategy == AuthStrategyOpenshift && auth.OpenShift.Impersonation.Enabled {
+		log.Infof("OpenShift impersonation mode is enabled")
+	}
 	if auth.Strategy == AuthStrategyAnonymous {
 		log.Warningf("Kiali auth strategy is configured for anonymous access - users will not be authenticated.")
 	} else if auth.Strategy != AuthStrategyOpenId &&

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -38,6 +38,7 @@ DEFAULT_REMOTE_CLUSTER_URL=""
 DEFAULT_RESOURCE_NAME="kiali"
 DEFAULT_VIEW_ONLY="true"
 DEFAULT_EXEC_AUTH_JSON=""
+DEFAULT_USE_IMPERSONATION="false"
 
 : ${ALLOW_SKIP_TLS_VERIFY:=${DEFAULT_ALLOW_SKIP_TLS_VERIFY}}
 : ${CLIENT_EXE:=${DEFAULT_CLIENT_EXE}}
@@ -57,6 +58,7 @@ DEFAULT_EXEC_AUTH_JSON=""
 : ${REMOTE_CLUSTER_URL:=${DEFAULT_REMOTE_CLUSTER_URL}}
 : ${VIEW_ONLY:=${DEFAULT_VIEW_ONLY}}
 : ${EXEC_AUTH_JSON:=${DEFAULT_EXEC_AUTH_JSON}}
+: ${USE_IMPERSONATION:=${DEFAULT_USE_IMPERSONATION}}
 
 DRY_RUN_ARG="--dry-run=none"
 
@@ -111,6 +113,14 @@ create_resources_in_remote_cluster() {
     helm_repo_arg=""
   fi
 
+  local auth_helm_args="--set auth.strategy=anonymous"
+  if [ "${USE_IMPERSONATION}" == "true" ]; then
+    if [ "${IS_OPENSHIFT}" != "true" ]; then
+      error "--use-impersonation is only supported on OpenShift clusters (requires OpenShift auth strategy)"
+    fi
+    auth_helm_args="--set auth.strategy=openshift --set auth.openshift.impersonation.enabled=true"
+  fi
+
   local helm_template_output="$(${HELM} template            \
       ${helm_version_arg:-}                                 \
       --namespace ${REMOTE_CLUSTER_NAMESPACE}               \
@@ -119,7 +129,7 @@ create_resources_in_remote_cluster() {
       --set deployment.instance_name=${KIALI_RESOURCE_NAME} \
       --set deployment.cluster_wide_access=true             \
       --set deployment.view_only_mode=${VIEW_ONLY}          \
-      --set auth.strategy=anonymous                         \
+      ${auth_helm_args}                                     \
       ${helm_repo_arg}                                      \
       kiali-server                                          \
       ${KIALI_SERVER_HELM_CHARTS})"
@@ -418,6 +428,11 @@ while [ $# -gt 0 ]; do
       REMOTE_CLUSTER_URL="$2"
       shift;shift
       ;;
+    -ui|--use-impersonation)
+      [ "${2:-}" != "true" ] && [ "${2:-}" != "false" ] && error "--use-impersonation must be 'true' or 'false'"
+      USE_IMPERSONATION="$2"
+      shift;shift
+      ;;
     -vo|--view-only)
       [ "${2:-}" != "true" ] && [ "${2:-}" != "false" ] && error "--view-only must be 'true' or 'false'"
       VIEW_ONLY="$2"
@@ -526,6 +541,12 @@ Valid command line arguments:
                              If empty, the local kubeconfig will be examined and the server
                              associated with the remote cluster context will be used.
                              Default: "${DEFAULT_REMOTE_CLUSTER_URL}"
+  -ui|--use-impersonation: if 'true' the remote cluster resources will be configured
+                           for Kubernetes API impersonation instead of per-cluster OAuth.
+                           The Kiali SA will get a ClusterRole with impersonate permissions
+                           on users and groups. No OAuthClient will be created.
+                           Only supported on OpenShift clusters.
+                           Default: "${DEFAULT_USE_IMPERSONATION}"
   -vo|--view-only: if 'true' then the created service account/remote secret
                    will only provide a read-only view of the remote cluster.
                    Default: "${DEFAULT_VIEW_ONLY}"
@@ -566,6 +587,7 @@ info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}
 info REMOTE_CLUSTER_NAMESPACE=${REMOTE_CLUSTER_NAMESPACE}
 info REMOTE_CLUSTER_URL=${REMOTE_CLUSTER_URL}
+info USE_IMPERSONATION=${USE_IMPERSONATION}
 info VIEW_ONLY=${VIEW_ONLY}
 info EXEC_AUTH_JSON="${EXEC_AUTH_JSON}"
 

--- a/hack/openshift-create-test-users.sh
+++ b/hack/openshift-create-test-users.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+#
+# Creates OpenShift users and groups via the htpasswd identity provider.
+#
+# This script is additive — running it multiple times adds new users and groups
+# without affecting existing ones. Existing users have their passwords updated
+# if specified again. Deleting is also surgical — only the specified users are
+# removed from htpasswd and their groups. Groups are deleted only if they become
+# empty after removing the user.
+#
+# Usage:
+#   ./hack/openshift-create-test-users.sh --context <kubecontext> \
+#     --user alice:alicepw:people,women \
+#     --user bob:bobpw:people,men
+#
+# Each --user value is formatted as: name:password:group1,group2,...
+# Groups are created if they don't exist. Users are added to the htpasswd
+# identity provider. If the IDP doesn't exist in the OAuth cluster config,
+# the script creates it automatically.
+#
+# Options:
+#   --context <name>     Optional. The kubecontext to use. Defaults to the current context.
+#   --user <spec>        Required (at least one). Format: name:password:group1,group2
+#   --idp-name <name>    Optional. Name of the htpasswd IDP. Default: my_htpasswd_provider
+#   --role <name>        Optional. ClusterRole to bind to each user. If the named role doesn't
+#                        exist, a default one granting namespace get/list and pods/log get is
+#                        created. Default: kiali-test-user
+#   --no-rbac            Skip RBAC creation (don't create ClusterRole or bindings).
+#   --delete             Delete the specified users and groups instead of creating them.
+#   --help               Show this help message.
+
+set -euo pipefail
+
+CONTEXT=""
+IDP_NAME="my_htpasswd_provider"
+ROLE_NAME="kiali-test-user"
+NO_RBAC=false
+DELETE_MODE=false
+declare -a USER_SPECS=()
+
+usage() {
+  sed -n '3,/^$/p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)
+      CONTEXT="$2"; shift 2 ;;
+    --user)
+      USER_SPECS+=("$2"); shift 2 ;;
+    --idp-name)
+      IDP_NAME="$2"; shift 2 ;;
+    --role)
+      ROLE_NAME="$2"; shift 2 ;;
+    --no-rbac)
+      NO_RBAC=true; shift ;;
+    --delete)
+      DELETE_MODE=true; shift ;;
+    --help|-h)
+      usage 0 ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$CONTEXT" ]]; then
+  CONTEXT=$(oc config current-context)
+  echo "No --context specified, using current context: ${CONTEXT}"
+fi
+
+if [[ ${#USER_SPECS[@]} -eq 0 ]]; then
+  echo "ERROR: at least one --user is required" >&2
+  usage 1
+fi
+
+OC="oc --context=${CONTEXT}"
+
+if ! $OC whoami &>/dev/null; then
+  echo "ERROR: Cannot connect to cluster with context '${CONTEXT}'. Either the context is invalid or you are not logged in." >&2
+  exit 1
+fi
+
+# Parse user specs into arrays
+declare -a USERNAMES=()
+declare -a PASSWORDS=()
+declare -a USER_GROUPS=()
+
+for spec in "${USER_SPECS[@]}"; do
+  IFS=':' read -r name password groups <<< "$spec"
+  if [[ -z "$name" || -z "$password" ]]; then
+    echo "ERROR: Invalid --user spec '${spec}'. Format: name:password:group1,group2" >&2
+    exit 1
+  fi
+  USERNAMES+=("$name")
+  PASSWORDS+=("$password")
+  USER_GROUPS+=("$groups")
+done
+
+# Collect all unique groups
+declare -A ALL_GROUPS=()
+for groups in "${USER_GROUPS[@]}"; do
+  IFS=',' read -ra group_arr <<< "$groups"
+  for g in "${group_arr[@]}"; do
+    [[ -n "$g" ]] && ALL_GROUPS["$g"]=1
+  done
+done
+
+if [[ "$DELETE_MODE" == "true" ]]; then
+  echo "=== Deleting users and groups (context: ${CONTEXT}) ==="
+
+  # Get htpasswd secret
+  SECRET_NAME=$($OC get oauth cluster -o jsonpath="{.spec.identityProviders[?(@.name==\"${IDP_NAME}\")].htpasswd.fileData.name}" 2>/dev/null)
+  if [[ -n "$SECRET_NAME" ]]; then
+    TMPFILE=$(mktemp)
+    $OC get secret "$SECRET_NAME" -n openshift-config -o jsonpath='{.data.htpasswd}' | base64 -d > "$TMPFILE"
+    for name in "${USERNAMES[@]}"; do
+      htpasswd -D "$TMPFILE" "$name" 2>/dev/null && echo "Removed $name from htpasswd" || true
+      $OC delete user "$name" --ignore-not-found 2>/dev/null
+      $OC delete identity "${IDP_NAME}:${name}" --ignore-not-found 2>/dev/null
+    done
+    $OC create secret generic "$SECRET_NAME" \
+      --from-file=htpasswd="$TMPFILE" \
+      -n openshift-config --dry-run=client -o yaml | $OC apply -f -
+    rm -f "$TMPFILE"
+  fi
+
+  # Remove users from groups; delete group if it becomes empty
+  for i in "${!USERNAMES[@]}"; do
+    IFS=',' read -ra group_arr <<< "${USER_GROUPS[$i]}"
+    for g in "${group_arr[@]}"; do
+      [[ -z "$g" ]] && continue
+      $OC adm groups remove-users "$g" "${USERNAMES[$i]}" 2>/dev/null && echo "Removed ${USERNAMES[$i]} from group $g" || true
+      # Check if group is now empty and delete it if so
+      MEMBERS=$($OC get group "$g" -o jsonpath='{.users}' 2>/dev/null || echo "")
+      if [[ "$MEMBERS" == "[]" || -z "$MEMBERS" ]]; then
+        $OC delete group "$g" --ignore-not-found 2>/dev/null && echo "Deleted empty group: $g" || true
+      fi
+    done
+  done
+
+  # Remove ClusterRoleBindings for each user
+  if [[ "$NO_RBAC" == "false" ]]; then
+    for name in "${USERNAMES[@]}"; do
+      $OC delete clusterrolebinding "${ROLE_NAME}-${name}" --ignore-not-found 2>/dev/null && echo "Deleted ClusterRoleBinding: ${ROLE_NAME}-${name}"
+    done
+  fi
+
+  echo "Done."
+  exit 0
+fi
+
+# === CREATE MODE ===
+echo "=== Creating users and groups (context: ${CONTEXT}) ==="
+
+# Get the htpasswd secret name from the OAuth config
+SECRET_NAME=$($OC get oauth cluster -o jsonpath="{.spec.identityProviders[?(@.name==\"${IDP_NAME}\")].htpasswd.fileData.name}" 2>/dev/null)
+if [[ -z "$SECRET_NAME" ]]; then
+  echo "HTPasswd IDP '${IDP_NAME}' not found in OAuth config. Creating it..."
+  SECRET_NAME="${IDP_NAME}-secret"
+
+  # Create empty htpasswd secret
+  TMPFILE=$(mktemp)
+  touch "$TMPFILE"
+  $OC create secret generic "$SECRET_NAME" \
+    --from-file=htpasswd="$TMPFILE" \
+    -n openshift-config
+  rm -f "$TMPFILE"
+
+  # Patch the OAuth config to add the IDP
+  $OC patch oauth cluster --type json -p "[{
+    \"op\": \"add\",
+    \"path\": \"/spec/identityProviders/-\",
+    \"value\": {
+      \"name\": \"${IDP_NAME}\",
+      \"type\": \"HTPasswd\",
+      \"mappingMethod\": \"claim\",
+      \"htpasswd\": {
+        \"fileData\": {
+          \"name\": \"${SECRET_NAME}\"
+        }
+      }
+    }
+  }]"
+  echo "Created IDP '${IDP_NAME}' with secret '${SECRET_NAME}'"
+fi
+
+# Download existing htpasswd and add users
+TMPFILE=$(mktemp)
+$OC get secret "$SECRET_NAME" -n openshift-config -o jsonpath='{.data.htpasswd}' | base64 -d > "$TMPFILE"
+
+for i in "${!USERNAMES[@]}"; do
+  htpasswd -bB "$TMPFILE" "${USERNAMES[$i]}" "${PASSWORDS[$i]}"
+done
+
+# Update the secret
+$OC create secret generic "$SECRET_NAME" \
+  --from-file=htpasswd="$TMPFILE" \
+  -n openshift-config --dry-run=client -o yaml | $OC apply -f -
+rm -f "$TMPFILE"
+
+echo "HTPasswd secret updated. OAuth pods will roll out automatically."
+
+# Create groups
+for g in "${!ALL_GROUPS[@]}"; do
+  $OC adm groups new "$g" 2>/dev/null && echo "Created group: $g" || echo "Group already exists: $g"
+done
+
+# Add users to groups
+for i in "${!USERNAMES[@]}"; do
+  IFS=',' read -ra group_arr <<< "${USER_GROUPS[$i]}"
+  for g in "${group_arr[@]}"; do
+    [[ -n "$g" ]] && $OC adm groups add-users "$g" "${USERNAMES[$i]}" 2>/dev/null
+  done
+done
+
+# Create RBAC: ClusterRole (if needed) and per-user ClusterRoleBindings
+if [[ "$NO_RBAC" == "false" ]]; then
+  if ! $OC get clusterrole "$ROLE_NAME" &>/dev/null; then
+    echo "Creating ClusterRole '${ROLE_NAME}' with basic Kiali read permissions..."
+    $OC apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${ROLE_NAME}
+  labels:
+    app.kubernetes.io/managed-by: kiali-hack-script
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods/log
+  verbs:
+  - get
+  - list
+EOF
+  else
+    echo "ClusterRole '${ROLE_NAME}' already exists — reusing."
+  fi
+
+  for name in "${USERNAMES[@]}"; do
+    $OC apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${ROLE_NAME}-${name}
+  labels:
+    app.kubernetes.io/managed-by: kiali-hack-script
+subjects:
+- kind: User
+  name: ${name}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ${ROLE_NAME}
+  apiGroup: rbac.authorization.k8s.io
+EOF
+    echo "  Bound '${name}' to ClusterRole '${ROLE_NAME}'"
+  done
+fi
+
+echo ""
+echo "=== Summary ==="
+echo "Users created:"
+for i in "${!USERNAMES[@]}"; do
+  echo "  ${USERNAMES[$i]} (groups: ${USER_GROUPS[$i]})"
+done
+echo ""
+echo "Groups:"
+$OC get groups 2>/dev/null | grep -E "^(NAME|$(IFS='|'; echo "${!ALL_GROUPS[*]}"))" || true
+echo ""
+echo "Note: OAuth pods are rolling out. Users may take ~30s to become active."

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,13 +31,14 @@ type AuthenticationHandler struct {
 }
 
 type AuthInfo struct {
-	Strategy                        string            `json:"strategy"`
 	AuthorizationEndpoint           string            `json:"authorizationEndpoint,omitempty"`
 	AuthorizationEndpointPerCluster map[string]string `json:"authorizationEndpointPerCluster,omitempty"`
+	ImpersonationEnabled            bool              `json:"impersonationEnabled,omitempty"`
 	LogoutEndpoint                  string            `json:"logoutEndpoint,omitempty"`
 	LogoutRedirect                  string            `json:"logoutRedirect,omitempty"`
-	SessionInfo                     sessionInfo       `json:"sessionInfo"`
 	SecretMissing                   bool              `json:"secretMissing,omitempty"`
+	SessionInfo                     sessionInfo       `json:"sessionInfo"`
+	Strategy                        string            `json:"strategy"`
 }
 
 type sessionClusterInfo struct {
@@ -73,6 +75,18 @@ func NewAuthenticationHandler(
 
 func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Defense-in-depth: strip user-supplied impersonation headers for all
+		// strategies except header, where a trusted proxy provides them.
+		if aHandler.conf.Auth.Strategy != config.AuthStrategyHeader {
+			r.Header.Del("Impersonate-User")
+			r.Header.Del("Impersonate-Group")
+			for key := range r.Header {
+				if strings.HasPrefix(key, "Impersonate-Extra-") {
+					r.Header.Del(key)
+				}
+			}
+		}
+
 		statusCode := http.StatusOK
 		userSessions := make(authentication.UserSessions)
 
@@ -207,9 +221,13 @@ func AuthenticationInfo(conf *config.Config, authController authentication.AuthC
 		switch conf.Auth.Strategy {
 		case config.AuthStrategyOpenshift:
 			response.AuthorizationEndpoint = fmt.Sprintf("%s/api/auth/redirect", httputil.GuessKialiURL(conf, r))
-			response.AuthorizationEndpointPerCluster = make(map[string]string)
-			for _, cluster := range clusters {
-				response.AuthorizationEndpointPerCluster[cluster] = fmt.Sprintf("%s/api/auth/redirect/%s", httputil.GuessKialiURL(conf, r), cluster)
+			if conf.Auth.OpenShift.Impersonation.Enabled {
+				response.ImpersonationEnabled = true
+			} else {
+				response.AuthorizationEndpointPerCluster = make(map[string]string)
+				for _, cluster := range clusters {
+					response.AuthorizationEndpointPerCluster[cluster] = fmt.Sprintf("%s/api/auth/redirect/%s", httputil.GuessKialiURL(conf, r), cluster)
+				}
 			}
 		case config.AuthStrategyOpenId:
 			// Do the redirection through an intermediary own endpoint

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -97,6 +97,11 @@ func (aHandler *AuthenticationHandler) Handle(next http.Handler) http.Handler {
 				if errors.Is(err, authentication.ErrSessionNotFound) || errors.Is(err, authentication.ErrSubjectMismatch) {
 					// Session doesn't exist or has an integrity violation - user needs to authenticate
 					statusCode = http.StatusUnauthorized
+				} else if errors.Is(err, authentication.ErrNotInAllowlist) {
+					statusCode = http.StatusForbidden
+					log.Warningf("Impersonation allowlist denied access [client: %s]: %s", r.RemoteAddr, err.Error())
+				} else if errors.Is(err, authentication.ErrImpersonationDenied) {
+					statusCode = http.StatusUnauthorized
 				} else if k8serrors.IsUnauthorized(err) {
 					// Kubernetes API rejected the token as invalid/expired.
 					// This can occur when ValidateSession calls GetNamespaces, which makes K8s API calls.

--- a/handlers/authentication/openshift_auth_controller.go
+++ b/handlers/authentication/openshift_auth_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -194,6 +195,11 @@ func (o *OpenshiftAuthController) OpenshiftAuthRedirect(w http.ResponseWriter, r
 func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.ResponseWriter) (UserSessions, error) {
 	userSessions := make(UserSessions)
 
+	// homeUserName and homeUserGroups store the verified identity from the home cluster's
+	// GetUserInfo call. Used by the impersonation block below.
+	var homeUserName string
+	var homeUserGroups []string
+
 	// In OpenShift auth, it is possible that a session is started by a 3rd party. If that's the case, Kiali
 	// can receive the OpenShift token of the session via HTTP Headers of via a URL Query string parameter.
 	// HTTP Headers have priority over URL parameters. If a token is received via some of these means,
@@ -207,6 +213,8 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 			return nil, err
 		}
 
+		homeUserName = user.Name
+		homeUserGroups = user.Groups
 		userSessions[o.conf.KubernetesConfig.ClusterName] = &UserSessionData{
 			AuthInfo:  &api.AuthInfo{Token: token},
 			ExpiresOn: expires,
@@ -225,6 +233,8 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 			return nil, err
 		}
 
+		homeUserName = user.Name
+		homeUserGroups = user.Groups
 		userSessions[o.conf.KubernetesConfig.ClusterName] = &UserSessionData{
 			AuthInfo:  &api.AuthInfo{Token: token},
 			ExpiresOn: expires,
@@ -249,11 +259,48 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 				}
 				return nil, err
 			}
+			if session.Cluster == o.conf.KubernetesConfig.ClusterName {
+				homeUserName = user.Name
+				homeUserGroups = user.Groups
+			}
 			userSessions[session.Cluster] = &UserSessionData{
 				AuthInfo:  &api.AuthInfo{Token: session.Payload.AccessToken},
 				ExpiresOn: session.ExpiresOn,
 				SessionID: session.SessionID,
 				Username:  user.Name,
+			}
+		}
+	}
+
+	// When impersonation is enabled, replace all cluster AuthInfo entries with
+	// impersonation-based credentials. The user's real OAuth token was used above
+	// to verify identity via GetUserInfo; all subsequent business logic API calls
+	// will use the SA token + impersonation headers instead.
+	if o.conf.Auth.OpenShift.Impersonation.Enabled {
+		if homeSession, ok := userSessions[o.conf.KubernetesConfig.ClusterName]; ok && homeUserName != "" {
+			groups := make([]string, 0, len(homeUserGroups)+2)
+			groups = append(groups, homeUserGroups...)
+			if !slices.Contains(groups, "system:authenticated") {
+				groups = append(groups, "system:authenticated")
+			}
+			if !slices.Contains(groups, "system:authenticated:oauth") {
+				groups = append(groups, "system:authenticated:oauth")
+			}
+
+			for _, cluster := range o.clusters {
+				existingSessionID := ""
+				if existing, ok := userSessions[cluster]; ok {
+					existingSessionID = existing.SessionID
+				}
+				userSessions[cluster] = &UserSessionData{
+					AuthInfo: &api.AuthInfo{
+						Impersonate:       homeUserName,
+						ImpersonateGroups: groups,
+					},
+					ExpiresOn: homeSession.ExpiresOn,
+					SessionID: existingSessionID,
+					Username:  homeUserName,
+				}
 			}
 		}
 	}

--- a/handlers/authentication/openshift_auth_controller.go
+++ b/handlers/authentication/openshift_auth_controller.go
@@ -2,6 +2,7 @@ package authentication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,6 +22,43 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/util"
 )
+
+var (
+	ErrImpersonationDenied = errors.New("impersonation denied: privileged identity")
+	ErrNotInAllowlist      = errors.New("impersonation denied: not in allowlist")
+)
+
+// Kubernetes RBAC has no deny rules — the hardcoded guard and RBAC resourceNames
+// serve complementary purposes. The guard blocks known-bad identities (system:*);
+// RBAC resourceNames restricts to known-good identities (the allowlist).
+func ValidateImpersonationIdentity(username string, groups []string) error {
+	if strings.HasPrefix(username, "system:") {
+		return fmt.Errorf("%w: identity %q is a privileged system identity", ErrImpersonationDenied, username)
+	}
+	for _, g := range groups {
+		if g == "system:masters" || g == "system:nodes" || strings.HasPrefix(g, "system:serviceaccounts") {
+			return fmt.Errorf("%w: identity %q belongs to privileged system group %q", ErrImpersonationDenied, username, g)
+		}
+	}
+	return nil
+}
+
+func FilterImpersonationGroups(groups []string, allowedGroups []string, username string) []string {
+	if len(allowedGroups) == 0 {
+		return groups
+	}
+	filtered := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if g == "system:authenticated" || g == "system:authenticated:oauth" {
+			filtered = append(filtered, g)
+		} else if slices.Contains(allowedGroups, g) {
+			filtered = append(filtered, g)
+		} else {
+			log.Warningf("Impersonation: dropping group %q for user %q (not in allowed_groups)", g, username)
+		}
+	}
+	return filtered
+}
 
 // openshiftSessionPayload holds the data that will be persisted in the SessionStore
 // in order to be able to maintain the session of the user across requests.
@@ -286,6 +324,20 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 			if !slices.Contains(groups, "system:authenticated:oauth") {
 				groups = append(groups, "system:authenticated:oauth")
 			}
+
+			if err := ValidateImpersonationIdentity(homeUserName, groups); err != nil {
+				log.Warningf("Impersonation rejected for user %q: %v", homeUserName, err)
+				return nil, err
+			}
+
+			if len(o.conf.Auth.OpenShift.Impersonation.AllowedUsers) > 0 {
+				if !slices.Contains(o.conf.Auth.OpenShift.Impersonation.AllowedUsers, homeUserName) {
+					log.Warningf("Impersonation denied: user %q is not in allowed_users list", homeUserName)
+					return nil, fmt.Errorf("%w: user %q", ErrNotInAllowlist, homeUserName)
+				}
+			}
+
+			groups = FilterImpersonationGroups(groups, o.conf.Auth.OpenShift.Impersonation.AllowedGroups, homeUserName)
 
 			for _, cluster := range o.clusters {
 				existingSessionID := ""

--- a/handlers/authentication/openshift_auth_controller.go
+++ b/handlers/authentication/openshift_auth_controller.go
@@ -293,6 +293,9 @@ func (o *OpenshiftAuthController) ValidateSession(r *http.Request, w http.Respon
 					existingSessionID = existing.SessionID
 				}
 				userSessions[cluster] = &UserSessionData{
+					// Token is intentionally empty. The SA token (from the remote cluster
+					// secret or in-cluster token file) provides authentication; impersonation
+					// headers carry the user identity. The client factory handles this.
 					AuthInfo: &api.AuthInfo{
 						Impersonate:       homeUserName,
 						ImpersonateGroups: groups,

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -459,6 +459,167 @@ func TestImpersonationDisabledPreservesLegacyBehavior(t *testing.T) {
 	require.Empty(eastSession.AuthInfo.ImpersonateGroups)
 }
 
+func TestImpersonationEnabledNoHomeSessionSkipsImpersonation(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.Auth.OpenShift.Impersonation.Enabled = true
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+
+	metadataServer := fakeOAuthMetadataServer(t)
+
+	eastClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+	)
+	eastClient.OpenShift = true
+	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	clients := map[string]kubernetes.UserClientInterface{"east": eastClient}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	authController, err := authentication.NewOpenshiftAuthController(conf, clientFactory)
+	require.NoError(err)
+
+	util.Clock = util.RealClock{}
+
+	// Bearer token that will fail GetUserInfo (no User "~" in the fake client)
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	_, err = authController.ValidateSession(r, w)
+	require.Error(err, "should fail when home cluster user cannot be validated")
+}
+
+func TestImpersonationWithBearerTokenSetsIdentity(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.Auth.OpenShift.Impersonation.Enabled = true
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+
+	metadataServer := fakeOAuthMetadataServer(t)
+
+	eastClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+		&osuser_v1.User{
+			Groups: []string{"developers"},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "~",
+			},
+		},
+	)
+	eastClient.OpenShift = true
+	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	westClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+	)
+	westClient.OpenShift = true
+	westClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	clients := map[string]kubernetes.UserClientInterface{
+		"east": eastClient,
+		"west": westClient,
+	}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	authController, err := authentication.NewOpenshiftAuthController(conf, clientFactory)
+	require.NoError(err)
+
+	util.Clock = util.RealClock{}
+
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	sessions, err := authController.ValidateSession(r, w)
+	require.NoError(err)
+	require.Len(sessions, 2)
+
+	// Both clusters should have impersonation from the Bearer token path
+	for cluster, session := range sessions {
+		require.Equal("~", session.AuthInfo.Impersonate,
+			"cluster %s should impersonate home user from Bearer token", cluster)
+		require.Contains(session.AuthInfo.ImpersonateGroups, "developers",
+			"cluster %s should include user's org group", cluster)
+		require.Contains(session.AuthInfo.ImpersonateGroups, "system:authenticated",
+			"cluster %s should include system:authenticated", cluster)
+	}
+}
+
+func TestImpersonationGroupDeduplication(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.Auth.OpenShift.Impersonation.Enabled = true
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+
+	metadataServer := fakeOAuthMetadataServer(t)
+
+	eastClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+		&osuser_v1.User{
+			Groups: []string{"system:authenticated", "system:authenticated:oauth", "developers"},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "~",
+			},
+		},
+	)
+	eastClient.OpenShift = true
+	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	clients := map[string]kubernetes.UserClientInterface{"east": eastClient}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	authController, err := authentication.NewOpenshiftAuthController(conf, clientFactory)
+	require.NoError(err)
+
+	util.Clock = util.RealClock{}
+
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	sessions, err := authController.ValidateSession(r, w)
+	require.NoError(err)
+
+	session := sessions["east"]
+	require.NotNil(session)
+
+	// Count occurrences — system groups should not be duplicated
+	count := 0
+	for _, g := range session.AuthInfo.ImpersonateGroups {
+		if g == "system:authenticated" {
+			count++
+		}
+	}
+	require.Equal(1, count, "system:authenticated should appear exactly once, not duplicated")
+}
+
 func TestTerminateSession(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -701,3 +701,68 @@ func TestTerminateSession(t *testing.T) {
 	require.Len(cookies, 1)
 	require.Equal(cookies[0].MaxAge, -1, fmt.Sprintf("cookie: %s should have been dropped.", cookies[0].Name))
 }
+
+func TestValidateImpersonationIdentity_RejectsSystemUsers(t *testing.T) {
+	cases := []struct {
+		name   string
+		user   string
+		groups []string
+	}{
+		{"system:admin", "system:admin", nil},
+		{"system:anonymous", "system:anonymous", nil},
+		{"system:serviceaccount prefix", "system:serviceaccount:default:kiali", nil},
+		{"system:node prefix", "system:node:worker-1", nil},
+		{"any system: prefix", "system:anything", nil},
+		{"system:masters group", "normaluser", []string{"developers", "system:masters"}},
+		{"system:nodes group", "normaluser", []string{"system:nodes"}},
+		{"system:serviceaccounts group", "normaluser", []string{"system:serviceaccounts"}},
+		{"system:serviceaccounts:namespace group", "normaluser", []string{"system:serviceaccounts:kube-system"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := authentication.ValidateImpersonationIdentity(tc.user, tc.groups)
+			require.Error(t, err)
+			require.ErrorIs(t, err, authentication.ErrImpersonationDenied)
+		})
+	}
+}
+
+func TestValidateImpersonationIdentity_AllowsNormalUsers(t *testing.T) {
+	cases := []struct {
+		name   string
+		user   string
+		groups []string
+	}{
+		{"normal user no groups", "developer@example.com", nil},
+		{"normal user with groups", "alice", []string{"developers", "sre-team"}},
+		{"normal user with system:authenticated", "bob", []string{"system:authenticated", "system:authenticated:oauth", "developers"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := authentication.ValidateImpersonationIdentity(tc.user, tc.groups)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFilterImpersonationGroups_FiltersCorrectly(t *testing.T) {
+	t.Run("empty allowedGroups returns all groups", func(t *testing.T) {
+		groups := []string{"system:authenticated", "developers", "sre-team"}
+		result := authentication.FilterImpersonationGroups(groups, nil, "user")
+		require.Equal(t, groups, result)
+	})
+
+	t.Run("filters to allowed groups plus system:authenticated", func(t *testing.T) {
+		groups := []string{"system:authenticated", "system:authenticated:oauth", "developers", "sre-team", "managers"}
+		allowed := []string{"developers", "sre-team"}
+		result := authentication.FilterImpersonationGroups(groups, allowed, "user")
+		require.Equal(t, []string{"system:authenticated", "system:authenticated:oauth", "developers", "sre-team"}, result)
+	})
+
+	t.Run("system:authenticated groups always pass through", func(t *testing.T) {
+		groups := []string{"system:authenticated", "system:authenticated:oauth", "unknown-group"}
+		allowed := []string{"developers"}
+		result := authentication.FilterImpersonationGroups(groups, allowed, "user")
+		require.Equal(t, []string{"system:authenticated", "system:authenticated:oauth"}, result)
+	})
+}

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -340,6 +340,125 @@ func TestMulticlusterUnauthorizedUserSessionGetsDropped(t *testing.T) {
 	require.True(sessionCookieWest.MaxAge < 0, "west session should be dropped")
 }
 
+func TestImpersonationEnabledSetsImpersonationOnAllClusters(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.Auth.OpenShift.Impersonation.Enabled = true
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+
+	metadataServer := fakeOAuthMetadataServer(t)
+
+	eastClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+		&osuser_v1.User{
+			Groups: []string{"org-admins"},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "~",
+			},
+		},
+	)
+	eastClient.OpenShift = true
+	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	westClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+	)
+	westClient.OpenShift = true
+	westClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	clients := map[string]kubernetes.UserClientInterface{
+		"east": eastClient,
+		"west": westClient,
+	}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	authController, err := authentication.NewOpenshiftAuthController(conf, clientFactory)
+	require.NoError(err)
+
+	util.Clock = util.RealClock{}
+
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	sessions, err := authController.ValidateSession(r, w)
+	require.NoError(err)
+	require.Len(sessions, 2)
+
+	for cluster, session := range sessions {
+		require.Equal("~", session.Username, "cluster %s should have username set", cluster)
+		require.Empty(session.AuthInfo.Token, "cluster %s should have empty Token when impersonating", cluster)
+		require.Equal("~", session.AuthInfo.Impersonate, "cluster %s should impersonate the home user", cluster)
+		require.Contains(session.AuthInfo.ImpersonateGroups, "system:authenticated",
+			"cluster %s should include system:authenticated", cluster)
+		require.Contains(session.AuthInfo.ImpersonateGroups, "system:authenticated:oauth",
+			"cluster %s should include system:authenticated:oauth", cluster)
+		require.Contains(session.AuthInfo.ImpersonateGroups, "org-admins",
+			"cluster %s should include user's org group", cluster)
+	}
+}
+
+func TestImpersonationDisabledPreservesLegacyBehavior(t *testing.T) {
+	require := require.New(t)
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.Auth.OpenShift.Impersonation.Enabled = false
+	conf.KubernetesConfig.ClusterName = "east"
+	conf.LoginToken.SigningKey = "kiali67890123456"
+
+	metadataServer := fakeOAuthMetadataServer(t)
+
+	eastClient := kubetest.NewFakeK8sClient(
+		&osoauth_v1.OAuthClient{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kiali-istio-system",
+			},
+			RedirectURIs: []string{"http://localhost:20001/kiali"},
+		},
+		&osuser_v1.User{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "~",
+			},
+		},
+	)
+	eastClient.OpenShift = true
+	eastClient.KubeClusterInfo.ClientConfig = &rest.Config{Host: metadataServer.URL}
+
+	clients := map[string]kubernetes.UserClientInterface{"east": eastClient}
+	clientFactory := kubetest.NewFakeClientFactory(conf, clients)
+
+	authController, err := authentication.NewOpenshiftAuthController(conf, clientFactory)
+	require.NoError(err)
+
+	util.Clock = util.RealClock{}
+
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	sessions, err := authController.ValidateSession(r, w)
+	require.NoError(err)
+	require.Len(sessions, 1)
+
+	eastSession := sessions["east"]
+	require.NotNil(eastSession)
+	require.Equal("test-token", eastSession.AuthInfo.Token)
+	require.Empty(eastSession.AuthInfo.Impersonate)
+	require.Empty(eastSession.AuthInfo.ImpersonateGroups)
+}
+
 func TestTerminateSession(t *testing.T) {
 	require := require.New(t)
 	conf := config.NewConfig()

--- a/handlers/authentication/openshift_auth_controller_test.go
+++ b/handlers/authentication/openshift_auth_controller_test.go
@@ -357,6 +357,8 @@ func TestImpersonationEnabledSetsImpersonationOnAllClusters(t *testing.T) {
 			},
 			RedirectURIs: []string{"http://localhost:20001/kiali"},
 		},
+		// In production, OpenShift resolves "~" to the real username (e.g. "developer@example.com").
+		// The fake client returns the object as-is, so Name must be "~" to match the GetUser("~") lookup.
 		&osuser_v1.User{
 			Groups: []string{"org-admins"},
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -456,6 +456,55 @@ func TestAuthenticationInfo(t *testing.T) {
 	}
 }
 
+func TestHandleStripsImpersonationHeadersForOpenShift(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenshift
+	conf.KubernetesConfig.ClusterName = "test-cluster"
+	conf.LoginToken.SigningKey = config.Credential(util.RandomString(16))
+
+	var capturedHeaders http.Header
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// The fakeAuthController returns a valid session so Handle proceeds to
+	// the next handler where we can inspect which headers survived.
+	authController := &fakeAuthController{
+		sessions: authentication.UserSessions{
+			"test-cluster": &authentication.UserSessionData{
+				AuthInfo:  &api.AuthInfo{Token: "sa-token"},
+				ExpiresOn: time.Now().Add(time.Hour),
+				Username:  "testuser",
+			},
+		},
+	}
+
+	handler := NewAuthenticationHandler(
+		conf,
+		authController,
+		kubetest.NewFakeK8sClient(),
+		nil,
+		map[string]kubernetes.ClientInterface{},
+	)
+
+	r := httptest.NewRequest("GET", "/api/namespaces", nil)
+	r.Header.Set("Impersonate-User", "cluster-admin")
+	r.Header.Set("Impersonate-Group", "system:masters")
+	r.Header.Set("Impersonate-Extra-Scopes", "full")
+	w := httptest.NewRecorder()
+
+	handler.Handle(nextHandler).ServeHTTP(w, r)
+
+	require.Equal(http.StatusOK, w.Code)
+	require.NotNil(capturedHeaders, "next handler should have been called")
+	require.Empty(capturedHeaders.Get("Impersonate-User"), "Impersonate-User should be stripped")
+	require.Empty(capturedHeaders.Get("Impersonate-Group"), "Impersonate-Group should be stripped")
+	require.Empty(capturedHeaders.Get("Impersonate-Extra-Scopes"), "Impersonate-Extra-* should be stripped")
+}
+
 type rejectClient struct{ kubernetes.UserClientInterface }
 
 func (r *rejectClient) GetNamespaces(labelSelector string) ([]core_v1.Namespace, error) {

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -316,10 +316,11 @@ func TestAuthenticationInfo(t *testing.T) {
 	// TODO: test session info.
 	oneHourFromNow := time.Now().Add(time.Hour)
 	cases := map[string]struct {
-		authStrategy     string
-		currentSessions  authentication.UserSessions
-		expectedResponse AuthInfo
-		clusters         []string
+		authStrategy         string
+		currentSessions      authentication.UserSessions
+		expectedResponse     AuthInfo
+		clusters             []string
+		impersonationEnabled bool
 	}{
 		"token auth returns just strategy": {
 			authStrategy: config.AuthStrategyToken,
@@ -427,6 +428,16 @@ func TestAuthenticationInfo(t *testing.T) {
 			},
 			clusters: []string{"test-cluster", "test-cluster-2"},
 		},
+		"openshift with impersonation returns impersonationEnabled and no per-cluster endpoints": {
+			authStrategy:         config.AuthStrategyOpenshift,
+			impersonationEnabled: true,
+			expectedResponse: AuthInfo{
+				AuthorizationEndpoint: "https://kiali.io:20001/api/auth/redirect",
+				ImpersonationEnabled:  true,
+				Strategy:              config.AuthStrategyOpenshift,
+			},
+			clusters: []string{"test-cluster", "test-cluster-2"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -436,6 +447,7 @@ func TestAuthenticationInfo(t *testing.T) {
 			conf.Server.WebFQDN = "kiali.io"
 			conf.Server.WebSchema = "https"
 			conf.Auth.Strategy = tc.authStrategy
+			conf.Auth.OpenShift.Impersonation.Enabled = tc.impersonationEnabled
 			authController := &fakeAuthController{
 				sessions: tc.currentSessions,
 			}

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -204,7 +204,7 @@ func Config(conf *config.Config, cache cache.KialiCache, discovery istio.MeshDis
 			publicConfig.Clusters[cluster.Name] = cluster
 
 			if client := userClients[cluster.Name]; client != nil {
-				if namespaces, found := cache.GetNamespaces(cluster.Name, client.GetToken()); found {
+				if namespaces, found := cache.GetNamespaces(cluster.Name, client.GetCacheKey()); found {
 					for _, ns := range namespaces {
 						if discovery.IsControlPlane(r.Context(), cluster.Name, ns.Name) {
 							publicConfig.ControlPlanes[cluster.Name] = ns.Name

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -50,6 +50,7 @@ type ClusterInfo struct {
 
 // ClientInterface defines a read-only client API (mocked functions are necessary here)
 type ClientInterface interface {
+	GetCacheKey() string
 	GetServerVersion() (*version.Info, error)
 	GetToken() string
 	IsOpenShift() bool
@@ -143,6 +144,16 @@ type K8SClient struct {
 
 // Ensure the K8SClient implements the full read-write UserClientInterface
 var _ UserClientInterface = &K8SClient{}
+
+// GetCacheKey returns a string suitable for keying per-user caches. Under impersonation,
+// different users share the same bearer token (the SA token); this method returns the
+// impersonated username instead, ensuring each user gets a distinct cache entry.
+func (client *K8SClient) GetCacheKey() string {
+	if client.restConfig != nil && client.restConfig.Impersonate.UserName != "" {
+		return client.restConfig.Impersonate.UserName
+	}
+	return client.token
+}
 
 // GetToken returns the BearerToken used from the config
 func (client *K8SClient) GetToken() string {

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -63,10 +63,6 @@ type clientFactory struct {
 	// remoteClusterInfos contains information on all remote clusters taken from the remote cluster secrets, keyed on cluster name.
 	remoteClusterInfos map[string]RemoteClusterInfo
 
-	// saTokenFile is the path to the SA token file for in-cluster authentication.
-	// Saved before stripping auth from baseRestConfig, used for home cluster impersonation.
-	saTokenFile string
-
 	// saClientEntries is a map of cluster name to a Kiali SA client for that cluster.
 	// The Kiali SA client uses the Kiali service account to access the cluster API.
 	// Note that the underlying type for this map is UserClientInterface but this is only because
@@ -77,6 +73,10 @@ type clientFactory struct {
 	// to write data when you expose them as UserClientInterface. Again, this is only for special cases
 	// like RBAC is disabled or anonymous mode is used).
 	saClientEntries map[string]UserClientInterface
+
+	// saTokenFile is the path to the SA token file for in-cluster authentication.
+	// Saved before stripping auth from baseRestConfig, used for home cluster impersonation.
+	saTokenFile string
 }
 
 // NewClientFactory creates a new client factory.
@@ -226,7 +226,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			// already used for identity verification in ValidateSession.
 			homeConfig := *cf.baseRestConfig
 			if cf.saTokenFile == "" {
-				log.Warning("Impersonation is enabled but no SA token file is available. Home cluster impersonation will fail.")
+				return nil, fmt.Errorf("impersonation is enabled but no SA token file is available for the home cluster")
 			}
 			homeConfig.BearerTokenFile = cf.saTokenFile
 			homeConfig.Impersonate = rest.ImpersonationConfig{

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -61,6 +62,10 @@ type clientFactory struct {
 
 	// remoteClusterInfos contains information on all remote clusters taken from the remote cluster secrets, keyed on cluster name.
 	remoteClusterInfos map[string]RemoteClusterInfo
+
+	// saTokenFile is the path to the SA token file for in-cluster authentication.
+	// Saved before stripping auth from baseRestConfig, used for home cluster impersonation.
+	saTokenFile string
 
 	// saClientEntries is a map of cluster name to a Kiali SA client for that cluster.
 	// The Kiali SA client uses the Kiali service account to access the cluster API.
@@ -139,6 +144,7 @@ func NewClientFactoryWithSAClients(ctx context.Context, conf *kialiconfig.Config
 func newClientFactory(ctx context.Context, kialiConf *kialiconfig.Config, restConf *rest.Config) (*clientFactory, error) {
 	// We only want to remove the auth info from the base rest config which is saved and used later
 	// but we will immediately use the auth info for the home cluster SA client.
+	saTokenFile := restConf.BearerTokenFile
 	baseRestConfig := *restConf
 	stripAuthInfo(&baseRestConfig)
 
@@ -149,6 +155,7 @@ func newClientFactory(ctx context.Context, kialiConf *kialiconfig.Config, restCo
 		homeCluster:     kialiConf.KubernetesConfig.ClusterName,
 		recycleChan:     make(chan string),
 		saClientEntries: make(map[string]UserClientInterface),
+		saTokenFile:     saTokenFile,
 	}
 
 	// after creating a client factory
@@ -199,7 +206,10 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 		config.Host = cf.kialiConfig.Auth.OpenId.ApiProxy
 	}
 
-	// Impersonation is valid only for header authentication strategy
+	// HOME CLUSTER impersonation for header strategy — uses proxy-supplied identity.
+	// OpenShift strategy handles its own impersonation (both home and remote) in the
+	// conditional blocks below, based on auth.openshift.impersonation.enabled.
+	// Do NOT merge these two impersonation paths.
 	if cf.kialiConfig.Auth.Strategy == kialiconfig.AuthStrategyHeader && authInfo.Impersonate != "" {
 		config.Impersonate.UserName = authInfo.Impersonate
 		config.Impersonate.Groups = authInfo.ImpersonateGroups
@@ -208,40 +218,78 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 
 	var newClient UserClientInterface
 	if cluster == cf.homeCluster {
-		client, err := NewClient(ClusterInfo{
-			ClientConfig: &config,
-			Name:         cf.homeCluster,
-		}, cf.kialiConfig)
-		if err != nil {
-			log.Errorf("Error creating client for cluster [%s]: %s", cluster, err.Error())
-			return nil, err
+		if cf.kialiConfig.Auth.Strategy == kialiconfig.AuthStrategyOpenshift &&
+			cf.kialiConfig.Auth.OpenShift.Impersonation.Enabled &&
+			authInfo.Impersonate != "" {
+			// IMPERSONATION PATH for home cluster: use the in-cluster SA credentials
+			// (token file) + impersonation headers. The user's OAuth token was
+			// already used for identity verification in ValidateSession.
+			homeConfig := *cf.baseRestConfig
+			if cf.saTokenFile == "" {
+				log.Warning("Impersonation is enabled but no SA token file is available. Home cluster impersonation will fail.")
+			}
+			homeConfig.BearerTokenFile = cf.saTokenFile
+			homeConfig.Impersonate = rest.ImpersonationConfig{
+				UserName: authInfo.Impersonate,
+				Groups:   authInfo.ImpersonateGroups,
+			}
+			cf.applySettings(&homeConfig)
+			client, err := NewClient(ClusterInfo{
+				ClientConfig: &homeConfig,
+				Name:         cf.homeCluster,
+			}, cf.kialiConfig)
+			if err != nil {
+				log.Errorf("Error creating client for cluster [%s]: %s", cluster, err.Error())
+				return nil, err
+			}
+			newClient = client
+		} else {
+			// LEGACY PATH: user's own token authenticates directly.
+			client, err := NewClient(ClusterInfo{
+				ClientConfig: &config,
+				Name:         cf.homeCluster,
+			}, cf.kialiConfig)
+			if err != nil {
+				log.Errorf("Error creating client for cluster [%s]: %s", cluster, err.Error())
+				return nil, err
+			}
+			newClient = client
 		}
-		newClient = client
 	} else {
-		// Remote clusters
-		clusterInfos, err := GetRemoteClusterInfos()
-		if err != nil {
-			log.Errorf("Error getting remote cluster infos: %c", err)
-			return nil, err
-		}
-
-		clusterInfo, ok := clusterInfos[cluster]
+		clusterInfo, ok := cf.remoteClusterInfos[cluster]
 		if !ok {
 			return nil, fmt.Errorf("unable to find cluster [%s] in remote cluster info", cluster)
 		}
 
-		cf.applySettings(clusterInfo.ClientConfig)
+		remoteConfig := rest.CopyConfig(clusterInfo.ClientConfig)
+		cf.applySettings(remoteConfig)
 
-		// Replace the Kiali SA token with the user's auth token
-		// and clear the rest of the auth fields.
-		stripAuthInfo(clusterInfo.ClientConfig)
-		clusterInfo.ClientConfig.BearerToken = authInfo.Token
+		if cf.kialiConfig.Auth.Strategy == kialiconfig.AuthStrategyOpenshift &&
+			cf.kialiConfig.Auth.OpenShift.Impersonation.Enabled &&
+			authInfo.Impersonate != "" {
+			// IMPERSONATION PATH: SA token from secret authenticates the request;
+			// impersonation headers carry the user's identity.
+			// stripAuthInfo is NOT called — the SA token must remain in remoteConfig.
+			remoteConfig.Impersonate = rest.ImpersonationConfig{
+				UserName: authInfo.Impersonate,
+				Groups:   authInfo.ImpersonateGroups,
+			}
+		} else {
+			// LEGACY PATH: user's own token authenticates directly.
+			stripAuthInfo(remoteConfig)
+			remoteConfig.BearerToken = authInfo.Token
+		}
 
-		newClient, err = NewClient(clusterInfo.ClusterInfo, cf.kialiConfig)
+		client, err := NewClient(ClusterInfo{
+			ClientConfig: remoteConfig,
+			Name:         clusterInfo.Name,
+			SecretName:   clusterInfo.SecretName,
+		}, cf.kialiConfig)
 		if err != nil {
 			log.Errorf("Error getting remote client for cluster [%s]. Err: %s", cluster, err.Error())
 			return nil, err
 		}
+		newClient = client
 	}
 
 	// run to recycle client
@@ -387,36 +435,38 @@ func (cf *clientFactory) deleteClient(token string) {
 
 // getTokenHash get the token hash of a client
 func getTokenHash(authInfo *api.AuthInfo) string {
-	tokenData := authInfo.Token
+	h := sha256.New()
 
-	if authInfo.Impersonate != "" {
-		tokenData += authInfo.Impersonate
-	}
+	// Null byte delimiter prevents collision between adjacent fields.
+	// No valid token, username, or group contains a null byte.
+	delim := []byte{0}
 
-	if authInfo.ImpersonateGroups != nil {
-		for _, group := range authInfo.ImpersonateGroups {
-			tokenData += group
-		}
+	h.Write([]byte(authInfo.Token))
+	h.Write(delim)
+	h.Write([]byte(authInfo.Impersonate))
+	h.Write(delim)
+
+	for _, group := range authInfo.ImpersonateGroups {
+		h.Write([]byte(group))
+		h.Write(delim)
 	}
 
 	if authInfo.ImpersonateUserExtra != nil {
-		for key, element := range authInfo.ImpersonateUserExtra {
-			for _, userExtra := range element {
-				tokenData += key + userExtra
+		keys := make([]string, 0, len(authInfo.ImpersonateUserExtra))
+		for k := range authInfo.ImpersonateUserExtra {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			h.Write([]byte(key))
+			h.Write(delim)
+			for _, val := range authInfo.ImpersonateUserExtra[key] {
+				h.Write([]byte(val))
+				h.Write(delim)
 			}
 		}
 	}
 
-	h := sha256.New()
-	_, err := h.Write([]byte(tokenData))
-	if err != nil {
-		// errcheck linter want us to check for the error returned by h.Write.
-		// However, docs of sha256 say that this Writer never returns an error.
-		// See: https://golang.org/pkg/hash/#Hash
-		// So, let's check the error, and panic. Per the docs, this panic should
-		// never be reached.
-		panic("sha256.Write returned error.")
-	}
 	return string(h.Sum(nil))
 }
 

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -239,7 +239,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 				Name:         cf.homeCluster,
 			}, cf.kialiConfig)
 			if err != nil {
-				log.Errorf("Error creating client for cluster [%s]: %s", cluster, err.Error())
+				log.Errorf("Error creating impersonation client for cluster [%s]: %s", cluster, err.Error())
 				return nil, err
 			}
 			newClient = client

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -145,6 +145,9 @@ func newClientFactory(ctx context.Context, kialiConf *kialiconfig.Config, restCo
 	// We only want to remove the auth info from the base rest config which is saved and used later
 	// but we will immediately use the auth info for the home cluster SA client.
 	saTokenFile := restConf.BearerTokenFile
+	if kialiConf.Auth.OpenShift.Impersonation.Enabled && saTokenFile == "" {
+		return nil, fmt.Errorf("impersonation is enabled but no SA token file is available; Kiali must run in-cluster")
+	}
 	baseRestConfig := *restConf
 	stripAuthInfo(&baseRestConfig)
 
@@ -225,9 +228,6 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			// (token file) + impersonation headers. The user's OAuth token was
 			// already used for identity verification in ValidateSession.
 			homeConfig := *cf.baseRestConfig
-			if cf.saTokenFile == "" {
-				return nil, fmt.Errorf("impersonation is enabled but no SA token file is available for the home cluster")
-			}
 			homeConfig.BearerTokenFile = cf.saTokenFile
 			homeConfig.Impersonate = rest.ImpersonationConfig{
 				UserName: authInfo.Impersonate,

--- a/kubernetes/client_factory_test.go
+++ b/kubernetes/client_factory_test.go
@@ -573,6 +573,53 @@ func TestNewClientFactoryClosesRecycleWhenCTXCancelled(t *testing.T) {
 }
 
 // TODO: This test fails when you have created the /kiali-remote-cluster-secrets directory locally.
+func TestGetTokenHashWithDelimiters(t *testing.T) {
+	// Two authInfos that would collide without null-byte delimiters must produce different hashes.
+	a1 := &api.AuthInfo{Impersonate: "user1", ImpersonateGroups: []string{"group1"}, Token: ""}
+	a2 := &api.AuthInfo{Impersonate: "user1group1", Token: ""}
+	assert.NotEqual(t, getTokenHash(a1), getTokenHash(a2))
+}
+
+func TestGetTokenHashDeterministic(t *testing.T) {
+	a := &api.AuthInfo{
+		Impersonate:       "user1",
+		ImpersonateGroups: []string{"g1", "g2"},
+		ImpersonateUserExtra: map[string][]string{
+			"key1": {"v1"},
+			"key2": {"v2"},
+		},
+		Token: "",
+	}
+	h1 := getTokenHash(a)
+	h2 := getTokenHash(a)
+	assert.Equal(t, h1, h2)
+}
+
+func TestGetTokenHashDifferentUsers(t *testing.T) {
+	a1 := &api.AuthInfo{Impersonate: "alice", ImpersonateGroups: []string{"system:authenticated"}}
+	a2 := &api.AuthInfo{Impersonate: "bob", ImpersonateGroups: []string{"system:authenticated"}}
+	assert.NotEqual(t, getTokenHash(a1), getTokenHash(a2))
+}
+
+func TestGetTokenHashExtraKeyOrder(t *testing.T) {
+	// Keys in ImpersonateUserExtra are sorted, so insertion order must not matter.
+	a1 := &api.AuthInfo{
+		Impersonate: "user1",
+		ImpersonateUserExtra: map[string][]string{
+			"alpha": {"a"},
+			"beta":  {"b"},
+		},
+	}
+	a2 := &api.AuthInfo{
+		Impersonate: "user1",
+		ImpersonateUserExtra: map[string][]string{
+			"beta":  {"b"},
+			"alpha": {"a"},
+		},
+	}
+	assert.Equal(t, getTokenHash(a1), getTokenHash(a2))
+}
+
 func TestClientFactoryGetClients(t *testing.T) {
 	cases := map[string]struct {
 		auth               config.AuthConfig

--- a/kubernetes/kubetest/fake.go
+++ b/kubernetes/kubetest/fake.go
@@ -190,21 +190,29 @@ type FakeK8sClient struct {
 	// Underlying gateway api clientset.
 	GatewayAPIClientset gatewayapi.Interface
 	// Token is the kiali token this client uses.
-	Token           string
+	Token string
+	// CacheKey overrides the cache identity when set (simulates impersonation).
+	CacheKey        string
 	KubeClusterInfo kialikube.ClusterInfo
 	ProjectFake     *projectfake.Clientset
 	UserFake        *userfake.Clientset
 	OAuthFake       *oauthfake.Clientset
 }
 
-func (c *FakeK8sClient) IsOpenShift() bool                  { return c.OpenShift }
-func (c *FakeK8sClient) IsGatewayAPI() bool                 { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) HasTCPRouteInV1() bool              { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) HasTLSRouteInV1() bool              { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) HasUDPRouteInV1() bool              { return c.GatewayAPIEnabled }
-func (c *FakeK8sClient) IsInferenceAPI() bool               { return c.InferenceAPIEnabled }
-func (c *FakeK8sClient) IsIstioGateway() bool               { return c.IstioGatewayInstalled }
-func (c *FakeK8sClient) IsIstioAPI() bool                   { return c.IstioAPIInstalled }
+func (c *FakeK8sClient) IsOpenShift() bool     { return c.OpenShift }
+func (c *FakeK8sClient) IsGatewayAPI() bool    { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) HasTCPRouteInV1() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) HasTLSRouteInV1() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) HasUDPRouteInV1() bool { return c.GatewayAPIEnabled }
+func (c *FakeK8sClient) IsInferenceAPI() bool  { return c.InferenceAPIEnabled }
+func (c *FakeK8sClient) IsIstioGateway() bool  { return c.IstioGatewayInstalled }
+func (c *FakeK8sClient) IsIstioAPI() bool      { return c.IstioAPIInstalled }
+func (c *FakeK8sClient) GetCacheKey() string {
+	if c.CacheKey != "" {
+		return c.CacheKey
+	}
+	return c.Token
+}
 func (c *FakeK8sClient) GetToken() string                   { return c.Token }
 func (c *FakeK8sClient) ClusterInfo() kialikube.ClusterInfo { return c.KubeClusterInfo }
 func (c *FakeK8sClient) SetProxyLogLevel(namespace string, podName string, level string) error {

--- a/kubernetes/kubetest/mock.go
+++ b/kubernetes/kubetest/mock.go
@@ -203,6 +203,11 @@ func (o *K8SClientMock) GetServerVersion() (*version.Info, error) {
 	return args.Get(0).(*version.Info), args.Error(1)
 }
 
+func (o *K8SClientMock) GetCacheKey() string {
+	args := o.Called()
+	return args.Get(0).(string)
+}
+
 func (o *K8SClientMock) GetToken() string {
 	args := o.Called()
 	return args.Get(0).(string)


### PR DESCRIPTION
Fixes: https://github.com/kiali/kiali/issues/10038

When spec.auth.openshift.impersonation.enabled is true, users authenticate once to the home cluster and Kiali uses its SA credentials with Kubernetes impersonation headers for all cluster API calls. This eliminates the need for per-cluster OAuth login flows that don't scale beyond a few clusters.

Generated-by: Cursor