### PR TITLE
Fix Cypress unsaved YAML modal tests (Monaco onChange race)

### DIFF
--- a/frontend/cypress/integration/common/istio_config_editor.ts
+++ b/frontend/cypress/integration/common/istio_config_editor.ts
@@ -2,17 +2,25 @@ import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 const editIstioConfigYaml = (): void => {
   cy.get('[data-test="istio-config-editor"] .monaco-editor').should('be.visible');
+  // Rendered view-lines prove the full mount+effect cycle completed, so
+  // @monaco-editor/react's onDidChangeModelContent listener is registered.
+  cy.get('[data-test="istio-config-editor"] .view-lines').should('not.be.empty');
+  cy.window().should('have.property', 'istioConfigEditor');
   cy.window().then((win: any) => {
-    const monaco = win.monaco;
-    const editors = monaco.editor.getEditors();
-    const ed = editors[editors.length - 1];
+    const ed = win.istioConfigEditor;
     const model = ed.getModel();
+    expect(model.getLineCount(), 'editor should have YAML content').to.be.greaterThan(1);
+
+    // Use trigger('type') rather than executeEdits. The latter can race with
+    // the @monaco-editor/react useEffect that registers the onChange listener;
+    // trigger('type') flows through Monaco's full input pipeline and reliably
+    // fires onDidChangeModelContent → React onChange → setIsModified(true).
     const lastLine = model.getLineCount();
     const lastCol = model.getLineMaxColumn(lastLine);
-    ed.executeEdits('cypress-test', [{ range: new monaco.Range(lastLine, lastCol, lastLine, lastCol), text: '     ' }]);
+    ed.setPosition({ lineNumber: lastLine, column: lastCol });
+    ed.trigger('cypress-test', 'type', { text: '\n# cypress-unsaved-edit' });
   });
-  // Wait for React to process the isModified state change before proceeding
-  cy.get('button').contains('Save').should('not.be.disabled');
+  cy.contains('button', 'Save').should('not.be.disabled');
 };
 
 When('user updates the {string} AuthorizationPolicy using the text field', (name: string) => {
@@ -20,7 +28,7 @@ When('user updates the {string} AuthorizationPolicy using the text field', (name
     statusCode: 200
   }).as(`${name}-update`);
   editIstioConfigYaml();
-  cy.get('button').contains('Save').should('not.be.disabled').click();
+  cy.contains('button', 'Save').should('not.be.disabled').click();
 });
 
 When('user edits the Istio config YAML', () => {

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -657,6 +657,7 @@ const IstioConfigDetailsPageComponent: React.FC<IstioConfigDetailsProps> = (prop
       monacoEditorRef.current = ed;
       monacoRef.current = monaco;
       (window as any).monaco = monaco;
+      (window as any).istioConfigEditor = ed;
       cursorDisposableRef.current?.dispose();
       cursorDisposableRef.current = ed.onDidChangeCursorPosition(handleCursorChange);
       applyValidationMarkers();


### PR DESCRIPTION
## Summary

- Replace `ed.executeEdits()` with `ed.trigger('type')` in the Cypress `editIstioConfigYaml` helper — `executeEdits` races with `@monaco-editor/react`'s `onDidChangeModelContent` listener (registered in a `useEffect`, one render cycle after `onMount`), so `onChange` never fires and `isModified` stays `false`.
- Expose `window.istioConfigEditor` in `handleEditorDidMount` as a stable handle for Cypress (avoids `getEditors()[last]` returning stale instances after `key`-based remount).
- Fix PF6 button selector: `cy.get('button').contains('Save')` returns the inner `<span class="pf-v6-c-button__text">` which is never `disabled`; use `cy.contains('button', 'Save')` instead.

Fixes #10111

## Test plan

- [ ] Run `@core-2` tagged scenarios in `istio_config_editor.feature` — both "Unsaved YAML edits show reload confirmation" and "Unsaved YAML edits show leave confirmation on Cancel" should pass
- [ ] Verify the `@core-caching` scenario (`Filter Istio Config editor objects by Valid configuration`) still passes
- [ ] Verify `user updates the AuthorizationPolicy` step (used in `wizard_istio_config.feature`) still works

Made with [Cursor](https://cursor.com)