### PR TITLE
CVE-2026-59877: Upgrade protobufjs to 7.6.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -194,7 +194,7 @@
     "dompurify": "^3.4.7",
     "js-cookie": "^3.0.8",
     "lodash": "^4.18.1",
-    "protobufjs": "^7.6.4",
+    "protobufjs": "^7.6.5",
     "react-markdown": "^8.0.7",
     "unist-util-visit-parents": "^5.1.3"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11800,9 +11800,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.6.4":
-  version: 7.6.4
-  resolution: "protobufjs@npm:7.6.4"
+"protobufjs@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -11815,7 +11815,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.3.2"
-  checksum: 10c0/6403eaa9c5a72cc6450c11f38fefafdde243fd806e7ac606ac8d591bc3fdaec45ae764febf83181a2d9aac51aca624e0f46dec368ceea191f7e85e2d6ccaaf93
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump the `protobufjs` resolution from `^7.6.4` to `^7.6.5` to address CVE-2026-59877 (Denial of Service via crafted `.proto` schema).
- `protobufjs` is a transitive dependency brought in by `@opentelemetry/otlp-transformer` and `cucumber-messages`.

## Test plan

- [x] `make build-ui` passes
- [ ] CI passes


Made with [Cursor](https://cursor.com)