### PR TITLE
[v2.27] Fix annotation editor value corruption and false-positive change detection

### DIFF
--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -9,7 +9,8 @@ import {
   TextArea,
   TextInput,
   Title,
-  TitleSizes
+  TitleSizes,
+  Tooltip
 } from '@patternfly/react-core';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
@@ -80,6 +81,79 @@ const validateSection = (entries: Entry[], sectionName: string): string[] => {
   return errors;
 };
 
+interface EditValuePopoverProps {
+  entryKey: string;
+  id: string;
+  onChange: (value: string) => void;
+  value: string;
+}
+
+const popoverActionsStyle = kialiStyle({
+  display: 'flex',
+  gap: '0.25rem',
+  position: 'absolute',
+  top: 'var(--pf-t--global--spacer--sm)',
+  right: 'var(--pf-t--global--spacer--md)'
+});
+
+const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, value }) => {
+  const [draft, setDraft] = React.useState(value);
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  return (
+    <Popover
+      appendTo={() =>
+        (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
+        document.body
+      }
+      headerContent={entryKey || t('Value')}
+      bodyContent={
+        <>
+          <div className={popoverActionsStyle}>
+            <Tooltip content={t('Save')}>
+              <Button
+                variant="plain"
+                size="sm"
+                icon={<KialiIcon.Check />}
+                onClick={() => {
+                  onChange(draft);
+                  setIsVisible(false);
+                }}
+              />
+            </Tooltip>
+            <Tooltip content={t('Cancel')}>
+              <Button
+                variant="plain"
+                size="sm"
+                icon={<KialiIcon.Close />}
+                onClick={() => {
+                  setDraft(value);
+                  setIsVisible(false);
+                }}
+              />
+            </Tooltip>
+          </div>
+          <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
+        </>
+      }
+      isVisible={isVisible}
+      shouldOpen={() => {
+        setDraft(value);
+        setIsVisible(true);
+      }}
+      shouldClose={() => {
+        setDraft(value);
+        setIsVisible(false);
+      }}
+      minWidth="40rem"
+      position="left"
+      showClose={false}
+    >
+      <Button variant="plain" icon={<KialiIcon.PencilAlt />} size="sm" />
+    </Popover>
+  );
+};
+
 interface SectionProps {
   canEdit: boolean;
   entries: Entry[];
@@ -128,32 +202,19 @@ const AnnotationSection: React.FC<SectionProps> = ({
               <Th width={40}>
                 <TextInput
                   id={`${sectionId}_value_${index}`}
-                  onChange={(_event, v) => onChange(index, [key, v])}
                   placeholder={t('Value')}
+                  readOnlyVariant="plain"
                   type="text"
                   value={value}
                 />
               </Th>
               <Th>
-                <Popover
-                  appendTo={() =>
-                    (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
-                    document.body
-                  }
-                  headerContent={key || t('Value')}
-                  bodyContent={
-                    <TextArea
-                      className={popoverTextAreaStyle}
-                      id={`${sectionId}_popover_value_${index}`}
-                      onChange={(_event, v) => onChange(index, [key, v])}
-                      value={value}
-                    />
-                  }
-                  minWidth="40rem"
-                  position="left"
-                >
-                  <Button variant="plain" icon={<KialiIcon.Expand />} size="sm" />
-                </Popover>
+                <EditValuePopover
+                  entryKey={key}
+                  id={`${sectionId}_popover_value_${index}`}
+                  onChange={v => onChange(index, [key, v])}
+                  value={value}
+                />
                 <Button variant="plain" icon={<KialiIcon.Delete />} onClick={() => onRemove(index)} />
               </Th>
             </Tr>

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -91,10 +91,17 @@ const validateSection = (entries: Entry[], sectionName: string): string[] => {
   return errors;
 };
 
+const disabledEditorStyle = kialiStyle({
+  opacity: 0.5,
+  pointerEvents: 'none',
+  userSelect: 'none'
+});
+
 interface EditValuePopoverProps {
   entryKey: string;
   id: string;
   onChange: (value: string) => void;
+  onVisibleChange?: (isVisible: boolean) => void;
   value: string;
 }
 
@@ -106,9 +113,14 @@ const popoverActionsStyle = kialiStyle({
   right: PFSpacer.md
 });
 
-const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, value }) => {
+const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, onVisibleChange, value }) => {
   const [draft, setDraft] = React.useState(value);
   const [isVisible, setIsVisible] = React.useState(false);
+
+  const setVisible = (visible: boolean): void => {
+    setIsVisible(visible);
+    onVisibleChange?.(visible);
+  };
 
   return (
     <Popover
@@ -120,25 +132,25 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
       bodyContent={
         <>
           <div className={popoverActionsStyle}>
-            <Tooltip content={t('Save')}>
+            <Tooltip content={t('Save')} trigger="mouseenter">
               <Button
                 variant="plain"
                 size="sm"
                 icon={<KialiIcon.Check />}
                 onClick={() => {
                   onChange(draft);
-                  setIsVisible(false);
+                  setVisible(false);
                 }}
               />
             </Tooltip>
-            <Tooltip content={t('Cancel')}>
+            <Tooltip content={t('Cancel')} trigger="mouseenter">
               <Button
                 variant="plain"
                 size="sm"
                 icon={<KialiIcon.Close />}
                 onClick={() => {
                   setDraft(value);
-                  setIsVisible(false);
+                  setVisible(false);
                 }}
               />
             </Tooltip>
@@ -146,18 +158,21 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
           <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
         </>
       }
+      elementToFocus={`#${id}`}
+      hideOnOutsideClick={false}
       isVisible={isVisible}
       shouldOpen={() => {
         setDraft(value);
-        setIsVisible(true);
+        setVisible(true);
       }}
       shouldClose={() => {
         setDraft(value);
-        setIsVisible(false);
+        setVisible(false);
       }}
       minWidth="40rem"
       position="left"
       showClose={false}
+      withFocusTrap
     >
       <Button variant="plain" icon={<KialiIcon.PencilAlt />} size="sm" />
     </Popover>
@@ -167,9 +182,11 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
 interface SectionProps {
   canEdit: boolean;
   entries: Entry[];
+  isDisabled?: boolean;
   onAdd: () => void;
   onChange: (index: number, entry: Entry) => void;
   onRemove: (index: number) => void;
+  onValueEditVisibleChange?: (isVisible: boolean) => void;
   sectionId: string;
   title: string;
 }
@@ -177,9 +194,11 @@ interface SectionProps {
 const AnnotationSection: React.FC<SectionProps> = ({
   canEdit,
   entries,
+  isDisabled = false,
   onAdd,
   onChange,
   onRemove,
+  onValueEditVisibleChange,
   sectionId,
   title
 }) => (
@@ -203,6 +222,7 @@ const AnnotationSection: React.FC<SectionProps> = ({
                 <TextInput
                   aria-invalid={key === '' || entries.filter(e => e[0] === key).length > 1}
                   id={`${sectionId}_key_${index}`}
+                  isDisabled={isDisabled}
                   onChange={(_event, newKey) => onChange(index, [newKey, value])}
                   placeholder={t('Key')}
                   type="text"
@@ -217,9 +237,15 @@ const AnnotationSection: React.FC<SectionProps> = ({
                   entryKey={key}
                   id={`${sectionId}_popover_value_${index}`}
                   onChange={v => onChange(index, [key, v])}
+                  onVisibleChange={onValueEditVisibleChange}
                   value={value}
                 />
-                <Button variant="plain" icon={<KialiIcon.Delete />} onClick={() => onRemove(index)} />
+                <Button
+                  variant="plain"
+                  icon={<KialiIcon.Delete />}
+                  isDisabled={isDisabled}
+                  onClick={() => onRemove(index)}
+                />
               </Th>
             </Tr>
           ) : (
@@ -237,6 +263,7 @@ const AnnotationSection: React.FC<SectionProps> = ({
         className={addMoreStyle}
         data-test={`${sectionId}-add-more`}
         icon={<KialiIcon.AddMore />}
+        isDisabled={isDisabled}
         onClick={onAdd}
         isInline
       >
@@ -257,6 +284,7 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
   const [controllerEntries, setControllerEntries] = React.useState<Entry[]>(() => toEntries(controllerAnnotations));
   const [templateEntries, setTemplateEntries] = React.useState<Entry[]>(() => toEntries(templateAnnotations));
   const [validation, setValidation] = React.useState<string[]>([]);
+  const [isEditingValue, setIsEditingValue] = React.useState(false);
   const wasOpen = React.useRef(false);
 
   React.useEffect(() => {
@@ -264,18 +292,26 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
       setControllerEntries(toEntries(controllerAnnotations));
       setTemplateEntries(toEntries(templateAnnotations));
       setValidation([]);
+      setIsEditingValue(false);
     }
     wasOpen.current = isOpen;
   }, [isOpen, controllerAnnotations, templateAnnotations]);
 
   const handleClose = (): void => {
+    if (isEditingValue) {
+      return;
+    }
     setControllerEntries(toEntries(controllerAnnotations));
     setTemplateEntries(toEntries(templateAnnotations));
     setValidation([]);
+    setIsEditingValue(false);
     onClose();
   };
 
   const handleSave = (): void => {
+    if (isEditingValue) {
+      return;
+    }
     const errors = [
       ...validateSection(controllerEntries, t('Controller Annotations')),
       ...validateSection(templateEntries, t('Pod Template Annotations'))
@@ -313,10 +349,10 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
     <ActionGroup>
       {canEdit ? (
         <>
-          <Button variant="primary" onClick={handleSave} data-test="save-button">
+          <Button variant="primary" onClick={handleSave} data-test="save-button" isDisabled={isEditingValue}>
             {t('Save')}
           </Button>
-          <Button variant="link" onClick={handleClose}>
+          <Button variant="link" onClick={handleClose} isDisabled={isEditingValue}>
             {t('Cancel')}
           </Button>
         </>
@@ -337,34 +373,40 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
       aria-labelledby="workload-annotations-wizard-title"
       footer={footer}
     >
-      <AnnotationSection
-        canEdit={canEdit}
-        entries={controllerEntries}
-        onAdd={makeAddHandler(setControllerEntries)}
-        onChange={makeChangeHandler(setControllerEntries)}
-        onRemove={makeRemoveHandler(setControllerEntries)}
-        sectionId="controller"
-        title={t('Controller Annotations')}
-      />
-      <AnnotationSection
-        canEdit={canEdit}
-        entries={templateEntries}
-        onAdd={makeAddHandler(setTemplateEntries)}
-        onChange={makeChangeHandler(setTemplateEntries)}
-        onRemove={makeRemoveHandler(setTemplateEntries)}
-        sectionId="template"
-        title={t('Pod Template Annotations')}
-      />
+      <div className={isEditingValue ? disabledEditorStyle : undefined}>
+        <AnnotationSection
+          canEdit={canEdit}
+          entries={controllerEntries}
+          isDisabled={isEditingValue}
+          onAdd={makeAddHandler(setControllerEntries)}
+          onChange={makeChangeHandler(setControllerEntries)}
+          onRemove={makeRemoveHandler(setControllerEntries)}
+          onValueEditVisibleChange={setIsEditingValue}
+          sectionId="controller"
+          title={t('Controller Annotations')}
+        />
+        <AnnotationSection
+          canEdit={canEdit}
+          entries={templateEntries}
+          isDisabled={isEditingValue}
+          onAdd={makeAddHandler(setTemplateEntries)}
+          onChange={makeChangeHandler(setTemplateEntries)}
+          onRemove={makeRemoveHandler(setTemplateEntries)}
+          onValueEditVisibleChange={setIsEditingValue}
+          sectionId="template"
+          title={t('Pod Template Annotations')}
+        />
 
-      {validation.length > 0 && (
-        <Alert variant="danger" className={alertStyle} isInline isExpandable title={t('An error occurred')}>
-          <List isPlain>
-            {validation.map((message, i) => (
-              <ListItem key={`validation_${i}`}>{message}</ListItem>
-            ))}
-          </List>
-        </Alert>
-      )}
+        {validation.length > 0 && (
+          <Alert variant="danger" className={alertStyle} isInline isExpandable title={t('An error occurred')}>
+            <List isPlain>
+              {validation.map((message, i) => (
+                <ListItem key={`validation_${i}`}>{message}</ListItem>
+              ))}
+            </List>
+          </Alert>
+        )}
+      </div>
     </Modal>
   );
 };

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -15,6 +15,7 @@ import {
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { KialiIcon } from 'config/KialiIcon';
+import { PFSpacer } from 'styles/PfSpacer';
 import { kialiStyle } from 'styles/StyleUtils';
 import { t } from 'utils/I18nUtils';
 
@@ -34,16 +35,25 @@ const addMoreStyle = kialiStyle({
   marginLeft: '1rem'
 });
 
-const clearButtonStyle = kialiStyle({
-  marginLeft: '0.5rem'
-});
-
 const alertStyle = kialiStyle({
   marginTop: '1rem'
 });
 
 const sectionStyle = kialiStyle({
   marginBottom: '1.5rem'
+});
+
+const valueCellStyle = kialiStyle({
+  overflow: 'hidden',
+  maxWidth: 0,
+  verticalAlign: 'middle'
+});
+
+const valueDisplayStyle = kialiStyle({
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
 });
 
 const popoverTextAreaStyle = kialiStyle({
@@ -92,8 +102,8 @@ const popoverActionsStyle = kialiStyle({
   display: 'flex',
   gap: '0.25rem',
   position: 'absolute',
-  top: 'var(--pf-t--global--spacer--sm)',
-  right: 'var(--pf-t--global--spacer--md)'
+  top: PFSpacer.sm,
+  right: PFSpacer.md
 });
 
 const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, value }) => {
@@ -199,14 +209,8 @@ const AnnotationSection: React.FC<SectionProps> = ({
                   value={key}
                 />
               </Th>
-              <Th width={40}>
-                <TextInput
-                  id={`${sectionId}_value_${index}`}
-                  placeholder={t('Value')}
-                  readOnlyVariant="plain"
-                  type="text"
-                  value={value}
-                />
+              <Th width={40} className={valueCellStyle}>
+                <span className={valueDisplayStyle}>{value}</span>
               </Th>
               <Th>
                 <EditValuePopover
@@ -264,14 +268,10 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
     wasOpen.current = isOpen;
   }, [isOpen, controllerAnnotations, templateAnnotations]);
 
-  const handleClear = (): void => {
+  const handleClose = (): void => {
     setControllerEntries(toEntries(controllerAnnotations));
     setTemplateEntries(toEntries(templateAnnotations));
     setValidation([]);
-  };
-
-  const handleClose = (): void => {
-    handleClear();
     onClose();
   };
 
@@ -315,9 +315,6 @@ export const WorkloadAnnotationsWizard: React.FC<WorkloadAnnotationsWizardProps>
         <>
           <Button variant="primary" onClick={handleSave} data-test="save-button">
             {t('Save')}
-          </Button>
-          <Button variant="secondary" className={clearButtonStyle} onClick={handleClear}>
-            {t('Clear')}
           </Button>
           <Button variant="link" onClick={handleClose}>
             {t('Cancel')}

--- a/frontend/src/pages/PageUtils.ts
+++ b/frontend/src/pages/PageUtils.ts
@@ -131,6 +131,39 @@ export const preserveHiddenAnnotations = (
   return { ...hidden, ...updatedVisible };
 };
 
+/**
+ * Builds a patch diff from the user's visible edits against the full original,
+ * re-attaching hidden annotations and marking deleted keys as null.
+ */
+export const buildAnnotationsDiff = (
+  original: Record<string, string>,
+  userVisible: Record<string, string>
+): Record<string, string | null> => {
+  const withHidden = preserveHiddenAnnotations(original, userVisible);
+  const diff: Record<string, string | null> = { ...withHidden };
+  for (const key of Object.keys(original)) {
+    if (!(key in withHidden)) {
+      diff[key] = null;
+    }
+  }
+  return diff;
+};
+
+/**
+ * Determines whether user edits differ from the original annotations.
+ * Uses an order-insensitive comparison against the full original.
+ */
+export const hasAnnotationsChanged = (
+  original: Record<string, string>,
+  userVisible: Record<string, string>
+): boolean => {
+  const diff = buildAnnotationsDiff(original, userVisible);
+  return (
+    Object.keys(diff).length !== Object.keys(original).length ||
+    Object.entries(diff).some(([k, v]) => original[k] !== v)
+  );
+};
+
 export const buildWorkloadMetadataPatch = (
   field: 'labels' | 'annotations',
   original: Record<string, string>,

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -54,13 +54,14 @@ import { EditableLabelsCard } from '../../components/Label/EditableLabelsCard';
 import { WorkloadAnnotationsWizard } from '../../components/IstioWizards/WorkloadAnnotationsWizard';
 import { Paths } from '../../config';
 import {
+  buildAnnotationsDiff,
   filterHiddenAnnotations,
+  hasAnnotationsChanged,
   navigateToFilteredList,
   buildWorkloadMetadataPatch,
   buildWorkloadAnnotationsPatch,
   getWorkloadAnnotations,
-  isTemplatedWorkloadKind,
-  preserveHiddenAnnotations
+  isTemplatedWorkloadKind
 } from '../PageUtils';
 import { t } from 'utils/I18nUtils';
 import { addError, addSuccess } from '../../utils/AlertUtils';
@@ -550,29 +551,8 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     const controllerFull = workload.annotations ?? {};
     const templateFull = workload.templateAnnotations ?? {};
 
-    const controllerWithHidden = preserveHiddenAnnotations(controllerFull, controller);
-    const templateWithHidden = preserveHiddenAnnotations(templateFull, template);
-
-    const controllerDiff: Record<string, string | null> = { ...controllerWithHidden };
-    for (const key of Object.keys(controllerFull)) {
-      if (!(key in controllerWithHidden)) {
-        controllerDiff[key] = null;
-      }
-    }
-
-    const templateDiff: Record<string, string | null> = { ...templateWithHidden };
-    for (const key of Object.keys(templateFull)) {
-      if (!(key in templateWithHidden)) {
-        templateDiff[key] = null;
-      }
-    }
-
-    const controllerChanged =
-      JSON.stringify(controllerDiff) !== JSON.stringify(controllerFull) ||
-      Object.keys(controllerDiff).some(k => controllerDiff[k] === null);
-    const templateChanged =
-      JSON.stringify(templateDiff) !== JSON.stringify(templateFull) ||
-      Object.keys(templateDiff).some(k => templateDiff[k] === null);
+    const controllerChanged = hasAnnotationsChanged(controllerFull, controller);
+    const templateChanged = hasAnnotationsChanged(templateFull, template);
 
     if (!controllerChanged && !templateChanged) {
       this.setState({ showAnnotationsWizard: false });
@@ -585,10 +565,10 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     } = {};
 
     if (controllerChanged) {
-      patch.metadata = { annotations: controllerDiff };
+      patch.metadata = { annotations: buildAnnotationsDiff(controllerFull, controller) };
     }
     if (templateChanged) {
-      patch.spec = { template: { metadata: { annotations: templateDiff } } };
+      patch.spec = { template: { metadata: { annotations: buildAnnotationsDiff(templateFull, template) } } };
     }
 
     const jsonPatch = JSON.stringify(patch);

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -547,31 +547,31 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
       return;
     }
 
-    const controllerOriginal = filterHiddenAnnotations(workload.annotations ?? {});
-    const templateOriginal = filterHiddenAnnotations(workload.templateAnnotations ?? {});
+    const controllerFull = workload.annotations ?? {};
+    const templateFull = workload.templateAnnotations ?? {};
 
-    const controllerWithHidden = preserveHiddenAnnotations(workload.annotations ?? {}, controller);
-    const templateWithHidden = preserveHiddenAnnotations(workload.templateAnnotations ?? {}, template);
+    const controllerWithHidden = preserveHiddenAnnotations(controllerFull, controller);
+    const templateWithHidden = preserveHiddenAnnotations(templateFull, template);
 
     const controllerDiff: Record<string, string | null> = { ...controllerWithHidden };
-    for (const key of Object.keys(workload.annotations ?? {})) {
+    for (const key of Object.keys(controllerFull)) {
       if (!(key in controllerWithHidden)) {
         controllerDiff[key] = null;
       }
     }
 
     const templateDiff: Record<string, string | null> = { ...templateWithHidden };
-    for (const key of Object.keys(workload.templateAnnotations ?? {})) {
+    for (const key of Object.keys(templateFull)) {
       if (!(key in templateWithHidden)) {
         templateDiff[key] = null;
       }
     }
 
     const controllerChanged =
-      JSON.stringify(controllerDiff) !== JSON.stringify(controllerOriginal) ||
+      JSON.stringify(controllerDiff) !== JSON.stringify(controllerFull) ||
       Object.keys(controllerDiff).some(k => controllerDiff[k] === null);
     const templateChanged =
-      JSON.stringify(templateDiff) !== JSON.stringify(templateOriginal) ||
+      JSON.stringify(templateDiff) !== JSON.stringify(templateFull) ||
       Object.keys(templateDiff).some(k => templateDiff[k] === null);
 
     if (!controllerChanged && !templateChanged) {

--- a/frontend/src/pages/__tests__/PageUtils.test.ts
+++ b/frontend/src/pages/__tests__/PageUtils.test.ts
@@ -3,6 +3,7 @@ import {
   buildWorkloadAnnotationsPatch,
   buildWorkloadMetadataPatch,
   getWorkloadAnnotations,
+  hasAnnotationsChanged,
   LAST_APPLIED_ANNOTATION,
   preserveHiddenAnnotations,
   navigateToFilteredList
@@ -342,5 +343,59 @@ describe('navigateToFilteredList', () => {
     navigateToFilteredList('services', 'env', 'prod');
     const url: string = mockNavigate.mock.calls[0][0];
     expect(url).not.toContain('namespaces=');
+  });
+});
+
+describe('hasAnnotationsChanged', () => {
+  it('returns false when no changes are made', () => {
+    const original = { 'app.kubernetes.io/name': 'reviews', version: '1' };
+    const userVisible = { 'app.kubernetes.io/name': 'reviews', version: '1' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(false);
+  });
+
+  it('returns false when last-applied-configuration is present but nothing else changed', () => {
+    const original = {
+      [LAST_APPLIED_ANNOTATION]: '{"big":"json"}',
+      'app.kubernetes.io/name': 'reviews'
+    };
+    const userVisible = { 'app.kubernetes.io/name': 'reviews' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(false);
+  });
+
+  it('returns false regardless of property order', () => {
+    const original: Record<string, string> = {};
+    Object.defineProperty(original, LAST_APPLIED_ANNOTATION, { value: '{}', enumerable: true, writable: true });
+    Object.defineProperty(original, 'alpha', { value: 'a', enumerable: true, writable: true });
+    Object.defineProperty(original, 'beta', { value: 'b', enumerable: true, writable: true });
+
+    const userVisible = { beta: 'b', alpha: 'a' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(false);
+  });
+
+  it('returns true when a value is modified', () => {
+    const original = { 'app.kubernetes.io/name': 'reviews', version: '1' };
+    const userVisible = { 'app.kubernetes.io/name': 'reviews', version: '2' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(true);
+  });
+
+  it('returns true when an annotation is added', () => {
+    const original = { 'app.kubernetes.io/name': 'reviews' };
+    const userVisible = { 'app.kubernetes.io/name': 'reviews', newKey: 'newValue' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(true);
+  });
+
+  it('returns true when an annotation is deleted', () => {
+    const original = { 'app.kubernetes.io/name': 'reviews', version: '1' };
+    const userVisible = { 'app.kubernetes.io/name': 'reviews' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(true);
+  });
+
+  it('returns true when a visible annotation is modified while hidden annotation exists', () => {
+    const original = {
+      [LAST_APPLIED_ANNOTATION]: '{"big":"json"}',
+      'app.kubernetes.io/name': 'reviews'
+    };
+    const userVisible = { 'app.kubernetes.io/name': 'updated' };
+    expect(hasAnnotationsChanged(original, userVisible)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Backport of #10060 to v2.27.

- Replace inline editable TextInput with a read-only display field and an edit popover (pencil icon with Save/Cancel actions), preventing multiline value corruption
- Fix false-positive change detection in `handleSaveAnnotations` that triggered unnecessary API PATCH calls when `last-applied-configuration` was present
- Improve popover UX: focus textarea on open, tooltips only on hover, trap focus / ignore outside clicks, and disable the parent editor while editing so drafts cannot be lost

Fixes #10041 (parts 1 and 2) on v2.27.

## Test plan

- [ ] Cherry-pick applied cleanly (no conflicts)
- [ ] Open annotation editor on a templated workload (Deployment)
- [ ] Verify value field is read-only; clicking pencil icon opens edit popover
- [ ] Edit a multiline annotation value in the popover — verify format is preserved
- [ ] Click Save (checkmark) to commit, or Cancel (X) to discard
- [ ] Save without changes on a workload with `last-applied-configuration` — verify no API call is made

Made with [Cursor](https://cursor.com)