### PR TITLE
Allow warning notifications to be shown once

### DIFF
--- a/frontend/src/utils/AlertUtils.ts
+++ b/frontend/src/utils/AlertUtils.ts
@@ -36,6 +36,13 @@ const addMessage = (msg: Message): void => {
   );
 };
 
+const hasMessage = (content: string, type: MessageType): boolean =>
+  store
+    .getState()
+    .notificationCenter.groups.some(
+      group => group.id === getMessageTypeGroup(type) && group.messages.some(message => message.content === content)
+    );
+
 // addDanger adds a Danger level notification message. Defaults: detail='', isAlert=true
 export const addDanger = (content: string, detail = '', isAlert = true): void => {
   store.dispatch(
@@ -49,8 +56,13 @@ export const addDanger = (content: string, detail = '', isAlert = true): void =>
   );
 };
 
-// addWarning adds a Warning level notification message. Defaults: detail='', isAlert=true
-export const addWarning = (content: string, detail = '', isAlert = true): void => {
+// addWarning adds a Warning level notification message.
+// Defaults: detail='', isAlert=true, showOnce=false
+export const addWarning = (content: string, detail = '', isAlert = true, showOnce = false): void => {
+  if (showOnce && hasMessage(content, MessageType.WARNING)) {
+    return;
+  }
+
   store.dispatch(
     NotificationCenterActions.addMessage(
       content,

--- a/frontend/src/utils/__tests__/AlertUtils.test.ts
+++ b/frontend/src/utils/__tests__/AlertUtils.test.ts
@@ -1,0 +1,62 @@
+import { NotificationCenterActions } from '../../actions/NotificationCenterActions';
+import { store } from '../../store/ConfigStore';
+import { MessageType } from '../../types/NotificationCenter';
+import { addWarning } from '../AlertUtils';
+
+describe('AlertUtils', () => {
+  afterEach(() => {
+    rstest.restoreAllMocks();
+  });
+
+  it('does not dispatch a duplicate warning when showOnce is enabled', () => {
+    rstest.spyOn(store, 'getState').mockReturnValue({
+      notificationCenter: {
+        groups: [
+          {
+            id: MessageType.WARNING,
+            messages: [{ content: 'Tracing configuration warning' }]
+          }
+        ]
+      }
+    } as any);
+    const dispatch = rstest.spyOn(store, 'dispatch');
+
+    addWarning('Tracing configuration warning', '', true, true);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches when showOnce is disabled', () => {
+    const dispatch = rstest.spyOn(store, 'dispatch');
+
+    addWarning('Repeated warning');
+
+    expect(dispatch).toHaveBeenCalledWith(
+      NotificationCenterActions.addMessage(
+        'Repeated warning',
+        '',
+        MessageType.WARNING,
+        MessageType.WARNING,
+        true
+      )
+    );
+  });
+
+  it('dispatches a show-once warning when no matching warning exists', () => {
+    rstest.spyOn(store, 'getState').mockReturnValue({
+      notificationCenter: {
+        groups: [
+          {
+            id: MessageType.INFO,
+            messages: [{ content: 'Tracing configuration warning' }]
+          }
+        ]
+      }
+    } as any);
+    const dispatch = rstest.spyOn(store, 'dispatch');
+
+    addWarning('Tracing configuration warning', '', true, true);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add an optional `showOnce` parameter to `addWarning`
- skip repeat warning dispatches when an identical warning already exists
- preserve existing warning behavior by default
- add regression tests for deduplicated and normal warning dispatches

## Validation

- targeted AlertUtils unit tests
- existing callers remain source-compatible because `showOnce` defaults to `false`

Fixes #6817