### PR TITLE
Add per-object validation ignore annotation support

### DIFF
--- a/ai/mcp/list_or_get_resources/list_or_get_resources.go
+++ b/ai/mcp/list_or_get_resources/list_or_get_resources.go
@@ -367,8 +367,7 @@ func getResourceDetails(ctx context.Context, businessLayer *business.Layer, kial
 			namespace,
 			resourceArgs.ResourceName,
 			interval,
-			resourceArgs.QueryTime,
-			true)
+			resourceArgs.QueryTime)
 		if err != nil {
 			return classifyError(err, "service", resourceArgs.ResourceName, namespace), classifyErrorStatus(err), nil
 		}

--- a/business/checkers/services/port_mapping_checker.go
+++ b/business/checkers/services/port_mapping_checker.go
@@ -36,8 +36,8 @@ func NewPortMappingChecker(deployments []apps_v1.Deployment, meshDiscovery istio
 func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
-	// Check Port naming for services in the service mesh
-	if p.hasMatchingPodsWithSidecar(p.Service) {
+	// Check Port naming for services in the service mesh (sidecar or ambient).
+	if p.isInMesh(p.Service) {
 		for portIndex, sp := range p.Service.Spec.Ports {
 			if _, ok := p.Service.Labels["kiali_wizard"]; ok || strings.ToLower(string(sp.Protocol)) == "udp" {
 				continue
@@ -70,10 +70,12 @@ func (p PortMappingChecker) Check() ([]*models.IstioCheck, bool) {
 	return validations, len(validations) == 0
 }
 
-func (p PortMappingChecker) hasMatchingPodsWithSidecar(service corev1.Service) bool {
+// isInMesh returns true when the service's matching pods are part of the mesh,
+// either via sidecar injection or ambient redirection.
+func (p PortMappingChecker) isInMesh(service corev1.Service) bool {
 	sPods := models.Pods{}
 	sPods.Parse(kubernetes.FilterPodsByService(&service, p.Pods), p.MeshDiscovery.IsControlPlane)
-	return sPods.HasIstioSidecar()
+	return sPods.HasIstioSidecar() || sPods.HasAnyAmbient()
 }
 
 func (p PortMappingChecker) findMatchingDeployment(selectors map[string]string) *apps_v1.Deployment {

--- a/business/checkers/services/port_mapping_checker_test.go
+++ b/business/checkers/services/port_mapping_checker_test.go
@@ -218,6 +218,24 @@ func TestServicePortNamingWithoutSidecar(t *testing.T) {
 	assert.Empty(vals)
 }
 
+func TestServicePortNamingAmbient(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	deployments := getDeployment(9080)
+	pods := getAmbientPods()
+	service := getService(9080, "http2foo", nil, "test-namespace", "app", "labelName1")
+	pmc := NewPortMappingChecker(deployments, discovery, pods, service)
+
+	vals, valid := pmc.Check()
+	assert.False(valid)
+	assert.NotEmpty(vals)
+	assert.NoError(validations.ConfirmIstioCheckMessage("port.name.mismatch", vals[0]))
+	assert.Equal("spec/ports[0]", vals[0].Path)
+}
+
 func getService(servicePort int32, portName string, appProtocol *string, namespace string, labelKey string, labelValue string) v1.Service {
 	return v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -284,6 +302,21 @@ func getPods(withSidecar bool) []v1.Pod {
 				},
 				Annotations: map[string]string{
 					annotation: "{\"version\":\"\",\"initContainers\":[\"istio-init\",\"enable-core-dump\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"]}",
+				},
+			},
+		},
+	}
+}
+
+func getAmbientPods() []v1.Pod {
+	return []v1.Pod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Labels: map[string]string{
+					"dep": "one",
+				},
+				Annotations: map[string]string{
+					config.AmbientAnnotation: config.AmbientAnnotationEnabled,
 				},
 			},
 		},

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -131,7 +131,6 @@ type validationClusterInfo struct {
 	identityDomain   string                      // resolved Istio identity domain for this cluster's control plane
 	istioConfig      *models.IstioConfigList     // config for the cluster (all namespaces)
 	kubeServiceHosts kubernetes.KubeServiceHosts // pre-built host lookup from K8s services
-	pods             []core_v1.Pod               // K8s pods for the cluster (all namespaces)
 	rootNamespaces   map[string]string           // namespace => rootNamespace, pre-computed from ControlPlaneForNamespace
 	services         []core_v1.Service           // K8s services for the cluster (all namespaces)
 }
@@ -327,12 +326,6 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 	}
 	vInfo.clusterInfo.deployments = depList.Items
 
-	var podList core_v1.PodList
-	if err := kubeCache.List(ctx, &podList, &client.ListOptions{}); err != nil {
-		return false, nil, fmt.Errorf("unable to list pods for cluster [%s]: %w", cluster, err)
-	}
-	vInfo.clusterInfo.pods = podList.Items
-
 	// grab all config for the cluster
 	criteria := IstioConfigCriteria{
 		IncludeAuthorizationPolicies:  true,
@@ -415,17 +408,26 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 	}
 
 	// Service port-mapping validations are independent of per-namespace Istio config and run once per cluster.
+	// Pods are fetched only when checkers run (not during change detection) and scoped to managed namespaces.
 	managedServices := make([]core_v1.Service, 0, len(vInfo.clusterInfo.services))
 	for _, svc := range vInfo.clusterInfo.services {
 		if _, managed := rootNamespaces[svc.Namespace]; managed {
 			managedServices = append(managedServices, svc)
 		}
 	}
+	var pods []core_v1.Pod
+	for ns := range rootNamespaces {
+		var podList core_v1.PodList
+		if err := kubeCache.List(ctx, &podList, client.InNamespace(ns)); err != nil {
+			return false, nil, fmt.Errorf("unable to list pods for cluster [%s] namespace [%s]: %w", cluster, ns, err)
+		}
+		pods = append(pods, podList.Items...)
+	}
 	serviceChecker := checkers.NewServiceChecker(
 		cluster,
 		vInfo.clusterInfo.deployments,
 		in.mesh.discovery,
-		vInfo.clusterInfo.pods,
+		pods,
 		managedServices,
 	)
 	validations.MergeValidations(runObjectCheckers(ctx, []checkers.ObjectChecker{serviceChecker}, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
@@ -461,15 +463,12 @@ func detectClusterConfigChange(vInfo *validationInfo) bool {
 		change = vInfo.update("SV", cluster, s.Namespace, s.Name, serviceVersion) || change
 	}
 
-	// Deployments and pods affect service port-mapping validations (KIA0601/KIA0701).
+	// Deployments affect service port-mapping validations (KIA0601/KIA0701).
+	// Pods are intentionally not tracked: they churn too often and would force frequent revalidation.
 	for _, d := range vInfo.clusterInfo.deployments {
 		change = vInfo.update("DP", cluster, d.Namespace, d.Name, d.ResourceVersion) || change
 	}
 	change = vInfo.update("validation-num-deployments", cluster, "", "", strconv.Itoa(len(vInfo.clusterInfo.deployments))) || change
-	for _, p := range vInfo.clusterInfo.pods {
-		change = vInfo.update("PO", cluster, p.Namespace, p.Name, p.ResourceVersion) || change
-	}
-	change = vInfo.update("validation-num-pods", cluster, "", "", strconv.Itoa(len(vInfo.clusterInfo.pods))) || change
 
 	// loop through the config and gather up their resourceVersions
 	config := vInfo.clusterInfo.istioConfig

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -396,7 +396,7 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 			continue
 		}
 
-		validations.MergeValidations(runObjectCheckers(ctx, objectCheckers, in.conf))
+		validations.MergeValidations(runObjectCheckers(ctx, objectCheckers, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
 	}
 
 	return true, validations, nil
@@ -798,7 +798,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		return models.IstioValidations{}, istioReferences, err
 	}
 
-	validations := runObjectCheckers(ctx, objectCheckers, conf).FilterByKey(objectGVK, object)
+	validations := runObjectCheckers(ctx, objectCheckers, conf, buildObjectIgnoreValidations(vInfo, cluster)).FilterByKey(objectGVK, object)
 	for k, v := range validations {
 		in.kialiCache.Validations().Set(k, v)
 	}
@@ -806,7 +806,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 	return validations, istioReferences, nil
 }
 
-func runObjectCheckers(ctx context.Context, objectCheckers []checkers.ObjectChecker, conf *config.Config) models.IstioValidations {
+func runObjectCheckers(ctx context.Context, objectCheckers []checkers.ObjectChecker, conf *config.Config, perObjectIgnores models.ObjectIgnoreValidations) models.IstioValidations {
 	objectTypeValidations := models.IstioValidations{}
 
 	// Run checks for each IstioObject type
@@ -814,9 +814,23 @@ func runObjectCheckers(ctx context.Context, objectCheckers []checkers.ObjectChec
 		objectTypeValidations.MergeValidations(runObjectChecker(ctx, conf, objectChecker))
 	}
 
-	objectTypeValidations.StripIgnoredChecks(conf)
+	objectTypeValidations.StripIgnoredChecks(conf, perObjectIgnores)
 
 	return objectTypeValidations
+}
+
+func buildObjectIgnoreValidations(vInfo *validationInfo, cluster string) models.ObjectIgnoreValidations {
+	perObjectIgnores := models.ObjectIgnoreValidations{}
+	if vInfo.clusterInfo != nil {
+		if vInfo.clusterInfo.istioConfig != nil {
+			perObjectIgnores.Merge(vInfo.clusterInfo.istioConfig.ObjectIgnoreValidations(cluster))
+		}
+		perObjectIgnores.Merge(models.BuildServiceIgnoreValidations(vInfo.clusterInfo.services, cluster))
+	}
+	if workloadsPerNamespace, ok := vInfo.wlMap[cluster]; ok {
+		perObjectIgnores.Merge(models.BuildWorkloadIgnoreValidations(workloadsPerNamespace, cluster))
+	}
+	return perObjectIgnores
 }
 
 func runObjectChecker(ctx context.Context, conf *config.Config, objectChecker checkers.ObjectChecker) models.IstioValidations {

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -374,6 +374,9 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 		}
 	}
 
+	// Cluster-scoped ignore annotations; reuse for namespace checkers and ServiceChecker.
+	perObjectIgnores := buildObjectIgnoreValidations(vInfo, cluster)
+
 	for _, namespace := range vInfo.nsMap[cluster] {
 		// Skip validations for a particular namespace, mesh config was not found
 		if _, managed := rootNamespaces[namespace.Name]; !managed {
@@ -404,7 +407,7 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 			continue
 		}
 
-		validations.MergeValidations(runObjectCheckers(ctx, objectCheckers, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
+		validations.MergeValidations(runObjectCheckers(ctx, objectCheckers, in.conf, perObjectIgnores))
 	}
 
 	// Service port-mapping validations are independent of per-namespace Istio config and run once per cluster.
@@ -430,7 +433,7 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 		pods,
 		managedServices,
 	)
-	validations.MergeValidations(runObjectCheckers(ctx, []checkers.ObjectChecker{serviceChecker}, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
+	validations.MergeValidations(runObjectCheckers(ctx, []checkers.ObjectChecker{serviceChecker}, in.conf, perObjectIgnores))
 
 	return true, validations, nil
 }

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -11,6 +11,7 @@ import (
 	istiov1alpha1 "istio.io/api/mesh/v1alpha1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -126,9 +127,11 @@ type validationNamespaceInfo struct {
 
 type validationClusterInfo struct {
 	cluster          string                      // the cluster being validated
+	deployments      []apps_v1.Deployment        // K8s deployments for the cluster (all namespaces)
 	identityDomain   string                      // resolved Istio identity domain for this cluster's control plane
 	istioConfig      *models.IstioConfigList     // config for the cluster (all namespaces)
 	kubeServiceHosts kubernetes.KubeServiceHosts // pre-built host lookup from K8s services
+	pods             []core_v1.Pod               // K8s pods for the cluster (all namespaces)
 	rootNamespaces   map[string]string           // namespace => rootNamespace, pre-computed from ControlPlaneForNamespace
 	services         []core_v1.Service           // K8s services for the cluster (all namespaces)
 }
@@ -318,6 +321,18 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 	vInfo.clusterInfo.services = svcList.Items
 	vInfo.clusterInfo.kubeServiceHosts = kubernetes.NewKubeServiceHostsWithNamespaceDefaults(svcList.Items, vInfo.clusterInfo.identityDomain, buildNamespaceToExportTo(vInfo.mesh, cluster, svcList.Items))
 
+	var depList apps_v1.DeploymentList
+	if err := kubeCache.List(ctx, &depList, &client.ListOptions{}); err != nil {
+		return false, nil, fmt.Errorf("unable to list deployments for cluster [%s]: %w", cluster, err)
+	}
+	vInfo.clusterInfo.deployments = depList.Items
+
+	var podList core_v1.PodList
+	if err := kubeCache.List(ctx, &podList, &client.ListOptions{}); err != nil {
+		return false, nil, fmt.Errorf("unable to list pods for cluster [%s]: %w", cluster, err)
+	}
+	vInfo.clusterInfo.pods = podList.Items
+
 	// grab all config for the cluster
 	criteria := IstioConfigCriteria{
 		IncludeAuthorizationPolicies:  true,
@@ -399,6 +414,22 @@ func (in *IstioValidationsService) Validate(ctx context.Context, cluster string,
 		validations.MergeValidations(runObjectCheckers(ctx, objectCheckers, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
 	}
 
+	// Service port-mapping validations are independent of per-namespace Istio config and run once per cluster.
+	managedServices := make([]core_v1.Service, 0, len(vInfo.clusterInfo.services))
+	for _, svc := range vInfo.clusterInfo.services {
+		if _, managed := rootNamespaces[svc.Namespace]; managed {
+			managedServices = append(managedServices, svc)
+		}
+	}
+	serviceChecker := checkers.NewServiceChecker(
+		cluster,
+		vInfo.clusterInfo.deployments,
+		in.mesh.discovery,
+		vInfo.clusterInfo.pods,
+		managedServices,
+	)
+	validations.MergeValidations(runObjectCheckers(ctx, []checkers.ObjectChecker{serviceChecker}, in.conf, buildObjectIgnoreValidations(vInfo, cluster)))
+
 	return true, validations, nil
 }
 
@@ -426,8 +457,19 @@ func detectClusterConfigChange(vInfo *validationInfo) bool {
 
 	// loop through the services and gather up their resourceVersions
 	for _, s := range vInfo.clusterInfo.services {
-		change = vInfo.update("SV", cluster, s.Namespace, s.Name, s.ResourceVersion) || change
+		serviceVersion := fmt.Sprintf("%s:%s", s.ResourceVersion, s.Annotations[models.IgnoreValidationsAnnotation])
+		change = vInfo.update("SV", cluster, s.Namespace, s.Name, serviceVersion) || change
 	}
+
+	// Deployments and pods affect service port-mapping validations (KIA0601/KIA0701).
+	for _, d := range vInfo.clusterInfo.deployments {
+		change = vInfo.update("DP", cluster, d.Namespace, d.Name, d.ResourceVersion) || change
+	}
+	change = vInfo.update("validation-num-deployments", cluster, "", "", strconv.Itoa(len(vInfo.clusterInfo.deployments))) || change
+	for _, p := range vInfo.clusterInfo.pods {
+		change = vInfo.update("PO", cluster, p.Namespace, p.Name, p.ResourceVersion) || change
+	}
+	change = vInfo.update("validation-num-pods", cluster, "", "", strconv.Itoa(len(vInfo.clusterInfo.pods))) || change
 
 	// loop through the config and gather up their resourceVersions
 	config := vInfo.clusterInfo.istioConfig

--- a/business/services.go
+++ b/business/services.go
@@ -7,14 +7,12 @@ import (
 	"time"
 
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
-	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
@@ -139,7 +137,6 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 	var (
 		svcs            []core_v1.Service
 		pods            []core_v1.Pod
-		deployments     []apps_v1.Deployment
 		istioConfigList models.IstioConfigList
 		err             error
 		kubeCache       client.Reader
@@ -173,14 +170,6 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 		pods = podList.Items
 	}
 
-	if !criteria.IncludeOnlyDefinitions {
-		depList := &apps_v1.DeploymentList{}
-		if err := kubeCache.List(ctx, depList, client.InNamespace(criteria.Namespace)); err != nil {
-			return nil, fmt.Errorf("Error fetching Deployments per namespace %s: %s", criteria.Namespace, err)
-		}
-		deployments = depList.Items
-	}
-
 	// ServiceEntries are always fetched because buildServiceEntryOverviews needs
 	// them to produce SE-backed services (replacing the old Istio Service Registry).
 	// The remaining Istio resources are only needed for building references/badges.
@@ -205,7 +194,7 @@ func (in *SvcService) getServiceListForCluster(ctx context.Context, criteria Ser
 	istioConfigList = *istioConfigs
 
 	// Convert to Kiali model
-	services := in.buildServiceList(ctx, cluster, criteria.Namespace, svcs, pods, deployments, istioConfigList, criteria)
+	services := in.buildServiceList(ctx, cluster, criteria.Namespace, svcs, pods, istioConfigList, criteria)
 
 	// Check if we need to add health
 
@@ -264,11 +253,13 @@ func getDRKialiScenario(dr []*networking_v1.DestinationRule) string {
 	return scenario
 }
 
-func (in *SvcService) buildServiceList(ctx context.Context, cluster string, namespace string, svcs []core_v1.Service, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList, criteria ServiceCriteria) *models.ServiceList {
+func (in *SvcService) buildServiceList(ctx context.Context, cluster string, namespace string, svcs []core_v1.Service, pods []core_v1.Pod, istioConfigList models.IstioConfigList, criteria ServiceCriteria) *models.ServiceList {
 	services := []models.ServiceOverview{}
 	validations := models.IstioValidations{}
 	if !criteria.IncludeOnlyDefinitions {
-		validations = in.getServiceValidations(cluster, svcs, deployments, pods)
+		if namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace); err == nil {
+			validations = filterServiceValidations(namespaceValidations)
+		}
 	}
 
 	kubernetesServices := in.buildKubernetesServices(ctx, svcs, pods, istioConfigList, criteria.IncludeOnlyDefinitions, cluster)
@@ -285,6 +276,16 @@ func (in *SvcService) buildServiceList(ctx context.Context, cluster string, name
 		services = append(services, seServices...)
 	}
 	return &models.ServiceList{Namespace: namespace, Services: services, Validations: validations}
+}
+
+func filterServiceValidations(validations models.IstioValidations) models.IstioValidations {
+	serviceValidations := models.IstioValidations{}
+	for key, validation := range validations {
+		if key.ObjectGVK.Kind == "service" {
+			serviceValidations[key] = validation
+		}
+	}
+	return serviceValidations
 }
 
 func (in *SvcService) buildKubernetesServices(ctx context.Context, svcs []core_v1.Service, pods []core_v1.Pod, istioConfigList models.IstioConfigList, onlyDefinitions bool, cluster string) []models.ServiceOverview {
@@ -464,8 +465,10 @@ func (in *SvcService) buildServiceEntryOverviews(ctx context.Context, serviceEnt
 }
 
 // GetService returns a single service and associated data using the interval and queryTime
-// includeValidations: Service specific validations outside the istio configs
+// includeValidations is retained for API compatibility. Service validations are loaded from the
+// validation cache by the handler via IstioValidationsService.GetValidationsForService.
 func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace, service, interval string, queryTime time.Time, includeValidations bool) (*models.ServiceDetails, error) {
+	_ = includeValidations
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetServiceDetails",
 		observability.Attribute("package", "business"),
@@ -672,19 +675,6 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 		s.WaypointWorkloads = waypointWk
 	}
 
-	if includeValidations {
-		svcList := &core_v1.ServiceList{}
-		if err := kubeCache.List(ctx, svcList, client.InNamespace(namespace)); err != nil {
-			return nil, fmt.Errorf("Error fetching Services per namespace %s: %s", namespace, err)
-		}
-		svcs := kubernetes.FilterServicesBySelector(svcList.Items, svc.Labels)
-		depList := &apps_v1.DeploymentList{}
-		if err := kubeCache.List(ctx, depList, client.InNamespace(namespace)); err != nil {
-			return nil, fmt.Errorf("Error fetching deployments per namespace %s: %s", namespace, err)
-		}
-		deployments := depList.Items
-		s.Validations = in.getServiceValidations(cluster, svcs, deployments, pods)
-	}
 	return &s, nil
 }
 
@@ -904,12 +894,6 @@ func (in *SvcService) GetService(ctx context.Context, cluster, namespace, servic
 	}
 
 	return svc, nil
-}
-
-func (in *SvcService) getServiceValidations(cluster string, services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
-	validations := checkers.NewServiceChecker(cluster, deployments, in.businessLayer.Mesh.discovery, pods, services).Check()
-	validations.StripIgnoredChecks(in.conf, models.BuildServiceIgnoreValidations(services, cluster))
-	return validations
 }
 
 // GetServiceTracingName returns a struct with all the information needed for tracing lookup

--- a/business/services.go
+++ b/business/services.go
@@ -257,7 +257,10 @@ func (in *SvcService) buildServiceList(ctx context.Context, cluster string, name
 	services := []models.ServiceOverview{}
 	validations := models.IstioValidations{}
 	if !criteria.IncludeOnlyDefinitions {
-		if namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace); err == nil {
+		namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace)
+		if err != nil {
+			log.Errorf("Error fetching validations for cluster [%s] namespace [%s]: %s", cluster, namespace, err)
+		} else {
 			validations = filterServiceValidations(namespaceValidations)
 		}
 	}

--- a/business/services.go
+++ b/business/services.go
@@ -467,11 +467,10 @@ func (in *SvcService) buildServiceEntryOverviews(ctx context.Context, serviceEnt
 	return services
 }
 
-// GetService returns a single service and associated data using the interval and queryTime
-// includeValidations is retained for API compatibility. Service validations are loaded from the
-// validation cache by the handler via IstioValidationsService.GetValidationsForService.
-func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace, service, interval string, queryTime time.Time, includeValidations bool) (*models.ServiceDetails, error) {
-	_ = includeValidations
+// GetServiceDetails returns a single service and associated data using the interval and queryTime.
+// Service validations are loaded from the validation cache by the handler via
+// IstioValidationsService.GetValidationsForService.
+func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
 	var end observability.EndFunc
 	ctx, end = observability.StartSpan(ctx, "GetServiceDetails",
 		observability.Attribute("package", "business"),
@@ -828,7 +827,7 @@ func (in *SvcService) UpdateService(ctx context.Context, cluster, namespace, ser
 	in.waitForCacheUpdate(ctx, cluster, svc)
 
 	// After the update we fetch the whole workload
-	return in.GetServiceDetails(ctx, cluster, namespace, service, interval, queryTime, false)
+	return in.GetServiceDetails(ctx, cluster, namespace, service, interval, queryTime)
 }
 
 func (in *SvcService) waitForCacheUpdate(ctx context.Context, cluster string, updatedService *core_v1.Service) {

--- a/business/services.go
+++ b/business/services.go
@@ -268,7 +268,7 @@ func (in *SvcService) buildServiceList(ctx context.Context, cluster string, name
 	services := []models.ServiceOverview{}
 	validations := models.IstioValidations{}
 	if !criteria.IncludeOnlyDefinitions {
-		validations = in.getServiceValidations(svcs, deployments, pods)
+		validations = in.getServiceValidations(cluster, svcs, deployments, pods)
 	}
 
 	kubernetesServices := in.buildKubernetesServices(ctx, svcs, pods, istioConfigList, criteria.IncludeOnlyDefinitions, cluster)
@@ -683,7 +683,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 			return nil, fmt.Errorf("Error fetching deployments per namespace %s: %s", namespace, err)
 		}
 		deployments := depList.Items
-		s.Validations = in.getServiceValidations(svcs, deployments, pods)
+		s.Validations = in.getServiceValidations(cluster, svcs, deployments, pods)
 	}
 	return &s, nil
 }
@@ -906,9 +906,9 @@ func (in *SvcService) GetService(ctx context.Context, cluster, namespace, servic
 	return svc, nil
 }
 
-func (in *SvcService) getServiceValidations(services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
-	validations := checkers.NewServiceChecker("", deployments, in.businessLayer.Mesh.discovery, pods, services).Check()
-
+func (in *SvcService) getServiceValidations(cluster string, services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
+	validations := checkers.NewServiceChecker(cluster, deployments, in.businessLayer.Mesh.discovery, pods, services).Check()
+	validations.StripIgnoredChecks(in.conf, models.BuildServiceIgnoreValidations(services, cluster))
 	return validations
 }
 

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/kubernetes/kubetest"
@@ -367,7 +368,7 @@ func TestGetWaypointServices(t *testing.T) {
 	assert.Len(waypointsList, 1)
 }
 
-func TestGetServiceDetailsValidations(t *testing.T) {
+func TestCachedServicePortMappingValidations(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -375,122 +376,84 @@ func TestGetServiceDetailsValidations(t *testing.T) {
 	conf.ExternalServices.Istio.IstioAPIEnabled = false
 	config.Set(conf)
 
-	clients := map[string]kubernetes.UserClientInterface{
-		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("bookinfo"),
-			&core_v1.Service{
-				ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
-				Spec:       core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9080, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
+	matchingSvc := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-ok", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
+		Spec:       core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9080, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
+	}
+	mismatchSvc := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-mismatch", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
+		Spec:       core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
+	}
+	ignoredSvc := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "ratings-ignored",
+			Namespace: "bookinfo",
+			Labels:    map[string]string{"app": "ratings"},
+			Annotations: map[string]string{
+				models.IgnoreValidationsAnnotation: "KIA0701",
 			},
-			FakeDeploymentWithPort("ratings", 9080),
-		),
+		},
+		Spec: core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
 	}
-
-	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
-	require.NoError(err)
-
-	promMock := new(prometheustest.PromAPIMock)
-	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
-	prom.Inject(promMock)
-	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
-
-	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
-	require.NoError(err)
-
-	validationKey := models.IstioValidationKey{
-		Cluster:   conf.KubernetesConfig.ClusterName,
-		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"},
-	}
-	assert.NotNil(s.Validations[validationKey])
-	assert.NotNil(s.Validations[validationKey].Checks)
-	assert.Equal(len(s.Validations[validationKey].Checks), 0)
-}
-
-func TestGetServiceDetailsValidationErrors(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	conf := config.NewConfig()
-	conf.ExternalServices.Istio.IstioAPIEnabled = false
-	config.Set(conf)
 
 	clients := map[string]kubernetes.UserClientInterface{
 		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
 			kubetest.FakeNamespace("bookinfo"),
-			&core_v1.Service{
-				ObjectMeta: meta_v1.ObjectMeta{Name: "ratings-home-cluster", Namespace: "bookinfo", Labels: map[string]string{"app": "ratings"}},
-				Spec:       core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
-			},
+			matchingSvc,
+			mismatchSvc,
+			ignoredSvc,
 			FakeDeploymentWithPort("ratings", 9080),
 		),
 	}
 
-	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
-	require.NoError(err)
+	layer := NewLayerBuilder(t, conf).WithClients(clients).Build()
+	services := []core_v1.Service{*matchingSvc, *mismatchSvc, *ignoredSvc}
+	deployments := []apps_v1.Deployment{*FakeDeploymentWithPort("ratings", 9080)}
+	validations := checkers.NewServiceChecker(
+		conf.KubernetesConfig.ClusterName,
+		deployments,
+		layer.Mesh.discovery,
+		nil,
+		services,
+	).Check()
+	validations.StripIgnoredChecks(conf, models.BuildServiceIgnoreValidations(services, conf.KubernetesConfig.ClusterName))
+	layer.Validations.kialiCache.Validations().Replace(validations)
 
-	promMock := new(prometheustest.PromAPIMock)
-	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
-	prom.Inject(promMock)
-	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
-
-	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
-	require.NoError(err)
-
-	validationKey := models.IstioValidationKey{
-		Cluster:   conf.KubernetesConfig.ClusterName,
-		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"},
-	}
-	assert.NotNil(s.Validations[validationKey])
-	assert.Equal(1, len(s.Validations[validationKey].Checks))
-	assert.Equal("KIA0701", s.Validations[validationKey].Checks[0].Code)
-	assert.Equal("Deployment exposing same port as Service not found", s.Validations[validationKey].Checks[0].Message)
-	assert.Equal(models.SeverityLevel("warning"), s.Validations[validationKey].Checks[0].Severity)
-	assert.Equal("spec/ports[0]", s.Validations[validationKey].Checks[0].Path)
-}
-
-func TestGetServiceDetailsIgnoresAnnotatedValidation(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	conf := config.NewConfig()
-	conf.ExternalServices.Istio.IstioAPIEnabled = false
-	config.Set(conf)
-
-	clients := map[string]kubernetes.UserClientInterface{
-		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
-			kubetest.FakeNamespace("bookinfo"),
-			&core_v1.Service{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      "ratings-home-cluster",
-					Namespace: "bookinfo",
-					Labels:    map[string]string{"app": "ratings"},
-					Annotations: map[string]string{
-						models.IgnoreValidationsAnnotation: "KIA0701",
-					},
-				},
-				Spec: core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
-			},
-			FakeDeploymentWithPort("ratings", 9080),
-		),
+	validationKey := func(name string) models.IstioValidationKey {
+		return models.IstioValidationKey{
+			Cluster:   conf.KubernetesConfig.ClusterName,
+			Namespace: "bookinfo",
+			Name:      name,
+			ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"},
+		}
 	}
 
-	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
+	okValidations, err := layer.Validations.GetValidationsForService(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-ok")
 	require.NoError(err)
+	assert.Empty(okValidations[validationKey("ratings-ok")].Checks)
 
-	promMock := new(prometheustest.PromAPIMock)
-	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
-	prom.Inject(promMock)
-	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
-
-	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
+	mismatchValidations, err := layer.Validations.GetValidationsForService(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-mismatch")
 	require.NoError(err)
+	require.Len(mismatchValidations[validationKey("ratings-mismatch")].Checks, 1)
+	assert.Equal("KIA0701", mismatchValidations[validationKey("ratings-mismatch")].Checks[0].Code)
+	assert.Equal("Deployment exposing same port as Service not found", mismatchValidations[validationKey("ratings-mismatch")].Checks[0].Message)
+	assert.Equal(models.SeverityLevel("warning"), mismatchValidations[validationKey("ratings-mismatch")].Checks[0].Severity)
+	assert.Equal("spec/ports[0]", mismatchValidations[validationKey("ratings-mismatch")].Checks[0].Path)
 
-	validationKey := models.IstioValidationKey{
-		Cluster:   conf.KubernetesConfig.ClusterName,
-		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"},
-	}
-	assert.NotNil(s.Validations[validationKey])
-	assert.Empty(s.Validations[validationKey].Checks)
+	ignoredValidations, err := layer.Validations.GetValidationsForService(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-ignored")
+	require.NoError(err)
+	assert.Empty(ignoredValidations[validationKey("ratings-ignored")].Checks)
+
+	serviceList, err := layer.Svc.GetServiceList(context.TODO(), ServiceCriteria{
+		Cluster:                conf.KubernetesConfig.ClusterName,
+		Namespace:              "bookinfo",
+		IncludeOnlyDefinitions: false,
+	})
+	require.NoError(err)
+	assert.Empty(serviceList.Validations[validationKey("ratings-ok")].Checks)
+	require.Len(serviceList.Validations[validationKey("ratings-mismatch")].Checks, 1)
+	assert.Equal("KIA0701", serviceList.Validations[validationKey("ratings-mismatch")].Checks[0].Code)
+	assert.Empty(serviceList.Validations[validationKey("ratings-ignored")].Checks)
 }
 
 func TestServiceListIncludesServiceEntryServices(t *testing.T) {

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -448,6 +448,51 @@ func TestGetServiceDetailsValidationErrors(t *testing.T) {
 	assert.Equal("spec/ports[0]", s.Validations[validationKey].Checks[0].Path)
 }
 
+func TestGetServiceDetailsIgnoresAnnotatedValidation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	conf := config.NewConfig()
+	conf.ExternalServices.Istio.IstioAPIEnabled = false
+	config.Set(conf)
+
+	clients := map[string]kubernetes.UserClientInterface{
+		conf.KubernetesConfig.ClusterName: kubetest.NewFakeK8sClient(
+			kubetest.FakeNamespace("bookinfo"),
+			&core_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ratings-home-cluster",
+					Namespace: "bookinfo",
+					Labels:    map[string]string{"app": "ratings"},
+					Annotations: map[string]string{
+						models.IgnoreValidationsAnnotation: "KIA0701",
+					},
+				},
+				Spec: core_v1.ServiceSpec{Ports: []core_v1.ServicePort{{Name: "http", Port: 9081, Protocol: "TCP"}}, Selector: map[string]string{"app": "ratings"}},
+			},
+			FakeDeploymentWithPort("ratings", 9080),
+		),
+	}
+
+	prom, err := prometheus.NewClient(*conf, clients[conf.KubernetesConfig.ClusterName].GetToken())
+	require.NoError(err)
+
+	promMock := new(prometheustest.PromAPIMock)
+	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
+	prom.Inject(promMock)
+	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
+
+	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "ratings-home-cluster", "60s", time.Now(), true)
+	require.NoError(err)
+
+	validationKey := models.IstioValidationKey{
+		Cluster:   conf.KubernetesConfig.ClusterName,
+		Namespace: "bookinfo", Name: "ratings-home-cluster", ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "service"},
+	}
+	assert.NotNil(s.Validations[validationKey])
+	assert.Empty(s.Validations[validationKey].Checks)
+}
+
 func TestServiceListIncludesServiceEntryServices(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -188,7 +188,7 @@ func TestMultiClusterGetServiceDetails(t *testing.T) {
 	promMock.SpyArgumentsAndReturnEmpty(func(mock.Arguments) {})
 	prom.Inject(promMock)
 	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
-	s, err := svc.GetServiceDetails(context.TODO(), "west", "bookinfo", "ratings-west-cluster", "60s", time.Now(), true)
+	s, err := svc.GetServiceDetails(context.TODO(), "west", "bookinfo", "ratings-west-cluster", "60s", time.Now())
 	require.NoError(err)
 
 	assert.Equal(s.Service.Name, "ratings-west-cluster")
@@ -942,7 +942,7 @@ func TestGetServiceDetailsSubServicesVersioned(t *testing.T) {
 
 	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
 
-	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "reviews", "60s", time.Now(), false)
+	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "reviews", "60s", time.Now())
 	require.NoError(err)
 
 	require.Len(s.SubServices, 2)
@@ -1133,7 +1133,7 @@ func TestGetServiceDetailsSubServicesFallbackToMainService(t *testing.T) {
 
 	svc := NewLayerBuilder(t, conf).WithClients(clients).WithProm(prom).Build().Svc
 
-	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "reviews", "60s", time.Now(), false)
+	s, err := svc.GetServiceDetails(context.TODO(), conf.KubernetesConfig.ClusterName, "bookinfo", "reviews", "60s", time.Now())
 	require.NoError(err)
 
 	require.Len(s.SubServices, 1)

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -18,7 +18,6 @@ import (
 	"github.com/nitishm/engarde/pkg/parser"
 	osapps_v1 "github.com/openshift/api/apps/v1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
-	security_v1 "istio.io/client-go/pkg/apis/security/v1"
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	core_v1 "k8s.io/api/core/v1"
@@ -28,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kiali/kiali/business/checkers"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
@@ -146,36 +144,6 @@ func (in *WorkloadService) isWorkloadIncluded(workload string) bool {
 		return true
 	}
 	return !in.excludedWorkloads[workload]
-}
-
-// @TODO do validations per cluster
-func (in *WorkloadService) getWorkloadValidations(ctx context.Context, authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads, cluster string, extraIgnores models.ObjectIgnoreValidations) models.IstioValidations {
-	userClient, ok := in.userClients[cluster]
-	if !ok {
-		return models.IstioValidations{}
-	}
-	namespaces, found := in.cache.GetNamespaces(cluster, userClient.GetToken())
-	if !found {
-		return models.IstioValidations{}
-	}
-
-	mesh, err := in.businessLayer.Mesh.discovery.Mesh(ctx)
-	if err != nil || mesh == nil {
-		return models.IstioValidations{}
-	}
-
-	rootNamespaces := make(map[string]string, len(workloadsPerNamespace))
-	for ns := range workloadsPerNamespace {
-		if cp, err := mesh.ControlPlaneForNamespace(cluster, ns); err == nil && cp != nil {
-			rootNamespaces[ns] = cp.RootNamespace
-		}
-	}
-
-	validations := checkers.NewWorkloadChecker(authpolicies, cluster, in.conf, rootNamespaces, namespaces, workloadsPerNamespace).Check()
-	perObjectIgnores := models.BuildWorkloadIgnoreValidations(workloadsPerNamespace, cluster)
-	perObjectIgnores.Merge(extraIgnores)
-	validations.StripIgnoredChecks(in.conf, perObjectIgnores)
-	return validations
 }
 
 // GetAllWorkloads fetches all workloads across the cluster's namespaces.
@@ -408,15 +376,22 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 	}
 
 	if criteria.IncludeIstioResources {
-		// @TODO multi cluster validations
-		authPolicies := istioConfigList.AuthorizationPolicies
-		allWorkloads := map[string]models.Workloads{}
-		allWorkloads[namespace] = ws
-		validations := in.getWorkloadValidations(ctx, authPolicies, allWorkloads, cluster, istioConfigList.ObjectIgnoreValidations(cluster))
-		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
+		if namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace); err == nil {
+			workloadList.Validations = workloadList.Validations.MergeValidations(filterWorkloadValidations(namespaceValidations))
+		}
 	}
 
 	return *workloadList, nil
+}
+
+func filterWorkloadValidations(validations models.IstioValidations) models.IstioValidations {
+	workloadValidations := models.IstioValidations{}
+	for key, validation := range validations {
+		if key.ObjectGVK.Kind == "workload" {
+			workloadValidations[key] = validation
+		}
+	}
+	return workloadValidations
 }
 
 func FilterWorkloadReferences(conf *config.Config, wLabels map[string]string, istioConfigList models.IstioConfigList, cluster string) []*models.IstioValidationKey {
@@ -1708,7 +1683,7 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 
 			w.ServiceAccountNames = w.Pods.ServiceAccounts()
 			slices.Sort(w.ServiceAccountNames)
-			w.ValidationVersion = fmt.Sprintf("%v:%v", w.Labels, w.ServiceAccountNames)
+			w.ValidationVersion = fmt.Sprintf("%v:%v:%v", w.Labels, w.ServiceAccountNames, w.Annotations[models.IgnoreValidationsAnnotation])
 
 			// Set SpireInfo if workload is SPIRE-managed or is a SPIRE server
 			spireMatches := w.SpireManagedIdentity()

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -376,7 +376,10 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 	}
 
 	if criteria.IncludeIstioResources {
-		if namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace); err == nil {
+		namespaceValidations, err := in.businessLayer.Validations.GetValidationsForNamespace(ctx, cluster, namespace)
+		if err != nil {
+			log.Errorf("Error fetching validations for cluster [%s] namespace [%s]: %s", cluster, namespace, err)
+		} else {
 			workloadList.Validations = workloadList.Validations.MergeValidations(filterWorkloadValidations(namespaceValidations))
 		}
 	}

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -149,7 +149,7 @@ func (in *WorkloadService) isWorkloadIncluded(workload string) bool {
 }
 
 // @TODO do validations per cluster
-func (in *WorkloadService) getWorkloadValidations(ctx context.Context, authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads, cluster string) models.IstioValidations {
+func (in *WorkloadService) getWorkloadValidations(ctx context.Context, authpolicies []*security_v1.AuthorizationPolicy, workloadsPerNamespace map[string]models.Workloads, cluster string, extraIgnores models.ObjectIgnoreValidations) models.IstioValidations {
 	userClient, ok := in.userClients[cluster]
 	if !ok {
 		return models.IstioValidations{}
@@ -172,7 +172,9 @@ func (in *WorkloadService) getWorkloadValidations(ctx context.Context, authpolic
 	}
 
 	validations := checkers.NewWorkloadChecker(authpolicies, cluster, in.conf, rootNamespaces, namespaces, workloadsPerNamespace).Check()
-
+	perObjectIgnores := models.BuildWorkloadIgnoreValidations(workloadsPerNamespace, cluster)
+	perObjectIgnores.Merge(extraIgnores)
+	validations.StripIgnoredChecks(in.conf, perObjectIgnores)
 	return validations
 }
 
@@ -410,8 +412,7 @@ func (in *WorkloadService) GetWorkloadList(ctx context.Context, criteria Workloa
 		authPolicies := istioConfigList.AuthorizationPolicies
 		allWorkloads := map[string]models.Workloads{}
 		allWorkloads[namespace] = ws
-		validations := in.getWorkloadValidations(ctx, authPolicies, allWorkloads, cluster)
-		validations.StripIgnoredChecks(in.conf)
+		validations := in.getWorkloadValidations(ctx, authPolicies, allWorkloads, cluster, istioConfigList.ObjectIgnoreValidations(cluster))
 		workloadList.Validations = workloadList.Validations.MergeValidations(validations)
 	}
 

--- a/frontend/src/components/Validations/ValidationList.tsx
+++ b/frontend/src/components/Validations/ValidationList.tsx
@@ -1,24 +1,38 @@
 import * as React from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { ObjectCheck, ValidationTypes } from '../../types/IstioObjects';
+import type { ObjectCheck } from '../../types/IstioObjects';
+import { ValidationTypes } from '../../types/IstioObjects';
 import { Validation } from './Validation';
 import { highestSeverity } from '../../types/ServiceInfo';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type ValidationListProps = {
   checks?: ObjectCheck[];
   tooltipPosition?: TooltipPosition;
 };
 
+const tooltipContentStyle = kialiStyle({
+  $nest: {
+    '& [class*="pf-v6-c-content"]': {
+      color: 'inherit'
+    }
+  }
+});
+
 export const ValidationList: React.FC<ValidationListProps> = (props: ValidationListProps) => {
-  const content = (props.checks ?? []).map((check, index) => {
-    return (
-      <Validation
-        key={`validation-check-${index}`}
-        severity={check.severity}
-        message={`${check.code ? `${check.code} ` : ''}${check.message}`}
-      />
-    );
-  });
+  const content = (
+    <div className={tooltipContentStyle}>
+      {(props.checks ?? []).map(check => {
+        return (
+          <Validation
+            key={`validation-check-${check.code}-${check.path}-${check.message}`}
+            severity={check.severity}
+            message={`${check.code ? `${check.code} ` : ''}${check.message}`}
+          />
+        );
+      })}
+    </div>
+  );
 
   const severity = highestSeverity(props.checks ?? []);
   const isValid = severity === ValidationTypes.Correct;

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -185,7 +185,7 @@ func ServiceDetails(
 			}()
 		}
 
-		serviceDetails, err := business.Svc.GetServiceDetails(r.Context(), cluster, namespace, service, rateInterval, queryTime, includeValidations)
+		serviceDetails, err := business.Svc.GetServiceDetails(r.Context(), cluster, namespace, service, rateInterval, queryTime)
 		if includeValidations && err == nil {
 			wg.Wait()
 			serviceDetails.Validations = istioConfigValidations.MergeValidations(serviceDetails.Validations)

--- a/models/ignore_validations.go
+++ b/models/ignore_validations.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func addObjectIgnoreValidationsFromObjects(
+	rules ObjectIgnoreValidations,
+	objects []client.Object,
+	objectGVK schema.GroupVersionKind,
+	cluster string,
+) {
+	for _, obj := range objects {
+		rule, ok := ParseIgnoreValidationsAnnotation(obj.GetAnnotations())
+		if !ok {
+			continue
+		}
+		rules[BuildKey(objectGVK, obj.GetName(), obj.GetNamespace(), cluster)] = rule
+	}
+}
+
+func (i *IstioConfigList) ObjectIgnoreValidations(cluster string) ObjectIgnoreValidations {
+	rules := ObjectIgnoreValidations{}
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.AuthorizationPolicies), kubernetes.AuthorizationPolicies, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.DestinationRules), kubernetes.DestinationRules, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.EnvoyFilters), kubernetes.EnvoyFilters, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.Gateways), kubernetes.Gateways, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sGateways), kubernetes.K8sGateways, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sGRPCRoutes), kubernetes.K8sGRPCRoutes, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sHTTPRoutes), kubernetes.K8sHTTPRoutes, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sInferencePools), kubernetes.K8sInferencePools, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sReferenceGrants), kubernetes.K8sReferenceGrants, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sTCPRoutes), kubernetes.K8sTCPRoutes, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.K8sTLSRoutes), kubernetes.K8sTLSRoutes, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.PeerAuthentications), kubernetes.PeerAuthentications, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.RequestAuthentications), kubernetes.RequestAuthentications, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.ServiceEntries), kubernetes.ServiceEntries, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.Sidecars), kubernetes.Sidecars, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.Telemetries), kubernetes.Telemetries, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.TrafficExtensions), kubernetes.TrafficExtensions, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.VirtualServices), kubernetes.VirtualServices, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.WasmPlugins), kubernetes.WasmPlugins, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.WorkloadEntries), kubernetes.WorkloadEntries, cluster)
+	addObjectIgnoreValidationsFromObjects(rules, asClientObjects(i.WorkloadGroups), kubernetes.WorkloadGroups, cluster)
+	return rules
+}
+
+var (
+	serviceValidationGVK  = schema.GroupVersionKind{Group: "", Version: "", Kind: "service"}
+	workloadValidationGVK = schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"}
+)
+
+func BuildServiceIgnoreValidations(services []core_v1.Service, cluster string) ObjectIgnoreValidations {
+	rules := ObjectIgnoreValidations{}
+	for _, service := range services {
+		rule, ok := ParseIgnoreValidationsAnnotation(service.Annotations)
+		if !ok {
+			continue
+		}
+		rules[BuildKey(serviceValidationGVK, service.Name, service.Namespace, cluster)] = rule
+	}
+	return rules
+}
+
+func BuildWorkloadIgnoreValidations(workloadsPerNamespace map[string]Workloads, cluster string) ObjectIgnoreValidations {
+	rules := ObjectIgnoreValidations{}
+	for namespace, workloads := range workloadsPerNamespace {
+		for _, workload := range workloads {
+			rule, ok := ParseIgnoreValidationsAnnotation(workload.Annotations)
+			if !ok {
+				continue
+			}
+			rules[BuildKey(workloadValidationGVK, workload.Name, namespace, cluster)] = rule
+		}
+	}
+	return rules
+}

--- a/models/ignore_validations_test.go
+++ b/models/ignore_validations_test.go
@@ -1,0 +1,169 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	security_v1 "istio.io/client-go/pkg/apis/security/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+)
+
+func TestParseIgnoreValidationsAnnotation(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		found       bool
+		ignoreAll   bool
+		codes       []string
+	}{
+		{
+			name:        "annotation not present",
+			annotations: map[string]string{},
+			found:       false,
+		},
+		{
+			name:        "ignore all validations",
+			annotations: map[string]string{IgnoreValidationsAnnotation: ""},
+			found:       true,
+			ignoreAll:   true,
+		},
+		{
+			name:        "ignore specific validations",
+			annotations: map[string]string{IgnoreValidationsAnnotation: "KIA0101,KIA0102"},
+			found:       true,
+			codes:       []string{"KIA0101", "KIA0102"},
+		},
+		{
+			name:        "ignore specific validations with spaces",
+			annotations: map[string]string{IgnoreValidationsAnnotation: " KIA0101 , KIA0102 "},
+			found:       true,
+			codes:       []string{"KIA0101", "KIA0102"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rule, found := ParseIgnoreValidationsAnnotation(tc.annotations)
+			assert.Equal(t, tc.found, found)
+			if !tc.found {
+				return
+			}
+			assert.Equal(t, tc.ignoreAll, rule.IgnoreAll)
+			assert.Equal(t, tc.codes, rule.Codes)
+		})
+	}
+}
+
+func TestIstioConfigListObjectIgnoreValidations(t *testing.T) {
+	configList := IstioConfigList{
+		AuthorizationPolicies: []*security_v1.AuthorizationPolicy{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:        "ignore-all",
+					Namespace:   "bookinfo",
+					Annotations: map[string]string{IgnoreValidationsAnnotation: ""},
+				},
+			},
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:        "ignore-specific",
+					Namespace:   "bookinfo",
+					Annotations: map[string]string{IgnoreValidationsAnnotation: "KIA0101,KIA0102"},
+				},
+			},
+		},
+	}
+
+	rules := configList.ObjectIgnoreValidations("east")
+
+	ignoreAllKey := BuildKey(kubernetes.AuthorizationPolicies, "ignore-all", "bookinfo", "east")
+	ignoreSpecificKey := BuildKey(kubernetes.AuthorizationPolicies, "ignore-specific", "bookinfo", "east")
+
+	assert.True(t, rules[ignoreAllKey].IgnoreAll)
+	assert.Equal(t, []string{"KIA0101", "KIA0102"}, rules[ignoreSpecificKey].Codes)
+}
+
+func TestBuildWorkloadIgnoreValidationsUsesControllerAnnotations(t *testing.T) {
+	workloads := map[string]Workloads{
+		"bookinfo": {
+			{
+				WorkloadListItem: WorkloadListItem{
+					Name:        "reviews-v1",
+					Annotations: map[string]string{IgnoreValidationsAnnotation: "KIA1301"},
+				},
+			},
+		},
+	}
+
+	rules := BuildWorkloadIgnoreValidations(workloads, "east")
+	key := BuildKey(schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"}, "reviews-v1", "bookinfo", "east")
+
+	assert.Equal(t, []string{"KIA1301"}, rules[key].Codes)
+}
+
+func TestStripIgnoredChecksPerObject(t *testing.T) {
+	key := IstioValidationKey{ObjectGVK: kubernetes.AuthorizationPolicies, Name: "policy", Namespace: "bookinfo", Cluster: "east"}
+	otherKey := IstioValidationKey{ObjectGVK: kubernetes.AuthorizationPolicies, Name: "other", Namespace: "bookinfo", Cluster: "east"}
+
+	validations := IstioValidations{
+		key: &IstioValidation{
+			Checks: []*IstioCheck{
+				{Code: "KIA0101", Severity: WarningSeverity},
+				{Code: "KIA0102", Severity: WarningSeverity},
+				{Code: "KIA0106", Severity: ErrorSeverity},
+			},
+		},
+		otherKey: &IstioValidation{
+			Checks: []*IstioCheck{
+				{Code: "KIA0101", Severity: WarningSeverity},
+			},
+		},
+	}
+
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	t.Run("ignore all validations for one object", func(t *testing.T) {
+		current := cloneValidations(validations)
+		current.StripIgnoredChecks(conf, ObjectIgnoreValidations{
+			key: {IgnoreAll: true},
+		})
+		assert.Empty(t, current[key].Checks)
+		assert.Len(t, current[otherKey].Checks, 1)
+	})
+
+	t.Run("ignore specific validations for one object", func(t *testing.T) {
+		current := cloneValidations(validations)
+		current.StripIgnoredChecks(conf, ObjectIgnoreValidations{
+			key: {Codes: []string{"KIA0101", "KIA0102"}},
+		})
+		assert.Len(t, current[key].Checks, 1)
+		assert.Equal(t, "KIA0106", current[key].Checks[0].Code)
+		assert.Len(t, current[otherKey].Checks, 1)
+	})
+
+	t.Run("global and per-object ignores combine", func(t *testing.T) {
+		current := cloneValidations(validations)
+		confWithGlobal := config.NewConfig()
+		confWithGlobal.KialiFeatureFlags.Validations.Ignore = []string{"KIA0106"}
+		current.StripIgnoredChecks(confWithGlobal, ObjectIgnoreValidations{
+			key: {Codes: []string{"KIA0101"}},
+		})
+		assert.Len(t, current[key].Checks, 1)
+		assert.Equal(t, "KIA0102", current[key].Checks[0].Code)
+	})
+}
+
+func cloneValidations(source IstioValidations) IstioValidations {
+	clone := IstioValidations{}
+	for key, validation := range source {
+		checks := make([]*IstioCheck, len(validation.Checks))
+		copy(checks, validation.Checks)
+		clone[key] = &IstioValidation{Checks: checks}
+	}
+	return clone
+}

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -9,6 +10,44 @@ import (
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/util"
 )
+
+const IgnoreValidationsAnnotation = "kiali.io/ignore-validations"
+
+// IgnoreValidationsRule describes which validation checks to ignore for a single object.
+// When IgnoreAll is true, all checks for the object are ignored.
+// Otherwise, only the listed validation codes are ignored.
+type IgnoreValidationsRule struct {
+	Codes     []string
+	IgnoreAll bool
+}
+
+// ObjectIgnoreValidations maps validation object keys to per-object ignore rules.
+type ObjectIgnoreValidations map[IstioValidationKey]IgnoreValidationsRule
+
+func ParseIgnoreValidationsAnnotation(annotations map[string]string) (IgnoreValidationsRule, bool) {
+	value, ok := annotations[IgnoreValidationsAnnotation]
+	if !ok {
+		return IgnoreValidationsRule{}, false
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return IgnoreValidationsRule{IgnoreAll: true}, true
+	}
+
+	codes := strings.Split(value, ",")
+	for i, code := range codes {
+		codes[i] = strings.TrimSpace(code)
+	}
+
+	return IgnoreValidationsRule{Codes: codes}, true
+}
+
+func (rules ObjectIgnoreValidations) Merge(other ObjectIgnoreValidations) {
+	for key, rule := range other {
+		rules[key] = rule
+	}
+}
 
 // NamespaceValidations represents a set of IstioValidations grouped by namespace
 type NamespaceValidations map[string]IstioValidations
@@ -613,32 +652,53 @@ func (iv *IstioValidations) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (iv *IstioValidations) StripIgnoredChecks(conf *config.Config) {
+func (iv *IstioValidations) StripIgnoredChecks(conf *config.Config, perObjectIgnores ObjectIgnoreValidations) {
 	// strip away codes that are to be ignored
 	codesToIgnore := conf.KialiFeatureFlags.Validations.Ignore
-	if len(codesToIgnore) > 0 {
-		for curValidationKey, curValidation := range *iv {
-			idx := 0
-			// loop over each IstioCheck in the current Validation and only keep it if it is not ignored
-			for _, curCheck := range curValidation.Checks {
-				ignoreCheck := false
-				for _, cti := range codesToIgnore {
-					if cti == curCheck.Code {
-						ignoreCheck = true
-						log.Tracef("Ignoring validation failure [%+v] for object [%s:%s] in namespace [%s]", curCheck, curValidationKey.ObjectGVK.String(), curValidationKey.Name, curValidationKey.Namespace)
-						break
-					}
-				}
-				if !ignoreCheck {
-					curValidation.Checks[idx] = curCheck
-					idx++
-				}
+	if len(codesToIgnore) == 0 && len(perObjectIgnores) == 0 {
+		return
+	}
+
+	for curValidationKey, curValidation := range *iv {
+		perObjectRule, hasPerObjectRule := perObjectIgnores[curValidationKey]
+		idx := 0
+		// loop over each IstioCheck in the current Validation and only keep it if it is not ignored
+		for _, curCheck := range curValidation.Checks {
+			if shouldIgnoreCheck(curCheck.Code, codesToIgnore, hasPerObjectRule, perObjectRule) {
+				log.Tracef("Ignoring validation failure [%+v] for object [%s:%s] in namespace [%s]", curCheck, curValidationKey.ObjectGVK.String(), curValidationKey.Name, curValidationKey.Namespace)
+				continue
 			}
-			// Prevent memory leak - nil out ignored checks
-			for extraIdx := idx; extraIdx < len(curValidation.Checks); extraIdx++ {
-				curValidation.Checks[extraIdx] = nil
-			}
-			curValidation.Checks = curValidation.Checks[:idx]
+			curValidation.Checks[idx] = curCheck
+			idx++
+		}
+		// Prevent memory leak - nil out ignored checks
+		for extraIdx := idx; extraIdx < len(curValidation.Checks); extraIdx++ {
+			curValidation.Checks[extraIdx] = nil
+		}
+		curValidation.Checks = curValidation.Checks[:idx]
+	}
+}
+
+func shouldIgnoreCheck(code string, globalIgnores []string, hasPerObjectRule bool, perObjectRule IgnoreValidationsRule) bool {
+	for _, ignoredCode := range globalIgnores {
+		if ignoredCode == code {
+			return true
 		}
 	}
+
+	if !hasPerObjectRule {
+		return false
+	}
+
+	if perObjectRule.IgnoreAll {
+		return true
+	}
+
+	for _, ignoredCode := range perObjectRule.Codes {
+		if ignoredCode == code {
+			return true
+		}
+	}
+
+	return false
 }

--- a/models/istio_validation_test.go
+++ b/models/istio_validation_test.go
@@ -78,7 +78,7 @@ func TestSummarizeValidations(t *testing.T) {
 	conf := config.NewConfig()
 	conf.KialiFeatureFlags.Validations.Ignore = []string{"FOO2", "FOO3"}
 	config.Set(conf)
-	validations.StripIgnoredChecks(conf)
+	validations.StripIgnoredChecks(conf, nil)
 	assert.Equal(1, len(validations[key1].Checks))
 	assert.Equal(1, len(validations[key2].Checks))
 	summary = validations.SummarizeValidation("bookinfo", "east")

--- a/models/workload.go
+++ b/models/workload.go
@@ -177,7 +177,7 @@ type WorkloadListItem struct {
 	ValidationKey string
 
 	// ValidationVersion is a pre-calculated string representing the workload "version", basically
-	// the workload information that, if changed, requires re-validation.
+	// the workload information that, if changed, requires re-validation (including per-object ignore rules).
 	ValidationVersion string
 }
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -409,6 +409,11 @@ func (workload *Workload) parseObjectMeta(meta *meta_v1.ObjectMeta, tplMeta *met
 
 	workload.CreatedAt = formatTime(meta.CreationTimestamp.Time)
 	workload.ResourceVersion = meta.ResourceVersion
+	if len(meta.Annotations) > 0 {
+		workload.Annotations = meta.Annotations
+	} else {
+		workload.Annotations = map[string]string{}
+	}
 	workload.AdditionalDetails = GetAdditionalDetails(conf, annotations)
 	workload.AdditionalDetailSample = GetFirstAdditionalIcon(conf, annotations)
 	workload.DashboardAnnotations = GetDashboardAnnotation(annotations)

--- a/models/workload_test.go
+++ b/models/workload_test.go
@@ -82,6 +82,7 @@ func TestParseReplicaSetToWorkload(t *testing.T) {
 	assert.Equal(int32(1), w.DesiredReplicas)
 	assert.Equal(int32(1), w.CurrentReplicas)
 	assert.Equal(int32(1), w.AvailableReplicas)
+	assert.Equal(map[string]string{"annotation": "value-annot"}, w.Annotations)
 	assert.Len(w.AdditionalDetails, 1)
 	assert.Equal("Annotation", w.AdditionalDetails[0].Title)
 	assert.Equal("value-annot", w.AdditionalDetails[0].Value)


### PR DESCRIPTION
### Describe the change

Adds support for the `kiali.io/ignore-validations` annotation on individual resources so users can hide validation errors or warnings that do not apply to their environment.

- Empty annotation value ignores all validations on that object
- Comma-separated codes ignore only specific validations (e.g. `KIA0101,KIA0102`)
- Works on Istio configuration objects, Gateway API resources, services, and workloads
- Per-object ignores are applied in addition to globally ignored codes in the Kiali CR

Also fixes two bugs discovered during testing:
- Service validations were not filtered by per-object ignores in list/details views
- Workload controller annotations were only propagated for Deployments, not other controller types

Additionally fixes validation tooltip text readability on the Service details Network panel (dark text on dark tooltip background).

### Steps to test the PR

Prerequisites: cluster with Istio and the bookinfo demo app installed (`./hack/istio/install-bookinfo-demo.sh -c kubectl`).

#### 1. Istio config object (AuthorizationPolicy, KIA0101)

Trigger the validation:

```bash
kubectl apply -f https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/801.yaml
```

In Kiali, open **Istio Config** and confirm the `httpbin` AuthorizationPolicy shows a KIA0101 warning.

Ignore all validations on that object:

```bash
kubectl annotate authorizationpolicy httpbin -n default kiali.io/ignore-validations=""
```

Refresh Kiali and confirm the validation icon/warning is gone for that object.

Ignore only specific codes (restore object first if needed):

```bash
kubectl annotate authorizationpolicy httpbin -n default kiali.io/ignore-validations="KIA0101,KIA0102" --overwrite
```

Confirm only those codes are hidden while any other validations would still appear.

Clean up:

```bash
kubectl delete authorizationpolicy httpbin -n default
```

#### 2. Service validation KIA0601 (invalid port name, bookinfo/productpage)

Trigger the validation on the productpage service:

```bash
kubectl patch svc productpage -n bookinfo --type=json \
  -p='[{"op":"replace","path":"/spec/ports/0/name","value":"badport"}]'
```

In Kiali, open **Services > bookinfo > productpage** and confirm the Network panel shows a KIA0601 warning on the port. Hover the validation icon and confirm the tooltip text is readable.

Ignore only KIA0601:

```bash
kubectl annotate svc productpage -n bookinfo kiali.io/ignore-validations="KIA0601" --overwrite
```

Refresh and confirm the KIA0601 warning disappears from the service list and details page.

Restore the service:

```bash
kubectl patch svc productpage -n bookinfo --type=json \
  -p='[{"op":"replace","path":"/spec/ports/0/name","value":"http"}]'
kubectl annotate svc productpage -n bookinfo kiali.io/ignore-validations-
```

#### 3. Service validation KIA0701 (port mismatch with workload)

Trigger the validation using the kiali.io example (creates a service with no matching deployment port):

```bash
kubectl apply -f https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/702.yaml
```

In Kiali, open the `ratings-java-svc` service in the `ratings-java` namespace and confirm KIA0701 appears.

Ignore the validation:

```bash
kubectl annotate svc ratings-java-svc -n ratings-java kiali.io/ignore-validations="KIA0701" --overwrite
```

Refresh and confirm the warning is hidden.

Clean up:

```bash
kubectl delete -f https://github.com/kiali/kiali.io/raw/current/static/files/validation_examples/702.yaml
```

#### 4. Workload validation KIA1301 (missing AuthorizationPolicy, bookinfo/productpage-v1)

In a mesh with AuthorizationPolicies enabled, bookinfo workloads such as `productpage-v1` may show KIA1301 ("This workload is not covered by any authorization policy") on the **Workloads** list and details page.

Confirm the warning appears for `productpage-v1` in namespace `bookinfo`.

Ignore KIA1301 on the deployment controller:

```bash
kubectl annotate deployment productpage-v1 -n bookinfo kiali.io/ignore-validations="KIA1301" --overwrite
```

Refresh Kiali and confirm the warning disappears from the workload list and details page (may take up to ~1 minute on workload details due to validation cache).

Restore:

```bash
kubectl annotate deployment productpage-v1 -n bookinfo kiali.io/ignore-validations-
```

#### 5. Ignore all validations on a service

With the KIA0601 example active on `productpage` (step 2, before restore), ignore all validations:

```bash
kubectl annotate svc productpage -n bookinfo kiali.io/ignore-validations="" --overwrite
```

Confirm all service validations are hidden regardless of code.

### Automation testing

- `models/ignore_validations_test.go` — annotation parsing and per-object ignore map building for Istio configs, services, and workloads
- `models/istio_validation_test.go` — `StripIgnoredChecks` with per-object ignore rules
- `business/services_test.go` — `TestGetServiceDetailsIgnoresAnnotatedValidation` verifies service-level ignore filtering
- `models/workload_test.go` — controller annotations propagated for all workload types

Run:

```bash
make test GO_TEST_FLAGS="-run 'TestGetServiceDetailsIgnoresAnnotatedValidation|TestBuildWorkloadIgnoreValidationsUsesControllerAnnotations|TestParseIgnoreValidationsAnnotation|TestStripIgnoredChecks'"
```

### Issue reference

Fixes #5309

Made with [Cursor](https://cursor.com)