### PR TITLE
[v2.22] CVE-2026-59877: Upgrade protobufjs to 7.6.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -186,6 +186,7 @@
     "js-yaml@npm:3.14.0": "npm:3.15.0",
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",
+    "protobufjs": "^7.6.5",
     "unist-util-visit-parents": "5.1.3",
     "react-markdown": "8.0.7",
     "workbox-webpack-plugin": "^7.1.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3464,13 +3464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/inquire@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/inquire@npm:1.1.2"
-  checksum: 10c0/af69597818a14cac6a00a74cd5b3fb85aa96658b9dbbae73e6d907cb154ebf470953a8c537b3e6095a43de565ec4e6c5b40227c72f4a7d762d34fbec7ac179e7
-  languageName: node
-  linkType: hard
-
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/path@npm:1.1.2"
@@ -16227,9 +16220,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.3.0":
-  version: 7.6.2
-  resolution: "protobufjs@npm:7.6.2"
+"protobufjs@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -16237,13 +16230,12 @@ __metadata:
     "@protobufjs/eventemitter": "npm:^1.1.1"
     "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.2"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.3.2"
-  checksum: 10c0/3c552dfe3cbcfad2d6c312a76cd189cf5be9fb36b203f6292f79c6020d675f7f33d5531ce312441c42ae75deb24ced32760e64fe4aa3d5b3c2295fd67cea270c
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `protobufjs` `^7.6.5` resolution to address CVE-2026-59877 (Denial of Service via crafted `.proto` schema).
- Backport of https://github.com/kiali/kiali/pull/10100 to v2.22.

## Test plan

- [ ] CI passes


Made with [Cursor](https://cursor.com)