### PR TITLE
Add consistent API query parameter validation (409 Conflict)

### DIFF
--- a/handlers/ai.go
+++ b/handlers/ai.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
 	"github.com/kiali/kiali/handlers/authentication"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -148,7 +149,12 @@ func ChatPrompts(conf *config.Config, kialiCache cache.KialiCache, clientFactory
 
 		ambientEnabled := kialiCache.IsAmbientEnabledInAnyCluster(accessibleClusterNames(clientFactory))
 
-		category := r.URL.Query().Get("category")
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "category"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+		category := query.Get("category")
 		catalog := prompts.Catalog()
 		filtered := make([]prompts.Prompt, 0, len(catalog))
 		for _, p := range catalog {
@@ -341,9 +347,14 @@ func DeleteConversations(conf *config.Config, aiStore aiTypes.AIStore) http.Hand
 			return
 		}
 
-		idsParam := r.URL.Query().Get("conversationIDs")
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "conversationIDs"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+		idsParam := query.Get("conversationIDs")
 		if idsParam == "" {
-			RespondWithError(w, http.StatusBadRequest, "Missing required query parameter: conversationIDs")
+			RespondWithQueryParamError(w, "Missing required query parameter: conversationIDs")
 			return
 		}
 
@@ -355,7 +366,7 @@ func DeleteConversations(conf *config.Config, aiStore aiTypes.AIStore) http.Hand
 			}
 		}
 		if len(ids) == 0 {
-			RespondWithError(w, http.StatusBadRequest, "No valid conversation IDs provided")
+			RespondWithQueryParamError(w, "No valid conversation IDs provided")
 			return
 		}
 

--- a/handlers/ai_test.go
+++ b/handlers/ai_test.go
@@ -958,7 +958,7 @@ func TestDeleteConversations_MissingParam(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { resp.Body.Close() })
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 }
 
 func TestDeleteConversations_StoreDisabled(t *testing.T) {

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -12,6 +11,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -31,22 +31,25 @@ type appParams struct {
 	IncludeIstioResources bool `json:"istioResources"`
 }
 
-func (p *appParams) extract(r *http.Request, conf *config.Config) {
+func (p *appParams) extract(r *http.Request, conf *config.Config) error {
 	vars := mux.Vars(r)
 	query := r.URL.Query()
-	p.baseExtract(conf, r)
+	if err := p.baseExtract(conf, r, "clusterName", "health", "istioResources", "namespaces", "queryTime", "rateInterval"); err != nil {
+		return err
+	}
 	p.Namespace = vars["namespace"]
-	p.ClusterName = clusterNameFromQuery(conf, query)
 	p.AppName = vars["app"]
+
 	var err error
-	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
+	p.IncludeHealth, err = queryparams.ParseBoolParam(query.Get("health"), "health", true)
 	if err != nil {
-		p.IncludeHealth = true
+		return err
 	}
-	p.IncludeIstioResources, err = strconv.ParseBool(query.Get("istioResources"))
+	p.IncludeIstioResources, err = queryparams.ParseBoolParam(query.Get("istioResources"), "istioResources", true)
 	if err != nil {
-		p.IncludeIstioResources = true
+		return err
 	}
+	return nil
 }
 
 // ClusterApps is the API handler to fetch all the apps to be displayed, related to a single cluster
@@ -65,7 +68,10 @@ func ClusterApps(
 		query := r.URL.Query()
 		namespacesQueryParam := query.Get("namespaces") // csl of namespaces
 		p := appParams{}
-		p.extract(r, conf)
+		if err := p.extract(r, conf); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		businessLayer, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -134,7 +140,10 @@ func AppDetails(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		p := appParams{}
-		p.extract(r, conf)
+		if err := p.extract(r, conf); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		criteria := business.AppCriteria{
 			Namespace: p.Namespace, AppName: p.AppName, IncludeIstioResources: true, IncludeHealth: p.IncludeHealth,

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+
+	"github.com/kiali/kiali/handlers/queryparams"
 )
 
 const maxRequestBodyBytes int64 = 10 * 1024 * 1024 // 10 MB
@@ -58,6 +60,11 @@ func RespondWithJSONIndent(w http.ResponseWriter, code int, payload interface{})
 
 func RespondWithError(w http.ResponseWriter, code int, message string) {
 	RespondWithJSON(w, code, responseError{Error: message})
+}
+
+// RespondWithQueryParamError returns a 409 response for invalid or unsupported query parameters.
+func RespondWithQueryParamError(w http.ResponseWriter, message string) {
+	RespondWithError(w, queryparams.ErrorStatusCode, message)
 }
 
 func RespondWithDetailedError(w http.ResponseWriter, code int, message, detail string) {

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -52,7 +53,7 @@ func CustomDashboard(
 		params := models.DashboardQuery{Namespace: namespace}
 		err = extractDashboardQueryParams(queryParams, &params, info)
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -89,6 +90,17 @@ func CustomDashboard(
 }
 
 func extractDashboardQueryParams(queryParams url.Values, q *models.DashboardQuery, namespaceInfo *models.Namespace) error {
+	allowed := append([]string{
+		"additionalLabels",
+		"clusterName",
+		"labelsFilters",
+		"rawDataAggregator",
+		"workload",
+	}, baseMetricsQueryParams...)
+	if err := queryparams.RejectUnknown(queryParams, allowed...); err != nil {
+		return err
+	}
+
 	q.FillDefaults()
 	q.LabelsFilters = extractLabelsFilters(queryParams.Get("labelsFilters"))
 	additionalLabels := strings.Split(queryParams.Get("additionalLabels"), ",")
@@ -145,7 +157,7 @@ func AppDashboard(
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, App: app}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -193,7 +205,7 @@ func ServiceDashboard(
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Service: service}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -242,7 +254,7 @@ func WorkloadDashboard(
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Workload: workload}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -284,7 +296,7 @@ func ZtunnelDashboard(
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
 
 		if err := extractIstioMetricsQueryParams(r, &params, oldestNs); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -96,6 +96,7 @@ func extractDashboardQueryParams(queryParams url.Values, q *models.DashboardQuer
 		"labelsFilters",
 		"rawDataAggregator",
 		"workload",
+		"workloadType",
 	}, baseMetricsQueryParams...)
 	if err := queryparams.RejectUnknown(queryParams, allowed...); err != nil {
 		return err

--- a/handlers/dashboards_test.go
+++ b/handlers/dashboards_test.go
@@ -13,9 +13,7 @@ import (
 func TestExtractEmptyDashboardQueryParams(t *testing.T) {
 	assert := assert.New(t)
 
-	queryParams := url.Values{
-		"": []string{""},
-	}
+	queryParams := url.Values{}
 
 	params := models.DashboardQuery{Namespace: "test"}
 	err := extractDashboardQueryParams(queryParams, &params, buildNamespace("ns", time.Time{}))

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -42,18 +42,21 @@ func ClusterHealth(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
+		if err := queryparams.RejectUnknown(params, "clusterName", "namespaces", "rateInterval", "type"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+
 		namespaces := params.Get("namespaces") // csl of namespaces
 		nss := []string{}
 		if len(namespaces) > 0 {
 			nss = strings.Split(namespaces, ",")
 		}
-		cluster := clusterNameFromQuery(conf, params)
+		cluster := queryparams.ClusterName(conf, params)
 
-		// Extract health type from query params
-		// If type is not specified, we'll fetch all types (app, service, workload)
 		healthType := params.Get("type")
-		if healthType != "" && healthType != "app" && healthType != "service" && healthType != "workload" {
-			RespondWithError(w, http.StatusBadRequest, "Bad request, query parameter 'type' must be one of ['app','service','workload']")
+		if err := queryparams.ValidateEnum(healthType, "type", "app", "service", "workload"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -86,6 +89,9 @@ func ClusterHealth(
 		rateInterval := params.Get("rateInterval")
 		if rateInterval == "" {
 			rateInterval = config.DefaultHealthRateInterval
+		} else if err := queryparams.ValidatePromDuration(rateInterval, "rateInterval"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
 		}
 		result, healthCachedHeader, err := businessLayer.Health.GetNamespaceHealth(r.Context(), nss, cluster, healthTypes, rateInterval)
 		if err != nil {
@@ -94,38 +100,6 @@ func ClusterHealth(
 		}
 		w.Header().Set(HealthCachedHeader, healthCachedHeader)
 		RespondWithJSON(w, http.StatusOK, result)
-	}
-}
-
-type baseHealthParams struct {
-	// Cluster name
-	ClusterName string `json:"clusterName"`
-	// The namespace scope
-	//
-	// in: path
-	Namespace string `json:"namespace"`
-	// The rate interval used for fetching error rate
-	//
-	// in: query
-	// default: 5m (matches health_config.compute.duration)
-	RateInterval string `json:"rateInterval"`
-	// The time to use for the prometheus query
-	QueryTime time.Time
-}
-
-func (p *baseHealthParams) baseExtract(conf *config.Config, r *http.Request) {
-	queryParams := r.URL.Query()
-	p.RateInterval = config.DefaultHealthRateInterval
-	p.QueryTime = util.Clock.Now()
-	if rateInterval := queryParams.Get("rateInterval"); rateInterval != "" {
-		p.RateInterval = rateInterval
-	}
-	p.ClusterName = clusterNameFromQuery(conf, queryParams)
-	if queryTime := queryParams.Get("queryTime"); queryTime != "" {
-		unix, err := strconv.ParseInt(queryTime, 10, 64)
-		if err == nil {
-			p.QueryTime = time.Unix(unix, 0)
-		}
 	}
 }
 

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -42,7 +42,7 @@ func ClusterHealth(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
-		if err := queryparams.RejectUnknown(params, "clusterName", "namespaces", "rateInterval", "type"); err != nil {
+		if err := queryparams.RejectUnknown(params, "clusterName", "namespaces", "queryTime", "rateInterval", "type"); err != nil {
 			RespondWithQueryParamError(w, err.Error())
 			return
 		}

--- a/handlers/health_params.go
+++ b/handlers/health_params.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers/queryparams"
+	"github.com/kiali/kiali/util"
+)
+
+type baseHealthParams struct {
+	// Cluster name
+	ClusterName string `json:"clusterName"`
+	// The namespace scope
+	//
+	// in: path
+	Namespace string `json:"namespace"`
+	// The rate interval used for fetching error rate
+	//
+	// in: query
+	// default: 5m (matches health_config.compute.duration)
+	RateInterval string `json:"rateInterval"`
+	// The time to use for the prometheus query
+	QueryTime time.Time
+}
+
+func (p *baseHealthParams) parse(conf *config.Config, queryParams url.Values) error {
+	p.RateInterval = config.DefaultHealthRateInterval
+	p.QueryTime = util.Clock.Now()
+	if rateInterval := queryParams.Get("rateInterval"); rateInterval != "" {
+		if err := queryparams.ValidatePromDuration(rateInterval, "rateInterval"); err != nil {
+			return err
+		}
+		p.RateInterval = rateInterval
+	}
+	p.ClusterName = queryparams.ClusterName(conf, queryParams)
+	if queryTime := queryParams.Get("queryTime"); queryTime != "" {
+		parsed, err := queryparams.ParseQueryTime(queryTime)
+		if err != nil {
+			return err
+		}
+		p.QueryTime = parsed
+	}
+	return nil
+}
+
+// baseExtract parses common health-related query parameters after validating the allowed set.
+func (p *baseHealthParams) baseExtract(conf *config.Config, r *http.Request, allowed ...string) error {
+	queryParams := r.URL.Query()
+	if err := queryparams.RejectUnknown(queryParams, allowed...); err != nil {
+		return err
+	}
+	return p.parse(conf, queryParams)
+}

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -319,6 +319,19 @@ func TestClustersHealthUnknownParam(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 }
 
+// TestClustersHealthAllowsQueryTime ensures the UI cache-bust/replay queryTime param is accepted.
+func TestClustersHealthAllowsQueryTime(t *testing.T) {
+	kubeObjects := []runtime.Object{fakeService("ns", "reviews"), setupMockData()}
+	k8s := kubetest.NewFakeK8sClient(kubeObjects...)
+	k8s.OpenShift = true
+	ts, _ := setupClustersHealthEndpoint(t, k8s)
+
+	url := ts.URL + "/api/clusters/health?namespaces=ns&type=app&queryTime=1523364061"
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 // TestClustersHealthPartialCacheMiss tests scenario where some namespaces are cached and some are not
 func TestClustersHealthPartialCacheMiss(t *testing.T) {
 	kubeObjects := []runtime.Object{fakeService("ns", "reviews"), fakeService("ns2", "httpbin"), setupMockData(), setupMockNamespace("ns2")}

--- a/handlers/health_test.go
+++ b/handlers/health_test.go
@@ -302,7 +302,21 @@ func TestClustersHealthInvalidType(t *testing.T) {
 	resp, err := http.Get(url)
 	require.NoError(t, err)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+// TestClustersHealthUnknownParam tests that unsupported query parameters are rejected.
+func TestClustersHealthUnknownParam(t *testing.T) {
+	kubeObjects := []runtime.Object{fakeService("ns", "reviews"), setupMockData()}
+	k8s := kubetest.NewFakeK8sClient(kubeObjects...)
+	k8s.OpenShift = true
+	ts, _ := setupClustersHealthEndpoint(t, k8s)
+
+	url := ts.URL + "/api/clusters/health?foo=bar"
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 }
 
 // TestClustersHealthPartialCacheMiss tests scenario where some namespaces are cached and some are not

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -36,33 +35,20 @@ func IstioConfigList(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		query := r.URL.Query()
-		objects := ""
+
+		listParams, err := parseIstioConfigListParams(conf, query)
+		if respondQueryParamError(w, err) {
+			return
+		}
+
 		parsedTypes := make([]string, 0)
-		if _, ok := query["objects"]; ok {
-			objects = query.Get("objects")
-			if len(objects) > 0 {
-				parsedTypes = strings.Split(objects, ";")
-			}
+		if len(listParams.Objects) > 0 {
+			parsedTypes = strings.Split(listParams.Objects, ";")
 		}
 
-		includeValidations, _ := strconv.ParseBool(query.Get("validate"))
-
-		labelSelector := ""
-		if _, found := query["labelSelector"]; found {
-			labelSelector = query.Get("labelSelector")
-		}
-
-		workloadSelector := ""
-		if _, found := query["workloadSelector"]; found {
-			workloadSelector = query.Get("workloadSelector")
-		}
-
-		cluster := clusterNameFromQuery(conf, query)
-		if !conf.IsValidationsEnabled() {
-			includeValidations = false
-		}
-
-		criteria := business.ParseIstioConfigCriteria(objects, labelSelector, workloadSelector)
+		criteria := business.ParseIstioConfigCriteria(listParams.Objects, listParams.LabelSelector, listParams.WorkloadSelector)
+		cluster := listParams.ClusterName
+		includeValidations := listParams.IncludeValidations
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -122,17 +108,14 @@ func IstioConfigDetails(
 		object := params["object"]
 
 		query := r.URL.Query()
-		includeValidations, _ := strconv.ParseBool(query.Get("validate"))
-
-		includeHelp := false
-		if _, found := query["help"]; found {
-			includeHelp = true
+		detailsParams, err := parseIstioConfigDetailsParams(conf, query)
+		if respondQueryParamError(w, err) {
+			return
 		}
 
-		cluster := clusterNameFromQuery(conf, query)
-		if !conf.IsValidationsEnabled() {
-			includeValidations = false
-		}
+		cluster := detailsParams.ClusterName
+		includeValidations := detailsParams.IncludeValidations
+		includeHelp := detailsParams.IncludeHelp
 
 		gvk := schema.GroupVersionKind{
 			Group:   objectGroup,
@@ -234,7 +217,10 @@ func IstioConfigDelete(
 		object := params["object"]
 
 		query := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, query)
+		cluster, err := parseIstioConfigClusterParams(conf, query)
+		if respondQueryParamError(w, err) {
+			return
+		}
 
 		gvk := schema.GroupVersionKind{
 			Group:   objectGroup,
@@ -283,7 +269,10 @@ func IstioConfigUpdate(
 		object := params["object"]
 
 		query := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, query)
+		cluster, err := parseIstioConfigClusterParams(conf, query)
+		if respondQueryParamError(w, err) {
+			return
+		}
 
 		gvk := schema.GroupVersionKind{
 			Group:   objectGroup,
@@ -339,7 +328,10 @@ func IstioConfigCreate(
 		objectKind := params["kind"]
 
 		query := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, query)
+		cluster, err := parseIstioConfigClusterParams(conf, query)
+		if respondQueryParamError(w, err) {
+			return
+		}
 
 		gvk := schema.GroupVersionKind{
 			Group:   objectGroup,
@@ -406,8 +398,10 @@ func IstioConfigPermissions(
 
 		// query params
 		params := r.URL.Query()
-		namespaces := params.Get("namespaces") // csl of namespaces
-		cluster := clusterNameFromQuery(conf, params)
+		cluster, namespaces, err := parseIstioConfigNamespacesParams(conf, params)
+		if respondQueryParamError(w, err) {
+			return
+		}
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -444,12 +438,14 @@ func IstioConfigValidationSummary(
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		params := r.URL.Query()
-		namespaces := params.Get("namespaces") // csl of namespaces
+		cluster, namespaces, err := parseIstioConfigNamespacesParams(conf, params)
+		if respondQueryParamError(w, err) {
+			return
+		}
 		nss := []string{}
 		if len(namespaces) > 0 {
 			nss = strings.Split(namespaces, ",")
 		}
-		cluster := clusterNameFromQuery(conf, params)
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {

--- a/handlers/istio_config_params.go
+++ b/handlers/istio_config_params.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers/queryparams"
+)
+
+type istioConfigListParams struct {
+	ClusterName        string
+	IncludeValidations bool
+	LabelSelector      string
+	Objects            string
+	WorkloadSelector   string
+}
+
+func parseIstioConfigListParams(conf *config.Config, query url.Values) (istioConfigListParams, error) {
+	if err := queryparams.RejectUnknown(query, "clusterName", "labelSelector", "objects", "validate", "workloadSelector"); err != nil {
+		return istioConfigListParams{}, err
+	}
+
+	includeValidations, err := queryparams.ParseBoolParam(query.Get("validate"), "validate", false)
+	if err != nil {
+		return istioConfigListParams{}, err
+	}
+	if !conf.IsValidationsEnabled() {
+		includeValidations = false
+	}
+
+	return istioConfigListParams{
+		ClusterName:        queryparams.ClusterName(conf, query),
+		IncludeValidations: includeValidations,
+		LabelSelector:      query.Get("labelSelector"),
+		Objects:            query.Get("objects"),
+		WorkloadSelector:   query.Get("workloadSelector"),
+	}, nil
+}
+
+type istioConfigDetailsParams struct {
+	ClusterName        string
+	IncludeHelp        bool
+	IncludeValidations bool
+}
+
+func parseIstioConfigDetailsParams(conf *config.Config, query url.Values) (istioConfigDetailsParams, error) {
+	if err := queryparams.RejectUnknown(query, "clusterName", "help", "validate"); err != nil {
+		return istioConfigDetailsParams{}, err
+	}
+
+	includeValidations, err := queryparams.ParseBoolParam(query.Get("validate"), "validate", false)
+	if err != nil {
+		return istioConfigDetailsParams{}, err
+	}
+	if !conf.IsValidationsEnabled() {
+		includeValidations = false
+	}
+
+	_, includeHelp := query["help"]
+	return istioConfigDetailsParams{
+		ClusterName:        queryparams.ClusterName(conf, query),
+		IncludeHelp:        includeHelp,
+		IncludeValidations: includeValidations,
+	}, nil
+}
+
+func parseIstioConfigClusterParams(conf *config.Config, query url.Values) (string, error) {
+	if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+		return "", err
+	}
+	return queryparams.ClusterName(conf, query), nil
+}
+
+func parseIstioConfigNamespacesParams(conf *config.Config, query url.Values) (cluster, namespaces string, err error) {
+	if err := queryparams.RejectUnknown(query, "clusterName", "namespaces"); err != nil {
+		return "", "", err
+	}
+	return queryparams.ClusterName(conf, query), query.Get("namespaces"), nil
+}
+
+func respondQueryParamError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+	RespondWithQueryParamError(w, err.Error())
+	return true
+}

--- a/handlers/istio_config_params.go
+++ b/handlers/istio_config_params.go
@@ -17,7 +17,7 @@ type istioConfigListParams struct {
 }
 
 func parseIstioConfigListParams(conf *config.Config, query url.Values) (istioConfigListParams, error) {
-	if err := queryparams.RejectUnknown(query, "clusterName", "labelSelector", "objects", "validate", "workloadSelector"); err != nil {
+	if err := queryparams.RejectUnknown(query, "_", "clusterName", "labelSelector", "objects", "validate", "workloadSelector"); err != nil {
 		return istioConfigListParams{}, err
 	}
 

--- a/handlers/istio_config_params_test.go
+++ b/handlers/istio_config_params_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/config"
+)
+
+func TestParseIstioConfigListParamsUnknownParam(t *testing.T) {
+	conf := config.NewConfig()
+	query := url.Values{}
+	query.Set("objects", "virtualservices")
+	query.Set("foo", "bar")
+
+	_, err := parseIstioConfigListParams(conf, query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported query parameter 'foo'")
+}
+
+func TestParseIstioConfigListParamsInvalidValidate(t *testing.T) {
+	conf := config.NewConfig()
+	query := url.Values{}
+	query.Set("validate", "maybe")
+
+	_, err := parseIstioConfigListParams(conf, query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validate")
+}

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -50,6 +50,7 @@ var istioMetricsQueryParams = []string{
 	"direction",
 	"duration",
 	"filters[]",
+	"namespaces",
 	"quantiles[]",
 	"queryTime",
 	"rateFunc",

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -30,9 +31,33 @@ import (
 
 var validPromLabelRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
-// validPromDurationRe matches a valid Prometheus duration string (e.g. "5m", "30s", "1h").
-// Prevents injection into PromQL range selectors via the rateInterval query parameter.
-var validPromDurationRe = regexp.MustCompile(`^[0-9]+(ms|s|m|h|d|w|y)$`)
+var baseMetricsQueryParams = []string{
+	"avg",
+	"byLabels[]",
+	"clusterName",
+	"duration",
+	"quantiles[]",
+	"queryTime",
+	"rateFunc",
+	"rateInterval",
+	"step",
+}
+
+var istioMetricsQueryParams = []string{
+	"avg",
+	"byLabels[]",
+	"clusterName",
+	"direction",
+	"duration",
+	"filters[]",
+	"quantiles[]",
+	"queryTime",
+	"rateFunc",
+	"rateInterval",
+	"reporter",
+	"requestProtocol",
+	"step",
+}
 
 // validK8sNameRe matches valid Kubernetes resource names (DNS label subset).
 // Used to validate URL path parameters before interpolating into PromQL queries.
@@ -54,7 +79,7 @@ func AppMetrics(conf *config.Config, cache cache.KialiCache, discovery *istio.Di
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, App: app}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -84,7 +109,7 @@ func WorkloadMetrics(conf *config.Config, cache cache.KialiCache, discovery *ist
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Workload: workload}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -114,7 +139,7 @@ func ServiceMetrics(conf *config.Config, cache cache.KialiCache, discovery *isti
 
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace, Service: service}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -166,15 +191,15 @@ func AggregateMetrics(conf *config.Config, cache cache.KialiCache, discovery *is
 
 		params := models.IstioMetricsQuery{Namespace: namespace, Aggregate: aggregate, AggregateValue: aggregateValue}
 		if err := extractIstioMetricsQueryParams(r, &params, oldestNs); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 		if params.Direction != "inbound" {
-			RespondWithError(w, http.StatusBadRequest, "AggregateMetrics 'direction' must be 'inbound' as the metrics are associated with inbound traffic to the destination workload.")
+			RespondWithQueryParamError(w, "AggregateMetrics 'direction' must be 'inbound' as the metrics are associated with inbound traffic to the destination workload.")
 			return
 		}
 		if params.Reporter != "destination" {
-			RespondWithError(w, http.StatusBadRequest, "AggregateMetrics 'reporter' must be 'destination' as the metrics are associated with inbound traffic to the destination workload.")
+			RespondWithQueryParamError(w, "AggregateMetrics 'reporter' must be 'destination' as the metrics are associated with inbound traffic to the destination workload.")
 			return
 		}
 
@@ -228,7 +253,7 @@ func ControlPlaneMetrics(
 
 		err = extractIstioMetricsQueryParams(r, &params, namespaceInfo)
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -283,7 +308,7 @@ func ResourceUsageMetrics(conf *config.Config, cache cache.KialiCache, discovery
 
 		params := models.IstioMetricsQuery{App: app, Cluster: cluster, Namespace: namespaceInfo.Name}
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -321,7 +346,7 @@ func NamespaceMetrics(conf *config.Config, cache cache.KialiCache, discovery *is
 		params := models.IstioMetricsQuery{Cluster: cluster, Namespace: namespace}
 
 		if err := extractIstioMetricsQueryParams(r, &params, namespaceInfo); err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -381,7 +406,7 @@ func ClustersMetrics(conf *config.Config, cache cache.KialiCache, discovery *ist
 
 			err = extractIstioMetricsQueryParams(r, &params, oldestNs)
 			if err != nil {
-				RespondWithError(w, http.StatusBadRequest, err.Error())
+				RespondWithQueryParamError(w, err.Error())
 				return
 			}
 
@@ -400,6 +425,9 @@ func ClustersMetrics(conf *config.Config, cache cache.KialiCache, discovery *ist
 
 func extractIstioMetricsQueryParams(r *http.Request, q *models.IstioMetricsQuery, namespaceInfo *models.Namespace) error {
 	queryParams := r.URL.Query()
+	if err := queryparams.RejectUnknown(queryParams, istioMetricsQueryParams...); err != nil {
+		return err
+	}
 
 	q.FillDefaults()
 
@@ -433,8 +461,8 @@ func extractIstioMetricsQueryParams(r *http.Request, q *models.IstioMetricsQuery
 
 func extractBaseMetricsQueryParams(queryParams url.Values, q *prometheus.RangeQuery, namespaceInfo *models.Namespace) error {
 	if ri := queryParams.Get("rateInterval"); ri != "" {
-		if !validPromDurationRe.MatchString(ri) {
-			return fmt.Errorf("bad request, invalid 'rateInterval' value: %q", ri)
+		if err := queryparams.ValidatePromDuration(ri, "rateInterval"); err != nil {
+			return fmt.Errorf("bad request, %w", err)
 		}
 		q.RateInterval = ri
 	}

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -87,6 +87,20 @@ func TestExtractMetricsQueryParamsUnknownParam(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported query parameter 'unknownParam'")
 }
 
+func TestExtractMetricsQueryParamsAllowsNamespaces(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://host/api/clusters/metrics", nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("direction", "outbound")
+	q.Add("namespaces", "bookinfo")
+	q.Add("reporter", "destination")
+	req.URL.RawQuery = q.Encode()
+
+	mq := models.IstioMetricsQuery{Namespace: "bookinfo"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("bookinfo", time.Time{}))
+	require.NoError(t, err)
+}
+
 func TestExtractMetricsQueryParamsStepLimitCase(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://host/api/namespaces/ns/services/svc/metrics", nil)
 	if err != nil {

--- a/handlers/metrics_test.go
+++ b/handlers/metrics_test.go
@@ -73,6 +73,20 @@ func TestExtractMetricsQueryParams(t *testing.T) {
 	assert.Equal(t, 1, mq.End.Second())
 }
 
+func TestExtractMetricsQueryParamsUnknownParam(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://host/api/namespaces/ns/services/svc/metrics", nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("duration", "60s")
+	q.Add("unknownParam", "value")
+	req.URL.RawQuery = q.Encode()
+
+	mq := models.IstioMetricsQuery{Namespace: "ns"}
+	err = extractIstioMetricsQueryParams(req, &mq, buildNamespace("ns", time.Time{}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported query parameter 'unknownParam'")
+}
+
 func TestExtractMetricsQueryParamsStepLimitCase(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://host/api/namespaces/ns/services/svc/metrics", nil)
 	if err != nil {
@@ -182,7 +196,7 @@ func TestAggregateMetricsDefault(t *testing.T) {
 
 	// default has direction=outbound
 	actual, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "'direction' must be 'inbound'")
 }
 
@@ -289,7 +303,7 @@ func TestAggregateMetricsBadDirection(t *testing.T) {
 
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "'direction' must be 'inbound'")
 }
 
@@ -313,7 +327,7 @@ func TestAggregateMetricsBadReporter(t *testing.T) {
 
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "'reporter' must be 'destination'")
 }
 
@@ -660,7 +674,7 @@ func TestWorkloadMetricsBadQueryTime(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'queryTime'")
 }
 
@@ -689,7 +703,7 @@ func TestWorkloadMetricsBadDuration(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'duration'")
 }
 
@@ -718,7 +732,7 @@ func TestWorkloadMetricsBadStep(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'step'")
 }
 
@@ -746,7 +760,7 @@ func TestWorkloadMetricsBadRateFunc(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "query parameter 'rateFunc' must be either 'rate' or 'irate'")
 }
 

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -41,9 +42,13 @@ func NamespaceList(conf *config.Config, kialiCache cache.KialiCache, clientFacto
 func NamespaceInfo(conf *config.Config, cache cache.KialiCache, clientFactory kubernetes.ClientFactory, discovery istio.MeshDiscovery) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
-		cluster := clusterNameFromQuery(conf, query)
+		cluster := queryparams.ClusterName(conf, query)
 
 		userClients, err := getUserClients(r, clientFactory)
 		if err != nil {
@@ -77,10 +82,14 @@ func NamespaceValidationSummary(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		vars := mux.Vars(r)
 		namespace := vars["namespace"]
 
-		cluster := clusterNameFromQuery(conf, query)
+		cluster := queryparams.ClusterName(conf, query)
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -132,7 +141,11 @@ func NamespaceUpdate(conf *config.Config, kialiCache cache.KialiCache, clientFac
 		jsonPatch := string(body)
 
 		query := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, query)
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+		cluster := queryparams.ClusterName(conf, query)
 
 		userClients, err := getUserClients(r, clientFactory)
 		if err != nil {

--- a/handlers/proxy_logging.go
+++ b/handlers/proxy_logging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/prometheus"
@@ -44,18 +45,22 @@ func LoggingUpdate(
 		namespace := params["namespace"]
 		pod := params["pod"]
 		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName", "level"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		level := query.Get("level")
 		switch {
 		case level == "":
-			RespondWithError(w, 400, "level query param is not set")
+			RespondWithQueryParamError(w, "level query param is not set")
 			return
 		case !business.IsValidProxyLogLevel(level):
 			msg := fmt.Sprintf("%s is an invalid log level. Valid log levels are: %s", level, strings.Join(business.ValidProxyLogLevels, ", "))
-			RespondWithError(w, 400, msg)
+			RespondWithQueryParamError(w, msg)
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, query)
+		cluster := queryparams.ClusterName(conf, query)
 
 		if err := businessLayer.ProxyLogging.SetLogLevel(cluster, namespace, pod, level); err != nil {
 			handleErrorResponse(w, err)

--- a/handlers/proxy_logging_test.go
+++ b/handlers/proxy_logging_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestMissingQueryParamFails(t *testing.T) {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
-	assert.Equalf(400, resp.StatusCode, "response text: %s", string(body))
+	assert.Equalf(http.StatusConflict, resp.StatusCode, "response text: %s", string(body))
 }
 
 func TestIncorrectQueryParamFails(t *testing.T) {
@@ -103,5 +104,5 @@ func TestIncorrectQueryParamFails(t *testing.T) {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
-	assert.Equalf(400, resp.StatusCode, "response text: %s", string(body))
+	assert.Equalf(http.StatusConflict, resp.StatusCode, "response text: %s", string(body))
 }

--- a/handlers/proxy_status.go
+++ b/handlers/proxy_status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 )
@@ -16,7 +17,13 @@ func ConfigDump(conf *config.Config, kialiCache cache.KialiCache, clientFactory 
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+
+		cluster := queryparams.ClusterName(conf, query)
 		namespace := params["namespace"]
 		pod := params["pod"]
 
@@ -48,7 +55,13 @@ func ConfigDumpResourceEntries(conf *config.Config, kialiCache cache.KialiCache,
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+
+		cluster := queryparams.ClusterName(conf, query)
 		namespace := params["namespace"]
 		pod := params["pod"]
 		resource := params["resource"]

--- a/handlers/queryparams/queryparams.go
+++ b/handlers/queryparams/queryparams.go
@@ -1,0 +1,89 @@
+package queryparams
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/kiali/kiali/config"
+)
+
+// ErrorStatusCode is the HTTP status returned for invalid or unsupported query parameters.
+const ErrorStatusCode = http.StatusConflict
+
+// validPromDurationRe matches a valid Prometheus duration string (e.g. "5m", "30s", "1h").
+var validPromDurationRe = regexp.MustCompile(`^[0-9]+(ms|s|m|h|d|w|y)$`)
+
+// RejectUnknown returns an error when query contains parameters not in the allowed list.
+func RejectUnknown(query url.Values, allowed ...string) error {
+	if len(query) == 0 {
+		return nil
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowedSet[name] = struct{}{}
+	}
+	for key := range query {
+		if _, ok := allowedSet[key]; !ok {
+			return fmt.Errorf("unsupported query parameter '%s'", key)
+		}
+	}
+	return nil
+}
+
+// ClusterName extracts the cluster name from query parameters, defaulting to the configured cluster.
+func ClusterName(conf *config.Config, query url.Values) string {
+	cluster := query.Get("clusterName")
+	if cluster == "" {
+		cluster = conf.KubernetesConfig.ClusterName
+	}
+	return cluster
+}
+
+// ParseQueryTime parses a Unix timestamp query parameter value.
+func ParseQueryTime(value string) (time.Time, error) {
+	unix, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cannot parse query parameter 'queryTime'")
+	}
+	return time.Unix(unix, 0), nil
+}
+
+// ParseBoolParam parses a boolean query parameter, returning defaultValue when value is empty.
+func ParseBoolParam(value, paramName string, defaultValue bool) (bool, error) {
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("cannot parse query parameter '%s'", paramName)
+	}
+	return parsed, nil
+}
+
+// ValidateEnum returns an error when value is non-empty and not in allowed.
+func ValidateEnum(value, paramName string, allowed ...string) error {
+	if value == "" {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("query parameter '%s' must be one of %v", paramName, allowed)
+}
+
+// ValidatePromDuration returns an error when value is non-empty and not a valid Prometheus duration.
+func ValidatePromDuration(value, paramName string) error {
+	if value == "" {
+		return nil
+	}
+	if !validPromDurationRe.MatchString(value) {
+		return fmt.Errorf("invalid '%s' value: %q", paramName, value)
+	}
+	return nil
+}

--- a/handlers/queryparams/queryparams_test.go
+++ b/handlers/queryparams/queryparams_test.go
@@ -1,0 +1,76 @@
+package queryparams
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRejectUnknown(t *testing.T) {
+	t.Run("allows known params", func(t *testing.T) {
+		query := url.Values{}
+		query.Set("duration", "60s")
+		query.Set("clusterName", "cluster-default")
+		assert.NoError(t, RejectUnknown(query, "duration", "clusterName"))
+	})
+
+	t.Run("rejects unknown params", func(t *testing.T) {
+		query := url.Values{}
+		query.Set("duration", "60s")
+		query.Set("foo", "bar")
+		err := RejectUnknown(query, "duration")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported query parameter 'foo'")
+	})
+
+	t.Run("allows array-style params", func(t *testing.T) {
+		query := url.Values{}
+		query.Add("filters[]", "request_count")
+		assert.NoError(t, RejectUnknown(query, "filters[]"))
+	})
+}
+
+func TestParseQueryTime(t *testing.T) {
+	parsed, err := ParseQueryTime("1523364061")
+	require.NoError(t, err)
+	assert.Equal(t, time.Unix(1523364061, 0), parsed)
+
+	_, err = ParseQueryTime("not-a-number")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "queryTime")
+}
+
+func TestParseBoolParam(t *testing.T) {
+	value, err := ParseBoolParam("", "health", true)
+	require.NoError(t, err)
+	assert.True(t, value)
+
+	value, err = ParseBoolParam("false", "health", true)
+	require.NoError(t, err)
+	assert.False(t, value)
+
+	_, err = ParseBoolParam("maybe", "health", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "health")
+}
+
+func TestValidateEnum(t *testing.T) {
+	assert.NoError(t, ValidateEnum("", "type", "app", "service"))
+	assert.NoError(t, ValidateEnum("app", "type", "app", "service"))
+
+	err := ValidateEnum("invalid", "type", "app", "service")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "type")
+}
+
+func TestValidatePromDuration(t *testing.T) {
+	assert.NoError(t, ValidatePromDuration("", "rateInterval"))
+	assert.NoError(t, ValidatePromDuration("5m", "rateInterval"))
+
+	err := ValidatePromDuration("5 minutes", "rateInterval")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rateInterval")
+}

--- a/handlers/queryparams/tracing.go
+++ b/handlers/queryparams/tracing.go
@@ -1,0 +1,109 @@
+package queryparams
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/models"
+)
+
+var tracingQueryParams = []string{
+	"clusterName",
+	"endMicros",
+	"limit",
+	"minDuration",
+	"startMicros",
+	"tags",
+}
+
+var errorTracesQueryParams = []string{
+	"clusterName",
+	"duration",
+}
+
+// ParseTracingQuery validates and parses tracing list/spans query parameters.
+func ParseTracingQuery(conf *config.Config, values url.Values) (models.TracingQuery, error) {
+	if err := RejectUnknown(values, tracingQueryParams...); err != nil {
+		return models.TracingQuery{}, err
+	}
+
+	q := models.TracingQuery{
+		End:     time.Now(),
+		Limit:   100,
+		Tags:    make(map[string]string),
+		Cluster: ClusterName(conf, values),
+	}
+
+	if v := values.Get("startMicros"); v != "" {
+		num, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'startMicros': %s", err.Error())
+		}
+		q.Start = time.Unix(0, num*int64(time.Microsecond))
+	}
+	if v := values.Get("endMicros"); v != "" {
+		num, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'endMicros': %s", err.Error())
+		}
+		q.End = time.Unix(0, num*int64(time.Microsecond))
+	}
+	if strLimit := values.Get("limit"); strLimit != "" {
+		num, err := strconv.Atoi(strLimit)
+		if err != nil {
+			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'limit': %s", err.Error())
+		}
+		if num <= 0 {
+			return models.TracingQuery{}, fmt.Errorf("parameter 'limit' must be positive")
+		}
+		if num > models.MaxTracingLimit {
+			num = models.MaxTracingLimit
+		}
+		q.Limit = num
+	}
+	if rawTags := values.Get("tags"); rawTags != "" {
+		var tags map[string]string
+		if err := json.Unmarshal([]byte(rawTags), &tags); err != nil {
+			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'tags': %s", err.Error())
+		}
+		q.Tags = tags
+	}
+	if strMinD := values.Get("minDuration"); strMinD != "" {
+		num, err := strconv.Atoi(strMinD)
+		if err != nil {
+			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'minDuration': %s", err.Error())
+		}
+		q.MinDuration = time.Duration(num) * time.Microsecond
+	}
+
+	for key, value := range config.Get().ExternalServices.Tracing.QueryScope {
+		q.Tags[key] = value
+	}
+
+	if values.Get("clusterName") != "" {
+		q.Tags[models.IstioClusterTag] = values.Get("clusterName")
+	} else {
+		q.Tags[models.IstioClusterTag] = q.Cluster
+	}
+
+	return q, nil
+}
+
+// ParseErrorTracesDuration validates error-traces query parameters and returns the duration.
+func ParseErrorTracesDuration(conf *config.Config, values url.Values) (time.Duration, string, error) {
+	if err := RejectUnknown(values, errorTracesQueryParams...); err != nil {
+		return 0, "", err
+	}
+
+	durationInSeconds := values.Get("duration")
+	conv, err := strconv.ParseInt(durationInSeconds, 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("cannot parse parameter 'duration': %s", err.Error())
+	}
+
+	return time.Second * time.Duration(conv), ClusterName(conf, values), nil
+}

--- a/handlers/queryparams/tracing_test.go
+++ b/handlers/queryparams/tracing_test.go
@@ -1,0 +1,33 @@
+package queryparams
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/config"
+)
+
+func TestParseTracingQueryUnknownParam(t *testing.T) {
+	conf := config.NewConfig()
+	query := url.Values{}
+	query.Set("limit", "10")
+	query.Set("foo", "bar")
+
+	_, err := ParseTracingQuery(conf, query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported query parameter 'foo'")
+}
+
+func TestParseErrorTracesDurationUnknownParam(t *testing.T) {
+	conf := config.NewConfig()
+	query := url.Values{}
+	query.Set("duration", "60")
+	query.Set("foo", "bar")
+
+	_, _, err := ParseErrorTracesDuration(conf, query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported query parameter 'foo'")
+}

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -32,24 +32,28 @@ type serviceListParams struct {
 	IncludeOnlyDefinitions bool `json:"onlyDefinitions"`
 }
 
-func (p *serviceListParams) extract(conf *config.Config, r *http.Request) {
+func (p *serviceListParams) extract(conf *config.Config, r *http.Request) error {
 	vars := mux.Vars(r)
 	query := r.URL.Query()
-	p.baseExtract(conf, r)
+	if err := p.baseExtract(conf, r, "clusterName", "health", "istioResources", "namespaces", "onlyDefinitions", "queryTime", "rateInterval"); err != nil {
+		return err
+	}
 	p.Namespace = vars["namespace"]
+
 	var err error
-	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
+	p.IncludeHealth, err = queryparams.ParseBoolParam(query.Get("health"), "health", true)
 	if err != nil {
-		p.IncludeHealth = true
+		return err
 	}
-	p.IncludeIstioResources, err = strconv.ParseBool(query.Get("istioResources"))
+	p.IncludeIstioResources, err = queryparams.ParseBoolParam(query.Get("istioResources"), "istioResources", true)
 	if err != nil {
-		p.IncludeIstioResources = true
+		return err
 	}
-	p.IncludeOnlyDefinitions, err = strconv.ParseBool(query.Get("onlyDefinitions"))
+	p.IncludeOnlyDefinitions, err = queryparams.ParseBoolParam(query.Get("onlyDefinitions"), "onlyDefinitions", true)
 	if err != nil {
-		p.IncludeOnlyDefinitions = true
+		return err
 	}
+	return nil
 }
 
 // ClustersServices is the API handler to fetch the list of services from a given cluster
@@ -67,7 +71,10 @@ func ClustersServices(
 		query := r.URL.Query()
 		namespacesQueryParam := query.Get("namespaces") // csl of namespaces
 		p := serviceListParams{}
-		p.extract(conf, r)
+		if err := p.extract(conf, r); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		businessLayer, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -149,15 +156,25 @@ func ServiceDetails(
 		}
 
 		queryParams := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, queryParams)
+		if err := queryparams.RejectUnknown(queryParams, "clusterName", "rateInterval", "validate"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+		cluster := queryparams.ClusterName(conf, queryParams)
 
-		// Rate interval is needed to fetch request rates based health
 		rateInterval := queryParams.Get("rateInterval")
 		if rateInterval == "" {
 			rateInterval = config.DefaultHealthRateInterval
+		} else if err := queryparams.ValidatePromDuration(rateInterval, "rateInterval"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
 		}
 
-		includeValidations, _ := strconv.ParseBool(queryParams.Get("validate"))
+		includeValidations, err := queryparams.ParseBoolParam(queryParams.Get("validate"), "validate", false)
+		if err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		if !conf.IsValidationsEnabled() {
 			includeValidations = false
 		}
@@ -222,12 +239,18 @@ func ServiceUpdate(
 		}
 
 		queryParams := r.URL.Query()
-		cluster := clusterNameFromQuery(conf, queryParams)
+		if err := queryparams.RejectUnknown(queryParams, "clusterName", "patchType", "rateInterval", "validate"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+		cluster := queryparams.ClusterName(conf, queryParams)
 
-		// Rate interval is needed to fetch request rates based health
 		rateInterval := queryParams.Get("rateInterval")
 		if rateInterval == "" {
 			rateInterval = config.DefaultHealthRateInterval
+		} else if err := queryparams.ValidatePromDuration(rateInterval, "rateInterval"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
 		}
 
 		patchType := queryParams.Get("patchType")
@@ -235,7 +258,11 @@ func ServiceUpdate(
 			patchType = defaultPatchType
 		}
 
-		includeValidations, _ := strconv.ParseBool(queryParams.Get("validate"))
+		includeValidations, err := queryparams.ParseBoolParam(queryParams.Get("validate"), "validate", false)
+		if err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		if !conf.IsValidationsEnabled() {
 			includeValidations = false
 		}

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -156,7 +156,7 @@ func ServiceDetails(
 		}
 
 		queryParams := r.URL.Query()
-		if err := queryparams.RejectUnknown(queryParams, "clusterName", "rateInterval", "validate"); err != nil {
+		if err := queryparams.RejectUnknown(queryParams, "clusterName", "health", "rateInterval", "validate"); err != nil {
 			RespondWithQueryParamError(w, err.Error())
 			return
 		}

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -157,7 +157,7 @@ func TestServiceMetricsBadQueryTime(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'queryTime'")
 }
 
@@ -187,7 +187,7 @@ func TestServiceMetricsBadDuration(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'duration'")
 }
 
@@ -217,7 +217,7 @@ func TestServiceMetricsCantParseQuantiles(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'quantiles'")
 }
 
@@ -247,7 +247,7 @@ func TestServiceMetricsBadQuantiles(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "invalid quantile(s)")
 }
 
@@ -276,7 +276,7 @@ func TestServiceMetricsBadStep(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "cannot parse query parameter 'step'")
 }
 
@@ -304,7 +304,7 @@ func TestServiceMetricsBadRateFunc(t *testing.T) {
 	}
 	actual, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	assert.Contains(t, string(actual), "query parameter 'rateFunc' must be either 'rate' or 'irate'")
 }
 

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
@@ -40,8 +41,13 @@ func NamespaceTls(
 		}
 
 		namespace := params["namespace"]
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
-		status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, clusterNameFromQuery(conf, r.URL.Query()))
+		status, err := business.TLS.NamespaceWidemTLSStatus(r.Context(), namespace, queryparams.ClusterName(conf, query))
 		if err != nil {
 			log.Error(err)
 			RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -65,6 +71,10 @@ func ClustersTls(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
+		if err := queryparams.RejectUnknown(params, "clusterName", "namespaces"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		namespaces := params.Get("namespaces") // csl of namespaces
 		namespaceNamesFromQuery := map[string]struct{}{}
 		if len(namespaces) > 0 {
@@ -72,7 +82,7 @@ func ClustersTls(
 				namespaceNamesFromQuery[name] = struct{}{}
 			}
 		}
-		cluster := clusterNameFromQuery(conf, params)
+		cluster := queryparams.ClusterName(conf, params)
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -125,8 +135,14 @@ func MeshTls(
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
-		revision := r.URL.Query().Get("revision")
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName", "revision"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+
+		cluster := queryparams.ClusterName(conf, query)
+		revision := query.Get("revision")
 		if revision == "" {
 			revision = "default"
 		}

--- a/handlers/tracing.go
+++ b/handlers/tracing.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -14,6 +11,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -72,12 +70,12 @@ func AppTraces(
 		namespace := params["namespace"]
 		app := params["app"]
 
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		cluster := q.Cluster
 		tracingName := business.App.GetAppTracingName(r.Context(), cluster, namespace, app)
 		traces, err := business.Tracing.GetAppTraces(r.Context(), namespace, tracingName.Lookup, app, q)
 		if err != nil {
@@ -107,9 +105,9 @@ func ServiceTraces(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		service := params["service"]
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 		traces, err := business.Tracing.GetServiceTraces(r.Context(), namespace, service, q)
@@ -141,9 +139,9 @@ func WorkloadTraces(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		workload := params["workload"]
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 		traces, err := business.Tracing.GetWorkloadTraces(r.Context(), namespace, workload, q)
@@ -175,14 +173,12 @@ func ErrorTraces(
 		namespace := params["namespace"]
 		app := params["app"]
 		queryParams := r.URL.Query()
-		durationInSeconds := queryParams.Get("duration")
-		conv, err := strconv.ParseInt(durationInSeconds, 10, 64)
+		duration, cluster, err := queryparams.ParseErrorTracesDuration(conf, queryParams)
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, "cannot parse parameter 'duration': "+err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
-		traces, err := business.Tracing.GetErrorTraces(r.Context(), cluster, namespace, app, time.Second*time.Duration(conv))
+		traces, err := business.Tracing.GetErrorTraces(r.Context(), cluster, namespace, app, duration)
 		if err != nil {
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 			return
@@ -248,12 +244,12 @@ func AppSpans(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		app := params["app"]
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		cluster := q.Cluster
 		spans, err := business.Tracing.GetAppSpans(r.Context(), cluster, namespace, app, q)
 		if err != nil {
 			RespondWithError(w, http.StatusServiceUnavailable, err.Error())
@@ -285,9 +281,9 @@ func ServiceSpans(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		service := params["service"]
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -322,9 +318,9 @@ func WorkloadSpans(
 		params := mux.Vars(r)
 		namespace := params["namespace"]
 		workload := params["workload"]
-		q, err := readQuery(conf, r.URL.Query())
+		q, err := queryparams.ParseTracingQuery(conf, r.URL.Query())
 		if err != nil {
-			RespondWithError(w, http.StatusBadRequest, err.Error())
+			RespondWithQueryParamError(w, err.Error())
 			return
 		}
 
@@ -336,72 +332,6 @@ func WorkloadSpans(
 
 		RespondWithJSON(w, http.StatusOK, spans)
 	}
-}
-
-func readQuery(conf *config.Config, values url.Values) (models.TracingQuery, error) {
-	q := models.TracingQuery{
-		End:     time.Now(),
-		Limit:   100,
-		Tags:    make(map[string]string),
-		Cluster: clusterNameFromQuery(conf, values),
-	}
-
-	if v := values.Get("startMicros"); v != "" {
-		if num, err := strconv.ParseInt(v, 10, 64); err == nil {
-			q.Start = time.Unix(0, num*int64(time.Microsecond))
-		} else {
-			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'startMicros': %s", err.Error())
-		}
-	}
-	if v := values.Get("endMicros"); v != "" {
-		if num, err := strconv.ParseInt(v, 10, 64); err == nil {
-			q.End = time.Unix(0, num*int64(time.Microsecond))
-		} else {
-			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'endMicros': %s", err.Error())
-		}
-	}
-	if strLimit := values.Get("limit"); strLimit != "" {
-		if num, err := strconv.Atoi(strLimit); err == nil {
-			if num <= 0 {
-				return models.TracingQuery{}, fmt.Errorf("parameter 'limit' must be positive")
-			}
-			if num > models.MaxTracingLimit {
-				num = models.MaxTracingLimit
-			}
-			q.Limit = num
-		} else {
-			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'limit': %s", err.Error())
-		}
-	}
-	if rawTags := values.Get("tags"); rawTags != "" {
-		var tags map[string]string
-		err := json.Unmarshal([]byte(rawTags), &tags)
-		if err != nil {
-			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'tags': %s", err.Error())
-		}
-		q.Tags = tags
-	}
-	if strMinD := values.Get("minDuration"); strMinD != "" {
-		if num, err := strconv.Atoi(strMinD); err == nil {
-			q.MinDuration = time.Duration(num) * time.Microsecond
-		} else {
-			return models.TracingQuery{}, fmt.Errorf("cannot parse parameter 'minDuration': %s", err.Error())
-		}
-	}
-
-	for key, value := range config.Get().ExternalServices.Tracing.QueryScope {
-		q.Tags[key] = value
-	}
-
-	// 'cluster' in tags is used to query in tracing by cluster in multi-cluster
-	// while 'Cluster' in models.TracingQuery can have default cluster
-	if values.Get("clusterName") != "" {
-		q.Tags[models.IstioClusterTag] = values.Get("clusterName")
-	} else {
-		q.Tags[models.IstioClusterTag] = q.Cluster
-	}
-
-	return q, nil
 }
 
 // TracingDiagnose is the API handler to diagnose Tracing configuration

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/grafana"
+	"github.com/kiali/kiali/handlers/queryparams"
 	"github.com/kiali/kiali/istio"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
@@ -42,21 +42,25 @@ type workloadParams struct {
 func (p *workloadParams) extract(r *http.Request, conf *config.Config) error {
 	vars := mux.Vars(r)
 	query := r.URL.Query()
-	p.baseExtract(conf, r)
+	if err := p.baseExtract(conf, r, "clusterName", "gvk", "health", "istioResources", "namespaces", "queryTime", "rateInterval", "validate"); err != nil {
+		return err
+	}
 	p.Namespace = vars["namespace"]
 	p.WorkloadName = vars["workload"]
 
 	var err error
-	p.IncludeHealth, err = strconv.ParseBool(query.Get("health"))
+	p.IncludeHealth, err = queryparams.ParseBoolParam(query.Get("health"), "health", true)
 	if err != nil {
-		p.IncludeHealth = true
+		return err
 	}
-	p.IncludeIstioResources, err = strconv.ParseBool(query.Get("istioResources"))
+	p.IncludeIstioResources, err = queryparams.ParseBoolParam(query.Get("istioResources"), "istioResources", true)
 	if err != nil {
-		p.IncludeIstioResources = true
+		return err
 	}
-	// Check for "validate" query param - defaults to false like other detail handlers
-	p.IncludeValidations, _ = strconv.ParseBool(query.Get("validate"))
+	p.IncludeValidations, err = queryparams.ParseBoolParam(query.Get("validate"), "validate", false)
+	if err != nil {
+		return err
+	}
 
 	p.WorkloadGVK, err = util.StringToGVK(query.Get("gvk"))
 	if err != nil {
@@ -82,7 +86,7 @@ func ClusterWorkloads(
 		p := workloadParams{}
 		errParse := p.extract(r, conf)
 		if errParse != nil {
-			RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
+			RespondWithQueryParamError(w, errParse.Error())
 			return
 		}
 
@@ -157,7 +161,7 @@ func WorkloadDetails(
 		p := workloadParams{}
 		errParse := p.extract(r, conf)
 		if errParse != nil {
-			RespondWithError(w, http.StatusInternalServerError, "Request parsing error: "+errParse.Error())
+			RespondWithQueryParamError(w, errParse.Error())
 			return
 		}
 
@@ -232,6 +236,10 @@ func WorkloadUpdate(
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName", "gvk", "patchType", "validate"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -248,13 +256,17 @@ func WorkloadUpdate(
 		workload := params["workload"]
 		workloadGVK, errGVK := util.StringToGVK(query.Get("gvk"))
 		if errGVK != nil {
-			RespondWithError(w, http.StatusBadRequest, "Update request with bad workloadGVK param: "+errGVK.Error())
+			RespondWithQueryParamError(w, "Update request with bad workloadGVK param: "+errGVK.Error())
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, query)
+		cluster := queryparams.ClusterName(conf, query)
 
-		includeValidations, _ := strconv.ParseBool(query.Get("validate"))
+		includeValidations, err := queryparams.ParseBoolParam(query.Get("validate"), "validate", false)
+		if err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 		if !conf.IsValidationsEnabled() {
 			includeValidations = false
 		}
@@ -310,6 +322,10 @@ func PodDetails(
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -317,7 +333,7 @@ func PodDetails(
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, query)
+		cluster := queryparams.ClusterName(conf, query)
 		namespace := vars["namespace"]
 		pod := vars["pod"]
 
@@ -350,6 +366,10 @@ func PodLogs(
 		}
 		vars := mux.Vars(r)
 		queryParams := r.URL.Query()
+		if err := queryparams.RejectUnknown(queryParams, "clusterName", "container", "duration", "logType", "maxLines", "sinceTime"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
 
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
@@ -357,7 +377,7 @@ func PodLogs(
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, queryParams)
+		cluster := queryparams.ClusterName(conf, queryParams)
 		namespace := vars["namespace"]
 		pod := vars["pod"]
 
@@ -395,13 +415,19 @@ func ConfigDumpZtunnel(
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
+		query := r.URL.Query()
+		if err := queryparams.RejectUnknown(query, "clusterName"); err != nil {
+			RespondWithQueryParamError(w, err.Error())
+			return
+		}
+
 		business, err := getLayer(r, conf, kialiCache, clientFactory, cpm, prom, traceClientLoader, grafana, discovery)
 		if err != nil {
 			RespondWithError(w, http.StatusInternalServerError, "Apps initialization error: "+err.Error())
 			return
 		}
 
-		cluster := clusterNameFromQuery(conf, r.URL.Query())
+		cluster := queryparams.ClusterName(conf, query)
 		namespace := params["namespace"]
 		pod := params["pod"]
 

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -366,7 +366,7 @@ func PodLogs(
 		}
 		vars := mux.Vars(r)
 		queryParams := r.URL.Query()
-		if err := queryparams.RejectUnknown(queryParams, "clusterName", "container", "duration", "logType", "maxLines", "sinceTime"); err != nil {
+		if err := queryparams.RejectUnknown(queryParams, "clusterName", "container", "duration", "logType", "maxLines", "service", "sinceTime", "workload"); err != nil {
 			RespondWithQueryParamError(w, err.Error())
 			return
 		}

--- a/tests/integration/tests/kiali_metrics_test.go
+++ b/tests/integration/tests/kiali_metrics_test.go
@@ -44,7 +44,7 @@ func TestServiceMetrics(t *testing.T) {
 	ctx := context.TODO()
 
 	pollErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
-		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
+		METRICS_PARAMS["clusterName"] = conf.KubernetesConfig.ClusterName
 		metrics, err := kiali.ObjectMetrics(kiali.BOOKINFO, name, "services", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestCount, metrics.RequestDurationMillis, metrics.RequestErrorCount), err
 	})
@@ -59,7 +59,7 @@ func TestAppMetrics(t *testing.T) {
 	ctx := context.TODO()
 
 	pollErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
-		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
+		METRICS_PARAMS["clusterName"] = conf.KubernetesConfig.ClusterName
 		metrics, err := kiali.ObjectMetrics(kiali.BOOKINFO, name, "apps", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestDurationMillis), err
 	})
@@ -74,7 +74,7 @@ func TestWorkloadMetrics(t *testing.T) {
 	ctx := context.TODO()
 
 	pollErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
-		METRICS_PARAMS["cluster"] = conf.KubernetesConfig.ClusterName
+		METRICS_PARAMS["clusterName"] = conf.KubernetesConfig.ClusterName
 		metrics, err := kiali.ObjectMetrics(kiali.BOOKINFO, name, "workloads", METRICS_PARAMS)
 		return CheckMetrics(metrics.RequestSize, metrics.ResponseSize), err
 	})

--- a/tests/integration/tests/namespaces_test.go
+++ b/tests/integration/tests/namespaces_test.go
@@ -71,12 +71,10 @@ func TestNamespaceHealthInvalidRate(t *testing.T) {
 
 	health, code, err := kiali.NamespaceAppHealth(kiali.BOOKINFO, params)
 
-	// With health cache enabled, invalid rateInterval is ignored and cached data is returned.
-	// The parameter is not validated when serving from cache.
-	require.NoError(err)
-	require.Equal(200, code)
-	require.NotNil(health)
-	// Health may contain cached data for bookinfo namespace - no assertion on contents
+	// Invalid rateInterval is rejected with 409 Conflict.
+	require.Error(err)
+	require.Equal(409, code)
+	require.Nil(health)
 }
 
 func TestNamespaceHealthService(t *testing.T) {


### PR DESCRIPTION
Introduce handlers/queryparams shared helpers to reject unsupported query parameters and validate supported values across REST handlers. Return HTTP 409 for query param errors via RespondWithQueryParamError.

Fixes kiali/kiali#9193

### Describe the change

Explanation of what this PR does

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
