### PR TITLE
Fix PF6 Save button disabled check in Cypress tests

### DIFF
--- a/frontend/cypress/integration/common/istio_config_editor.ts
+++ b/frontend/cypress/integration/common/istio_config_editor.ts
@@ -2,17 +2,21 @@ import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 const editIstioConfigYaml = (): void => {
   cy.get('[data-test="istio-config-editor"] .monaco-editor').should('be.visible');
-  cy.window().then((win: any) => {
-    const monaco = win.monaco;
-    const editors = monaco.editor.getEditors();
-    const ed = editors[editors.length - 1];
-    const model = ed.getModel();
-    const lastLine = model.getLineCount();
-    const lastCol = model.getLineMaxColumn(lastLine);
-    ed.executeEdits('cypress-test', [{ range: new monaco.Range(lastLine, lastCol, lastLine, lastCol), text: '     ' }]);
-  });
-  // Wait for React to process the isModified state change before proceeding
-  cy.get('button').contains('Save').should('not.be.disabled');
+  // window.monaco is set in handleEditorDidMount — waiting for it guarantees the
+  // onMount effect (and the onChange listener registered in the same flush) has fired.
+  cy.window()
+    .should('have.property', 'monaco')
+    .then((monaco: any) => {
+      const editors = monaco.editor.getEditors();
+      const ed = editors[editors.length - 1];
+      const model = ed.getModel();
+      const lastLine = model.getLineCount();
+      const lastCol = model.getLineMaxColumn(lastLine);
+      ed.executeEdits('cypress-test', [
+        { range: new monaco.Range(lastLine, lastCol, lastLine, lastCol), text: '     ' }
+      ]);
+    });
+  cy.contains('button', 'Save').should('not.be.disabled');
 };
 
 When('user updates the {string} AuthorizationPolicy using the text field', (name: string) => {
@@ -20,7 +24,7 @@ When('user updates the {string} AuthorizationPolicy using the text field', (name
     statusCode: 200
   }).as(`${name}-update`);
   editIstioConfigYaml();
-  cy.get('button').contains('Save').should('not.be.disabled').click();
+  cy.contains('button', 'Save').should('not.be.disabled').click();
 });
 
 When('user edits the Istio config YAML', () => {


### PR DESCRIPTION
## Summary

Two bugs fixed in `editIstioConfigYaml()` (`frontend/cypress/integration/common/istio_config_editor.ts`):

1. **PF6 selector bug**: `cy.get('button').contains('Save')` returns the inner `<span class="pf-v6-c-button__text">`, not the `<button>`. `.should('not.be.disabled')` on a `<span>` is vacuously true (spans have no `disabled` attribute). Changed to `cy.contains('button', 'Save')` which returns the `<button>` element.

2. **Monaco initialization race**: `.monaco-editor` DOM element becomes visible before `@monaco-editor/react`'s `useEffect` registers the `onChange` listener. `executeEdits` fires but `onChange` never triggers → `isModified` stays `false` → Save button stays disabled. Fixed by adding `cy.window().should('have.property', 'monaco')` which retries until `handleEditorDidMount` has run (same effect flush as `onChange` listener registration).

Fixes #10111
Supersedes #10094
Related: #10092, #10093

## Test plan

- [ ] Verify `Unsaved YAML edits show reload confirmation` passes in CI
- [ ] Verify `Unsaved YAML edits show leave confirmation on Cancel` passes in CI
- [ ] Verify `user updates the AuthorizationPolicy` multicluster scenarios unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)