### PR TITLE
chore(deps): upgrade eventemitter3 to v5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,7 +111,7 @@
     "axios": "^1.17.0",
     "bootstrap-slider-without-jquery": "10.0.0",
     "deep-freeze": "0.0.1",
-    "eventemitter3": "4.0.7",
+    "eventemitter3": "5.0.4",
     "i18next": "^23.10.1",
     "i18next-http-backend": "^2.5.0",
     "js-yaml": "^4.3.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1715,7 +1715,7 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.15.2"
     eslint-plugin-jsx-a11y-x: "npm:^0.2.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
-    eventemitter3: "npm:4.0.7"
+    eventemitter3: "npm:5.0.4"
     gherkin-lint: "npm:^4.2.4"
     globals: "npm:^16.2.0"
     husky: "npm:^9.1.7"
@@ -7288,14 +7288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:4.0.7":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^5.0.1":
+"eventemitter3@npm:5.0.4, eventemitter3@npm:^5.0.1":
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a


### PR DESCRIPTION
## What changed
Upgrades `eventemitter3` from `4.0.7` to `5.0.1`.

Part of #9707.

## Scope note
#9707 asks for 5 dependency upgrades: `i18next`, `i18next-http-backend`,
`react-i18next`, `eventemitter3`, and `react-resize-detector`. This PR
intentionally covers **only `eventemitter3`**, split out as its own PR
rather than one combined PR for all 5. Reasoning:

- The 3 i18next-related packages are tightly coupled to each other (peer
  dependencies) and touch the app's translation system broadly — that's a
  larger, higher-risk change that deserves its own focused PR and review.
- `react-resize-detector` looks small on paper but its v10+ release removed
  the entire component-based API in favor of a hook-only API, requiring
  real code changes across 5 files — also warrants its own PR.
- `eventemitter3` genuinely requires zero code changes (same export style
  in v5 as v4), so it's a clean, low-risk, independently reviewable PR.

Planning to follow up with `react-resize-detector` and then the i18next
trio as separate PRs against the same issue.

## Why this is safe
- Checked eventemitter3 v5's source directly — it still exports
  `EventEmitter` as both a default export and via `module.exports`,
  identical to v4's export style.
- Only 2 files in the codebase use this package (`GraphDataSource.ts`,
  `MeshDataSource.ts`), both importing it as
  `import EventEmitter from 'eventemitter3'` — this exact syntax is
  unchanged and works as-is on v5.
- No source code changes were required — this is a version bump only.

## Testing
- `yarn test`: 901 passed, 2 failed, 11 skipped — matches the known
  pre-existing baseline exactly (the 2 failures are unrelated Windows
  CRLF snapshot issues, reproducible on a clean `master`).
- `yarn lint`: 0 errors (474 pre-existing warnings, unrelated to this change).
- `GraphDataSource.test.ts` directly exercises the `EventEmitter` API this
  bump touches (`.on('loadStart', ...)`, `.on('fetchSuccess', ...)`,
  `.on('fetchError', ...)`) and passes against the new version.
- Manual verification of the Graph/Mesh pages in a live browser wasn't
  possible in this environment (no local Kiali backend/Kubernetes cluster
  available to authenticate against) — this is an environment limitation,
  not something specific to this change.

## AI disclosure
Per `AI_POLICY.md`, this PR was completed with AI assistance (Claude),
disclosed via the `Co-authored-by:` trailer on the commit.