### PR TITLE
[Flake] Wait for Ambient traffic

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -76,17 +76,17 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
   retryCount = 0,
   lastEdgeCount = -1
 ): void => {
-  if (retryCount >= maxRetries) {
-    throw new Error(
-      `Condition not met after ${maxRetries} retries (waitForBookinfoWaypointTrafficGeneratedInGraph, ambientTraffic=${ambientTraffic}, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, expected>=${
-        ambientTraffic === 'waypoint' ? 8 : 9
-      }, baseUrl=${Cypress.config('baseUrl')})`
-    );
+  let totalEdges = 9;
+  if (ambientTraffic === 'waypoint' || ambientTraffic === 'total') {
+    totalEdges = 8;
   }
 
-  let totalEdges = 9;
-  if (ambientTraffic === 'waypoint') {
-    totalEdges = 8;
+  if (retryCount >= maxRetries) {
+    throw new Error(
+      `Condition not met after ${maxRetries} retries (waitForBookinfoWaypointTrafficGeneratedInGraph, ambientTraffic=${ambientTraffic}, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, expected>=${totalEdges}, baseUrl=${Cypress.config(
+        'baseUrl'
+      )})`
+    );
   }
 
   cy.request({
@@ -294,8 +294,8 @@ const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: strin
         responseBody === undefined
           ? 'undefined'
           : typeof responseBody === 'string'
-          ? responseBody
-          : JSON.stringify(responseBody);
+            ? responseBody
+            : JSON.stringify(responseBody);
       const responseBodyShort = responseBodyStr.length > 800 ? `${responseBodyStr.slice(0, 800)}...` : responseBodyStr;
 
       const workload = responseBody;
@@ -434,6 +434,10 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
   waitForBookinfoWaypointTrafficGeneratedInGraph(namespace, 'waypoint');
 });
 
+Then('the graph page has enough data for sidecar ambient traffic', () => {
+  waitForBookinfoWaypointTrafficGeneratedInGraph('test-ambient,test-sidecar', 'total', 12);
+});
+
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
   waitForWorkloadTracesInApi(namespace, workload);
 });
@@ -562,7 +566,8 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .contains('a,button', waypoint)
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
-      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+      const target =
+        $el.prop('tagName')?.toLowerCase() === 'a' ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
       expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
         // Even if the button exist, the click event doesn't work (Even with force).
@@ -583,7 +588,7 @@ Then('the waypoint link points to the {string} cluster', (cluster: string) => {
     const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
     expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+    const target = $el.is('a') ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
     expect(target).to.include(`clusterName=${cluster}`);
   });
 });

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -178,7 +178,10 @@ const waitForSidecarAmbientTrafficGeneratedInGraph = (
     expect(response.status).to.equal(200);
     const edges = response.body.elements?.edges ?? [];
     const edgeCount = edges.length;
-    const httpEdgeCount = edges.filter((e: { data?: { protocol?: string } }) => e.data?.protocol === 'http').length;
+    // Graph API puts protocol under data.traffic; UI decorates data.protocol later.
+    const httpEdgeCount = edges.filter(
+      (e: { data?: { traffic?: { protocol?: string } } }) => e.data?.traffic?.protocol === 'http'
+    ).length;
 
     if (httpEdgeCount >= minHttpEdges && edgeCount >= minTotalEdges) {
       return;

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -72,18 +72,21 @@ const waitForWorkloadEnrolled = (targetNamespace: string, maxRetries = 30, retry
 const waitForBookinfoWaypointTrafficGeneratedInGraph = (
   targetNamespace: string,
   ambientTraffic: string,
-  maxRetries = 30,
+  maxRetries = 60,
   retryCount = 0,
-  lastEdgeCount = -1
+  lastEdgeCount = -1,
+  lastHttpEdgeCount = -1
 ): void => {
   let totalEdges = 9;
   if (ambientTraffic === 'waypoint') {
     totalEdges = 8;
   }
+  // TCP-only graphs show up first; wait until HTTP edges exist too.
+  const minHttpEdges = 2;
 
   if (retryCount >= maxRetries) {
     throw new Error(
-      `Condition not met after ${maxRetries} retries (waitForBookinfoWaypointTrafficGeneratedInGraph, ambientTraffic=${ambientTraffic}, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, expected>=${totalEdges}, baseUrl=${Cypress.config(
+      `Condition not met after ${maxRetries} retries (waitForBookinfoWaypointTrafficGeneratedInGraph, ambientTraffic=${ambientTraffic}, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, lastHttpEdgeCount=${lastHttpEdgeCount}, expected>=${totalEdges}, expectedHttp>=${minHttpEdges}, baseUrl=${Cypress.config(
         'baseUrl'
       )})`
     );
@@ -108,39 +111,45 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
     }
   }).then(response => {
     expect(response.status).to.equal(200);
-    const elements = response.body.elements;
-    const edgeCount = elements?.edges?.length ?? -1;
+    const edges = response.body.elements?.edges ?? [];
+    const edgeCount = edges.length;
+    // Graph API puts protocol under data.traffic; UI decorates data.protocol later.
+    const httpEdgeCount = edges.filter(
+      (e: { data?: { traffic?: { protocol?: string } } }) => e.data?.traffic?.protocol === 'http'
+    ).length;
 
-    if (edgeCount >= totalEdges) {
+    if (edgeCount >= totalEdges && httpEdgeCount >= minHttpEdges) {
       return;
-    } else {
-      if (retryCount === 0 || retryCount % 5 === 0) {
-        Cypress.log({
-          name: 'waitForGraphTraffic',
-          message: `retry=${retryCount}/${maxRetries} url=${Cypress.config(
-            'baseUrl'
-          )}/api/namespaces/graph ambientTraffic=${ambientTraffic} edges=${edgeCount} expected>=${totalEdges} baseUrl=${Cypress.config(
-            'baseUrl'
-          )} targetNamespace=${targetNamespace}`
-        });
-      }
-      return cy.wait(10000).then(() => {
-        return waitForBookinfoWaypointTrafficGeneratedInGraph(
-          targetNamespace,
-          ambientTraffic,
-          maxRetries,
-          retryCount + 1,
-          edgeCount
-        );
+    }
+
+    if (retryCount === 0 || retryCount % 5 === 0) {
+      Cypress.log({
+        name: 'waitForGraphTraffic',
+        message: `retry=${retryCount}/${maxRetries} url=${Cypress.config(
+          'baseUrl'
+        )}/api/namespaces/graph ambientTraffic=${ambientTraffic} edges=${edgeCount} httpEdges=${httpEdgeCount} expected>=${totalEdges} expectedHttp>=${minHttpEdges} baseUrl=${Cypress.config(
+          'baseUrl'
+        )} targetNamespace=${targetNamespace}`
       });
     }
+
+    return cy.wait(10000).then(() => {
+      return waitForBookinfoWaypointTrafficGeneratedInGraph(
+        targetNamespace,
+        ambientTraffic,
+        maxRetries,
+        retryCount + 1,
+        edgeCount,
+        httpEdgeCount
+      );
+    });
   });
 };
 
 // Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
 // adds more for a full 8-edge graph. Wait for HTTP readiness and the full edge count.
 const waitForSidecarAmbientTrafficGeneratedInGraph = (
-  maxRetries = 45,
+  maxRetries = 60,
   retryCount = 0,
   lastEdgeCount = -1,
   lastHttpEdgeCount = -1

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -140,7 +140,7 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
 // Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
 // adds more for a full 8-edge graph. Wait for HTTP readiness and the full edge count.
 const waitForSidecarAmbientTrafficGeneratedInGraph = (
-  maxRetries = 30,
+  maxRetries = 45,
   retryCount = 0,
   lastEdgeCount = -1,
   lastHttpEdgeCount = -1
@@ -357,8 +357,8 @@ const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: strin
         responseBody === undefined
           ? 'undefined'
           : typeof responseBody === 'string'
-          ? responseBody
-          : JSON.stringify(responseBody);
+            ? responseBody
+            : JSON.stringify(responseBody);
       const responseBodyShort = responseBodyStr.length > 800 ? `${responseBodyStr.slice(0, 800)}...` : responseBodyStr;
 
       const workload = responseBody;
@@ -629,7 +629,8 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .contains('a,button', waypoint)
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
-      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+      const target =
+        $el.prop('tagName')?.toLowerCase() === 'a' ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
       expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
         // Even if the button exist, the click event doesn't work (Even with force).
@@ -650,7 +651,7 @@ Then('the waypoint link points to the {string} cluster', (cluster: string) => {
     const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
     expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+    const target = $el.is('a') ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
     expect(target).to.include(`clusterName=${cluster}`);
   });
 });

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -77,7 +77,7 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
   lastEdgeCount = -1
 ): void => {
   let totalEdges = 9;
-  if (ambientTraffic === 'waypoint' || ambientTraffic === 'total') {
+  if (ambientTraffic === 'waypoint') {
     totalEdges = 8;
   }
 
@@ -134,6 +134,66 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
         );
       });
     }
+  });
+};
+
+// Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
+// adds more for a full 8-edge graph. Wait for HTTP readiness and the full edge count.
+const waitForSidecarAmbientTrafficGeneratedInGraph = (
+  maxRetries = 30,
+  retryCount = 0,
+  lastEdgeCount = -1,
+  lastHttpEdgeCount = -1
+): void => {
+  const targetNamespace = 'test-ambient,test-sidecar';
+  const minHttpEdges = 4;
+  const minTotalEdges = 8;
+
+  if (retryCount >= maxRetries) {
+    throw new Error(
+      `Condition not met after ${maxRetries} retries (waitForSidecarAmbientTrafficGeneratedInGraph, namespace=${targetNamespace}, lastEdgeCount=${lastEdgeCount}, lastHttpEdgeCount=${lastHttpEdgeCount}, expectedHttp>=${minHttpEdges}, expectedTotal>=${minTotalEdges}, baseUrl=${Cypress.config(
+        'baseUrl'
+      )})`
+    );
+  }
+
+  cy.request({
+    method: 'GET',
+    url: `${Cypress.config('baseUrl')}/api/namespaces/graph`,
+    qs: {
+      duration: '300s',
+      graphType: 'versionedApp',
+      includeIdleEdges: false,
+      injectServiceNodes: true,
+      boxBy: 'cluster,namespace,app',
+      waypoints: false,
+      ambientTraffic: 'total',
+      appenders: 'deadNode,istio,serviceEntry,meshCheck,workloadEntry,health,ambient',
+      rateGrpc: 'requests',
+      rateHttp: 'requests',
+      rateTcp: 'sent',
+      namespaces: targetNamespace
+    }
+  }).then(response => {
+    expect(response.status).to.equal(200);
+    const edges = response.body.elements?.edges ?? [];
+    const edgeCount = edges.length;
+    const httpEdgeCount = edges.filter((e: { data?: { protocol?: string } }) => e.data?.protocol === 'http').length;
+
+    if (httpEdgeCount >= minHttpEdges && edgeCount >= minTotalEdges) {
+      return;
+    }
+
+    if (retryCount === 0 || retryCount % 5 === 0) {
+      Cypress.log({
+        name: 'waitForSidecarAmbientTraffic',
+        message: `retry=${retryCount}/${maxRetries} edges=${edgeCount} httpEdges=${httpEdgeCount} expectedHttp>=${minHttpEdges} expectedTotal>=${minTotalEdges} targetNamespace=${targetNamespace}`
+      });
+    }
+
+    return cy.wait(10000).then(() => {
+      return waitForSidecarAmbientTrafficGeneratedInGraph(maxRetries, retryCount + 1, edgeCount, httpEdgeCount);
+    });
   });
 };
 
@@ -294,8 +354,8 @@ const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: strin
         responseBody === undefined
           ? 'undefined'
           : typeof responseBody === 'string'
-            ? responseBody
-            : JSON.stringify(responseBody);
+          ? responseBody
+          : JSON.stringify(responseBody);
       const responseBodyShort = responseBodyStr.length > 800 ? `${responseBodyStr.slice(0, 800)}...` : responseBodyStr;
 
       const workload = responseBody;
@@ -435,7 +495,7 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
 });
 
 Then('the graph page has enough data for sidecar ambient traffic', () => {
-  waitForBookinfoWaypointTrafficGeneratedInGraph('test-ambient,test-sidecar', 'total', 12);
+  waitForSidecarAmbientTrafficGeneratedInGraph();
 });
 
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
@@ -566,8 +626,7 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .contains('a,button', waypoint)
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
-      const target =
-        $el.prop('tagName')?.toLowerCase() === 'a' ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
+      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
       expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
         // Even if the button exist, the click event doesn't work (Even with force).
@@ -588,7 +647,7 @@ Then('the waypoint link points to the {string} cluster', (cluster: string) => {
     const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
     expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    const target = $el.is('a') ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
+    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
     expect(target).to.include(`clusterName=${cluster}`);
   });
 });

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -398,7 +398,8 @@ Feature: Kiali Waypoint related features
     Then the user updates the log level to "Debug"
 
   Scenario: [Traffic] Sidecar Ambient traffic
-    Given user is at the "graph" page
+    Given the graph page has enough data for sidecar ambient traffic
+    And user is at the "graph" page
     When user graphs "test-ambient,test-sidecar" namespaces
     Then user sees the "test-ambient" namespace
     Then user sees the "test-sidecar" namespace

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -16,8 +16,6 @@ Feature: Kiali Waypoint related features
   Scenario: [Setup] namespace is labeled with waypoint label
     Then "bookinfo" namespace is labeled with the waypoint label
     And the graph page has enough data
-    # Start Sidecar↔Ambient traffic wait early so metrics are ready before the late scenario.
-    And the graph page has enough data for sidecar ambient traffic
     And the "bookinfo-gateway-istio" tracing data is ready in the "bookinfo" namespace
     And use_waypoint_name is enabled if tracing services contain waypoint in "bookinfo"
 

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -16,6 +16,8 @@ Feature: Kiali Waypoint related features
   Scenario: [Setup] namespace is labeled with waypoint label
     Then "bookinfo" namespace is labeled with the waypoint label
     And the graph page has enough data
+    # Start Sidecar↔Ambient traffic wait early so metrics are ready before the late scenario.
+    And the graph page has enough data for sidecar ambient traffic
     And the "bookinfo-gateway-istio" tracing data is ready in the "bookinfo" namespace
     And use_waypoint_name is enabled if tracing services contain waypoint in "bookinfo"
 

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -194,11 +194,13 @@ EOF
         "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_ERROR_RATES}
       else
         ${CLIENT_EXE} apply -f "${SCRIPT_DIR}/ambient/resources/waypoint.yaml" -n bookinfo
-        echo "Deploying waypoint proxies ..."
-        "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
 
+        # Install early so Sidecar↔Ambient traffic accumulates while other demos start.
         echo "Deploying sidecar-ambient ..."
         "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
+
+        echo "Deploying waypoint proxies ..."
+        "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
       fi
       echo "Deploying sleep demo ..."
       "${SCRIPT_DIR}/install-sleep-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_BOOKINFO}
@@ -211,14 +213,15 @@ EOF
 
     # Only install additional demos if not in bookinfo-only mode
     if [ "${BOOKINFO_ONLY}" != "true" ]; then
+      # Install early so Sidecar↔Ambient traffic accumulates while other demos start.
+      echo "Deploying sidecar-ambient ..."
+      "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
+
       echo "Deploying sleep demo ..."
       "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_BOOKINFO}
 
       echo "Deploying waypoint proxies ..."
       "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
-
-      echo "Deploying sidecar-ambient ..."
-      "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
     fi
 
   else
@@ -250,6 +253,11 @@ EOF
 
   if [ "${BOOKINFO_ONLY}" == "true" ]; then
     wait_for_workloads "bookinfo"
+  elif [ "${AMBIENT_ENABLED}" == "true" ]; then
+    for namespace in bookinfo alpha beta gamma test-ambient test-sidecar
+    do
+      wait_for_workloads "${namespace}"
+    done
   else
     for namespace in bookinfo alpha beta gamma
     do


### PR DESCRIPTION
### Describe the change

The test flake shows that the graph has not generated http traffic graph yet, just tcp. So wait until it has generated http traffic. 

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10105
