### PR TITLE
Add Release MCP workflow for quay.io/kiali/kiali_mcp

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -160,7 +160,6 @@ jobs:
     permissions:
       contents: read
     name: Build and push image
-    if: ${{ github.repository == 'kiali/kiali' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: [initialize, build_backend]
     env:
@@ -171,6 +170,11 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ needs.initialize.outputs.release_branch }}
+
+    - name: Set version for image build
+      run: |
+        # Embed the calculated Quay release version in the binary (do not commit).
+        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,208 @@
+name: Release MCP
+
+# Builds the Kiali image from a release branch and publishes it to
+# quay.io/kiali/kiali_mcp. Versioning is derived from existing Quay tags for
+# that branch line (e.g. v2.27 -> next patch v2.27.N). Tags pushed:
+#   - vX.Y.Z-<git-sha>    (immutable/traceable release version with short git sha)
+#   - vX.Y                (floating minor/branch line — overwrites on each publish)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: Release branch to publish from (e.g. v2.27)
+        required: true
+        default: v2.27
+        type: choice
+        options:
+        - v2.27
+        - v2.22
+        - v2.17
+        - v2.11
+        - v2.4
+      quay_repository:
+        description: Quay repository
+        type: string
+        default: quay.io/kiali/kiali_mcp
+        required: true
+
+permissions: read-all
+
+jobs:
+  initialize:
+    permissions:
+      contents: read
+    name: Initialize
+    runs-on: ubuntu-latest
+    outputs:
+      release_branch: ${{ steps.versions.outputs.release_branch }}
+      release_version: ${{ steps.versions.outputs.release_version }}
+      quay_tag: ${{ steps.versions.outputs.quay_tag }}
+      git_sha: ${{ steps.versions.outputs.git_sha }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ github.event.inputs.release_branch }}
+
+    - name: Determine next Quay version
+      id: versions
+      env:
+        RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
+        QUAY_REPOSITORY: ${{ github.event.inputs.quay_repository }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! "${RELEASE_BRANCH}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+          echo "release_branch must match vX.Y (got: ${RELEASE_BRANCH})"
+          exit 1
+        fi
+
+        if [ -z "${QUAY_REPOSITORY}" ]; then
+          QUAY_REPOSITORY="quay.io/kiali/kiali_mcp"
+        fi
+
+        # quay.io/org/repo -> org/repo for the Quay API
+        QUAY_PATH="${QUAY_REPOSITORY#quay.io/}"
+
+        GIT_SHA="$(git rev-parse --short=7 HEAD)"
+
+        cat <<-EOF > next_version.py
+        import json
+        import re
+        import sys
+        import urllib.error
+        import urllib.request
+
+        branch = sys.argv[1]
+        quay_path = sys.argv[2]
+        # Match bare vX.Y.Z and sha-suffixed vX.Y.Z-<sha> (and any -suffix)
+        pattern = re.compile(rf"^{re.escape(branch)}\.(\d+)(-|$)")
+
+        tags = []
+        page = 1
+        while True:
+            url = (
+                f"https://quay.io/api/v1/repository/{quay_path}/tag/"
+                f"?page={page}&limit=100&onlyActiveTags=true"
+            )
+            try:
+                with urllib.request.urlopen(url) as resp:
+                    payload = json.load(resp)
+            except urllib.error.HTTPError as err:
+                if err.code == 404:
+                    payload = {"tags": [], "has_additional": False}
+                else:
+                    raise
+
+            tags.extend(t.get("name", "") for t in payload.get("tags", []))
+            if not payload.get("has_additional"):
+                break
+            page += 1
+
+        max_patch = -1
+        for name in tags:
+            match = pattern.match(name)
+            if match:
+                max_patch = max(max_patch, int(match.group(1)))
+
+        next_patch = 0 if max_patch < 0 else max_patch + 1
+        print(f"{branch}.{next_patch}")
+        EOF
+
+        RELEASE_VERSION="$(python next_version.py "${RELEASE_BRANCH}" "${QUAY_PATH}")"
+        TRACE_TAG="${RELEASE_VERSION}-${GIT_SHA}"
+        QUAY_TAG="${QUAY_REPOSITORY}:${TRACE_TAG} ${QUAY_REPOSITORY}:${RELEASE_BRANCH}"
+
+        {
+          echo "release_branch=${RELEASE_BRANCH}"
+          echo "release_version=${RELEASE_VERSION}"
+          echo "git_sha=${GIT_SHA}"
+          echo "quay_tag=${QUAY_TAG}"
+        } >> "${GITHUB_OUTPUT}"
+
+        {
+          echo "### Release MCP"
+          echo ""
+          echo "| | |"
+          echo "|---|---|"
+          echo "| Branch | \`${RELEASE_BRANCH}\` |"
+          echo "| Commit | \`${GIT_SHA}\` |"
+          echo "| Version | \`${RELEASE_VERSION}\` |"
+          echo "| Trace tag | \`${TRACE_TAG}\` |"
+          echo "| Branch tag | \`${RELEASE_BRANCH}\` |"
+          echo "| Quay | \`${QUAY_REPOSITORY}\` |"
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        echo "Release branch: ${RELEASE_BRANCH}"
+        echo "Git SHA: ${GIT_SHA}"
+        echo "Release version: ${RELEASE_VERSION}"
+        echo "Quay tags: ${QUAY_TAG}"
+
+        rm -f next_version.py
+
+  build_frontend:
+    name: Build frontend
+    uses: ./.github/workflows/build-frontend.yml
+    needs: [initialize]
+    with:
+      target_branch: ${{ needs.initialize.outputs.release_branch }}
+      build_branch: ${{ needs.initialize.outputs.release_branch }}
+
+  build_backend:
+    name: Build backend
+    uses: ./.github/workflows/build-backend.yml
+    needs: [initialize, build_frontend]
+    with:
+      build_branch: ${{ needs.initialize.outputs.release_branch }}
+
+  publish:
+    permissions:
+      contents: read
+    name: Build and push image
+    if: ${{ github.repository == 'kiali/kiali' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    needs: [initialize, build_backend]
+    env:
+      QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
+      RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.initialize.outputs.release_branch }}
+
+    - name: Set up Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Download frontend build
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: build
+        path: frontend/build
+
+    - name: Login to Quay.io
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build and push image
+      run: make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
+
+    - name: Summarize published tags
+      run: |
+        {
+          echo "### Published tags"
+          echo ""
+          echo "Image version \`${RELEASE_VERSION}\` pushed with:"
+          echo ""
+          for tag in ${QUAY_TAG}; do
+            echo "- \`${tag}\`"
+          done
+        } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       release_branch: ${{ steps.versions.outputs.release_branch }}
       release_version: ${{ steps.versions.outputs.release_version }}
+      quay_name: ${{ steps.versions.outputs.quay_name }}
       quay_tag: ${{ steps.versions.outputs.quay_tag }}
       git_sha: ${{ steps.versions.outputs.git_sha }}
     steps:
@@ -115,6 +116,7 @@ jobs:
           echo "release_branch=${RELEASE_BRANCH}"
           echo "release_version=${RELEASE_VERSION}"
           echo "git_sha=${GIT_SHA}"
+          echo "quay_name=${QUAY_REPOSITORY}"
           echo "quay_tag=${QUAY_TAG}"
         } >> "${GITHUB_OUTPUT}"
 
@@ -160,6 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [initialize, build_backend]
     env:
+      QUAY_NAME: ${{ needs.initialize.outputs.quay_name }}
       QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
     steps:
@@ -193,8 +196,13 @@ jobs:
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    # QUAY_NAME/QUAY_TAG override Makefile defaults (CONTAINER_NAME/kiali).
     - name: Build and push image
-      run: make -e DOCKER_CLI_EXPERIMENTAL=enabled build-linux-multi-arch container-multi-arch-all-push-kiali-quay
+      run: |
+        make -e DOCKER_CLI_EXPERIMENTAL=enabled \
+          QUAY_NAME="${QUAY_NAME}" \
+          QUAY_TAG="${QUAY_TAG}" \
+          build-linux-multi-arch container-multi-arch-all-push-kiali-quay
 
     - name: Summarize published tags
       run: |

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -17,9 +17,6 @@ on:
         options:
         - v2.27
         - v2.22
-        - v2.17
-        - v2.11
-        - v2.4
       quay_repository:
         description: Quay repository
         type: string


### PR DESCRIPTION
## Summary
- Add a new manual `Release MCP` workflow that builds Kiali from a selected release branch and publishes to quay.io/kiali/kiali_mcp
- Auto-bumps patch from existing Quay tags for that line (e.g. v2.27 → v2.27.0, then v2.27.1, ...)
- Pushes two tags to the same digest: `vX.Y.Z-<sha7>` (traceable) and floating `vX.Y`

## Test plan
- [ ] Run Actions → Release MCP with branch `v2.27` against an empty/test Quay repo (or quay.io/kiali/kiali_mcp)
- [ ] Confirm tags `v2.27.0-<sha>` and `v2.27` appear
- [ ] Re-run and confirm next patch is `v2.27.1-<sha>` and `v2.27` is updated

Ref. #10086  

Made with [Cursor](https://cursor.com)