### PR TITLE
Fix health config so failure: 0 triggers Failure status

### DIFF
--- a/business/health_calculator.go
+++ b/business/health_calculator.go
@@ -208,19 +208,19 @@ func (c *HealthCalculator) aggregateMatchingCodes(codes map[string]float64, code
 	return errorCount, totalCount
 }
 
-// applyThresholds determines the health status based on error ratio and thresholds
-// Matches frontend ascendingThresholdCheck (Health.ts):
+// applyThresholds determines the health status based on error ratio and thresholds.
+// Matches frontend ascendingThresholdCheck (Health.ts) and docs priority:
 // - Only check thresholds if there are errors (errorRatio > 0)
-// - When degraded=0 (not set), any error > 0% triggers degraded
-// - When failure=0 (not set), skip failure check
+// - failure: 0 means any error >= 0% is Failure (docs: value >= FAILURE threshold)
+// - degraded: 0 means any error triggers Degraded when below the Failure tier
 func (c *HealthCalculator) applyThresholds(errorRatio, degraded, failure float64) models.HealthStatus {
 	if errorRatio <= 0 {
 		// No errors, healthy
 		return models.HealthStatusHealthy
 	}
 
-	// There are errors, check thresholds
-	if failure > 0 && errorRatio >= failure {
+	// There are errors, check thresholds (failure: 0 is a valid threshold)
+	if errorRatio >= failure {
 		return models.HealthStatusFailure
 	}
 	if errorRatio >= degraded {

--- a/business/health_calculator_test.go
+++ b/business/health_calculator_test.go
@@ -488,7 +488,7 @@ func TestCalculateWithZeroDegradedThreshold(t *testing.T) {
 }
 
 func TestCalculateWithZeroFailureThreshold(t *testing.T) {
-	// Test behavior when failure threshold is 0 (should skip failure check)
+	// failure: 0 is a valid threshold (docs: any matching error rate >= 0% → Failure)
 	conf := config.NewConfig()
 	conf.HealthConfig.Rate = []config.Rate{
 		{
@@ -508,8 +508,31 @@ func TestCalculateWithZeroFailureThreshold(t *testing.T) {
 	}
 
 	result := calc.CalculateServiceHealth("test", "my-service", health, nil)
-	// With failure=0, should only trigger degraded (not failure)
-	assert.Equal(t, models.HealthStatusDegraded, result.Status)
+	assert.Equal(t, models.HealthStatusFailure, result.Status)
+}
+
+func TestCalculateWithZeroDegradedAndZeroFailureThreshold(t *testing.T) {
+	// Both at 0: Failure wins by priority (value >= failure)
+	conf := config.NewConfig()
+	conf.HealthConfig.Rate = []config.Rate{
+		{
+			Tolerance: []config.Tolerance{
+				{Code: "5XX", Protocol: "http", Direction: ".*", Degraded: 0, Failure: 0},
+			},
+		},
+	}
+	calc := NewHealthCalculator(conf)
+
+	health := &models.ServiceHealth{
+		Requests: models.RequestHealth{
+			Inbound: map[string]map[string]float64{
+				"http": {"200": 99, "500": 1}, // 1% errors
+			},
+		},
+	}
+
+	result := calc.CalculateServiceHealth("test", "my-service", health, nil)
+	assert.Equal(t, models.HealthStatusFailure, result.Status)
 }
 
 func TestCalculateReturnsErrorRatio(t *testing.T) {

--- a/frontend/src/types/Health.ts
+++ b/frontend/src/types/Health.ts
@@ -6,14 +6,14 @@ import {
   NewProcessIcon,
   UnknownIcon
 } from '@patternfly/react-icons';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { getName } from '../utils/RateIntervals';
 import { PFColors } from 'components/Pf/PfColors';
 import { calculateErrorRate } from './ErrorRate';
-import { ToleranceConfig } from './ServerConfig';
+import type { ToleranceConfig } from './ServerConfig';
 import { serverConfig } from '../config';
-import { HealthAnnotationType } from './HealthAnnotation';
-import { NamespaceStatus } from './NamespaceInfo';
+import type { HealthAnnotationType } from './HealthAnnotation';
+import type { NamespaceStatus } from './NamespaceInfo';
 import { t } from 'utils/I18nUtils';
 
 interface HealthConfig {
@@ -309,8 +309,9 @@ export const mergeStatus = (s1: Status, s2: Status): Status => {
 
 export const ascendingThresholdCheck = (value: number, thresholds: Thresholds): ThresholdStatus => {
   if (value > 0) {
-    // failure === 0 means "unset" / no failure tier (same as business/health_calculator.go applyThresholds).
-    if (thresholds.failure > 0 && value >= thresholds.failure) {
+    // failure: 0 is a valid threshold (docs: value >= FAILURE → Failure), same as
+    // business/health_calculator.go applyThresholds.
+    if (value >= thresholds.failure) {
       return {
         value: value,
         status: FAILURE,
@@ -330,7 +331,7 @@ export const ascendingThresholdCheck = (value: number, thresholds: Thresholds): 
 
 export const getRequestErrorsStatus = (ratio: number, tolerance?: ToleranceConfig): ThresholdStatus => {
   if (tolerance && ratio >= 0) {
-    let thresholds = {
+    const thresholds = {
       degraded: tolerance.degraded,
       failure: tolerance.failure,
       unit: '%'
@@ -383,7 +384,7 @@ export abstract class Health {
     // Check if the config applied is the kiali defaults one
     const tolConfDefault = serverConfig.healthConfig.rate[serverConfig.healthConfig.rate.length - 1].tolerance;
 
-    for (let tol of tolConfDefault) {
+    for (const tol of tolConfDefault) {
       // Check if the tolerance applied is one of kiali defaults
       if (this.health.statusConfig && tol === this.health.statusConfig.threshold) {
         // In the case is a kiali's default return undefined
@@ -429,6 +430,16 @@ interface HealthContext {
 const emptyRequestHealth = (): RequestHealth => ({ inbound: {}, outbound: {}, healthAnnotations: {} });
 
 export class ServiceHealth extends Health {
+  constructor(
+    ns: string,
+    srv: string,
+    public requests: RequestHealth,
+    ctx: HealthContext,
+    backendStatus?: CalculatedHealthStatus
+  ) {
+    super(ServiceHealth.computeItems(ns, srv, requests, ctx), backendStatus);
+  }
+
   public static fromJson = (ns: string, srv: string, json: any, ctx: HealthContext): ServiceHealth =>
     new ServiceHealth(ns, srv, json.requests ?? emptyRequestHealth(), ctx, json.status);
 
@@ -476,19 +487,20 @@ export class ServiceHealth extends Health {
     }
     return { items, statusConfig };
   }
+}
 
+export class AppHealth extends Health {
   constructor(
     ns: string,
-    srv: string,
+    app: string,
+    workloadStatuses: WorkloadStatus[],
     public requests: RequestHealth,
     ctx: HealthContext,
     backendStatus?: CalculatedHealthStatus
   ) {
-    super(ServiceHealth.computeItems(ns, srv, requests, ctx), backendStatus);
+    super(AppHealth.computeItems(ns, app, workloadStatuses, requests, ctx), backendStatus);
   }
-}
 
-export class AppHealth extends Health {
   public static fromJson = (ns: string, app: string, json: any, ctx: HealthContext): AppHealth =>
     new AppHealth(ns, app, json.workloadStatuses ?? [], json.requests ?? emptyRequestHealth(), ctx, json.status);
 
@@ -556,17 +568,6 @@ export class AppHealth extends Health {
 
     return { items, statusConfig };
   }
-
-  constructor(
-    ns: string,
-    app: string,
-    workloadStatuses: WorkloadStatus[],
-    public requests: RequestHealth,
-    ctx: HealthContext,
-    backendStatus?: CalculatedHealthStatus
-  ) {
-    super(AppHealth.computeItems(ns, app, workloadStatuses, requests, ctx), backendStatus);
-  }
 }
 
 const emptyWorkloadStatus = (): WorkloadStatus => ({
@@ -578,6 +579,17 @@ const emptyWorkloadStatus = (): WorkloadStatus => ({
 });
 
 export class WorkloadHealth extends Health {
+  constructor(
+    ns: string,
+    workload: string,
+    workloadStatus: WorkloadStatus,
+    public requests: RequestHealth,
+    ctx: HealthContext,
+    backendStatus?: CalculatedHealthStatus
+  ) {
+    super(WorkloadHealth.computeItems(ns, workload, workloadStatus, requests, ctx), backendStatus);
+  }
+
   public static fromJson = (ns: string, workload: string, json: any, ctx: HealthContext): WorkloadHealth =>
     new WorkloadHealth(
       ns,
@@ -680,17 +692,6 @@ export class WorkloadHealth extends Health {
     }
 
     return { items, statusConfig };
-  }
-
-  constructor(
-    ns: string,
-    workload: string,
-    workloadStatus: WorkloadStatus,
-    public requests: RequestHealth,
-    ctx: HealthContext,
-    backendStatus?: CalculatedHealthStatus
-  ) {
-    super(WorkloadHealth.computeItems(ns, workload, workloadStatus, requests, ctx), backendStatus);
   }
 }
 

--- a/frontend/src/types/__tests__/Health.test.ts
+++ b/frontend/src/types/__tests__/Health.test.ts
@@ -1,6 +1,6 @@
 import * as H from '../Health';
 import { DEGRADED, HEALTHY } from '../Health';
-import { ToleranceConfig } from '../ServerConfig';
+import type { ToleranceConfig } from '../ServerConfig';
 import { setServerConfig } from '../../config/ServerConfig';
 import { healthConfig } from '../__testData__/HealthConfig';
 
@@ -71,14 +71,14 @@ describe('Health', () => {
     expect(result.value).toEqual(50);
     expect(result.violation).toEqual('50.00%>=20%');
   });
-  it('should skip failure tier when failure is 0 (matches server applyThresholds)', () => {
+  it('should treat failure: 0 as Failure when there are errors (matches server applyThresholds)', () => {
     const tol: ToleranceConfig = { code: '', degraded: 10, failure: 0 };
-    expect(H.getRequestErrorsStatus(0.15, tol).status).toEqual(H.DEGRADED);
-    expect(H.getRequestErrorsStatus(0.05, tol).status).toEqual(H.HEALTHY);
+    expect(H.getRequestErrorsStatus(0.15, tol).status).toEqual(H.FAILURE);
+    expect(H.getRequestErrorsStatus(0.05, tol).status).toEqual(H.FAILURE);
   });
-  it('should use degraded tier when failure is 0 and degraded is 0 but there are errors', () => {
+  it('should use Failure when failure is 0 and degraded is 0 but there are errors', () => {
     const tol: ToleranceConfig = { code: '', degraded: 0, failure: 0 };
-    expect(H.getRequestErrorsStatus(0.01, tol).status).toEqual(H.DEGRADED);
+    expect(H.getRequestErrorsStatus(0.01, tol).status).toEqual(H.FAILURE);
   });
   it('should get comparable error ratio with NA', () => {
     const r1 = H.getRequestErrorsStatus(-1, toleranceDefault);

--- a/graph/telemetry/istio/appender/health.go
+++ b/graph/telemetry/istio/appender/health.go
@@ -525,16 +525,14 @@ func (a *HealthAppender) calculateEdgeStatusWithTolerances(
 			errorRatio := (errorCount / totalRequests) * 100
 
 			var status models.HealthStatus
-			// Match frontend behavior:
+			// Match HealthCalculator.applyThresholds / docs priority:
 			// - Only enter status checks if there are any errors (errorRatio > 0)
-			// - When degraded=0 (not set), any error > 0% triggers degraded
-			// - When failure=0 (not set), skip failure check
+			// - failure: 0 means any error >= 0% is Failure
+			// - degraded: 0 means any error triggers Degraded when below Failure
 			if errorRatio > 0 {
-				if tol.Failure > 0 && errorRatio >= float64(tol.Failure) {
+				if errorRatio >= float64(tol.Failure) {
 					status = models.HealthStatusFailure
 				} else if errorRatio >= float64(tol.Degraded) {
-					// When degraded=0, any errorRatio > 0 will satisfy this (0 >= 0 is true,
-					// but we're inside the errorRatio > 0 block, so there are actual errors)
 					status = models.HealthStatusDegraded
 				} else {
 					status = models.HealthStatusHealthy


### PR DESCRIPTION
### Describe the change

`health_config.rate` tolerances with `failure: 0` (or omitted `failure`, which YAML defaults to `0`) were treated as “unset / skip Failure tier” after health precompute. That contradicted the [Traffic Health docs](https://kiali.io/docs/configuration/health/) priority table and examples (`value >= FAILURE` including `0` → Failure).

This PR restores documented semantics in:
- `business.HealthCalculator.applyThresholds`
- graph edge health (`calculateEdgeStatusWithTolerances`)
- frontend `ascendingThresholdCheck`

When there are matching errors (`errorRatio > 0`) and `failure: 0`, status is **Failure**. Defaults (`failure: 10` for 5xx, etc.) are unchanged.

### Steps to test the PR

1. Configure Kiali with:

```yaml
health_config:
  rate:
  - namespace: "bookinfo"
    kind: ".*"
    name: ".*"
    tolerance:
    - code: "^5\\d\\d$"
      direction: ".*"
      protocol: "http"
      degraded: 0
      failure: 0
```

2. Inject HTTP 500 errors on a bookinfo service (e.g. VirtualService fault injection) so the error rate is > 0%.
3. Wait for health cache refresh.
4. Confirm `kiali_health_status` reports `3` (Failure) for affected entities (not `2` Degraded).
5. Optionally set `failure: 1` and confirm Failure still works; set `failure: 10` with a small error rate and confirm Degraded still works for defaults-style configs.

### Automation testing

- `business/health_calculator_test.go`: `TestCalculateWithZeroFailureThreshold`, `TestCalculateWithZeroDegradedAndZeroFailureThreshold`
- `frontend/src/types/__tests__/Health.test.ts`: failure:0 / degraded:0 Failure expectations

### Issue reference

Fixes #10072

Made with [Cursor](https://cursor.com)