### PR TITLE
Replace context.TODO() with request context in service details

### DIFF
--- a/business/services.go
+++ b/business/services.go
@@ -577,7 +577,7 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 
 	var vsCreate, vsUpdate, vsDelete bool
 	wg.Add(1)
-	go func() {
+	go func(ctx context.Context) {
 		defer wg.Done()
 		/*
 			We can safely assume that permissions for VirtualServices will be similar as DestinationRules.
@@ -590,8 +590,8 @@ func (in *SvcService) GetServiceDetails(ctx context.Context, cluster, namespace,
 			errChan <- fmt.Errorf("client not found for cluster: %s", cluster)
 			return
 		}
-		vsCreate, vsUpdate, vsDelete = getPermissions(context.TODO(), userClient, cluster, namespace, kubernetes.VirtualServices, in.conf)
-	}()
+		vsCreate, vsUpdate, vsDelete = getPermissions(ctx, userClient, cluster, namespace, kubernetes.VirtualServices, in.conf)
+	}(ctx)
 
 	wg.Wait()
 	if len(errChan) != 0 {
@@ -818,7 +818,7 @@ func (in *SvcService) UpdateService(ctx context.Context, cluster, namespace, ser
 	// Identify controller and apply patch to workload
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetClusterNamespace(context.TODO(), namespace, cluster); err != nil {
+	if _, err := in.businessLayer.Namespace.GetClusterNamespace(ctx, namespace, cluster); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Describe the change

Two call sites in `business/services.go` used `context.TODO()` even though a proper request `ctx` was already in scope. That broke tracing context propagation and prevented request cancellation from flowing through those calls.

1. **`GetServiceDetails`** — the permissions goroutine now takes `ctx` as a parameter (same pattern as the sibling goroutines) and passes it to `getPermissions`.
2. **`UpdateService`** — the namespace RBAC check now calls `GetClusterNamespace(ctx, ...)` instead of `context.TODO()`.

### Steps to test the PR

1. Review the diff in `business/services.go` and confirm both former `context.TODO()` call sites now use `ctx`.
2. Optionally run: `go test ./business/ -run 'TestMultiClusterGetServiceDetails|TestGetServiceDetails' -count=1`

### Automation testing

No new automated tests. Existing unit tests covering `GetServiceDetails` pass:
- `TestMultiClusterGetServiceDetails`
- `TestGetServiceDetails*`

### Issue reference

Fixes #10069