### PR TITLE
Fix race condition in unsaved YAML modal Cypress tests

### DIFF
--- a/frontend/cypress/integration/common/istio_config_editor.ts
+++ b/frontend/cypress/integration/common/istio_config_editor.ts
@@ -11,6 +11,8 @@ const editIstioConfigYaml = (): void => {
     const lastCol = model.getLineMaxColumn(lastLine);
     ed.executeEdits('cypress-test', [{ range: new monaco.Range(lastLine, lastCol, lastLine, lastCol), text: '     ' }]);
   });
+  // Wait for React to process the isModified state change before proceeding
+  cy.get('button').contains('Save').should('not.be.disabled');
 };
 
 When('user updates the {string} AuthorizationPolicy using the text field', (name: string) => {


### PR DESCRIPTION
## Description

Fix Cypress test race condition causing `Unsaved YAML edits show leave confirmation on Cancel` and `Unsaved YAML edits show reload confirmation` scenarios to fail intermittently.

## Root Cause

`editIstioConfigYaml()` calls `ed.executeEdits()` which triggers Monaco's `onChange` → React batches `setIsModified(true)` asynchronously. The next test step clicks Cancel/Reload before state propagates → component checks `isModified` (still `false`) → navigates away without modal → `[data-test="unsaved-changes-modal"]` never appears → 40s timeout.

## Fix

After `executeEdits`, wait for the Save button to become enabled (`isDisabled` is tied to `isModified`):

```typescript
cy.get('button').contains('Save').should('not.be.disabled');
```

This ensures React has processed the state change before the test proceeds.

Fixes #10092

Made with [Cursor](https://cursor.com)