### PR TITLE
[CI] Add a retry and check for mcp ready before tests start

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -516,6 +516,39 @@ ensureBookinfoGraphReady() {
   done
 }
 
+# Wait until the MCP HTTP endpoint answers before starting go tests.
+# Graph readiness alone is not enough: KinD CI can still stall Kiali briefly afterward.
+ensureMCPReady() {
+  infomsg "Waiting for MCP endpoint to respond"
+  local start_time
+  local end_time
+  local mcp_url
+  local http_code
+  start_time=$(date +%s)
+  end_time=$((start_time + 120))
+  mcp_url="${KIALI_URL}/api/chat/mcp/list_clusters"
+
+  while true; do
+    http_code=$(curl -k -s -o /dev/null -w "%{http_code}" --max-time 15 \
+      -X POST "${mcp_url}" \
+      -H 'Content-Type: application/json' \
+      -d '{}' || true)
+
+    if [ "${http_code}" != "000" ] && [ -n "${http_code}" ]; then
+      infomsg "MCP endpoint is ready (HTTP ${http_code})"
+      return 0
+    fi
+
+    local now
+    now=$(date +%s)
+    if [ "${now}" -gt "${end_time}" ]; then
+      echo "Timed out waiting for MCP endpoint at ${mcp_url}"
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 ensureMulticlusterApplicationsAreHealthy() {
   local start_time
   local timeout=300
@@ -580,6 +613,7 @@ if [ "${TEST_SUITE}" == "${BACKEND}" ]; then
   if [ "${MCP_TOOLS}" == "true" ]; then
     echo "Running backend MCP integration tests"
     ensureBookinfoGraphReady
+    ensureMCPReady
     cd "${SCRIPT_DIR}"/../tests/integration/mcp_tools
     go test -tags exclude_frontend -v -failfast ./... 2>&1 | tee >(go-junit-report > ../junit-rest-report-mcp-tools.xml) ../int-test-mcp-tools.log
   else

--- a/tests/integration/mcp_tools/mcp_client.go
+++ b/tests/integration/mcp_tools/mcp_client.go
@@ -16,7 +16,11 @@ import (
 
 var mcpClient *MCPClient
 
-const MCPTimeout = 30 * time.Second
+const (
+	MCPTimeout     = 90 * time.Second
+	MCPMaxAttempts = 2
+	MCPRetryWait   = 2 * time.Second
+)
 
 type MCPClient struct {
 	kialiURL   string
@@ -53,7 +57,38 @@ func mcpToolURL(toolName string) string {
 	return fmt.Sprintf("%s/api/chat/mcp/%s", mcpClient.kialiURL, toolName)
 }
 
+func isTransientMCPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "Client.Timeout") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "EOF")
+}
+
 func CallMCPTool(toolName string, args map[string]interface{}) (*MCPResponse, error) {
+	var lastErr error
+	for attempt := 1; attempt <= MCPMaxAttempts; attempt++ {
+		resp, err := callMCPToolOnce(toolName, args)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if attempt < MCPMaxAttempts && isTransientMCPError(err) {
+			log.Warningf("MCP tool %q attempt %d/%d failed with transient error, retrying in %s: %v",
+				toolName, attempt, MCPMaxAttempts, MCPRetryWait, err)
+			time.Sleep(MCPRetryWait)
+			continue
+		}
+		return nil, err
+	}
+	return nil, lastErr
+}
+
+func callMCPToolOnce(toolName string, args map[string]interface{}) (*MCPResponse, error) {
 	var body []byte
 	var err error
 	if args != nil {


### PR DESCRIPTION
### Describe the change
Add a retry and check for mcp ready before tests start for mcp tests

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10067 
