### PR TITLE
[v2.22] Add Gateway API and Inference API support to AI MCP tools (#9988)

### DIFF
--- a/ai/mcp/manage_istio_config/istio_create.go
+++ b/ai/mcp/manage_istio_config/istio_create.go
@@ -39,7 +39,16 @@ func IstioCreate(r *http.Request, args map[string]interface{}, businessLayer *bu
 		return msg, code
 	}
 
-	body, err := yaml.YAMLToJSON([]byte(data))
+	// Merge LLM-provided data with the resource template to ensure a complete
+	// resource body is submitted. The LLM may provide only spec-level content
+	// without apiVersion/kind/metadata, or omit required fields that the
+	// template supplies as defaults.
+	completeYAML, err := ensureCompleteCreateYAML(args, data, r.Context(), businessLayer, conf)
+	if err != nil {
+		completeYAML = data
+	}
+
+	body, err := yaml.YAMLToJSON([]byte(completeYAML))
 	if err != nil {
 		return fmt.Sprintf("Invalid data (must be valid JSON or YAML): %s", err.Error()), http.StatusBadRequest
 	}

--- a/ai/mcp/manage_istio_config/istio_helper.go
+++ b/ai/mcp/manage_istio_config/istio_helper.go
@@ -13,8 +13,44 @@ import (
 	"github.com/kiali/kiali/ai/mcputil"
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 )
+
+// isGatewayAPIEnabled checks whether Gateway API CRDs are installed on the
+// target cluster by querying the Kubernetes client's discovery cache.
+// If clusterName is empty, falls back to the home cluster.
+func isGatewayAPIEnabled(ki *mcputil.KialiInterface, clusterName string) bool {
+	if ki == nil || ki.ClientFactory == nil {
+		return false
+	}
+	client := getSAClient(ki, clusterName)
+	if client == nil {
+		return false
+	}
+	return client.IsGatewayAPI()
+}
+
+// isInferenceAPIEnabled checks whether Inference API CRDs
+// (inference.networking.k8s.io) are installed on the target cluster.
+// If clusterName is empty, falls back to the home cluster.
+func isInferenceAPIEnabled(ki *mcputil.KialiInterface, clusterName string) bool {
+	if ki == nil || ki.ClientFactory == nil {
+		return false
+	}
+	client := getSAClient(ki, clusterName)
+	if client == nil {
+		return false
+	}
+	return client.IsInferenceAPI()
+}
+
+func getSAClient(ki *mcputil.KialiInterface, clusterName string) kubernetes.ClientInterface {
+	if clusterName == "" {
+		return ki.ClientFactory.GetSAHomeClusterClient()
+	}
+	return ki.ClientFactory.GetSAClient(clusterName)
+}
 
 func audit(r *http.Request, operation, namespace, gvk, message string) {
 	if config.Get().Server.AuditLog {

--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -19,27 +19,34 @@ import (
 	"github.com/kiali/kiali/models"
 )
 
-var istioConfigCriteria = business.IstioConfigCriteria{
-	IncludeGateways:               true,
-	IncludeK8sGateways:            true,
-	IncludeK8sGRPCRoutes:          true,
-	IncludeK8sHTTPRoutes:          true,
-	IncludeK8sInferencePools:      true,
-	IncludeK8sReferenceGrants:     true,
-	IncludeK8sTCPRoutes:           true,
-	IncludeK8sTLSRoutes:           true,
-	IncludeVirtualServices:        true,
-	IncludeDestinationRules:       true,
-	IncludeServiceEntries:         true,
-	IncludeSidecars:               true,
-	IncludeAuthorizationPolicies:  true,
-	IncludePeerAuthentications:    true,
-	IncludeRequestAuthentications: true,
-	IncludeWorkloadEntries:        true,
-	IncludeWorkloadGroups:         true,
-	IncludeEnvoyFilters:           true,
-	IncludeWasmPlugins:            true,
-	IncludeTelemetry:              true,
+// defaultIstioConfigCriteria returns the criteria for listing Istio config objects.
+// When isGatewayAPIEnabled is true (i.e. Gateway API CRDs are installed), Gateway API types (K8sGateways, K8sHTTPRoutes, etc.)
+// are included; otherwise they are excluded to avoid unnecessary API calls.
+// When isInferenceAPIEnabled is true (i.e. inference.networking.k8s.io CRDs are installed),
+// InferencePool resources are included.
+func defaultIstioConfigCriteria(isGatewayAPIEnabled bool, isInferenceAPIEnabled bool) business.IstioConfigCriteria {
+	return business.IstioConfigCriteria{
+		IncludeGateways:               true,
+		IncludeK8sGateways:            isGatewayAPIEnabled,
+		IncludeK8sGRPCRoutes:          isGatewayAPIEnabled,
+		IncludeK8sHTTPRoutes:          isGatewayAPIEnabled,
+		IncludeK8sInferencePools:      isInferenceAPIEnabled,
+		IncludeK8sReferenceGrants:     isGatewayAPIEnabled,
+		IncludeK8sTCPRoutes:           isGatewayAPIEnabled,
+		IncludeK8sTLSRoutes:           isGatewayAPIEnabled,
+		IncludeVirtualServices:        true,
+		IncludeDestinationRules:       true,
+		IncludeServiceEntries:         true,
+		IncludeSidecars:               true,
+		IncludeAuthorizationPolicies:  true,
+		IncludePeerAuthentications:    true,
+		IncludeRequestAuthentications: true,
+		IncludeWorkloadEntries:        true,
+		IncludeWorkloadGroups:         true,
+		IncludeEnvoyFilters:           true,
+		IncludeWasmPlugins:            true,
+		IncludeTelemetry:              true,
+	}
 }
 
 type IstioListItem struct {
@@ -61,7 +68,7 @@ type ValidationCheckSummary struct {
 	Message  string `json:"message"`
 }
 
-func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *business.Layer, conf *config.Config) (interface{}, int) {
+func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *business.Layer, conf *config.Config, isGatewayAPIEnabled bool, isInferenceAPIEnabled bool) (interface{}, int) {
 	// Extract parameters
 	cluster := mcputil.GetStringArg(args, "clusterName")
 	namespace := mcputil.GetStringArg(args, "namespace")
@@ -75,9 +82,12 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		cluster = conf.KubernetesConfig.ClusterName
 	}
 
-	criteria := istioConfigCriteria
+	criteria := defaultIstioConfigCriteria(isGatewayAPIEnabled, isInferenceAPIEnabled)
 	if kind != "" {
-		criteria = criteriaForListFilter(group, kind)
+		if group == "" {
+			group = inferGroupFromKind(kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
+		}
+		criteria = criteriaForListFilter(group, kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
 	}
 
 	if namespace == "" {
@@ -199,10 +209,10 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 			}
 		}
 		destinationRules = filteredDR
-	}
 
-	// Filter gateways to only those referenced by VirtualServices
-	gateways, _ = filterGatewaysReferencedByVirtualServices(ctx, businessLayer, cluster, virtualServices, gateways)
+		// When filtering by service, only show Gateways referenced by the matching VirtualServices
+		gateways, _ = filterGatewaysReferencedByVirtualServices(ctx, businessLayer, cluster, virtualServices, gateways)
+	}
 
 	// Get validation warnings for context
 	istioValidations, err := businessLayer.Validations.GetValidations(ctx, cluster)
@@ -665,7 +675,7 @@ func filterGatewaysReferencedByVirtualServices(
 	return out, warnings
 }
 
-func criteriaForListFilter(group, kind string) business.IstioConfigCriteria {
+func criteriaForListFilter(group, kind string, isGatewayAPIEnabled, isInferenceAPIEnabled bool) business.IstioConfigCriteria {
 	// Default: if we can't confidently map it, keep original behavior.
 	c := business.IstioConfigCriteria{}
 
@@ -723,5 +733,5 @@ func criteriaForListFilter(group, kind string) business.IstioConfigCriteria {
 		}
 	}
 
-	return istioConfigCriteria
+	return defaultIstioConfigCriteria(isGatewayAPIEnabled, isInferenceAPIEnabled)
 }

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -76,7 +76,7 @@ func TestIstioList_ReturnsCompactYAML(t *testing.T) {
 		"namespace": "bookinfo",
 	}
 
-	res, status := IstioList(context.Background(), args, businessLayer, conf)
+	res, status := IstioList(context.Background(), args, businessLayer, conf, false, false)
 	require.Equal(t, http.StatusOK, status)
 
 	out, ok := res.([]IstioListItem)
@@ -141,7 +141,7 @@ func TestIstioList_FilterByService(t *testing.T) {
 		"serviceName": "reviews",
 	}
 
-	res, status := IstioList(context.Background(), args, businessLayer, conf)
+	res, status := IstioList(context.Background(), args, businessLayer, conf, false, false)
 	require.Equal(t, http.StatusOK, status)
 
 	out, ok := res.([]IstioListItem)

--- a/ai/mcp/manage_istio_config/manage_istio_config.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config.go
@@ -28,7 +28,9 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")
 	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
-	if err := validateReadOnlyIstioConfigInput(args); err != nil {
+	isGatewayAPIEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
+	isInferenceAPIEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
+	if err := validateReadOnlyIstioConfigInput(args, isGatewayAPIEnabled, isInferenceAPIEnabled); err != nil {
 		return err.Error(), http.StatusOK
 	}
 	if action != "list" {
@@ -37,9 +39,6 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 		kind := mcputil.GetStringArg(args, "kind")
 		gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
 		if !business.GetIstioAPI(gvk) {
-			if group == "gateway.networking.k8s.io" && kind == "Gateway" && version == "v1beta1" {
-				return fmt.Sprintf("Object type not managed: %s. Hint: try version 'v1' for Gateway API resources.", gvk.String()), http.StatusOK
-			}
 			return fmt.Sprintf("Object type not managed: %s", gvk.String()), http.StatusOK
 		}
 	}
@@ -57,7 +56,7 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 
 	switch action {
 	case "list":
-		return IstioList(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf)
+		return IstioList(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf, isGatewayAPIEnabled, isInferenceAPIEnabled)
 	case "get":
 		return IstioGet(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf)
 	default:
@@ -69,11 +68,14 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	action := mcputil.GetStringArg(args, "action")
 	confirmed := mcputil.AsBool(args["confirmed"])
 	mcpMode := mcputil.AsBoolOrDefault(args, false, "mcp_mode")
+	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
+	isGatewayAPIEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
+	isInferenceAPIEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
 
 	if action == "list" || action == "get" {
 		return "for list and get actions use the manage_istio_config_read tool", http.StatusBadRequest
 	}
-	if err := validateIstioConfigInput(args); err != nil {
+	if err := validateIstioConfigInput(args, isGatewayAPIEnabled, isInferenceAPIEnabled); err != nil {
 		return err.Error(), http.StatusBadRequest
 	}
 
@@ -83,9 +85,6 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		kind := mcputil.GetStringArg(args, "kind")
 		gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
 		if !business.GetIstioAPI(gvk) {
-			if group == "gateway.networking.k8s.io" && kind == "Gateway" && version == "v1beta1" {
-				return fmt.Sprintf("Object type not managed: %s. Hint: try version 'v1' for Gateway API resources.", gvk.String()), http.StatusBadRequest
-			}
 			return fmt.Sprintf("Object type not managed: %s", gvk.String()), http.StatusBadRequest
 		}
 	}
@@ -329,6 +328,16 @@ func ensureCompleteCreateYAML(args map[string]interface{}, data string, ctx cont
 
 	gvk := schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
 
+	// When data is empty, return the template directly as a complete resource
+	if strings.TrimSpace(data) == "" {
+		base := buildResourceTemplate(gvk, object, namespace)
+		baseYAML, err := yaml.Marshal(base)
+		if err != nil {
+			return "", err
+		}
+		return string(baseYAML), nil
+	}
+
 	// Parse the LLM-provided YAML
 	var llmData map[string]interface{}
 	if err := yaml.Unmarshal([]byte(data), &llmData); err != nil {
@@ -344,8 +353,16 @@ func ensureCompleteCreateYAML(args map[string]interface{}, data string, ctx cont
 	}
 
 	if hasAPIVersion && hasKind && hasMetadata {
-		// LLM provided a complete document - use it as-is
-		return normalizeToYAML(data)
+		// LLM provided a complete document — but if spec is empty/missing,
+		// merge onto the template so required fields are populated.
+		spec, _ := llmData["spec"].(map[string]interface{})
+		if len(spec) > 0 {
+			normalized, err := normalizeToYAML(data)
+			if err != nil {
+				return "", err
+			}
+			return applyGVKFixups(gvk, normalized)
+		}
 	}
 
 	// Try to load existing object from clusterName (same approach as PATCH preview)
@@ -390,6 +407,8 @@ func ensureCompleteCreateYAML(args map[string]interface{}, data string, ctx cont
 		return "", err
 	}
 
+	mergedJSON = applyGVKFixupsJSON(gvk, mergedJSON)
+
 	mergedYAML, err := yaml.JSONToYAML(mergedJSON)
 	if err != nil {
 		return "", err
@@ -400,6 +419,121 @@ func ensureCompleteCreateYAML(args map[string]interface{}, data string, ctx cont
 		out += "\n"
 	}
 	return out, nil
+}
+
+// applyGVKFixupsJSON applies GVK-specific corrections to JSON data in-place.
+func applyGVKFixupsJSON(gvk schema.GroupVersionKind, data []byte) []byte {
+	if gvk.Group == "gateway.networking.k8s.io" && gvk.Kind == "HTTPRoute" {
+		data = fixHTTPRoutePathTypes(data)
+	}
+	if gvk.Group == "inference.networking.k8s.io" && gvk.Kind == "InferencePool" {
+		data = fixInferencePoolSpec(data)
+	}
+	return data
+}
+
+// applyGVKFixups applies GVK-specific corrections to a YAML string.
+func applyGVKFixups(gvk schema.GroupVersionKind, yamlData string) (string, error) {
+	jsonData, err := yaml.YAMLToJSON([]byte(yamlData))
+	if err != nil {
+		return yamlData, nil
+	}
+	fixed := applyGVKFixupsJSON(gvk, jsonData)
+	fixedYAML, err := yaml.JSONToYAML(fixed)
+	if err != nil {
+		return yamlData, nil
+	}
+	return string(fixedYAML), nil
+}
+
+// fixHTTPRoutePathTypes corrects common LLM mistakes in HTTPRoute path match types.
+// LLMs frequently generate "Prefix" instead of the correct "PathPrefix".
+func fixHTTPRoutePathTypes(data []byte) []byte {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	spec, _ := obj["spec"].(map[string]interface{})
+	if spec == nil {
+		return data
+	}
+	rules, _ := spec["rules"].([]interface{})
+	for _, r := range rules {
+		rule, _ := r.(map[string]interface{})
+		if rule == nil {
+			continue
+		}
+		matches, _ := rule["matches"].([]interface{})
+		for _, m := range matches {
+			match, _ := m.(map[string]interface{})
+			if match == nil {
+				continue
+			}
+			path, _ := match["path"].(map[string]interface{})
+			if path == nil {
+				continue
+			}
+			if t, ok := path["type"].(string); ok && t == "Prefix" {
+				path["type"] = "PathPrefix"
+			}
+		}
+	}
+	fixed, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return fixed
+}
+
+// fixInferencePoolSpec corrects common LLM mistakes in InferencePool specs.
+// LLMs frequently produce the deprecated flat format instead of the required v1 structure:
+//   - "targetPortNumber" (int) → "targetPorts" (array of {number: int})
+//   - flat "selector: {app: x}" → "selector: {matchLabels: {app: x}}"
+//   - missing "endpointPickerRef" → adds default
+func fixInferencePoolSpec(data []byte) []byte {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	spec, _ := obj["spec"].(map[string]interface{})
+	if spec == nil {
+		return data
+	}
+
+	// Fix targetPortNumber → targetPorts
+	if portNum, ok := spec["targetPortNumber"]; ok {
+		delete(spec, "targetPortNumber")
+		if num, ok := portNum.(float64); ok {
+			spec["targetPorts"] = []interface{}{map[string]interface{}{"number": num}}
+		}
+	}
+	if spec["targetPorts"] == nil {
+		spec["targetPorts"] = []interface{}{map[string]interface{}{"number": float64(8000)}}
+	}
+
+	// Fix flat selector → selector.matchLabels
+	if sel, ok := spec["selector"].(map[string]interface{}); ok {
+		if _, hasMatchLabels := sel["matchLabels"]; !hasMatchLabels {
+			spec["selector"] = map[string]interface{}{"matchLabels": sel}
+		}
+	}
+
+	// Ensure endpointPickerRef exists
+	if spec["endpointPickerRef"] == nil {
+		spec["endpointPickerRef"] = map[string]interface{}{
+			"group":       "",
+			"kind":        "Service",
+			"name":        "example-model-epp",
+			"port":        map[string]interface{}{"number": float64(9002)},
+			"failureMode": "FailClose",
+		}
+	}
+
+	fixed, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return fixed
 }
 
 // buildResourceTemplate creates a minimal valid template for each Istio resource type
@@ -462,9 +596,66 @@ func buildResourceTemplate(gvk schema.GroupVersionKind, name, namespace string) 
 				"mode": "STRICT",
 			},
 		}
+	case gvk.Group == "gateway.networking.k8s.io" && gvk.Kind == "Gateway":
+		base["spec"] = map[string]interface{}{
+			"gatewayClassName": "istio",
+			"listeners": []interface{}{
+				map[string]interface{}{
+					"name":     "http",
+					"port":     80,
+					"protocol": "HTTP",
+				},
+			},
+		}
+	case gvk.Group == "gateway.networking.k8s.io" && gvk.Kind == "HTTPRoute":
+		base["spec"] = map[string]interface{}{
+			"parentRefs": []interface{}{
+				map[string]interface{}{
+					"name": "example-gateway",
+				},
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"matches": []interface{}{
+						map[string]interface{}{
+							"path": map[string]interface{}{
+								"type":  "PathPrefix",
+								"value": "/",
+							},
+						},
+					},
+					"backendRefs": []interface{}{
+						map[string]interface{}{
+							"name": "example",
+							"port": 80,
+						},
+					},
+				},
+			},
+		}
+	case gvk.Group == "inference.networking.k8s.io" && gvk.Kind == "InferencePool":
+		base["spec"] = map[string]interface{}{
+			"targetPorts": []interface{}{
+				map[string]interface{}{
+					"number": 8000,
+				},
+			},
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"app": "example-model",
+				},
+			},
+			"endpointPickerRef": map[string]interface{}{
+				"group": "",
+				"kind":  "Service",
+				"name":  "example-model-epp",
+				"port": map[string]interface{}{
+					"number": 9002,
+				},
+				"failureMode": "FailClose",
+			},
+		}
 	}
-	// For other resource types, just return the base (apiVersion, kind, metadata)
-	// The LLM should provide a complete spec for those.
 
 	return base
 }
@@ -488,13 +679,72 @@ var allowedSecurityIstioKinds = map[string]struct{}{
 	"RequestAuthentication": {},
 }
 
-// validateManagedIstioGroupAndKind ensures group is networking.istio.io or security.istio.io
-// and kind is allowed for that API group.
-func validateManagedIstioGroupAndKind(group, kind string) error {
+// allowedGatewayAPIKinds are the Gateway API kinds supported when Gateway API CRDs are installed.
+var allowedGatewayAPIKinds = map[string]struct{}{
+	"Gateway":        {},
+	"GRPCRoute":      {},
+	"HTTPRoute":      {},
+	"ReferenceGrant": {},
+	"TCPRoute":       {},
+	"TLSRoute":       {},
+}
+
+// allowedInferenceAPIKinds are the Inference API kinds supported when inference.networking.k8s.io CRDs are installed.
+var allowedInferenceAPIKinds = map[string]struct{}{
+	"InferencePool": {},
+}
+
+// inferGroupFromKind attempts to resolve the API group from the kind alone.
+// Returns the group if the kind unambiguously belongs to one group, or "" if ambiguous
+// (e.g. "Gateway" exists in both networking.istio.io and gateway.networking.k8s.io).
+func inferGroupFromKind(kind string, isGatewayAPIEnabled, isInferenceAPIEnabled bool) string {
+	if _, ok := allowedSecurityIstioKinds[kind]; ok {
+		return "security.istio.io"
+	}
+	if _, ok := allowedInferenceAPIKinds[kind]; ok && isInferenceAPIEnabled {
+		return "inference.networking.k8s.io"
+	}
+	inNetworking := false
+	if _, ok := allowedNetworkingIstioKinds[kind]; ok {
+		inNetworking = true
+	}
+	inGatewayAPI := false
+	if _, ok := allowedGatewayAPIKinds[kind]; ok && isGatewayAPIEnabled {
+		inGatewayAPI = true
+	}
+	if inNetworking && !inGatewayAPI {
+		return "networking.istio.io"
+	}
+	if inGatewayAPI && !inNetworking {
+		return "gateway.networking.k8s.io"
+	}
+	return ""
+}
+
+// validateManagedIstioGroupAndKind ensures group is networking.istio.io, security.istio.io,
+// (when Gateway API is discovered) gateway.networking.k8s.io, or (when Inference API is
+// discovered) inference.networking.k8s.io, and kind is allowed for that group.
+// When group is empty but kind is unambiguous, the group is inferred automatically.
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
+func validateManagedIstioGroupAndKind(group, kind string, flags ...bool) error {
 	g := strings.TrimSpace(group)
 	k := strings.TrimSpace(kind)
+	isGatewayAPIEnabled := len(flags) > 0 && flags[0]
+	isInferenceAPIEnabled := len(flags) > 1 && flags[1]
+	if g == "" && k != "" {
+		if inferred := inferGroupFromKind(k, isGatewayAPIEnabled, isInferenceAPIEnabled); inferred != "" {
+			g = inferred
+		}
+	}
 	if g == "" {
-		return fmt.Errorf(`group is required and must be "networking.istio.io" or "security.istio.io"`)
+		groups := []string{`"networking.istio.io"`, `"security.istio.io"`}
+		if isGatewayAPIEnabled {
+			groups = append(groups, `"gateway.networking.k8s.io"`)
+		}
+		if isInferenceAPIEnabled {
+			groups = append(groups, `"inference.networking.k8s.io"`)
+		}
+		return fmt.Errorf("group is required and must be %s", strings.Join(groups, ", "))
 	}
 	if k == "" {
 		return fmt.Errorf("kind is required for group %q", g)
@@ -516,13 +766,43 @@ func validateManagedIstioGroupAndKind(group, kind string) error {
 			)
 		}
 		return nil
+	case "gateway.networking.k8s.io":
+		if !isGatewayAPIEnabled {
+			return fmt.Errorf(`invalid group %q: Gateway API CRDs are not installed on the cluster`, g)
+		}
+		if _, ok := allowedGatewayAPIKinds[k]; !ok {
+			return fmt.Errorf(
+				"invalid kind %q for group %q: must be one of Gateway, HTTPRoute, GRPCRoute, ReferenceGrant, TCPRoute, TLSRoute",
+				k, g,
+			)
+		}
+		return nil
+	case "inference.networking.k8s.io":
+		if !isInferenceAPIEnabled {
+			return fmt.Errorf(`invalid group %q: Inference API CRDs are not installed on the cluster`, g)
+		}
+		if _, ok := allowedInferenceAPIKinds[k]; !ok {
+			return fmt.Errorf(
+				"invalid kind %q for group %q: must be InferencePool",
+				k, g,
+			)
+		}
+		return nil
 	default:
-		return fmt.Errorf(`invalid group %q: must be "networking.istio.io" or "security.istio.io"`, g)
+		groups := []string{`"networking.istio.io"`, `"security.istio.io"`}
+		if isGatewayAPIEnabled {
+			groups = append(groups, `"gateway.networking.k8s.io"`)
+		}
+		if isInferenceAPIEnabled {
+			groups = append(groups, `"inference.networking.k8s.io"`)
+		}
+		return fmt.Errorf("invalid group %q: must be %s", g, strings.Join(groups, ", "))
 	}
 }
 
 // validateReadOnlyIstioConfigInput validates args for read-only actions (list, get).
-func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
+func validateReadOnlyIstioConfigInput(args map[string]interface{}, flags ...bool) error {
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")
 	group := mcputil.GetStringArg(args, "group")
@@ -531,10 +811,24 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 	object := mcputil.GetStringArg(args, "object")
 	switch action {
 	case "list":
-		if strings.TrimSpace(group) != "" || strings.TrimSpace(kind) != "" {
-			return validateManagedIstioGroupAndKind(group, kind)
+		hasGroup := strings.TrimSpace(group) != ""
+		hasKind := strings.TrimSpace(kind) != ""
+		if !hasGroup && !hasKind {
+			return nil
 		}
-		return nil
+		if hasKind && !hasGroup {
+			isGatewayAPIEnabled := len(flags) > 0 && flags[0]
+			isInferenceAPIEnabled := len(flags) > 1 && flags[1]
+			inferred := inferGroupFromKind(kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
+			if inferred != "" {
+				return validateManagedIstioGroupAndKind(inferred, kind, flags...)
+			}
+			return fmt.Errorf("group is required when kind is specified for action %q", action)
+		}
+		if hasGroup && !hasKind {
+			return fmt.Errorf("kind is required when group is specified for action %q", action)
+		}
+		return validateManagedIstioGroupAndKind(group, kind, flags...)
 	case "get":
 		if namespace == "" {
 			return fmt.Errorf("namespace is required for action %q", action)
@@ -551,7 +845,7 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 		if object == "" {
 			return fmt.Errorf("name is required for action %q", action)
 		}
-		return validateManagedIstioGroupAndKind(group, kind)
+		return validateManagedIstioGroupAndKind(group, kind, flags...)
 	default:
 		return fmt.Errorf("invalid action %q: must be one of list, get", action)
 	}
@@ -561,7 +855,8 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}) error {
 // It also normalizes args: if "object" is missing it falls back to "name" or
 // extracts metadata.name from "data", writing the resolved value back into
 // args["object"] so downstream code sees it.
-func validateIstioConfigInput(args map[string]interface{}) error {
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
+func validateIstioConfigInput(args map[string]interface{}, flags ...bool) error {
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")
 	group := mcputil.GetStringArg(args, "group")
@@ -607,7 +902,7 @@ func validateIstioConfigInput(args map[string]interface{}) error {
 				return fmt.Errorf("object (resource name) is required for action %q — set the 'object' parameter", action)
 			}
 		}
-		return validateManagedIstioGroupAndKind(group, kind)
+		return validateManagedIstioGroupAndKind(group, kind, flags...)
 	default:
 		return fmt.Errorf("invalid action %q: must be one of create, patch, delete", action)
 	}

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +63,15 @@ func kialiIntf(r *http.Request, businessLayer *business.Layer, conf *config.Conf
 		Request:       r,
 		BusinessLayer: businessLayer,
 		Conf:          conf,
+	}
+}
+
+func kialiIntfWithFactory(r *http.Request, businessLayer *business.Layer, conf *config.Config, cf kubernetes.ClientFactory) *mcputil.KialiInterface {
+	return &mcputil.KialiInterface{
+		Request:       r,
+		BusinessLayer: businessLayer,
+		Conf:          conf,
+		ClientFactory: cf,
 	}
 }
 
@@ -254,9 +264,12 @@ func TestValidateReadOnlyIstioConfigInput(t *testing.T) {
 			wantErr: "invalid kind",
 		},
 		{
-			name:    "list filter kind without group",
-			args:    map[string]interface{}{"action": "list", "kind": "VirtualService"},
-			wantErr: "group is required",
+			name: "list filter kind without group infers networking",
+			args: map[string]interface{}{"action": "list", "kind": "VirtualService"},
+		},
+		{
+			name: "list filter Gateway kind without group infers Istio when GW API disabled",
+			args: map[string]interface{}{"action": "list", "kind": "Gateway"},
 		},
 		{
 			name:    "list filter group without kind",
@@ -310,10 +323,14 @@ func TestValidateManagedIstioGroupAndKind(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "empty group",
-			group:   "",
-			kind:    "VirtualService",
-			wantErr: "group is required",
+			name:  "empty group infers from unambiguous kind",
+			group: "",
+			kind:  "VirtualService",
+		},
+		{
+			name:  "empty group infers Gateway as Istio when GW API disabled",
+			group: "",
+			kind:  "Gateway",
 		},
 		{
 			name:    "empty kind",
@@ -1798,4 +1815,656 @@ func TestExecute_CreateAlreadyExistsThroughExecute(t *testing.T) {
 	assert.Contains(t, resStr, "ERROR:")
 	assert.Contains(t, resStr, "already exists")
 	assert.Contains(t, resStr, "patch")
+}
+
+// ---------------------------------------------------------------------------
+// 17. Gateway API support tests
+// ---------------------------------------------------------------------------
+
+func setupTestWithGatewayAPI(t *testing.T, objs ...runtime.Object) (*business.Layer, *config.Config, kubernetes.ClientFactory) {
+	t.Helper()
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs)+1)
+	runtimeObjs = append(runtimeObjs, kubetest.FakeNamespace("bookinfo"))
+	runtimeObjs = append(runtimeObjs, objs...)
+	k8s := kubetest.NewFakeK8sClient(runtimeObjs...)
+	k8s.GatewayAPIEnabled = true
+	cf := kubetest.NewFakeClientFactoryWithClient(conf, k8s)
+	return business.NewLayerBuilder(t, conf).WithClient(k8s).Build(), conf, cf
+}
+
+func TestValidateManagedIstioGroupAndKind_GatewayAPIEnabled(t *testing.T) {
+	gatewayAPIKinds := []string{"Gateway", "HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute"}
+
+	tests := []struct {
+		name    string
+		group   string
+		kind    string
+		enabled bool
+		wantErr string
+	}{
+		{
+			name:    "gateway API disabled rejects group",
+			group:   "gateway.networking.k8s.io",
+			kind:    "Gateway",
+			enabled: false,
+			wantErr: "Gateway API CRDs are not installed on the cluster",
+		},
+		{
+			name:    "gateway API enabled accepts Gateway",
+			group:   "gateway.networking.k8s.io",
+			kind:    "Gateway",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled accepts HTTPRoute",
+			group:   "gateway.networking.k8s.io",
+			kind:    "HTTPRoute",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled accepts GRPCRoute",
+			group:   "gateway.networking.k8s.io",
+			kind:    "GRPCRoute",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled accepts ReferenceGrant",
+			group:   "gateway.networking.k8s.io",
+			kind:    "ReferenceGrant",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled accepts TCPRoute",
+			group:   "gateway.networking.k8s.io",
+			kind:    "TCPRoute",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled accepts TLSRoute",
+			group:   "gateway.networking.k8s.io",
+			kind:    "TLSRoute",
+			enabled: true,
+		},
+		{
+			name:    "gateway API enabled rejects invalid kind",
+			group:   "gateway.networking.k8s.io",
+			kind:    "InferencePool",
+			enabled: true,
+			wantErr: "invalid kind",
+		},
+		{
+			name:    "gateway API enabled still validates Istio kinds",
+			group:   "networking.istio.io",
+			kind:    "VirtualService",
+			enabled: true,
+		},
+	}
+
+	_ = gatewayAPIKinds
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateManagedIstioGroupAndKind(tt.group, tt.kind, tt.enabled)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateReadOnlyIstioConfigInput_GatewayAPIEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "list filter gateway API group with enabled",
+			args: map[string]interface{}{"action": "list", "group": "gateway.networking.k8s.io", "kind": "HTTPRoute"},
+		},
+		{
+			name: "list filter HTTPRoute without group infers gateway API",
+			args: map[string]interface{}{"action": "list", "kind": "HTTPRoute"},
+		},
+		{
+			name:    "list filter Gateway without group is ambiguous when GW API enabled",
+			args:    map[string]interface{}{"action": "list", "kind": "Gateway"},
+			wantErr: "group is required",
+		},
+		{
+			name: "get gateway API resource with enabled",
+			args: map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "gateway.networking.k8s.io", "version": "v1", "kind": "Gateway", "object": "test-gw"},
+		},
+		{
+			name:    "get gateway API invalid kind with enabled",
+			args:    map[string]interface{}{"action": "get", "namespace": "bookinfo", "group": "gateway.networking.k8s.io", "version": "v1", "kind": "InferencePool", "object": "test"},
+			wantErr: "invalid kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateReadOnlyIstioConfigInput(tt.args, true)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateIstioConfigInput_GatewayAPIEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "create gateway API HTTPRoute with enabled",
+			args: map[string]interface{}{
+				"action": "create", "namespace": "bookinfo",
+				"group": "gateway.networking.k8s.io", "version": "v1",
+				"kind": "HTTPRoute", "object": "my-route", "data": "{}",
+			},
+		},
+		{
+			name: "patch gateway API Gateway with enabled",
+			args: map[string]interface{}{
+				"action": "patch", "namespace": "bookinfo",
+				"group": "gateway.networking.k8s.io", "version": "v1",
+				"kind": "Gateway", "object": "my-gw", "data": "{}",
+			},
+		},
+		{
+			name: "delete gateway API ReferenceGrant with enabled",
+			args: map[string]interface{}{
+				"action": "delete", "namespace": "bookinfo",
+				"group": "gateway.networking.k8s.io", "version": "v1",
+				"kind": "ReferenceGrant", "object": "my-rg",
+			},
+		},
+		{
+			name: "create gateway API rejected when disabled",
+			args: map[string]interface{}{
+				"action": "create", "namespace": "bookinfo",
+				"group": "gateway.networking.k8s.io", "version": "v1",
+				"kind": "HTTPRoute", "object": "my-route", "data": "{}",
+			},
+			wantErr: "Gateway API CRDs are not installed on the cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isGatewayAPIEnabled := !strings.Contains(tt.name, "rejected when disabled")
+			err := validateIstioConfigInput(tt.args, isGatewayAPIEnabled)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExecuteReadOnly_GatewayAPIEnabled_ListFilterGateway(t *testing.T) {
+	businessLayer, conf, cf := setupTestWithGatewayAPI(t)
+	r := reqWithAuth()
+
+	args := map[string]interface{}{
+		"action": "list",
+		"group":  "gateway.networking.k8s.io",
+		"kind":   "HTTPRoute",
+	}
+
+	res, status := ExecuteReadOnly(kialiIntfWithFactory(r, businessLayer, conf, cf), args)
+	require.Equal(t, http.StatusOK, status)
+	result, ok := res.([]IstioListItem)
+	require.True(t, ok, "expected []IstioListItem, got %T", res)
+	assert.NotNil(t, result)
+}
+
+func TestExecute_GatewayAPIEnabled_CreateHTTPRoute(t *testing.T) {
+	businessLayer, conf, cf := setupTestWithGatewayAPI(t)
+	r := reqWithAuth()
+
+	args := map[string]interface{}{
+		"action":    "create",
+		"confirmed": true,
+		"namespace": "bookinfo",
+		"group":     "gateway.networking.k8s.io",
+		"version":   "v1",
+		"kind":      "HTTPRoute",
+		"object":    "my-route",
+		"data":      `{"metadata":{"name":"my-route","namespace":"bookinfo"},"spec":{"parentRefs":[{"name":"my-gw"}],"rules":[{"backendRefs":[{"name":"reviews","port":80}]}]}}`,
+	}
+
+	res, status := Execute(kialiIntfWithFactory(r, businessLayer, conf, cf), args)
+	require.Equal(t, http.StatusOK, status)
+
+	b, err := json.Marshal(res)
+	require.NoError(t, err)
+	var resp previewResponse
+	require.NoError(t, json.Unmarshal(b, &resp))
+	require.Len(t, resp.Actions, 1)
+	assert.Equal(t, "create", resp.Actions[0].Operation)
+	assert.Equal(t, "HTTPRoute", resp.Actions[0].KindName)
+	assert.Equal(t, "gateway.networking.k8s.io", resp.Actions[0].Group)
+}
+
+func TestExecute_GatewayAPIDisabled_RejectsCreate(t *testing.T) {
+	businessLayer, conf := setupTest(t)
+	r := reqWithAuth()
+
+	args := map[string]interface{}{
+		"action":    "create",
+		"confirmed": true,
+		"namespace": "bookinfo",
+		"group":     "gateway.networking.k8s.io",
+		"version":   "v1",
+		"kind":      "HTTPRoute",
+		"object":    "my-route",
+		"data":      `{"metadata":{"name":"my-route","namespace":"bookinfo"},"spec":{}}`,
+	}
+
+	res, status := Execute(kialiIntf(r, businessLayer, conf), args)
+	assert.Equal(t, http.StatusBadRequest, status)
+	resStr, ok := res.(string)
+	require.True(t, ok)
+	assert.Contains(t, resStr, "Gateway API CRDs are not installed on the cluster")
+}
+
+func TestBuildResourceTemplate_K8sGateway(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"}
+	tpl := buildResourceTemplate(gvk, "my-gw", "bookinfo")
+
+	assert.Equal(t, "gateway.networking.k8s.io/v1", tpl["apiVersion"])
+	assert.Equal(t, "Gateway", tpl["kind"])
+	spec, ok := tpl["spec"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "istio", spec["gatewayClassName"])
+	assert.NotNil(t, spec["listeners"])
+}
+
+func TestBuildResourceTemplate_HTTPRoute(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}
+	tpl := buildResourceTemplate(gvk, "my-route", "bookinfo")
+
+	assert.Equal(t, "gateway.networking.k8s.io/v1", tpl["apiVersion"])
+	assert.Equal(t, "HTTPRoute", tpl["kind"])
+	spec, ok := tpl["spec"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotNil(t, spec["parentRefs"])
+	rules, ok := spec["rules"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, rules, 1)
+	rule := rules[0].(map[string]interface{})
+	matches, ok := rule["matches"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, matches, 1)
+	match := matches[0].(map[string]interface{})
+	path := match["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", path["type"])
+	assert.Equal(t, "/", path["value"])
+}
+
+func TestFixHTTPRoutePathTypes(t *testing.T) {
+	input := []byte(`{"spec":{"rules":[{"matches":[{"path":{"type":"Prefix","value":"/"}}]}]}}`)
+	fixed := fixHTTPRoutePathTypes(input)
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(fixed, &obj))
+	spec := obj["spec"].(map[string]interface{})
+	rules := spec["rules"].([]interface{})
+	rule := rules[0].(map[string]interface{})
+	matches := rule["matches"].([]interface{})
+	match := matches[0].(map[string]interface{})
+	path := match["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", path["type"])
+	assert.Equal(t, "/", path["value"])
+}
+
+func TestDefaultIstioConfigCriteria_GatewayAPIEnabled(t *testing.T) {
+	criteria := defaultIstioConfigCriteria(true, false)
+	assert.True(t, criteria.IncludeK8sGateways)
+	assert.True(t, criteria.IncludeK8sHTTPRoutes)
+	assert.True(t, criteria.IncludeK8sGRPCRoutes)
+	assert.True(t, criteria.IncludeK8sReferenceGrants)
+	assert.True(t, criteria.IncludeK8sTCPRoutes)
+	assert.True(t, criteria.IncludeK8sTLSRoutes)
+	assert.False(t, criteria.IncludeK8sInferencePools)
+	assert.True(t, criteria.IncludeVirtualServices)
+}
+
+func TestDefaultIstioConfigCriteria_GatewayAPIDisabled(t *testing.T) {
+	criteria := defaultIstioConfigCriteria(false, false)
+	assert.False(t, criteria.IncludeK8sGateways)
+	assert.False(t, criteria.IncludeK8sHTTPRoutes)
+	assert.False(t, criteria.IncludeK8sGRPCRoutes)
+	assert.False(t, criteria.IncludeK8sReferenceGrants)
+	assert.False(t, criteria.IncludeK8sTCPRoutes)
+	assert.False(t, criteria.IncludeK8sTLSRoutes)
+	assert.False(t, criteria.IncludeK8sInferencePools)
+	assert.True(t, criteria.IncludeVirtualServices)
+	assert.True(t, criteria.IncludeDestinationRules)
+}
+
+func TestDefaultIstioConfigCriteria_InferenceAPIEnabled(t *testing.T) {
+	criteria := defaultIstioConfigCriteria(false, true)
+	assert.False(t, criteria.IncludeK8sGateways)
+	assert.True(t, criteria.IncludeK8sInferencePools)
+	assert.True(t, criteria.IncludeVirtualServices)
+}
+
+func TestDefaultIstioConfigCriteria_BothEnabled(t *testing.T) {
+	criteria := defaultIstioConfigCriteria(true, true)
+	assert.True(t, criteria.IncludeK8sGateways)
+	assert.True(t, criteria.IncludeK8sHTTPRoutes)
+	assert.True(t, criteria.IncludeK8sInferencePools)
+	assert.True(t, criteria.IncludeVirtualServices)
+}
+
+func TestValidateManagedIstioGroupAndKind_InferenceAPIEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   string
+		kind    string
+		gwFlag  bool
+		infFlag bool
+		wantErr string
+	}{
+		{
+			name:    "inference API disabled rejects group",
+			group:   "inference.networking.k8s.io",
+			kind:    "InferencePool",
+			gwFlag:  false,
+			infFlag: false,
+			wantErr: "Inference API CRDs are not installed on the cluster",
+		},
+		{
+			name:    "inference API enabled accepts InferencePool",
+			group:   "inference.networking.k8s.io",
+			kind:    "InferencePool",
+			gwFlag:  false,
+			infFlag: true,
+		},
+		{
+			name:    "inference API enabled rejects invalid kind",
+			group:   "inference.networking.k8s.io",
+			kind:    "InvalidKind",
+			gwFlag:  false,
+			infFlag: true,
+			wantErr: "invalid kind",
+		},
+		{
+			name:    "inference API enabled still validates Istio kinds",
+			group:   "networking.istio.io",
+			kind:    "VirtualService",
+			gwFlag:  false,
+			infFlag: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateManagedIstioGroupAndKind(tt.group, tt.kind, tt.gwFlag, tt.infFlag)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExecuteReadOnly_InferenceAPIDisabled(t *testing.T) {
+	businessLayer, conf := setupTest(t)
+	r := reqWithAuth()
+
+	args := map[string]interface{}{
+		"action":    "get",
+		"namespace": "bookinfo",
+		"group":     "inference.networking.k8s.io",
+		"version":   "v1alpha2",
+		"kind":      "InferencePool",
+		"object":    "test-pool",
+	}
+
+	res, status := ExecuteReadOnly(kialiIntf(r, businessLayer, conf), args)
+	assert.Equal(t, http.StatusOK, status)
+	resStr, ok := res.(string)
+	require.True(t, ok)
+	assert.Contains(t, resStr, "Inference API CRDs are not installed")
+}
+
+func TestBuildResourceTemplate_InferencePool(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "inference.networking.k8s.io", Version: "v1", Kind: "InferencePool"}
+	tpl := buildResourceTemplate(gvk, "my-pool", "default")
+	assert.Equal(t, "inference.networking.k8s.io/v1", tpl["apiVersion"])
+	assert.Equal(t, "InferencePool", tpl["kind"])
+	spec, ok := tpl["spec"].(map[string]interface{})
+	require.True(t, ok)
+	targetPorts, ok := spec["targetPorts"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, targetPorts, 1)
+	port := targetPorts[0].(map[string]interface{})
+	assert.Equal(t, 8000, port["number"])
+	selector, ok := spec["selector"].(map[string]interface{})
+	require.True(t, ok)
+	matchLabels, ok := selector["matchLabels"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "example-model", matchLabels["app"])
+	epr, ok := spec["endpointPickerRef"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "Service", epr["kind"])
+	assert.Equal(t, "example-model-epp", epr["name"])
+	assert.Equal(t, "FailClose", epr["failureMode"])
+}
+
+// ---------------------------------------------------------------------------
+// fixHTTPRoutePathTypes unit tests
+// ---------------------------------------------------------------------------
+
+func TestFixHTTPRoutePathTypes_PrefixCorrected(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Prefix","value":"/api"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	path := obj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", path["type"], "LLM 'Prefix' should be corrected to 'PathPrefix'")
+	assert.Equal(t, "/api", path["value"], "path value should be preserved")
+}
+
+func TestFixHTTPRoutePathTypes_AlreadyPathPrefix(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/api"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	assert.JSONEq(t, input, string(output), "already-correct PathPrefix should be unchanged")
+}
+
+func TestFixHTTPRoutePathTypes_ExactTypeUntouched(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Exact","value":"/ping"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	assert.JSONEq(t, input, string(output), "Exact path type should not be modified")
+}
+
+func TestFixHTTPRoutePathTypes_MultipleRulesAndMatches(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Prefix","value":"/a"}},{"path":{"type":"Exact","value":"/b"}}]},{"matches":[{"path":{"type":"Prefix","value":"/c"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	rules := obj["spec"].(map[string]interface{})["rules"].([]interface{})
+	// rule[0] match[0]: Prefix → PathPrefix
+	m00 := rules[0].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", m00["type"])
+	// rule[0] match[1]: Exact → unchanged
+	m01 := rules[0].(map[string]interface{})["matches"].([]interface{})[1].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "Exact", m01["type"])
+	// rule[1] match[0]: Prefix → PathPrefix
+	m10 := rules[1].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", m10["type"])
+}
+
+func TestFixHTTPRoutePathTypes_InvalidJSONPassthrough(t *testing.T) {
+	input := []byte(`not-json`)
+	output := fixHTTPRoutePathTypes(input)
+	assert.Equal(t, input, output, "invalid JSON should be returned unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// fixInferencePoolSpec unit tests
+// ---------------------------------------------------------------------------
+
+func TestFixInferencePoolSpec_TargetPortNumberMigrated(t *testing.T) {
+	input := `{"spec":{"targetPortNumber":8080,"selector":{"matchLabels":{"app":"model"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	spec := obj["spec"].(map[string]interface{})
+	assert.Nil(t, spec["targetPortNumber"], "targetPortNumber should be removed")
+	targetPorts, ok := spec["targetPorts"].([]interface{})
+	require.True(t, ok, "targetPorts should be set")
+	require.Len(t, targetPorts, 1)
+	assert.Equal(t, float64(8080), targetPorts[0].(map[string]interface{})["number"])
+}
+
+func TestFixInferencePoolSpec_FlatSelectorWrapped(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"app":"my-model"},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	sel := obj["spec"].(map[string]interface{})["selector"].(map[string]interface{})
+	ml, ok := sel["matchLabels"].(map[string]interface{})
+	require.True(t, ok, "flat selector should be wrapped under matchLabels")
+	assert.Equal(t, "my-model", ml["app"])
+}
+
+func TestFixInferencePoolSpec_AlreadyMatchLabelsSelectorUnchanged(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	assert.JSONEq(t, input, string(output), "already-correct selector should not be double-wrapped")
+}
+
+func TestFixInferencePoolSpec_MissingEndpointPickerRefAdded(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	epr := obj["spec"].(map[string]interface{})["endpointPickerRef"].(map[string]interface{})
+	assert.Equal(t, "Service", epr["kind"])
+	assert.Equal(t, "example-model-epp", epr["name"])
+	assert.Equal(t, "FailClose", epr["failureMode"])
+}
+
+func TestFixInferencePoolSpec_ExistingEndpointPickerRefPreserved(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"my-real-epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	epr := obj["spec"].(map[string]interface{})["endpointPickerRef"].(map[string]interface{})
+	assert.Equal(t, "my-real-epp", epr["name"], "user-provided endpointPickerRef.name should not be overwritten")
+}
+
+func TestFixInferencePoolSpec_MissingTargetPortsAdded(t *testing.T) {
+	input := `{"spec":{"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	targetPorts, ok := obj["spec"].(map[string]interface{})["targetPorts"].([]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(8000), targetPorts[0].(map[string]interface{})["number"])
+}
+
+func TestFixInferencePoolSpec_InvalidJSONPassthrough(t *testing.T) {
+	input := []byte(`not-json`)
+	output := fixInferencePoolSpec(input)
+	assert.Equal(t, input, output, "invalid JSON should be returned unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// inferGroupFromKind unit tests
+// ---------------------------------------------------------------------------
+
+func TestInferGroupFromKind(t *testing.T) {
+	tests := []struct {
+		name                  string
+		kind                  string
+		isGatewayAPIEnabled   bool
+		isInferenceAPIEnabled bool
+		expectedGroup         string
+	}{
+		{
+			name:          "security kind inferred without any flags",
+			kind:          "AuthorizationPolicy",
+			expectedGroup: "security.istio.io",
+		},
+		{
+			name:          "networking-only kind inferred when GW API disabled",
+			kind:          "VirtualService",
+			expectedGroup: "networking.istio.io",
+		},
+		{
+			name:                "networking-only kind inferred when GW API enabled",
+			kind:                "VirtualService",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "networking.istio.io",
+		},
+		{
+			name:                "Gateway is ambiguous when GW API enabled",
+			kind:                "Gateway",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "",
+		},
+		{
+			name:                "Gateway infers networking.istio.io when GW API disabled",
+			kind:                "Gateway",
+			isGatewayAPIEnabled: false,
+			expectedGroup:       "networking.istio.io",
+		},
+		{
+			name:                  "InferencePool inferred when inference API enabled",
+			kind:                  "InferencePool",
+			isInferenceAPIEnabled: true,
+			expectedGroup:         "inference.networking.k8s.io",
+		},
+		{
+			name:                  "InferencePool returns empty when inference API disabled",
+			kind:                  "InferencePool",
+			isInferenceAPIEnabled: false,
+			expectedGroup:         "",
+		},
+		{
+			name:                "HTTPRoute inferred as gateway API when enabled",
+			kind:                "HTTPRoute",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "gateway.networking.k8s.io",
+		},
+		{
+			name:                "HTTPRoute returns empty when GW API disabled",
+			kind:                "HTTPRoute",
+			isGatewayAPIEnabled: false,
+			expectedGroup:       "",
+		},
+		{
+			name:          "unknown kind returns empty",
+			kind:          "NoSuchKind",
+			expectedGroup: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferGroupFromKind(tt.kind, tt.isGatewayAPIEnabled, tt.isInferenceAPIEnabled)
+			assert.Equal(t, tt.expectedGroup, got)
+		})
+	}
 }

--- a/ai/mcp/tools/manage_istio_config.yaml
+++ b/ai/mcp/tools/manage_istio_config.yaml
@@ -1,5 +1,5 @@
 - name: "manage_istio_config"
-  description: "Create, patch, or delete Istio config. For list and get (read-only) use manage_istio_config_read."
+  description: "Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read."
   toolset: [default, mcp]
   input_schema:
     type: "object"
@@ -20,21 +20,21 @@
         description: "Namespace containing the Istio object."
       group:
         type: "string"
-        description: "API group of the Istio object."
-        enum: ["networking.istio.io", "security.istio.io"]
+        description: "API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources."
+        enum: ["networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"]
       version:
         type: "string"
-        description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway."
+        description: "API version. Use 'v1' for all resource types."
       kind:
         type: "string"
         description: "Kind of the Istio object (e.g., 'VirtualService', 'DestinationRule')."
-        enum: ["VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication"]
+        enum: ["VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication", "HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute", "InferencePool"]
       object:
         type: "string"
         description: "Name of the Istio object."
       data:
         type: "string"
-        description: "Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element."
+        description: "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want."
       dataFormat:
         type: "string"
         description: "Optional hint for the payload format. Usually leave as 'auto'."

--- a/ai/mcp/tools/manage_istio_config_read.yaml
+++ b/ai/mcp/tools/manage_istio_config_read.yaml
@@ -1,5 +1,5 @@
 - name: "manage_istio_config_read"
-  description: "Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config."
+  description: "Read-only Istio, Gateway API, and Inference API config: list or get objects. For action 'list', returns ALL config objects in a SINGLE call (omit group/kind to get everything). Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For create, patch, or delete use manage_istio_config."
   toolset: [default, mcp]
   input_schema:
     type: "object"
@@ -17,15 +17,15 @@
         description: "Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required."
       group:
         type: "string"
-        description: "API group of the Istio object. Required for 'get' action."
-        enum: ["networking.istio.io", "security.istio.io"]
+        description: "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources."
+        enum: ["networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"]
       version:
         type: "string"
-        description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action."
+        description: "API version. Use 'v1' for all resource types. Required for 'get' action."
       kind:
         type: "string"
-        description: "Kind of the Istio object. Required for 'get' action."
-        enum: ["VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication"]
+        description: "Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once — do NOT call separately for each kind."
+        enum: ["VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication", "HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute", "InferencePool"]
       object:
         type: "string"
         description: "Name of the Istio object. Required for 'get' action."

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -420,12 +420,12 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 			},
 			"group": {
 				Type:        genai.TypeString,
-				Description: "API group of the Istio object.",
-				Enum:        []string{"networking.istio.io", "security.istio.io"},
+				Description: "API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
+				Enum:        []string{"networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"},
 			},
 			"version": {
 				Type:        genai.TypeString,
-				Description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway.",
+				Description: "API version. Use 'v1' for all resource types.",
 			},
 			"kind": {
 				Type:        genai.TypeString,
@@ -434,6 +434,8 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 					"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar",
 					"WorkloadEntry", "WorkloadGroup", "EnvoyFilter",
 					"AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication",
+					"HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute",
+					"InferencePool",
 				},
 			},
 			"object": {
@@ -442,7 +444,7 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 			},
 			"data": {
 				Type:        genai.TypeString,
-				Description: "Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element.",
+				Description: "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
 			},
 			"dataFormat": {
 				Type:        genai.TypeString,
@@ -480,20 +482,22 @@ func TestConvertToolToGoogle_FromToolDefinition_ManageIstioConfigRead(t *testing
 			},
 			"group": {
 				Type:        genai.TypeString,
-				Description: "API group of the Istio object. Required for 'get' action.",
-				Enum:        []string{"networking.istio.io", "security.istio.io"},
+				Description: "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
+				Enum:        []string{"networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"},
 			},
 			"version": {
 				Type:        genai.TypeString,
-				Description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+				Description: "API version. Use 'v1' for all resource types. Required for 'get' action.",
 			},
 			"kind": {
 				Type:        genai.TypeString,
-				Description: "Kind of the Istio object. Required for 'get' action.",
+				Description: "Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once \u2014 do NOT call separately for each kind.",
 				Enum: []string{
 					"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar",
 					"WorkloadEntry", "WorkloadGroup", "EnvoyFilter",
 					"AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication",
+					"HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute",
+					"InferencePool",
 				},
 			},
 			"object": {

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -552,7 +552,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 		OfFunction: &openai.ChatCompletionFunctionToolParam{
 			Function: openai.FunctionDefinitionParam{
 				Name:        "manage_istio_config",
-				Description: openai.String("Create, patch, or delete Istio config. For list and get (read-only) use manage_istio_config_read."),
+				Description: openai.String("Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"required": []interface{}{
@@ -588,15 +588,17 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 						},
 						"group": map[string]interface{}{
 							"type":        "string",
-							"description": "API group of the Istio object.",
+							"description": "API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
 							"enum": []interface{}{
 								"networking.istio.io",
 								"security.istio.io",
+								"gateway.networking.k8s.io",
+								"inference.networking.k8s.io",
 							},
 						},
 						"version": map[string]interface{}{
 							"type":        "string",
-							"description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway.",
+							"description": "API version. Use 'v1' for all resource types.",
 						},
 						"kind": map[string]interface{}{
 							"type":        "string",
@@ -613,6 +615,12 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 								"AuthorizationPolicy",
 								"PeerAuthentication",
 								"RequestAuthentication",
+								"HTTPRoute",
+								"GRPCRoute",
+								"ReferenceGrant",
+								"TCPRoute",
+								"TLSRoute",
+								"InferencePool",
 							},
 						},
 						"object": map[string]interface{}{
@@ -621,7 +629,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfig(t *testing.T) 
 						},
 						"data": map[string]interface{}{
 							"type":        "string",
-							"description": "Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element.",
+							"description": "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
 						},
 						"dataFormat": map[string]interface{}{
 							"type":        "string",
@@ -652,7 +660,7 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 		OfFunction: &openai.ChatCompletionFunctionToolParam{
 			Function: openai.FunctionDefinitionParam{
 				Name:        "manage_istio_config_read",
-				Description: openai.String("Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config."),
+				Description: openai.String("Read-only Istio, Gateway API, and Inference API config: list or get objects. For action 'list', returns ALL config objects in a SINGLE call (omit group/kind to get everything). Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For create, patch, or delete use manage_istio_config."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"required": []interface{}{
@@ -677,19 +685,21 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 						},
 						"group": map[string]interface{}{
 							"type":        "string",
-							"description": "API group of the Istio object. Required for 'get' action.",
+							"description": "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
 							"enum": []interface{}{
 								"networking.istio.io",
 								"security.istio.io",
+								"gateway.networking.k8s.io",
+								"inference.networking.k8s.io",
 							},
 						},
 						"version": map[string]interface{}{
 							"type":        "string",
-							"description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+							"description": "API version. Use 'v1' for all resource types. Required for 'get' action.",
 						},
 						"kind": map[string]interface{}{
 							"type":        "string",
-							"description": "Kind of the Istio object. Required for 'get' action.",
+							"description": "Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once \u2014 do NOT call separately for each kind.",
 							"enum": []interface{}{
 								"VirtualService",
 								"DestinationRule",
@@ -702,6 +712,12 @@ func TestConvertToolToOpenAI_FromToolDefinition_ManageIstioConfigRead(t *testing
 								"AuthorizationPolicy",
 								"PeerAuthentication",
 								"RequestAuthentication",
+								"HTTPRoute",
+								"GRPCRoute",
+								"ReferenceGrant",
+								"TCPRoute",
+								"TLSRoute",
+								"InferencePool",
 							},
 						},
 						"object": map[string]interface{}{


### PR DESCRIPTION
### Describe the change

Backport of https://github.com/kiali/kiali/pull/9988 into `v2.22`.

- Enable `manage_istio_config` and `manage_istio_config_read` tools to handle `gateway.networking.k8s.io` and `inference.networking.k8s.io` resources via auto-discovery
- Add `inferGroupFromKind` to resolve the API group when the LLM omits it for unambiguous kinds
- Add resource templates and post-merge fixups for HTTPRoute / InferencePool LLM mistakes

Adapted for v2.22 differences (no TrafficExtensions, flat `[]IstioListItem` list response, no Anthropic provider tests).

### Steps to test the PR

- Same as #9988: list/create HTTPRoute, Gateway, InferencePool via Kiali AI
- Unit tests for `ai/mcp/manage_istio_config` and OpenAI/Google provider schema tests

### Automation testing

- Unit tests in `ai/mcp/manage_istio_config/*_test.go`
- Provider schema tests (OpenAI, Google)

### Issue reference

Ref #9946
Backport of #9988
Also see v2.27 backport: #10089


Made with [Cursor](https://cursor.com)