### PR TITLE
Fix Argo Rollout pod listing and scaled-to-0 visibility for custom controllers

### DIFF
--- a/business/test_util.go
+++ b/business/test_util.go
@@ -1145,6 +1145,145 @@ func FakeCustomControllerRSSyncedWithPods(conf *config.Config) []apps_v1.Replica
 	}
 }
 
+func FakeMultiReplicaSetCustomController(conf *config.Config) ([]apps_v1.ReplicaSet, []core_v1.Pod) {
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	controller := true
+	rolloutOwner := meta_v1.OwnerReference{
+		Controller: &controller,
+		APIVersion: "argoproj.io/v1alpha1",
+		Kind:       "Rollout",
+		Name:       "rollouts-demo-canary",
+	}
+	canaryReplicas := int32(1)
+	stableReplicas := int32(2)
+
+	replicaSets := []apps_v1.ReplicaSet{
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
+				Kind:       kubernetes.ReplicaSets.Kind,
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "rollouts-demo-canary-canary-hash",
+				Namespace:         "Namespace",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				OwnerReferences:   []meta_v1.OwnerReference{rolloutOwner},
+			},
+			Spec: apps_v1.ReplicaSetSpec{
+				Replicas: &canaryReplicas,
+				Template: core_v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "details", versionLabel: "v2"},
+					},
+				},
+			},
+			Status: apps_v1.ReplicaSetStatus{
+				Replicas:          1,
+				AvailableReplicas: 0,
+			},
+		},
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
+				Kind:       kubernetes.ReplicaSets.Kind,
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "rollouts-demo-canary-stable-hash",
+				Namespace:         "Namespace",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				OwnerReferences:   []meta_v1.OwnerReference{rolloutOwner},
+			},
+			Spec: apps_v1.ReplicaSetSpec{
+				Replicas: &stableReplicas,
+				Template: core_v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "details", versionLabel: "v1"},
+					},
+				},
+			},
+			Status: apps_v1.ReplicaSetStatus{
+				Replicas:          2,
+				AvailableReplicas: 2,
+			},
+		},
+	}
+
+	makePod := func(name, rsName, version string) core_v1.Pod {
+		return core_v1.Pod{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              name,
+				Namespace:         "Namespace",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				Labels:            map[string]string{appLabel: "details", versionLabel: version},
+				OwnerReferences: []meta_v1.OwnerReference{{
+					Controller: &controller,
+					APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
+					Kind:       kubernetes.ReplicaSets.Kind,
+					Name:       rsName,
+				}},
+				Annotations: kubetest.FakeIstioAnnotations(),
+			},
+			Spec: core_v1.PodSpec{
+				Containers: []core_v1.Container{
+					{Name: "details", Image: "whatever"},
+					{Name: "istio-proxy", Image: "docker.io/istio/proxy:0.7.1"},
+				},
+			},
+		}
+	}
+
+	pods := []core_v1.Pod{
+		makePod("rollouts-demo-canary-canary-pod", "rollouts-demo-canary-canary-hash", "v2"),
+		makePod("rollouts-demo-canary-stable-pod-1", "rollouts-demo-canary-stable-hash", "v1"),
+		makePod("rollouts-demo-canary-stable-pod-2", "rollouts-demo-canary-stable-hash", "v1"),
+	}
+
+	return replicaSets, pods
+}
+
+// FakeScaledToZeroCustomController returns a Rollout-owned ReplicaSet with zero replicas and no pods.
+// Models Anthony's inactive Rollout case from https://github.com/kiali/kiali/issues/10008.
+func FakeScaledToZeroCustomController(conf *config.Config) []apps_v1.ReplicaSet {
+	appLabel := conf.IstioLabels.AppLabelName
+	versionLabel := conf.IstioLabels.VersionLabelName
+	t1, _ := time.Parse(time.RFC822Z, "08 Mar 18 17:44 +0300")
+	controller := true
+	replicas := int32(0)
+	return []apps_v1.ReplicaSet{
+		{
+			TypeMeta: meta_v1.TypeMeta{
+				APIVersion: kubernetes.ReplicaSets.GroupVersion().String(),
+				Kind:       kubernetes.ReplicaSets.Kind,
+			},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:              "my-inactive-app-aabbccdd22",
+				Namespace:         "Namespace",
+				CreationTimestamp: meta_v1.NewTime(t1),
+				OwnerReferences: []meta_v1.OwnerReference{{
+					Controller: &controller,
+					APIVersion: "argoproj.io/v1alpha1",
+					Kind:       "Rollout",
+					Name:       "my-inactive-app",
+				}},
+			},
+			Spec: apps_v1.ReplicaSetSpec{
+				Replicas: &replicas,
+				Template: core_v1.PodTemplateSpec{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{appLabel: "my-inactive-app", versionLabel: "abc123"},
+					},
+				},
+			},
+			Status: apps_v1.ReplicaSetStatus{
+				Replicas:          0,
+				AvailableReplicas: 0,
+			},
+		},
+	}
+}
+
 func FakeServices(conf config.Config) []core_v1.Service {
 	appLabelName := conf.IstioLabels.AppLabelName
 	if appLabelName == "" {

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -940,6 +940,66 @@ func (in *WorkloadService) setPodsForDeployment(dep *apps_v1.Deployment, pods []
 	}
 }
 
+// collectPodsForCustomController gathers pods from every ReplicaSet owned by a custom controller (e.g. Argo Rollout).
+//
+// Custom controllers configured via custom_workload_types do not have typed parsers in Kiali. Pods are discovered
+// indirectly through child ReplicaSets. During canary or degraded updates a single controller may own multiple
+// active ReplicaSets at once; all of them must be considered or pods from stable/canary revisions are missed
+// (see https://github.com/kiali/kiali/issues/10008).
+func (in *WorkloadService) collectPodsForCustomController(w *models.Workload, controllerName string, controllerGVK schema.GroupVersionKind, controllerNamespace string, repset []apps_v1.ReplicaSet, pods []core_v1.Pod) []core_v1.Pod {
+	var cPods []core_v1.Pod
+	podSeen := make(map[string]struct{})
+	rsSeen := make(map[string]struct{})
+	parsedParent := false
+	var desiredReplicas, currentReplicas, availableReplicas int32
+
+	for _, rs := range repset {
+		rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
+		if rsOwnerRef == nil || rs.Namespace != controllerNamespace || rsOwnerRef.Name != controllerName || rsOwnerRef.Kind != controllerGVK.Kind {
+			continue
+		}
+		// The informer list may contain the same ReplicaSet more than once; count each set only once.
+		rsKey := rs.Namespace + "/" + rs.Name
+		if _, seen := rsSeen[rsKey]; seen {
+			continue
+		}
+		rsSeen[rsKey] = struct{}{}
+
+		// Workload metadata (labels, GVK, name) comes from the parent controller; use the first matching RS as template.
+		if !parsedParent {
+			w.ParseReplicaSetParent(&rs, controllerName, controllerGVK, in.conf)
+			parsedParent = true
+		}
+		// Sum replica counts across revisions so totals reflect the whole controller during multi-RS transitions.
+		if rs.Spec.Replicas != nil {
+			desiredReplicas += *rs.Spec.Replicas
+		}
+		currentReplicas += rs.Status.Replicas
+		availableReplicas += rs.Status.AvailableReplicas
+
+		for _, pod := range pods {
+			if !meta_v1.IsControlledBy(&pod, &rs) {
+				continue
+			}
+			// A pod belongs to one RS; the map guards against duplicate list entries only.
+			podKey := pod.Namespace + "/" + pod.Name
+			if _, seen := podSeen[podKey]; seen {
+				continue
+			}
+			podSeen[podKey] = struct{}{}
+			cPods = append(cPods, pod)
+		}
+	}
+
+	if parsedParent {
+		w.DesiredReplicas = desiredReplicas
+		w.CurrentReplicas = currentReplicas
+		w.AvailableReplicas = availableReplicas
+	}
+
+	return cPods
+}
+
 // fetchWorkloadsFromCluster returns all cluster workloads for the specified namespaces. The caller must have access to all of
 // the specified namespaces or it is an error. If <namespaces> is empty it returns the workloads for all accessible namespaces.
 func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluster string, fetchNamespaces []string, labelSelector string, waypoints models.Workloads) (models.Workloads, error) {
@@ -1405,16 +1465,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			controllers[depKey] = kubernetes.Deployments
 		}
 	}
-	for _, rs := range repset {
-		selectorCheck := true
-		if selector != nil {
-			selectorCheck = selector.Matches(labels.Set(rs.Spec.Template.Labels))
-		}
-		rsKey := controllers.key(rs.Namespace, rs.Name)
-		if _, exist := controllers[rsKey]; !exist && len(rs.OwnerReferences) == 0 && selectorCheck {
-			controllers[rsKey] = kubernetes.ReplicaSets
-		}
-	}
+	controllers.addControllersFromReplicaSetsWithoutPods(repset, selector)
 	for _, dc := range depcon {
 		selectorCheck := true
 		if selector != nil {
@@ -1662,19 +1713,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
 			// Note, we will use the controller found in the Pod resolution, instead that the passed by parameter
 			// This will cover cornercase for https://github.com/kiali/kiali/issues/3830
-			var cPods []core_v1.Pod
-			for _, rs := range repset {
-				rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
-				if rsOwnerRef != nil && rs.Namespace == controllerNamespace && rsOwnerRef.Name == controllerName && rsOwnerRef.Kind == controllerGVK.Kind {
-					w.ParseReplicaSetParent(&rs, controllerName, controllerGVK, in.conf)
-					for _, pod := range pods {
-						if meta_v1.IsControlledBy(&pod, &rs) {
-							cPods = append(cPods, pod)
-						}
-					}
-					break
-				}
-			}
+			cPods := in.collectPodsForCustomController(w, controllerName, controllerGVK, controllerNamespace, repset, pods)
 			if len(cPods) == 0 {
 				// If no pods were found for a ReplicaSet type, it's possible the controller
 				// is managing the pods itself i.e. the pod's have an owner ref directly to the controller type.
@@ -1751,6 +1790,39 @@ func (in controllerMap) parse(key string) (namespace, name string) {
 		return parts[0], parts[1]
 	}
 	return "", key // fallback for malformed key
+}
+
+// addControllersFromReplicaSetsWithoutPods surfaces workloads that own ReplicaSets but currently
+// have no pods (e.g. an Argo Rollout scaled to 0). Pod-based discovery cannot find those because
+// there are no pods to walk. Typed controllers (Deployments, StatefulSets, etc.) already have
+// their own empty-controller loops; this mainly adds custom parents such as Rollout. ReplicaSets
+// with no owner remain listed as ReplicaSet workloads (existing orphan behavior).
+// See https://github.com/kiali/kiali/issues/10008.
+func (in controllerMap) addControllersFromReplicaSetsWithoutPods(repset []apps_v1.ReplicaSet, selector labels.Selector) {
+	for _, rs := range repset {
+		if selector != nil && !selector.Matches(labels.Set(rs.Spec.Template.Labels)) {
+			continue
+		}
+
+		ownerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
+		if ownerRef != nil {
+			refGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+			if err != nil {
+				log.Errorf("could not parse OwnerReference api version %q: %v", ownerRef.APIVersion, err)
+				continue
+			}
+			parentKey := in.key(rs.Namespace, ownerRef.Name)
+			if _, exist := in[parentKey]; !exist {
+				in[parentKey] = refGV.WithKind(ownerRef.Kind)
+			}
+			continue
+		}
+
+		rsKey := in.key(rs.Namespace, rs.Name)
+		if _, exist := in[rsKey]; !exist {
+			in[rsKey] = kubernetes.ReplicaSets
+		}
+	}
 }
 
 func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadCriteria, waypoints models.Workloads) (*models.Workload, error) {
@@ -2147,12 +2219,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			controllers[depKey] = kubernetes.Deployments
 		}
 	}
-	for _, rs := range repset {
-		rsKey := controllers.key(rs.Namespace, rs.Name)
-		if _, exist := controllers[rsKey]; !exist && len(rs.OwnerReferences) == 0 {
-			controllers[rsKey] = kubernetes.ReplicaSets
-		}
-	}
+	controllers.addControllersFromReplicaSetsWithoutPods(repset, nil)
 	if depcon != nil {
 		dcKey := controllers.key(depcon.Namespace, depcon.Name)
 		if _, exist := controllers[dcKey]; !exist {
@@ -2353,19 +2420,7 @@ func (in *WorkloadService) fetchWorkload(ctx context.Context, criteria WorkloadC
 			// ReplicaSet should be used to link Pods with a custom controller type i.e. Argo Rollout
 			// Note, we will use the controller found in the Pod resolution, instead that the passed by parameter
 			// This will cover cornercase for https://github.com/kiali/kiali/issues/3830
-			var cPods []core_v1.Pod
-			for _, rs := range repset {
-				rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
-				if rsOwnerRef != nil && rs.Namespace == criteria.Namespace && rsOwnerRef.Name == criteria.WorkloadName && rsOwnerRef.Kind == discoveredControllerGVK.Kind {
-					w.ParseReplicaSetParent(&rs, criteria.WorkloadName, discoveredControllerGVK, in.conf)
-					for _, pod := range pods {
-						if meta_v1.IsControlledBy(&pod, &rs) {
-							cPods = append(cPods, pod)
-						}
-					}
-					break
-				}
-			}
+			cPods := in.collectPodsForCustomController(&w, criteria.WorkloadName, discoveredControllerGVK, criteria.Namespace, repset, pods)
 
 			if len(cPods) == 0 {
 				cPods = kubernetes.FilterPodsByControllerAndNamespace(criteria.WorkloadName, discoveredControllerGVK, criteria.Namespace, pods)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -946,14 +946,22 @@ func (in *WorkloadService) setPodsForDeployment(dep *apps_v1.Deployment, pods []
 // indirectly through child ReplicaSets. During canary or degraded updates a single controller may own multiple
 // active ReplicaSets at once; all of them must be considered or pods from stable/canary revisions are missed
 // (see https://github.com/kiali/kiali/issues/10008).
+func replicaSetDesiredCount(rs *apps_v1.ReplicaSet) int32 {
+	if rs.Spec.Replicas != nil {
+		return *rs.Spec.Replicas
+	}
+	return rs.Status.Replicas
+}
+
 func (in *WorkloadService) collectPodsForCustomController(w *models.Workload, controllerName string, controllerGVK schema.GroupVersionKind, controllerNamespace string, repset []apps_v1.ReplicaSet, pods []core_v1.Pod) []core_v1.Pod {
 	var cPods []core_v1.Pod
 	podSeen := make(map[string]struct{})
 	rsSeen := make(map[string]struct{})
-	parsedParent := false
+	var bestRS *apps_v1.ReplicaSet
 	var desiredReplicas, currentReplicas, availableReplicas int32
 
-	for _, rs := range repset {
+	for i := range repset {
+		rs := &repset[i]
 		rsOwnerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
 		if rsOwnerRef == nil || rs.Namespace != controllerNamespace || rsOwnerRef.Name != controllerName || rsOwnerRef.Kind != controllerGVK.Kind {
 			continue
@@ -965,20 +973,18 @@ func (in *WorkloadService) collectPodsForCustomController(w *models.Workload, co
 		}
 		rsSeen[rsKey] = struct{}{}
 
-		// Workload metadata (labels, GVK, name) comes from the parent controller; use the first matching RS as template.
-		if !parsedParent {
-			w.ParseReplicaSetParent(&rs, controllerName, controllerGVK, in.conf)
-			parsedParent = true
+		// Prefer the ReplicaSet with the most desired replicas for workload metadata (labels/version).
+		// During canary/degraded updates the first matching RS may be an empty or failed revision.
+		if bestRS == nil || replicaSetDesiredCount(rs) > replicaSetDesiredCount(bestRS) {
+			bestRS = rs
 		}
 		// Sum replica counts across revisions so totals reflect the whole controller during multi-RS transitions.
-		if rs.Spec.Replicas != nil {
-			desiredReplicas += *rs.Spec.Replicas
-		}
+		desiredReplicas += replicaSetDesiredCount(rs)
 		currentReplicas += rs.Status.Replicas
 		availableReplicas += rs.Status.AvailableReplicas
 
 		for _, pod := range pods {
-			if !meta_v1.IsControlledBy(&pod, &rs) {
+			if !meta_v1.IsControlledBy(&pod, rs) {
 				continue
 			}
 			// A pod belongs to one RS; the map guards against duplicate list entries only.
@@ -991,7 +997,8 @@ func (in *WorkloadService) collectPodsForCustomController(w *models.Workload, co
 		}
 	}
 
-	if parsedParent {
+	if bestRS != nil {
+		w.ParseReplicaSetParent(bestRS, controllerName, controllerGVK, in.conf)
 		w.DesiredReplicas = desiredReplicas
 		w.CurrentReplicas = currentReplicas
 		w.AvailableReplicas = availableReplicas
@@ -1795,8 +1802,8 @@ func (in controllerMap) parse(key string) (namespace, name string) {
 // addControllersFromReplicaSetsWithoutPods surfaces workloads that own ReplicaSets but currently
 // have no pods (e.g. an Argo Rollout scaled to 0). Pod-based discovery cannot find those because
 // there are no pods to walk. Typed controllers (Deployments, StatefulSets, etc.) already have
-// their own empty-controller loops; this mainly adds custom parents such as Rollout. ReplicaSets
-// with no owner remain listed as ReplicaSet workloads (existing orphan behavior).
+// their own empty-controller loops and are skipped here; this mainly adds custom parents such as
+// Rollout. ReplicaSets with no owner references remain listed as ReplicaSet workloads (orphan behavior).
 // See https://github.com/kiali/kiali/issues/10008.
 func (in controllerMap) addControllersFromReplicaSetsWithoutPods(repset []apps_v1.ReplicaSet, selector labels.Selector) {
 	for _, rs := range repset {
@@ -1806,6 +1813,10 @@ func (in controllerMap) addControllersFromReplicaSetsWithoutPods(repset []apps_v
 
 		ownerRef := meta_v1.GetControllerOf(&rs.ObjectMeta)
 		if ownerRef != nil {
+			// Known typed kinds are handled by their own no-pods loops above; avoid redundant entries.
+			if _, known := controllerOrder[ownerRef.Kind]; known {
+				continue
+			}
 			refGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
 			if err != nil {
 				log.Errorf("could not parse OwnerReference api version %q: %v", ownerRef.APIVersion, err)
@@ -1818,9 +1829,12 @@ func (in controllerMap) addControllersFromReplicaSetsWithoutPods(repset []apps_v
 			continue
 		}
 
-		rsKey := in.key(rs.Namespace, rs.Name)
-		if _, exist := in[rsKey]; !exist {
-			in[rsKey] = kubernetes.ReplicaSets
+		// Orphan ReplicaSet: only when there are no owner references at all.
+		if len(rs.OwnerReferences) == 0 {
+			rsKey := in.key(rs.Namespace, rs.Name)
+			if _, exist := in[rsKey]; !exist {
+				in[rsKey] = kubernetes.ReplicaSets
+			}
 		}
 	}
 }

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -940,12 +940,6 @@ func (in *WorkloadService) setPodsForDeployment(dep *apps_v1.Deployment, pods []
 	}
 }
 
-// collectPodsForCustomController gathers pods from every ReplicaSet owned by a custom controller (e.g. Argo Rollout).
-//
-// Custom controllers configured via custom_workload_types do not have typed parsers in Kiali. Pods are discovered
-// indirectly through child ReplicaSets. During canary or degraded updates a single controller may own multiple
-// active ReplicaSets at once; all of them must be considered or pods from stable/canary revisions are missed
-// (see https://github.com/kiali/kiali/issues/10008).
 func replicaSetDesiredCount(rs *apps_v1.ReplicaSet) int32 {
 	if rs.Spec.Replicas != nil {
 		return *rs.Spec.Replicas
@@ -953,6 +947,12 @@ func replicaSetDesiredCount(rs *apps_v1.ReplicaSet) int32 {
 	return rs.Status.Replicas
 }
 
+// collectPodsForCustomController gathers pods from every ReplicaSet owned by a custom controller (e.g. Argo Rollout).
+//
+// Custom controllers configured via custom_workload_types do not have typed parsers in Kiali. Pods are discovered
+// indirectly through child ReplicaSets. During canary or degraded updates a single controller may own multiple
+// active ReplicaSets at once; all of them must be considered or pods from stable/canary revisions are missed
+// (see https://github.com/kiali/kiali/issues/10008).
 func (in *WorkloadService) collectPodsForCustomController(w *models.Workload, controllerName string, controllerGVK schema.GroupVersionKind, controllerNamespace string, repset []apps_v1.ReplicaSet, pods []core_v1.Pod) []core_v1.Pod {
 	var cPods []core_v1.Pod
 	podSeen := make(map[string]struct{})

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -715,6 +715,127 @@ func TestGetWorkloadFromPods(t *testing.T) {
 	assert.Equal(0, len(workload.AdditionalDetails))
 }
 
+func TestGetWorkloadFromCustomControllerWithMultipleReplicaSets(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.ExternalServices.CustomDashboards.Enabled = false
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	kubernetes.SetConfig(t, *conf)
+
+	replicaSets, pods := FakeMultiReplicaSetCustomController(conf)
+	kubeObjs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Namespace"}},
+	}
+	for _, obj := range replicaSets {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	for _, obj := range pods {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
+	k8s.OpenShift = true
+	svc := setupWorkloadService(t, k8s, conf)
+
+	criteria := WorkloadCriteria{
+		Cluster:         conf.KubernetesConfig.ClusterName,
+		Namespace:       "Namespace",
+		WorkloadName:    "rollouts-demo-canary",
+		WorkloadGVK:     schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Rollout"},
+		IncludeServices: false,
+	}
+	workload, err := svc.GetWorkload(context.TODO(), criteria)
+	require.NoError(err)
+
+	assert.Equal("rollouts-demo-canary", workload.Name)
+	assert.Equal("Rollout", workload.WorkloadGVK.Kind)
+	assert.Equal(3, len(workload.Pods))
+	assert.Equal(int32(3), workload.DesiredReplicas)
+	assert.Equal(int32(3), workload.CurrentReplicas)
+}
+
+func TestGetWorkloadListFromCustomControllerWithMultipleReplicaSets(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	replicaSets, pods := FakeMultiReplicaSetCustomController(conf)
+	kubeObjs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Namespace"}},
+	}
+	for _, obj := range replicaSets {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	for _, obj := range pods {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
+	k8s.OpenShift = true
+	svc := setupWorkloadService(t, k8s, conf)
+
+	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	workloadList, err := svc.GetWorkloadList(context.TODO(), criteria)
+	require.NoError(err)
+
+	require.Len(workloadList.Workloads, 1)
+	assert.Equal("rollouts-demo-canary", workloadList.Workloads[0].Name)
+	assert.Equal("Rollout", workloadList.Workloads[0].WorkloadGVK.Kind)
+	assert.Equal(3, workloadList.Workloads[0].PodCount)
+}
+
+func TestGetWorkloadListFromCustomControllerScaledToZero(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.IstioLabels.AppLabelName = "app"
+	conf.IstioLabels.VersionLabelName = "version"
+	config.Set(conf)
+
+	replicaSets := FakeScaledToZeroCustomController(conf)
+	kubeObjs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Namespace"}},
+	}
+	for _, obj := range replicaSets {
+		o := obj
+		kubeObjs = append(kubeObjs, &o)
+	}
+	k8s := kubetest.NewFakeK8sClient(kubeObjs...)
+	k8s.OpenShift = true
+	svc := setupWorkloadService(t, k8s, conf)
+
+	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false, IncludeHealth: false}
+	workloadList, err := svc.GetWorkloadList(context.TODO(), criteria)
+	require.NoError(err)
+
+	require.Len(workloadList.Workloads, 1)
+	assert.Equal("my-inactive-app", workloadList.Workloads[0].Name)
+	assert.Equal("Rollout", workloadList.Workloads[0].WorkloadGVK.Kind)
+	assert.Equal(0, workloadList.Workloads[0].PodCount)
+
+	detail, err := svc.GetWorkload(context.TODO(), WorkloadCriteria{
+		Cluster:      conf.KubernetesConfig.ClusterName,
+		Namespace:    "Namespace",
+		WorkloadName: "my-inactive-app",
+		WorkloadGVK:  schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Rollout"},
+	})
+	require.NoError(err)
+	require.NotNil(detail)
+	assert.Equal("my-inactive-app", detail.Name)
+	assert.Equal("Rollout", detail.WorkloadGVK.Kind)
+	assert.Equal(0, len(detail.Pods))
+}
+
 func TestGetPod(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
### Describe the change

Fixes two related bugs for custom controllers (e.g. Argo Rollouts) discovered via ReplicaSet owner references:

1. **Incomplete / empty pod lists on multi-RS Rollouts**  
   When resolving pods for a custom controller, Kiali previously stopped after the first matching child ReplicaSet. During canary or degraded updates a Rollout can own multiple active ReplicaSets, so pods from the other revisions were missed (detail view showed "No Pods" even though pods were running).  
   `collectPodsForCustomController()` now walks **all** owned ReplicaSets, aggregates pods, sums replica counts, and deduplicates list entries. Used in both workload list and detail paths.

2. **Scaled-to-0 Rollouts missing from the workload list**  
   Workload discovery is pod-based. A Rollout with `replicas: 0` has no pods, so it never entered the controllers map. Its ReplicaSets still have an owner ref to the Rollout, so they also were not listed as orphan ReplicaSets.  
   `addControllersFromReplicaSetsWithoutPods()` now surfaces the parent controller from owned ReplicaSets when there are no pods (same idea as empty Deployments). Orphan ReplicaSets with no owner refs still appear as `ReplicaSet` workloads.

Note: `custom_workload_types` is frontend UI feature gating only. Backend discovery works via owner references for any custom controller, not only Rollouts listed in the Kiali CR.

### Steps to test the PR

#### Prerequisites

- Argo Rollouts installed
- Kiali configured with (from [#10008](https://github.com/kiali/kiali/issues/10008)):

```yaml
spec:
  kiali_feature_flags:
    custom_workload_types:
    - group: "argoproj.io"
      version: "v1alpha1"
      kind: "Rollout"
```

#### A) Multi-RS / degraded Rollout — pods must all appear

1. Deploy a canary Rollout and leave it healthy with one active ReplicaSet (pods should already show).
2. Trigger a degraded / multi-RS state, e.g.:

```bash
kubectl argo rollouts set image <rollout-name> <container>=nginx:does-not-exist -n <namespace>
```

   Or use a Rollout status like the reporter's degraded case (`phase: Degraded`, `stableRS` and `currentPodHash` differ, two active ReplicaSets).
3. Open the Rollout in Kiali **Workloads → detail**.
4. **Expected:** pods from **both** stable and canary/failed ReplicaSets appear (not "No Pods").
5. Workload list `PodCount` matches the total pod count.

Example degraded Rollout shape from the issue discussion:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: my-app
  namespace: my-namespace
  labels:
    app.kubernetes.io/name: my-app
    app.kubernetes.io/version: abc123
spec:
  replicas: 1
  revisionHistoryLimit: 5
  selector:
    matchLabels:
      app.kubernetes.io/name: my-app
  strategy:
    canary:
      canaryMetadata:
        labels:
          role: canary
      stableMetadata:
        labels:
          role: stable
      maxSurge: 20%
      maxUnavailable: 0
      steps:
      - setWeight: 20
      - pause:
          duration: 270s
  template:
    metadata:
      labels:
        app.kubernetes.io/name: my-app
        app.kubernetes.io/version: abc123
    spec:
      containers:
      - name: my-app
        image: my-image:abc123
status:
  phase: Degraded
  currentStepIndex: 0
  currentPodHash: aabbccdd11
  stableRS: aabbccdd22
  replicas: 2
  readyReplicas: 1
  updatedReplicas: 1
  availableReplicas: 1
  message: 'ProgressDeadlineExceeded:  ReplicaSet "my-app-aabbccdd11" has timed out progressing.'
```

#### B) Active vs scaled-to-0 Rollouts — both must appear in the list

Apply the reporter YAMLs from [#10008](https://github.com/kiali/kiali/issues/10008#issuecomment-4984206028) in the same namespace:

**Active Rollout (`replicas: 1`):**

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: my-active-app
  namespace: my-namespace
  labels:
    app.kubernetes.io/name: my-active-app
    app.kubernetes.io/version: abc123
spec:
  replicas: 1
  revisionHistoryLimit: 5
  selector:
    matchLabels:
      app.kubernetes.io/name: my-active-app
  strategy:
    canary:
      canaryMetadata:
        labels:
          role: canary
      stableMetadata:
        labels:
          role: stable
      maxSurge: 20%
      maxUnavailable: 0
      steps:
      - setWeight: 20
      - pause:
          duration: 60s
      - pause:
          duration: 60s
      - setWeight: 40
      - pause:
          duration: 60s
      - setWeight: 60
      - pause:
          duration: 60s
      - setWeight: 80
      - pause:
          duration: 60s
  template:
    metadata:
      labels:
        app.kubernetes.io/name: my-active-app
        app.kubernetes.io/version: abc123
        sidecar.istio.io/inject: "true"
    spec:
      containers:
      - name: my-app
        image: my-image:abc123
        ports:
        - containerPort: 8080
          name: http
```

**Scaled-to-0 Rollout (`replicas: 0`):**

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: my-inactive-app
  namespace: my-namespace
  labels:
    app.kubernetes.io/name: my-inactive-app
    app.kubernetes.io/version: abc123
spec:
  replicas: 0
  revisionHistoryLimit: 5
  selector:
    matchLabels:
      app.kubernetes.io/name: my-inactive-app
  strategy:
    canary:
      maxSurge: 20%
      maxUnavailable: 0
      steps:
      - setWeight: 20
      - pause:
          duration: 270s
  template:
    metadata:
      labels:
        app.kubernetes.io/name: my-inactive-app
        app.kubernetes.io/version: abc123
        sidecar.istio.io/inject: "true"
    spec:
      containers:
      - name: my-app
        image: my-image:abc123
```

**Expected:**
- `my-active-app` appears as type `Rollout` (with pods when the image pulls successfully)
- `my-inactive-app` appears as type `Rollout` with `PodCount` 0 (not missing, and not only as a bare ReplicaSet)

### Automation testing

Unit tests in `business/workloads_test.go`:

- `TestGetWorkloadFromCustomControllerWithMultipleReplicaSets` — detail view returns all pods and correct replica totals from 2 ReplicaSets
- `TestGetWorkloadListFromCustomControllerWithMultipleReplicaSets` — list view `PodCount` matches multi-RS total
- `TestGetWorkloadListFromCustomControllerScaledToZero` — scaled-to-0 Rollout appears in list and detail with `PodCount` 0

Fixtures in `business/test_util.go`:
- `FakeMultiReplicaSetCustomController()`
- `FakeScaledToZeroCustomController()`

### Issue reference

Fixes #10008