### PR TITLE
Scope Istio config list validations to the requested namespace

### DIFF
--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -147,10 +147,13 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
 
     const workloadSelector = wkLabels.join(',');
     if (workloadSelector) {
+      // Resources only: validations for these objects come from getWorkload(?validate=true)
+      // via workload.validations (GetValidationsForWorkload). Avoid pulling cluster/ns-wide
+      // validations from /namespaces/{ns}/istio?validate=true.
       API.getIstioConfig(
         this.props.namespace,
         workloadIstioResources,
-        true,
+        false,
         '',
         workloadSelector,
         this.props.workload.cluster
@@ -634,7 +637,15 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     const workloadEntries = workload?.workloadEntries ?? [];
 
     const istioConfigItems = skipUnrelatedK8sGateways(
-      this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig, workload?.cluster || '') : [],
+      this.state.workloadIstioConfig
+        ? toIstioItems(
+            {
+              ...this.state.workloadIstioConfig,
+              validations: workload?.validations ?? this.state.workloadIstioConfig.validations ?? {}
+            },
+            workload?.cluster || ''
+          )
+        : [],
       this.props.workload?.labels[AMBIENT_WAYPOINT_GATEWAY_LABEL]
     );
 

--- a/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -221,14 +221,12 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
               (!pod.istioContainers || pod.istioContainers.length === 0) &&
               (!pod.istioInitContainers || pod.istioInitContainers.length === 0)
             ) {
-              if (
-                !(
-                  serverConfig.ambientEnabled &&
-                  (pod.annotations
-                    ? pod.annotations[istioAnnotations.ambientAnnotation] === istioAnnotations.ambientAnnotationEnabled
-                    : false)
-                )
-              ) {
+              if (!(
+                serverConfig.ambientEnabled &&
+                (pod.annotations
+                  ? pod.annotations[istioAnnotations.ambientAnnotation] === istioAnnotations.ambientAnnotationEnabled
+                  : false)
+              )) {
                 validations.pod[pod.name].checks.push(noIstiosidecar);
               }
             } else {

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -86,7 +86,13 @@ func IstioConfigList(
 		}
 
 		if includeValidations {
-			istioConfig.IstioValidations, err = business.Validations.GetValidations(r.Context(), cluster)
+			// Namespace-scoped list should only return validations for that namespace.
+			// Cluster-wide list (/api/istio/config) keeps cluster validations.
+			if namespace != "" {
+				istioConfig.IstioValidations, err = business.Validations.GetValidationsForNamespace(r.Context(), cluster, namespace)
+			} else {
+				istioConfig.IstioValidations, err = business.Validations.GetValidations(r.Context(), cluster)
+			}
 			if err != nil {
 				RespondWithError(w, http.StatusInternalServerError, "Error while getting validations: "+err.Error())
 				return


### PR DESCRIPTION
### Describe the change
Return de validations list filtered just by the namespace requested. 

### Steps to test the PR

- [ ] `curl -s 'http://localhost:8000/api/namespaces/bookinfo/istio?validate=true' | jq '[.validations[] | to_entries[].value.namespace] | unique'` → only `["bookinfo"]` (Where there are any other istio config in other namespace, can be compared with master)
- [ ] Same URL on master (or without the fix) still includes foreign namespaces in `validations`
- [ ] `GET /api/istio/config?validate=true` still returns cluster-wide validations
- [ ] Workload details page still shows Istio config items and validation badges for related objects

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10098 
