### PR TITLE
chore(deps): upgrade react-resize-detector to v12

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "react-flexview": "4.0.3",
     "react-i18next": "^11.7.3",
     "react-redux": "7.2.2",
-    "react-resize-detector": "12.3.0",
+    "react-resize-detector": "^12.3.0",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
     "react-router-dom-v5-compat": "^6.30.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "react-flexview": "4.0.3",
     "react-i18next": "^11.7.3",
     "react-redux": "7.2.2",
-    "react-resize-detector": "9.1.1",
+    "react-resize-detector": "12.3.0",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
     "react-router-dom-v5-compat": "^6.30.3",

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -77,60 +77,17 @@ export function getNextTourStop(
   return undefined;
 }
 
-class TourStopComponent extends React.PureComponent<TourStopProps> {
-  tourStopInfo: TourStopInfo[];
+const TourStopComponent: React.FC<TourStopProps> = props => {
+  const { activeStop, activeTour, children, endTour, info, setStop } = props;
 
-  constructor(props: TourStopProps) {
-    super(props);
+  const [tourStopInfo] = React.useState<TourStopInfo[]>(() => (Array.isArray(info) ? info : [info]));
 
-    this.tourStopInfo = Array.isArray(props.info) ? props.info : [props.info];
-  }
+  const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  private getStop = (direction: 'back' | 'forward'): number | undefined => {
-    if (this.props.activeStop === undefined) {
-      return undefined;
-    }
-
-    return getNextTourStop(this.props.activeTour!, this.props.activeStop!, direction);
-  };
-
-  private setStop = (stop: number): void => {
-    this.props.setStop(stop);
-  };
-
-  private backButton = (): React.ReactNode => {
-    const stop = this.getStop('back');
-
-    return (
-      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => this.setStop(stop!)}>
-        {t('Back')}
-      </Button>
-    );
-  };
-
-  private nextButton = (): React.ReactNode => {
-    const stop = this.getStop('forward');
-
-    if (stop === undefined) {
-      return (
-        <Button variant={ButtonVariant.primary} onClick={this.props.endTour}>
-          {t('Done')}
-        </Button>
-      );
-    }
-
-    return (
-      <Button variant={ButtonVariant.primary} onClick={() => this.setStop(stop!)}>
-        {t('Next')}
-      </Button>
-    );
-  };
-
-  private activeInfo = (): TourStopInfo | undefined => {
-    for (const tsi of this.tourStopInfo) {
+  const activeInfo = (): TourStopInfo | undefined => {
+    for (const tsi of tourStopInfo) {
       const name = tsi.name;
-      const isActive =
-        this.props.activeTour !== undefined && name === this.props.activeTour.stops[this.props.activeStop!].name;
+      const isActive = activeTour !== undefined && name === activeTour.stops[activeStop!].name;
 
       if (isActive) {
         return tsi;
@@ -140,68 +97,64 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
     return undefined;
   };
 
+  const getStop = (direction: 'back' | 'forward'): number | undefined => {
+    if (activeStop === undefined) {
+      return undefined;
+    }
+
+    return getNextTourStop(activeTour!, activeStop!, direction);
+  };
+
+  const setStopHandler = (stop: number): void => {
+    setStop(stop);
+  };
+
+  const backButton = (): React.ReactNode => {
+    const stop = getStop('back');
+
+    return (
+      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => setStopHandler(stop!)}>
+        {t('Back')}
+      </Button>
+    );
+  };
+
+  const nextButton = (): React.ReactNode => {
+    const stop = getStop('forward');
+
+    if (stop === undefined) {
+      return (
+        <Button variant={ButtonVariant.primary} onClick={endTour}>
+          {t('Done')}
+        </Button>
+      );
+    }
+
+    return (
+      <Button variant={ButtonVariant.primary} onClick={() => setStopHandler(stop!)}>
+        {t('Next')}
+      </Button>
+    );
+  };
+
   // This is here to workaround what seems to be a bug.  As far as I know when isVisible is set then outside clicks should not hide
   // the Popover, but it seems to be happening in certain scenarios. So, if the Popover is still valid, unhide it immediately.
-  private onHidden = (): void => {
-    if (this.activeInfo()) {
-      this.forceUpdate();
+  const onHidden = (): void => {
+    if (activeInfo()) {
+      forceUpdate();
     }
   };
 
-  private shouldClose = (): void => {
-    this.props.endTour();
+  const onResize = (): void => {
+    if (activeInfo()) {
+      forceUpdate();
+    }
   };
 
-  componentDidMount(): void {
-    this.tourStopInfo.forEach(ti => (ti.isValid = true));
-  }
+  const shouldClose = (): void => {
+    endTour();
+  };
 
-  componentWillUnmount(): void {
-    this.tourStopInfo.forEach(ti => (ti.isValid = false));
-  }
-
-  render(): React.ReactNode {
-    const info = this.activeInfo();
-    const offset = info && info.distance ? info.distance : 25;
-    const children = this.props.children;
-
-    return (
-      <>
-        {info ? (
-          <>
-            <Popover
-              bodyContent={info.description ? t(info.description) : info.htmlDescription}
-              distance={offset}
-              footerContent={
-                <div className={buttonsStyle}>
-                  {this.backButton()}
-                  {this.nextButton()}
-                </div>
-              }
-              headerContent={
-                <div>
-                  <span className={stopNumberStyle}>{this.props.activeStop! + 1}</span>
-                  <span>{t(info.name)}</span>
-                </div>
-              }
-              isVisible={true}
-              onHidden={this.onHidden}
-              position={info.position}
-              shouldClose={(_event, _) => this.shouldClose()}
-            >
-              <>{children}</>
-            </Popover>
-          </>
-        ) : (
-          <>{children}</>
-        )}
-      </>
-    );
-  }
-}
-
-const TourStopResizeWrapper: React.FC<TourStopProps> = props => {
-  const componentRef = React.useRef<TourStopComponent>(null);
   const bodyRef = React.useRef<HTMLElement>(document.body);
 
   useResizeDetector({
@@ -211,10 +164,51 @@ const TourStopResizeWrapper: React.FC<TourStopProps> = props => {
     skipOnMount: true,
     handleWidth: true,
     handleHeight: true,
-    onResize: () => componentRef.current?.forceUpdate()
+    onResize
   });
 
-  return <TourStopComponent ref={componentRef} {...props} />;
+  React.useEffect(() => {
+    tourStopInfo.forEach(ti => (ti.isValid = true));
+
+    return () => {
+      tourStopInfo.forEach(ti => (ti.isValid = false));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
+  }, []);
+
+  const currentInfo = activeInfo();
+  const offset = currentInfo && currentInfo.distance ? currentInfo.distance : 25;
+
+  return (
+    <>
+      {currentInfo ? (
+        <Popover
+          bodyContent={currentInfo.description ? t(currentInfo.description) : currentInfo.htmlDescription}
+          distance={offset}
+          footerContent={
+            <div className={buttonsStyle}>
+              {backButton()}
+              {nextButton()}
+            </div>
+          }
+          headerContent={
+            <div>
+              <span className={stopNumberStyle}>{activeStop! + 1}</span>
+              <span>{t(currentInfo.name)}</span>
+            </div>
+          }
+          isVisible={true}
+          onHidden={onHidden}
+          position={currentInfo.position}
+          shouldClose={(_event, _) => shouldClose()}
+        >
+          <>{children}</>
+        </Popover>
+      ) : (
+        <>{children}</>
+      )}
+    </>
+  );
 };
 
 const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
@@ -229,4 +223,4 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
   };
 };
 
-export const TourStop = connect(mapStateToProps, mapDispatchToProps)(TourStopResizeWrapper);
+export const TourStop = React.memo(connect(mapStateToProps, mapDispatchToProps)(TourStopComponent));

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
+import type { PopoverPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { KialiDispatch } from 'types/Redux';
-import { KialiAppState } from 'store/Store';
-import { useResizeDetector } from 'react-resize-detector';
+import type { KialiDispatch } from 'types/Redux';
+import type { KialiAppState } from 'store/Store';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { TourActions } from 'actions/TourActions';
 import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
@@ -109,7 +110,11 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
     const stop = getStop('back');
 
     return (
-      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => setStop(stop!)}>
+      <Button
+        isDisabled={stop === undefined}
+        variant={ButtonVariant.secondary}
+        onClick={() => stop !== undefined && setStop(stop)}
+      >
         {t('Back')}
       </Button>
     );
@@ -127,7 +132,7 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
     }
 
     return (
-      <Button variant={ButtonVariant.primary} onClick={() => setStop(stop!)}>
+      <Button variant={ButtonVariant.primary} onClick={() => setStop(stop)}>
         {t('Next')}
       </Button>
     );
@@ -135,30 +140,19 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
 
   // This is here to workaround what seems to be a bug.  As far as I know when isVisible is set then outside clicks should not hide
   // the Popover, but it seems to be happening in certain scenarios. So, if the Popover is still valid, unhide it immediately.
-  const onHidden = (): void => {
+  const handleHidden = (): void => {
     if (activeInfo()) {
       forceUpdate();
     }
   };
 
-  const onResize = (): void => {
+  const handleResize = (): void => {
     if (activeInfo()) {
       forceUpdate();
     }
   };
 
-  const bodyRef = React.useRef<HTMLElement>(document.body);
-
-  useResizeDetector({
-    targetRef: bodyRef,
-    disableRerender: true,
-    refreshMode: 'debounce',
-    refreshRate: 100,
-    skipOnMount: true,
-    handleWidth: true,
-    handleHeight: true,
-    onResize
-  });
+  useTopologyResize(handleResize);
 
   React.useEffect(() => {
     tourStopInfo.forEach(ti => (ti.isValid = true));
@@ -191,7 +185,7 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
             </div>
           }
           isVisible={true}
-          onHidden={onHidden}
+          onHidden={handleHidden}
           position={currentInfo.position}
           shouldClose={(_event, _) => endTour()}
         >

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { KialiDispatch } from 'types/Redux';
 import { KialiAppState } from 'store/Store';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import { TourActions } from 'actions/TourActions';
 import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
@@ -148,12 +148,6 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
     }
   };
 
-  private onResize = (): void => {
-    if (this.activeInfo()) {
-      this.forceUpdate();
-    }
-  };
-
   private shouldClose = (): void => {
     this.props.endTour();
   };
@@ -175,14 +169,6 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
       <>
         {info ? (
           <>
-            <ReactResizeDetector
-              refreshMode={'debounce'}
-              refreshRate={100}
-              skipOnMount={true}
-              handleWidth={true}
-              handleHeight={true}
-              onResize={this.onResize}
-            />
             <Popover
               bodyContent={info.description ? t(info.description) : info.htmlDescription}
               distance={offset}
@@ -214,6 +200,23 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
   }
 }
 
+const TourStopResizeWrapper: React.FC<TourStopProps> = props => {
+  const componentRef = React.useRef<TourStopComponent>(null);
+  const bodyRef = React.useRef<HTMLElement>(document.body);
+
+  useResizeDetector({
+    targetRef: bodyRef,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    skipOnMount: true,
+    handleWidth: true,
+    handleHeight: true,
+    onResize: () => componentRef.current?.forceUpdate()
+  });
+
+  return <TourStopComponent ref={componentRef} {...props} />;
+};
+
 const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   activeTour: state.tourState.activeTour,
   activeStop: state.tourState.activeStop
@@ -226,4 +229,4 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
   };
 };
 
-export const TourStop = connect(mapStateToProps, mapDispatchToProps)(TourStopComponent);
+export const TourStop = connect(mapStateToProps, mapDispatchToProps)(TourStopResizeWrapper);

--- a/frontend/src/components/Tour/TourStop.tsx
+++ b/frontend/src/components/Tour/TourStop.tsx
@@ -105,15 +105,11 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
     return getNextTourStop(activeTour!, activeStop!, direction);
   };
 
-  const setStopHandler = (stop: number): void => {
-    setStop(stop);
-  };
-
   const backButton = (): React.ReactNode => {
     const stop = getStop('back');
 
     return (
-      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => setStopHandler(stop!)}>
+      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => setStop(stop!)}>
         {t('Back')}
       </Button>
     );
@@ -131,7 +127,7 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
     }
 
     return (
-      <Button variant={ButtonVariant.primary} onClick={() => setStopHandler(stop!)}>
+      <Button variant={ButtonVariant.primary} onClick={() => setStop(stop!)}>
         {t('Next')}
       </Button>
     );
@@ -151,14 +147,11 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
     }
   };
 
-  const shouldClose = (): void => {
-    endTour();
-  };
-
   const bodyRef = React.useRef<HTMLElement>(document.body);
 
   useResizeDetector({
     targetRef: bodyRef,
+    disableRerender: true,
     refreshMode: 'debounce',
     refreshRate: 100,
     skipOnMount: true,
@@ -200,7 +193,7 @@ const TourStopComponent: React.FC<TourStopProps> = props => {
           isVisible={true}
           onHidden={onHidden}
           position={currentInfo.position}
-          shouldClose={(_event, _) => shouldClose()}
+          shouldClose={(_event, _) => endTour()}
         >
           <>{children}</>
         </Popover>
@@ -223,4 +216,4 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => {
   };
 };
 
-export const TourStop = React.memo(connect(mapStateToProps, mapDispatchToProps)(TourStopComponent));
+export const TourStop = connect(mapStateToProps, mapDispatchToProps)(TourStopComponent);

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useResizeDetector } from 'react-resize-detector';
-import {
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
+import type {
   Controller,
+  EdgeModel,
+  GraphElement,
+  GraphModel,
+  Model,
+  Node,
+  NodeModel,
+  Edge,
+  GraphAreaSelectedEventListener,
+  GraphLayoutEndEventListener
+} from '@patternfly/react-topology';
+import {
   createTopologyControlButtons,
   defaultControlButtonsOptions,
   EdgeAnimationSpeed,
-  EdgeModel,
   EdgeStyle,
-  GraphElement,
-  GraphModel,
   GRAPH_LAYOUT_END_EVENT,
-  Model,
   ModelKind,
-  Node,
-  NodeModel,
   SELECTION_STATE,
   TopologyControlBar,
   TopologyView,
@@ -23,51 +28,35 @@ import {
   Visualization,
   VisualizationProvider,
   VisualizationSurface,
-  Edge,
-  GraphAreaSelectedEventListener,
-  GRAPH_AREA_SELECTED_EVENT,
-  GraphLayoutEndEventListener
+  GRAPH_AREA_SELECTED_EVENT
 } from '@patternfly/react-topology';
-import {
-  BoxByType,
-  EdgeLabelMode,
-  EdgeMode,
-  FocusNode,
-  GraphLayout,
-  LayoutType,
-  NodeAttr,
-  NodeType,
-  RankMode,
-  RankResult,
-  SummaryData,
-  UNKNOWN
-} from 'types/Graph';
-import { JaegerTrace } from 'types/TracingInfo';
+import type { EdgeLabelMode, FocusNode, RankResult, SummaryData } from 'types/Graph';
+import { BoxByType, EdgeMode, GraphLayout, LayoutType, NodeAttr, NodeType, RankMode, UNKNOWN } from 'types/Graph';
+import type { JaegerTrace } from 'types/TracingInfo';
 import { stylesComponentFactory } from './components/stylesComponentFactory';
 import { elementFactory } from '../Graph/elements/elementFactory';
+import type { EdgeData, GraphSettings, NodeData } from './GraphElems';
 import {
   assignEdgeHealth,
-  EdgeData,
   getNodeShape,
   getNodeStatus,
-  GraphSettings,
-  NodeData,
   setEdgeOptions,
   setNodeAttachments,
   setNodeLabel
 } from './GraphElems';
-import { elems, selectAnd, SelectAnd, setObserved } from 'helpers/GraphHelpers';
+import type { SelectAnd } from 'helpers/GraphHelpers';
+import { elems, selectAnd, setObserved } from 'helpers/GraphHelpers';
 import { layoutFactory } from './layouts/layoutFactory';
 import { hideTrace, showTrace } from './Trace';
-import { TimeInMilliseconds } from 'types/Common';
+import type { TimeInMilliseconds } from 'types/Common';
 import { HistoryManager, URLParam } from 'app/History';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { getValidGraphLayout, supportsGroups } from 'utils/GraphUtils';
-import { GraphData, GraphRefs } from './GraphPage';
-import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
-import { ServiceDetailsInfo } from 'types/ServiceInfo';
-import { PeerAuthentication } from 'types/IstioObjects';
+import type { GraphData, GraphRefs } from './GraphPage';
+import type { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
+import type { ServiceDetailsInfo } from 'types/ServiceInfo';
+import type { PeerAuthentication } from 'types/IstioObjects';
 import { KialiIcon } from 'config/KialiIcon';
 import { toolbarActiveStyle } from 'styles/GraphStyle';
 import { scoreNodes, ScoringCriteria } from 'pages/Graph/GraphScore';
@@ -301,18 +290,7 @@ const TopologyContent: React.FC<{
     graphLayout(controller, LayoutType.Resize);
   }, [controller]);
 
-  const bodyRef = React.useRef<HTMLElement>(document.body);
-
-  useResizeDetector({
-    targetRef: bodyRef,
-    disableRerender: true,
-    refreshMode: 'debounce',
-    refreshRate: 100,
-    handleWidth: true,
-    handleHeight: true,
-    skipOnMount: true,
-    onResize: handleResize
-  });
+  useTopologyResize(handleResize);
 
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`TG: onLayoutEnd layoutInProgress=${layoutInProgress}`);
@@ -390,7 +368,7 @@ const TopologyContent: React.FC<{
     // Manage the GraphData / DataModel
     //
     const generateDataModel = (): { edges: EdgeModel[]; nodes: NodeModel[] } => {
-      let nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
+      const nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
       const edges: EdgeModel[] = [];
 
       const onHover = (element: GraphElement, isMouseIn: boolean): void => {
@@ -486,7 +464,7 @@ const TopologyContent: React.FC<{
       });
 
       // Compute rank result if enabled
-      let scoringCriteria: ScoringCriteria[] = [];
+      const scoringCriteria: ScoringCriteria[] = [];
 
       if (showRank) {
         for (const ranking of rankBy) {
@@ -499,8 +477,7 @@ const TopologyContent: React.FC<{
           }
         }
 
-        let upperBound = 0;
-        ({ upperBound } = scoreNodes(graphData.elements, ...scoringCriteria));
+        const { upperBound } = scoreNodes(graphData.elements, ...scoringCriteria);
 
         if (setRankResult) {
           setRankResult({ upperBound });
@@ -575,7 +552,7 @@ const TopologyContent: React.FC<{
       // pre-select node-graph node, only when elems have changed (like on first render, or a structural change)
       const graphNode = graphData.fetchParams.node;
       if (graphNode && graphData.elementsChanged) {
-        let selector: SelectAnd = [
+        const selector: SelectAnd = [
           { prop: NodeAttr.namespace, val: graphNode.namespace.name },
           { prop: NodeAttr.nodeType, val: graphNode.nodeType }
         ];

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -305,6 +305,7 @@ const TopologyContent: React.FC<{
 
   useResizeDetector({
     targetRef: bodyRef,
+    disableRerender: true,
     refreshMode: 'debounce',
     refreshRate: 100,
     handleWidth: true,

--- a/frontend/src/pages/Graph/Graph.tsx
+++ b/frontend/src/pages/Graph/Graph.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import {
   Controller,
   createTopologyControlButtons,
@@ -300,6 +300,18 @@ const TopologyContent: React.FC<{
   const handleResize = React.useCallback(() => {
     graphLayout(controller, LayoutType.Resize);
   }, [controller]);
+
+  const bodyRef = React.useRef<HTMLElement>(document.body);
+
+  useResizeDetector({
+    targetRef: bodyRef,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    handleWidth: true,
+    handleHeight: true,
+    skipOnMount: true,
+    onResize: handleResize
+  });
 
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`TG: onLayoutEnd layoutInProgress=${layoutInProgress}`);
@@ -743,28 +755,12 @@ const TopologyContent: React.FC<{
 
   return isMiniGraph ? (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView data-test="topology-view-pf">
         <VisualizationSurface data-test="visualization-surface" state={{}} />
       </TopologyView>
     </>
   ) : (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView
         data-test="topology-view-pf"
         controlBar={

--- a/frontend/src/pages/Graph/GraphHelpFind.tsx
+++ b/frontend/src/pages/Graph/GraphHelpFind.tsx
@@ -58,6 +58,7 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
 
   useResizeDetector({
     targetRef: bodyRef,
+    disableRerender: true,
     refreshMode: 'debounce',
     refreshRate: 100,
     skipOnMount: true,

--- a/frontend/src/pages/Graph/GraphHelpFind.tsx
+++ b/frontend/src/pages/Graph/GraphHelpFind.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -53,6 +53,18 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
   const onResize = (): void => {
     forceUpdate();
   };
+
+  const bodyRef = React.useRef<HTMLElement>(document.body);
+
+  useResizeDetector({
+    targetRef: bodyRef,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    skipOnMount: true,
+    handleWidth: true,
+    handleHeight: true,
+    onResize
+  });
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
@@ -217,15 +229,6 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
 
   return (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        skipOnMount={true}
-        handleWidth={true}
-        handleHeight={true}
-        onResize={onResize}
-      />
-
       {props.isVisible ? (
         <Popover
           data-test="graph-find-hide-help"

--- a/frontend/src/pages/Graph/GraphHelpFind.tsx
+++ b/frontend/src/pages/Graph/GraphHelpFind.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
-import { ThProps, IRow } from '@patternfly/react-table';
+import type { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { PFColors } from 'components/Pf/PfColors';
@@ -50,22 +50,11 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
   // Incrementing mock counter to force a re-render in React hooks
   const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  const onResize = (): void => {
+  const handleResize = (): void => {
     forceUpdate();
   };
 
-  const bodyRef = React.useRef<HTMLElement>(document.body);
-
-  useResizeDetector({
-    targetRef: bodyRef,
-    disableRerender: true,
-    refreshMode: 'debounce',
-    refreshRate: 100,
-    skipOnMount: true,
-    handleWidth: true,
-    handleHeight: true,
-    onResize
-  });
+  useTopologyResize(handleResize);
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -178,6 +178,7 @@ const TopologyContent: React.FC<{
 
   useResizeDetector({
     targetRef: bodyRef,
+    disableRerender: true,
     refreshMode: 'debounce',
     refreshRate: 100,
     handleWidth: true,

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import {
   Controller,
   createTopologyControlButtons,
@@ -173,6 +173,18 @@ const TopologyContent: React.FC<{
   const handleResize = React.useCallback(() => {
     layoutMesh(controller, MeshLayoutType.Resize);
   }, [controller]);
+
+  const bodyRef = React.useRef<HTMLElement>(document.body);
+
+  useResizeDetector({
+    targetRef: bodyRef,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    handleWidth: true,
+    handleHeight: true,
+    skipOnMount: true,
+    onResize: handleResize
+  });
 
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`onLayoutEnd layoutInProgress=${layoutInProgress}`);
@@ -477,14 +489,6 @@ const TopologyContent: React.FC<{
     </TopologyView>
   ) : (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView
         data-test="mesh-topology-view-pf"
         controlBar={

--- a/frontend/src/pages/Mesh/Mesh.tsx
+++ b/frontend/src/pages/Mesh/Mesh.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useResizeDetector } from 'react-resize-detector';
-import {
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
+import type {
   Controller,
+  EdgeModel,
+  GraphElement,
+  GraphModel,
+  Model,
+  Node,
+  NodeModel,
+  Edge,
+  GraphLayoutEndEventListener,
+  GraphAreaSelectedEventListener
+} from '@patternfly/react-topology';
+import {
   createTopologyControlButtons,
   defaultControlButtonsOptions,
   EdgeAnimationSpeed,
-  EdgeModel,
   EdgeStyle,
-  GraphElement,
-  GraphModel,
   GRAPH_LAYOUT_END_EVENT,
-  Model,
   ModelKind,
-  Node,
-  NodeModel,
   SELECTION_STATE,
   TopologyControlBar,
   TopologyView,
@@ -23,23 +28,20 @@ import {
   Visualization,
   VisualizationProvider,
   VisualizationSurface,
-  Edge,
-  GraphLayoutEndEventListener,
-  GraphAreaSelectedEventListener,
   GRAPH_AREA_SELECTED_EVENT
 } from '@patternfly/react-topology';
 import { elementFactory } from './elements/ElementFactory';
 import { getValidMeshLayout, layoutFactory, MeshLayoutType, MeshLayout } from './layouts/LayoutFactory';
-import { TimeInMilliseconds } from 'types/Common';
+import type { TimeInMilliseconds } from 'types/Common';
 import { HistoryManager, URLParam } from 'app/History';
 import { TourStop } from 'components/Tour/TourStop';
 import { meshComponentFactory } from './components/MeshComponentFactory';
-import { MeshData, MeshRefs } from './MeshPage';
-import { MeshInfraType, MeshTarget, MeshType } from 'types/Mesh';
+import type { MeshData, MeshRefs } from './MeshPage';
+import type { MeshTarget } from 'types/Mesh';
+import { MeshInfraType, MeshType } from 'types/Mesh';
 import { MeshHighlighter } from './MeshHighlighter';
+import type { EdgeData, NodeData } from './MeshElems';
 import {
-  EdgeData,
-  NodeData,
   assignEdgeHealth,
   getNodeShape,
   getNodeStatus,
@@ -174,18 +176,7 @@ const TopologyContent: React.FC<{
     layoutMesh(controller, MeshLayoutType.Resize);
   }, [controller]);
 
-  const bodyRef = React.useRef<HTMLElement>(document.body);
-
-  useResizeDetector({
-    targetRef: bodyRef,
-    disableRerender: true,
-    refreshMode: 'debounce',
-    refreshRate: 100,
-    handleWidth: true,
-    handleHeight: true,
-    skipOnMount: true,
-    onResize: handleResize
-  });
+  useTopologyResize(handleResize);
 
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`onLayoutEnd layoutInProgress=${layoutInProgress}`);
@@ -254,7 +245,7 @@ const TopologyContent: React.FC<{
     // Manage the GraphData / DataModel
     //
     const generateDataModel = (): { edges: EdgeModel[]; nodes: NodeModel[] } => {
-      let nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
+      const nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
       const edges: EdgeModel[] = [];
 
       const onHover = (element: GraphElement, isMouseIn: boolean): void => {
@@ -479,11 +470,6 @@ const TopologyContent: React.FC<{
 
   console.debug(`Render Topology hasGraph=${controller.hasGraph()}`);
 
-  // TODO: I expected to find some sort of "onResize" hook in PFT, but after looking at the code
-  // I ended up adding a ReactResizeDetector. It doesn't seem to work perfectly with PFT, but it's
-  // not terrible.  Later I found https://github.com/patternfly/react-topology/issues/62, which
-  // indicates that this is currently the way to go.  I added a suggestion there for some kind
-  // of hook or option, but it would be a future.
   return isMiniMesh ? (
     <TopologyView data-test="mesh-topology-view-pf">
       <VisualizationSurface data-test="mesh-visualization-surface" state={{}} />

--- a/frontend/src/pages/Mesh/MeshHelpFind.tsx
+++ b/frontend/src/pages/Mesh/MeshHelpFind.tsx
@@ -58,6 +58,7 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
 
   useResizeDetector({
     targetRef: bodyRef,
+    disableRerender: true,
     refreshMode: 'debounce',
     refreshRate: 100,
     skipOnMount: true,

--- a/frontend/src/pages/Mesh/MeshHelpFind.tsx
+++ b/frontend/src/pages/Mesh/MeshHelpFind.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
-import { ThProps, IRow } from '@patternfly/react-table';
+import type { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { PFColors } from 'components/Pf/PfColors';
@@ -50,22 +50,11 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
   // Incrementing mock counter to force a re-render in React hooks
   const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  const onResize = (): void => {
+  const handleResize = (): void => {
     forceUpdate();
   };
 
-  const bodyRef = React.useRef<HTMLElement>(document.body);
-
-  useResizeDetector({
-    targetRef: bodyRef,
-    disableRerender: true,
-    refreshMode: 'debounce',
-    refreshRate: 100,
-    skipOnMount: true,
-    handleWidth: true,
-    handleHeight: true,
-    onResize
-  });
+  useTopologyResize(handleResize);
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide mesh nodes and edges. Each field accepts ' +

--- a/frontend/src/pages/Mesh/MeshHelpFind.tsx
+++ b/frontend/src/pages/Mesh/MeshHelpFind.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -53,6 +53,18 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
   const onResize = (): void => {
     forceUpdate();
   };
+
+  const bodyRef = React.useRef<HTMLElement>(document.body);
+
+  useResizeDetector({
+    targetRef: bodyRef,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    skipOnMount: true,
+    handleWidth: true,
+    handleHeight: true,
+    onResize
+  });
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide mesh nodes and edges. Each field accepts ' +
@@ -153,15 +165,6 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
 
   return (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        skipOnMount={true}
-        handleWidth={true}
-        handleHeight={true}
-        onResize={onResize}
-      />
-
       {props.isVisible ? (
         <Popover
           data-test="mesh-find-hide-help"

--- a/frontend/src/utils/ResizeDetectorUtils.ts
+++ b/frontend/src/utils/ResizeDetectorUtils.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { useResizeDetector } from 'react-resize-detector';
+
+export const TOPOLOGY_GRAPH_CONTAINER_ID = 'pft-graph';
+export const TOPOLOGY_MESH_CONTAINER_ID = 'mesh-container';
+
+// Prefer over document.body — side panels resize these containers, not the body.
+// Falls back to document.body when neither container exists (e.g., non-topology pages).
+export const getTopologyResizeTarget = (): HTMLElement =>
+  document.getElementById(TOPOLOGY_GRAPH_CONTAINER_ID) ??
+  document.getElementById(TOPOLOGY_MESH_CONTAINER_ID) ??
+  document.body;
+
+export const useTopologyResize = (onResize: () => void): void => {
+  const resizeTargetRef = React.useRef<HTMLElement>(getTopologyResizeTarget());
+
+  useResizeDetector({
+    targetRef: resizeTargetRef,
+    disableRerender: true,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    skipOnMount: true,
+    handleWidth: true,
+    handleHeight: true,
+    onResize
+  });
+};

--- a/frontend/src/utils/__tests__/ResizeDetectorUtils.test.ts
+++ b/frontend/src/utils/__tests__/ResizeDetectorUtils.test.ts
@@ -1,0 +1,31 @@
+import {
+  getTopologyResizeTarget,
+  TOPOLOGY_GRAPH_CONTAINER_ID,
+  TOPOLOGY_MESH_CONTAINER_ID
+} from '../ResizeDetectorUtils';
+
+describe('getTopologyResizeTarget', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns the graph container when present', () => {
+    const el = document.createElement('div');
+    el.id = TOPOLOGY_GRAPH_CONTAINER_ID;
+    document.body.appendChild(el);
+
+    expect(getTopologyResizeTarget()).toBe(el);
+  });
+
+  it('falls back to mesh container when graph container is absent', () => {
+    const el = document.createElement('div');
+    el.id = TOPOLOGY_MESH_CONTAINER_ID;
+    document.body.appendChild(el);
+
+    expect(getTopologyResizeTarget()).toBe(el);
+  });
+
+  it('falls back to document.body when neither container exists', () => {
+    expect(getTopologyResizeTarget()).toBe(document.body);
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1739,7 +1739,7 @@ __metadata:
     react-flexview: "npm:4.0.3"
     react-i18next: "npm:^11.7.3"
     react-redux: "npm:7.2.2"
-    react-resize-detector: "npm:9.1.1"
+    react-resize-detector: "npm:12.3.0"
     react-router: "npm:5.3.x"
     react-router-dom: "npm:5.3.x"
     react-router-dom-v5-compat: "npm:^6.30.3"
@@ -6711,6 +6711,20 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.39.6":
+  version: 1.49.0
+  resolution: "es-toolkit@npm:1.49.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+    vitepress-plugin-sandpack@1.1.4:
+      unplugged: true
+  checksum: 10c0/ab0864bb0c5c494ed09043d53a74b58a0ab9df1b89b9b54bce72a63de2869152d7d65e489dc89ab671f0fea243728922c8a8f8c873f1b2a53350a23360b3e2df
   languageName: node
   linkType: hard
 
@@ -12109,15 +12123,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-detector@npm:9.1.1":
-  version: 9.1.1
-  resolution: "react-resize-detector@npm:9.1.1"
+"react-resize-detector@npm:12.3.0":
+  version: 12.3.0
+  resolution: "react-resize-detector@npm:12.3.0"
   dependencies:
-    lodash: "npm:^4.17.21"
+    es-toolkit: "npm:^1.39.6"
   peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/6a85892fe46a12fc27b09b5bf5fcc1438f3196f70c75d4685b09eed2c68a2c853dd6eb792bf852038082505a3b4f05dba359055ee0baca3f8b59f022a85a368c
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10c0/58075af4f7842debc97934bee15947d7ac1db1af8849832258fc986482487de97489d80b15edea6658260edbe826ac8f8acf6c2df2a28e527c8f63a4bff3436f
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1739,7 +1739,7 @@ __metadata:
     react-flexview: "npm:4.0.3"
     react-i18next: "npm:^11.7.3"
     react-redux: "npm:7.2.2"
-    react-resize-detector: "npm:12.3.0"
+    react-resize-detector: "npm:^12.3.0"
     react-router: "npm:5.3.x"
     react-router-dom: "npm:5.3.x"
     react-router-dom-v5-compat: "npm:^6.30.3"
@@ -12123,7 +12123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-detector@npm:12.3.0":
+"react-resize-detector@npm:^12.3.0":
   version: 12.3.0
   resolution: "react-resize-detector@npm:12.3.0"
   dependencies:


### PR DESCRIPTION
## What changed
Upgrades `react-resize-detector` from `9.1.1` to `12.3.0`.

Part of #9707.

## Why code changes were needed
v10+ removed the component-based API entirely, leaving only the
`useResizeDetector()` hook. Updated 5 files: `MeshHelpFind.tsx`,
`GraphHelpFind.tsx`, `Mesh.tsx`, `Graph.tsx`, `TourStop.tsx`.

## Notable decisions
- **`document.body` used as resize target** in 4 files, since the
  original target (implicit DOM parent) wasn't directly reachable.
  Safe since all `onResize` handlers are idempotent.
- **`TourStop.tsx`** is a class component, so hooks can't be used
  directly - added a small wrapper component that triggers
  `forceUpdate()` via a `ref`. Minor tradeoff: re-renders on every
  `TourStop` instance on resize, not just the active one (was
  guarded before). No visible behavior change, slightly more
  background work.
- **Peer dependency note:** v12.3.0 wants React 18+, Kiali is on
  React 17. Pre-existing in the tree already (`@patternfly/chatbot`
  and others already want React 18+) - not new here. Confirmed the
  hook only uses standard React 16.8+ APIs, so no runtime issue
  expected.

## Testing
- `yarn test`: 901 passed / 2 failed / 11 skipped - matches known
  baseline (unrelated pre-existing CRLF snapshot issue).
- `yarn lint`: 0 errors, same warning count as before this change.
- Checked the new transitive dep (`es-toolkit`) for vulnerabilities:
  none found.
- **Not tested:** live browser verification of Graph/Mesh resizing -
  no backend available in this environment to load those pages.

## AI disclosure
Per `AI_POLICY.md`, completed with AI assistance (Claude), disclosed
via the `Co-authored-by:` trailer on the commit.