### PR TITLE
Skip useBlocker in OSSMC kiosk mode to fix Console runtime crash

### DIFF
--- a/frontend/cypress/integration/featureFiles/istio_config_editor.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config_editor.feature
@@ -22,6 +22,7 @@ Feature: Kiali Istio Config editor page
 
   @bookinfo-app
   @core-2
+  @skip-ossmc
   Scenario: Unsaved YAML edits show reload confirmation
     When user clicks in "Name" column on the "bookinfo" text
     And user can see istio config editor
@@ -34,6 +35,7 @@ Feature: Kiali Istio Config editor page
 
   @bookinfo-app
   @core-2
+  @skip-ossmc
   Scenario: Unsaved YAML edits show leave confirmation on Cancel
     When user clicks in "Name" column on the "bookinfo" text
     And user can see istio config editor

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -104,6 +104,13 @@ const paramToTab: { [key: string]: number } = {
 
 type ConfirmModalType = 'leave' | 'reload';
 
+const IDLE_BLOCKER: { location: undefined; proceed: undefined; reset: undefined; state: 'unblocked' } = {
+  location: undefined,
+  proceed: undefined,
+  reset: undefined,
+  state: 'unblocked'
+};
+
 interface ReduxProps {
   kiosk: string;
   theme: string;
@@ -417,7 +424,9 @@ const IstioConfigDetailsPageComponent: React.FC<IstioConfigDetailsProps> = (prop
     [isModified, parentKiosk]
   );
 
-  const blocker = useBlocker(shouldBlock);
+  // parentKiosk is static for the app lifetime (set once at init), so the branch is stable across renders.
+  // eslint-disable-next-line react-hooks/rules-of-hooks, @eslint-react/rules-of-hooks
+  const blocker = parentKiosk ? IDLE_BLOCKER : useBlocker(shouldBlock);
   const isBlockedState = blocker.state === 'blocked';
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

- Guard the `useBlocker` call in `IstioConfigDetailsPage` so it is only invoked in standalone Kiali (where a data router is present), skipping it entirely in OSSMC kiosk mode
- OpenShift Console's shared `react-router-dom-v5-compat` does not export the stable `useBlocker` (only `unstable_useBlocker` in older builds), and Console does not use a data router — so the hook crashes with `useBlocker is not a function` or `must be used within a data router`

<img width="1607" height="753" alt="image" src="https://github.com/user-attachments/assets/5f5294b0-4321-40d5-a62c-19d9038e57e2" />

- Since OSSMC always sets `parentKiosk = true` and `shouldBlock` already returns `false` in that mode, the blocker is a no-op — safe to skip

## Test plan

- [ ] `yarn build` succeeds in both kiali/kiali and openshift-servicemesh-plugin
- [ ] Open an Istio config detail tab in OSSMC — no crash
- [ ] Edit YAML in standalone Kiali, navigate away — unsaved changes modal still appears
- [ ] Edit YAML in OSSMC (kiosk mode), navigate away — no modal (beforeunload only on tab close/refresh)

Fixes https://github.com/kiali/kiali/issues/10093

Made with [Cursor](https://cursor.com)