### PR TITLE
[v2.27] CVE-2026-49978: Upgrade dompurify to 3.4.7+

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -186,6 +186,7 @@
     "typescript": "^5.9.0"
   },
   "resolutions": {
+    "dompurify": "^3.4.7",
     "esbuild": "^0.25.2",
     "js-cookie": "^3.0.8",
     "js-yaml@npm:3.14.0": "npm:3.15.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8678,27 +8678,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
+"dompurify@npm:^3.4.7":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "dompurify@npm:3.3.1"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of #10077 to v2.27.

DOMPurify prior to 3.4.7 has an IN_PLACE sanitization bypass via shadow contents in `<template>.content`, allowing attacker-controlled markup to survive and execute (XSS).

Add a resolutions entry to force dompurify >= 3.4.7.

Made with [Cursor](https://cursor.com)