### PR TITLE
Implement OIDC RP-Initiated Logout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -609,9 +609,10 @@ type ImpersonationConfig struct {
 // DiscoveryOverrideConfig contains explicit OIDC endpoints to override auto-discovery
 type DiscoveryOverrideConfig struct {
 	AuthorizationEndpoint string `yaml:"authorization_endpoint,omitempty"`
+	EndSessionEndpoint    string `yaml:"end_session_endpoint,omitempty"`
+	JwksUri               string `yaml:"jwks_uri,omitempty"`
 	TokenEndpoint         string `yaml:"token_endpoint,omitempty"`
 	UserinfoEndpoint      string `yaml:"userinfo_endpoint,omitempty"`
-	JwksUri               string `yaml:"jwks_uri,omitempty"`
 }
 
 // OpenIdConfig contains specific configuration for authentication using an OpenID provider
@@ -632,6 +633,7 @@ type OpenIdConfig struct {
 	HTTPSProxy            string                  `yaml:"https_proxy,omitempty"`
 	InsecureSkipVerifyTLS bool                    `yaml:"insecure_skip_verify_tls,omitempty"`
 	IssuerUri             string                  `yaml:"issuer_uri,omitempty"`
+	PostLogoutRedirectURI string                  `yaml:"post_logout_redirect_uri,omitempty"`
 	Scopes                []string                `yaml:"scopes,omitempty"`
 	UsernameClaim         string                  `yaml:"username_claim,omitempty"`
 }
@@ -1045,12 +1047,14 @@ func NewConfig() (c *Config) {
 				DisableRBAC:             false,
 				DiscoveryOverride: DiscoveryOverrideConfig{
 					AuthorizationEndpoint: "",
+					EndSessionEndpoint:    "",
+					JwksUri:               "",
 					TokenEndpoint:         "",
 					UserinfoEndpoint:      "",
-					JwksUri:               "",
 				},
 				InsecureSkipVerifyTLS: false,
 				IssuerUri:             "",
+				PostLogoutRedirectURI: "",
 				Scopes:                []string{"openid", "profile", "email"},
 				UsernameClaim:         "sub",
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1489,9 +1489,11 @@ func TestOpenIdDiscoveryOverrideDefaults(t *testing.T) {
 
 	// Test that DiscoveryOverride fields are initialized to empty strings
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
+	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.EndSessionEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, "", conf.Auth.OpenId.DiscoveryOverride.JwksUri)
+	assert.Equal(t, "", conf.Auth.OpenId.PostLogoutRedirectURI)
 }
 
 // TestOpenIdDiscoveryOverrideUnmarshaling tests that DiscoveryOverride can be unmarshaled from YAML
@@ -1502,8 +1504,10 @@ auth:
   openid:
     issuer_uri: "https://example.com"
     client_id: "kiali-client"
+    post_logout_redirect_uri: "https://example.com/kiali"
     discovery_override:
       authorization_endpoint: "https://custom.example.com/auth"
+      end_session_endpoint: "https://custom.example.com/logout"
       token_endpoint: "https://custom.example.com/token"
       userinfo_endpoint: "https://custom.example.com/userinfo"
       jwks_uri: "https://custom.example.com/jwks"
@@ -1515,7 +1519,9 @@ auth:
 	assert.Equal(t, "openid", conf.Auth.Strategy)
 	assert.Equal(t, "https://example.com", conf.Auth.OpenId.IssuerUri)
 	assert.Equal(t, "kiali-client", conf.Auth.OpenId.ClientId)
+	assert.Equal(t, "https://example.com/kiali", conf.Auth.OpenId.PostLogoutRedirectURI)
 	assert.Equal(t, "https://custom.example.com/auth", conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
+	assert.Equal(t, "https://custom.example.com/logout", conf.Auth.OpenId.DiscoveryOverride.EndSessionEndpoint)
 	assert.Equal(t, "https://custom.example.com/token", conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
 	assert.Equal(t, "https://custom.example.com/userinfo", conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, "https://custom.example.com/jwks", conf.Auth.OpenId.DiscoveryOverride.JwksUri)
@@ -1528,8 +1534,10 @@ func TestOpenIdDiscoveryOverrideMarshalUnmarshal(t *testing.T) {
 	conf.Auth.Strategy = "openid"
 	conf.Auth.OpenId.IssuerUri = "https://example.com"
 	conf.Auth.OpenId.ClientId = "kiali-client"
+	conf.Auth.OpenId.PostLogoutRedirectURI = "https://example.com/kiali"
 	conf.Auth.OpenId.DiscoveryOverride = DiscoveryOverrideConfig{
 		AuthorizationEndpoint: "https://custom.example.com/auth",
+		EndSessionEndpoint:    "https://custom.example.com/logout",
 		TokenEndpoint:         "https://custom.example.com/token",
 		UserinfoEndpoint:      "https://custom.example.com/userinfo",
 		JwksUri:               "https://custom.example.com/jwks",
@@ -1547,7 +1555,9 @@ func TestOpenIdDiscoveryOverrideMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, conf.Auth.Strategy, conf2.Auth.Strategy)
 	assert.Equal(t, conf.Auth.OpenId.IssuerUri, conf2.Auth.OpenId.IssuerUri)
 	assert.Equal(t, conf.Auth.OpenId.ClientId, conf2.Auth.OpenId.ClientId)
+	assert.Equal(t, conf.Auth.OpenId.PostLogoutRedirectURI, conf2.Auth.OpenId.PostLogoutRedirectURI)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint, conf2.Auth.OpenId.DiscoveryOverride.AuthorizationEndpoint)
+	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.EndSessionEndpoint, conf2.Auth.OpenId.DiscoveryOverride.EndSessionEndpoint)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.TokenEndpoint, conf2.Auth.OpenId.DiscoveryOverride.TokenEndpoint)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint, conf2.Auth.OpenId.DiscoveryOverride.UserinfoEndpoint)
 	assert.Equal(t, conf.Auth.OpenId.DiscoveryOverride.JwksUri, conf2.Auth.OpenId.DiscoveryOverride.JwksUri)

--- a/frontend/src/actions/LoginThunkActions.ts
+++ b/frontend/src/actions/LoginThunkActions.ts
@@ -1,10 +1,10 @@
 import moment from 'moment';
-import { KialiAppState, LoginSession, LoginState } from '../store/Store';
+import type { KialiAppState, LoginSession, LoginState } from '../store/Store';
 import { LoginActions } from './LoginActions';
 import * as API from '../services/Api';
 import * as Login from '../services/Login';
 import { AuthResult } from '../types/Auth';
-import { KialiDispatch } from '../types/Redux';
+import type { KialiDispatch } from '../types/Redux';
 import { isAuthStrategyOAuth } from '../config/AuthenticationConfig';
 import { addError } from '../utils/AlertUtils';
 
@@ -13,15 +13,15 @@ const Dispatcher = new Login.LoginDispatcher();
 const shouldRelogin = (state?: LoginState): boolean =>
   !state || !state.session || moment(state.session!.expiresOn).diff(moment()) > 0;
 
-const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
+const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession): Promise<void> => {
   dispatch(LoginActions.loginSuccess(session));
 };
 
 // Performs the user login, dispatching to the proper login implementations.
 // The `data` argument is defined as `any` because the dispatchers receive
 // different kinds of data (such as e-mail/password, tokens).
-const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
-  const bail = (loginResult: Login.LoginResult) => {
+const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any): void => {
+  const bail = (loginResult: Login.LoginResult): void => {
     if (isAuthStrategyOAuth()) {
       dispatch(LoginActions.loginFailure(loginResult.error));
     } else {
@@ -43,13 +43,13 @@ const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any)
 
 export const LoginThunkActions = {
   authenticate: (username: string, password: string) => {
-    return (dispatch: KialiDispatch, getState: () => KialiAppState) => {
+    return (dispatch: KialiDispatch, getState: () => KialiAppState): void => {
       dispatch(LoginActions.loginRequest());
       performLogin(dispatch, getState(), { username, password });
     };
   },
   checkCredentials: () => {
-    return (dispatch: KialiDispatch, getState: () => KialiAppState) => {
+    return (dispatch: KialiDispatch, getState: () => KialiAppState): void => {
       const state: KialiAppState = getState();
 
       dispatch(LoginActions.loginRequest());
@@ -62,16 +62,18 @@ export const LoginThunkActions = {
     };
   },
   extendSession: (session: LoginSession) => {
-    return (dispatch: KialiDispatch) => {
+    return (dispatch: KialiDispatch): void => {
       dispatch(LoginActions.loginExtend(session));
     };
   },
   logout: () => {
-    return async (dispatch: KialiDispatch) => {
+    return async (dispatch: KialiDispatch): Promise<void> => {
       try {
         const response = await API.logout();
 
-        if (response.status === 204) {
+        if (response.status === 200 && response.data?.redirect_url) {
+          window.location.href = response.data.redirect_url;
+        } else {
           dispatch(LoginActions.logoutSuccess());
         }
       } catch (err) {

--- a/frontend/src/actions/__tests__/LoginAction.test.ts
+++ b/frontend/src/actions/__tests__/LoginAction.test.ts
@@ -1,6 +1,9 @@
+import type { AxiosHeaders } from 'axios';
 import { getType } from 'typesafe-actions';
 import { LoginActions } from '../LoginActions';
+import { LoginThunkActions } from '../LoginThunkActions';
 import { LoginStatus } from '../../store/Store';
+import * as API from '../../services/Api';
 
 const session = {
   expiresOn: '2018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761',
@@ -29,5 +32,59 @@ describe('LoginActions', () => {
     };
 
     expect(LoginActions.logoutSuccess().payload).toEqual(expectedAction);
+  });
+});
+
+describe('LoginThunkActions.logout', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: 'http://localhost/kiali' }
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation
+    });
+    rstest.clearAllMocks();
+  });
+
+  it('redirects to IdP when backend returns 200 with redirect_url', async () => {
+    rstest.spyOn(API, 'logout').mockResolvedValue({
+      status: 200,
+      data: { redirect_url: 'https://idp.example.com/logout?id_token_hint=abc' },
+      statusText: 'OK',
+      headers: {},
+      config: { headers: {} as AxiosHeaders }
+    });
+
+    const dispatch = rstest.fn();
+    await LoginThunkActions.logout()(dispatch);
+
+    expect(window.location.href).toBe('https://idp.example.com/logout?id_token_hint=abc');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches logoutSuccess when backend returns 204', async () => {
+    rstest.spyOn(API, 'logout').mockResolvedValue({
+      status: 204,
+      data: {},
+      statusText: 'No Content',
+      headers: {},
+      config: { headers: {} as AxiosHeaders }
+    });
+
+    const dispatch = rstest.fn();
+    await LoginThunkActions.logout()(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ status: LoginStatus.loggedOut })
+      })
+    );
   });
 });

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1,45 +1,41 @@
-import axios, { AxiosHeaders } from 'axios';
+import type { AxiosHeaders } from 'axios';
+import axios from 'axios';
 import { config } from '../config';
-import { LoginSession } from '../store/Store';
-import { App, AppQuery } from '../types/App';
-import { AppList, AppListQuery } from '../types/AppList';
-import { AuthInfo, getCSRFToken } from '../types/Auth';
-import { DurationInSeconds, HTTP_VERBS, Password, TimeInSeconds, UserName } from '../types/Common';
-import { DashboardModel } from 'types/Dashboards';
-import { GrafanaInfo } from '../types/GrafanaInfo';
-import { ChatSessionUsageMetric } from '../types/Chatbot';
-import { GraphDefinition, GraphElementsQuery, NodeParamsType, NodeType } from '../types/Graph';
-import {
-  AppHealth,
+import type { LoginSession } from '../store/Store';
+import type { App, AppQuery } from '../types/App';
+import type { AppList, AppListQuery } from '../types/AppList';
+import type { AuthInfo } from '../types/Auth';
+import { getCSRFToken } from '../types/Auth';
+import type { DurationInSeconds, Password, TimeInSeconds, UserName } from '../types/Common';
+import { HTTP_VERBS } from '../types/Common';
+import type { DashboardModel } from 'types/Dashboards';
+import type { GrafanaInfo } from '../types/GrafanaInfo';
+import type { ChatSessionUsageMetric } from '../types/Chatbot';
+import type { GraphDefinition, GraphElementsQuery, NodeParamsType } from '../types/Graph';
+import { NodeType } from '../types/Graph';
+import type {
   HealthStatusId,
   NamespaceAppHealth,
   NamespaceHealth,
   NamespaceHealthQuery,
   NamespaceServiceHealth,
-  NamespaceWorkloadHealth,
-  ServiceHealth,
-  WorkloadHealth
+  NamespaceWorkloadHealth
 } from '../types/Health';
-import {
+import { AppHealth, ServiceHealth, WorkloadHealth } from '../types/Health';
+import type {
   IstioConfigDetails,
   IstioConfigDetailsQuery,
   IstioPermissions,
   IstioPermissionsQuery
 } from '../types/IstioConfigDetails';
-import {
-  dicTypeToGVK,
-  gvkType,
-  IstioConfigList,
-  IstioConfigListQuery,
-  IstioConfigsMapQuery
-} from '../types/IstioConfigList';
-import {
+import type { IstioConfigList, IstioConfigListQuery, IstioConfigsMapQuery } from '../types/IstioConfigList';
+import { dicTypeToGVK, gvkType } from '../types/IstioConfigList';
+import type {
   Pod,
   PodLogs,
   ValidationStatus,
   EnvoyProxyDump,
   VirtualService,
-  DestinationRuleC,
   K8sHTTPRoute,
   K8sGRPCRoute,
   OutboundTrafficPolicy,
@@ -49,41 +45,43 @@ import {
   GroupVersionKind,
   ZtunnelConfigDump
 } from '../types/IstioObjects';
-import { ComponentStatus, IstiodResourceThresholds } from '../types/IstioStatus';
-import {
+import { DestinationRuleC } from '../types/IstioObjects';
+import type { ComponentStatus, IstiodResourceThresholds } from '../types/IstioStatus';
+import type {
   ConfigurationValidation,
   TracingCheck,
   TracingInfo,
   TracingResponse,
   TracingSingleResponse
 } from '../types/TracingInfo';
-import { ControlPlane, MeshDefinition, MeshQuery } from '../types/Mesh';
-import { DashboardQuery, IstioMetricsOptions, MetricsStatsQuery } from '../types/MetricsOptions';
-import { IstioMetricsMap, MetricsPerNamespace, MetricsStatsResult, ResourceUsageMetricsMap } from '../types/Metrics';
-import { Namespace } from '../types/Namespace';
-import { KialiDisabledFeatures, ServerConfig } from '../types/ServerConfig';
-import { StatusState } from '../types/StatusState';
-import {
-  ServiceDetailsInfo,
-  ServiceDetailsQuery,
-  ServiceUpdateQuery,
-  isServiceDetailsInfo
-} from '../types/ServiceInfo';
-import { ServiceList, ServiceListQuery } from '../types/ServiceList';
-import { Span, TracingQuery } from 'types/Tracing';
-import { TLSStatus } from '../types/TLSStatus';
-import {
+import type { ControlPlane, MeshDefinition, MeshQuery } from '../types/Mesh';
+import type { DashboardQuery, IstioMetricsOptions, MetricsStatsQuery } from '../types/MetricsOptions';
+import type {
+  IstioMetricsMap,
+  MetricsPerNamespace,
+  MetricsStatsResult,
+  ResourceUsageMetricsMap
+} from '../types/Metrics';
+import type { Namespace } from '../types/Namespace';
+import type { KialiDisabledFeatures, ServerConfig } from '../types/ServerConfig';
+import type { StatusState } from '../types/StatusState';
+import type { ServiceDetailsInfo, ServiceDetailsQuery, ServiceUpdateQuery } from '../types/ServiceInfo';
+import { isServiceDetailsInfo } from '../types/ServiceInfo';
+import type { ServiceList, ServiceListQuery } from '../types/ServiceList';
+import type { Span, TracingQuery } from 'types/Tracing';
+import type { TLSStatus } from '../types/TLSStatus';
+import type {
   Workload,
   WorkloadListQuery,
   ClusterWorkloadsResponse,
   WorkloadQuery,
   WorkloadUpdateQuery
 } from '../types/Workload';
-import { ApiError, ApiResponse } from 'types/Api';
+import type { ApiError, ApiResponse } from 'types/Api';
 import { healthComputeDurationValidSeconds } from '../utils/HealthComputeDuration';
 import { getGVKTypeString } from '../utils/IstioConfigUtils';
-import { PersesInfo } from '../types/PersesInfo';
-import { ChatRequest, Prompt } from 'types/Chatbot';
+import type { PersesInfo } from '../types/PersesInfo';
+import type { ChatRequest, Prompt } from 'types/Chatbot';
 
 export const ANONYMOUS_USER = 'anonymous';
 
@@ -191,9 +189,13 @@ export const login = async (
   return axios(axiosRequest);
 };
 
-export const logout = (): Promise<ApiResponse<void>> => {
-  return newRequest<void>(HTTP_VERBS.GET, urls.logout, {}, {});
+export const logout = (): Promise<ApiResponse<LogoutResponse>> => {
+  return newRequest<LogoutResponse>(HTTP_VERBS.GET, urls.logout, {}, {});
 };
+
+export interface LogoutResponse {
+  redirect_url?: string;
+}
 
 export const getAuthInfo = async (): Promise<ApiResponse<AuthInfo>> => {
   return newRequest<AuthInfo>(HTTP_VERBS.GET, urls.authInfo, {}, {});

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -272,7 +272,14 @@ func Logout(conf *config.Config, authController authentication.AuthController) h
 			RespondWithCode(w, http.StatusNoContent)
 		} else {
 			err := authController.TerminateSession(r, w)
-			if err != nil {
+			if lr, ok := err.(*authentication.LogoutRedirect); ok {
+				if conf.Server.AuditLog {
+					log.FromRequest(r).Info().
+						Str("client", r.RemoteAddr).
+						Msg("AUDIT: Logout completed (redirecting to IdP)")
+				}
+				RespondWithJSON(w, http.StatusOK, map[string]string{"redirect_url": lr.RedirectURL})
+			} else if err != nil {
 				log.Errorf("Logout failed [client: %s]: %s", r.RemoteAddr, err.Error())
 				if e, ok := err.(*authentication.TerminateSessionError); ok {
 					RespondWithError(w, e.HttpStatus, e.Error())

--- a/handlers/authentication/auth_controller.go
+++ b/handlers/authentication/auth_controller.go
@@ -42,6 +42,8 @@ type AuthController interface {
 
 	// TerminateSession performs the needed procedures to terminate an existing session. If there is no
 	// active session, nothing is performed. If there is some invalid session, it is cleared.
+	// Implementations may return a *LogoutRedirect (which satisfies error) to signal that the
+	// caller should redirect the user to an IdP logout page; this is not an error condition.
 	TerminateSession(r *http.Request, w http.ResponseWriter) error
 }
 
@@ -111,6 +113,20 @@ func (e *AuthenticationFailureError) Error() string {
 	}
 
 	return e.Reason
+}
+
+// LogoutRedirect is returned by TerminateSession when the IdP supports
+// RP-Initiated Logout. It carries the URL the frontend should navigate to
+// in order to terminate the IdP session. It implements the error interface
+// (following the io.EOF sentinel pattern) so it can travel through the
+// existing TerminateSession() error return without changing the
+// AuthController interface -- only the OpenID controller uses it.
+type LogoutRedirect struct {
+	RedirectURL string
+}
+
+func (e *LogoutRedirect) Error() string {
+	return fmt.Sprintf("logout redirect to: %s", e.RedirectURL)
 }
 
 // ErrSubjectMismatch is returned when the subject claim in a token does not match

--- a/handlers/authentication/openid_auth_controller.go
+++ b/handlers/authentication/openid_auth_controller.go
@@ -54,12 +54,13 @@ var openIdFlightGroup singleflight.Group
 // This was borrowed from https://github.com/coreos/go-oidc/blob/8d771559cf6e5111c9b9159810d0e4538e7cdc82/oidc.go
 // and some additional fields were added.
 type openIdMetadata struct {
-	Issuer      string   `json:"issuer"`
-	AuthURL     string   `json:"authorization_endpoint"`
-	TokenURL    string   `json:"token_endpoint"`
-	JWKSURL     string   `json:"jwks_uri"`
-	UserInfoURL string   `json:"userinfo_endpoint"`
-	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+	Issuer        string   `json:"issuer"`
+	AuthURL       string   `json:"authorization_endpoint"`
+	EndSessionURL string   `json:"end_session_endpoint"`
+	TokenURL      string   `json:"token_endpoint"`
+	JWKSURL       string   `json:"jwks_uri"`
+	UserInfoURL   string   `json:"userinfo_endpoint"`
+	Algorithms    []string `json:"id_token_signing_alg_values_supported"`
 
 	// Some extra fields
 	ScopesSupported        []string `json:"scopes_supported"`
@@ -69,6 +70,12 @@ type openIdMetadata struct {
 // oidcSessionPayload is a helper type used as session data storage. An instance
 // of this type is used with the SessionPersistor for session creation and persistance.
 type oidcSessionPayload struct {
+	// IdToken holds the id_token from the OpenId server, stored separately only when
+	// api_token is "access_token" (i.e., Token holds the access_token). When api_token
+	// is "id_token" (the default), IdToken is empty and Token itself is the id_token.
+	// TerminateSession uses IdToken for id_token_hint, falling back to Token when empty.
+	IdToken string `json:"id_token,omitempty"`
+
 	// Subject is the resolved name of the user that logged into Kiali.
 	Subject string `json:"subject,omitempty"`
 
@@ -287,10 +294,63 @@ func (c OpenIdAuthController) ValidateSession(r *http.Request, w http.ResponseWr
 	return userSessions, nil
 }
 
-// TerminateSession unconditionally terminates any existing session without any validation.
+// TerminateSession clears the local Kiali session and, when the IdP publishes an
+// end_session_endpoint (OIDC RP-Initiated Logout), returns a LogoutRedirect so the
+// caller can direct the browser to the IdP's logout page. When the endpoint is
+// unavailable the method returns nil and the caller falls back to local-only logout.
 func (c OpenIdAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) error {
+	// Read the session before clearing it so we can extract the id_token for the hint.
+	// IdToken is set separately only when api_token is access_token; otherwise the
+	// Token field itself holds the id_token, so we fall back to it.
+	var idTokenHint string
+	sData, err := c.SessionStore.ReadSession(r, w, c.conf.KubernetesConfig.ClusterName)
+	if err == nil && sData != nil && sData.Payload != nil {
+		idTokenHint = sData.Payload.IdToken
+		if idTokenHint == "" {
+			idTokenHint = sData.Payload.Token
+		}
+	}
+
 	c.SessionStore.TerminateSession(r, w, c.conf.KubernetesConfig.ClusterName)
-	return nil
+
+	metadata, err := getOpenIdMetadata(c.conf)
+	if err != nil {
+		log.Warningf("Could not fetch OpenID metadata for RP-Initiated Logout: %v", err)
+		return nil
+	}
+
+	if metadata.EndSessionURL == "" {
+		log.Debugf("OpenID provider does not publish end_session_endpoint; performing local-only logout")
+		return nil
+	}
+
+	logoutURL, err := url.Parse(metadata.EndSessionURL)
+	if err != nil {
+		log.Warningf("Invalid end_session_endpoint URL [%s]: %v", metadata.EndSessionURL, err)
+		return nil
+	}
+
+	if logoutURL.Scheme != "https" && logoutURL.Scheme != "http" {
+		log.Warningf("Rejecting end_session_endpoint with unsupported scheme [%s]: %s", logoutURL.Scheme, metadata.EndSessionURL)
+		return nil
+	}
+
+	q := logoutURL.Query()
+	if idTokenHint != "" {
+		q.Set("id_token_hint", idTokenHint)
+	} else {
+		q.Set("client_id", c.conf.Auth.OpenId.ClientId)
+	}
+
+	postLogoutURI := c.conf.Auth.OpenId.PostLogoutRedirectURI
+	if postLogoutURI == "" {
+		postLogoutURI = httputil.GuessKialiURL(c.conf, r)
+	}
+	q.Set("post_logout_redirect_uri", postLogoutURI)
+
+	logoutURL.RawQuery = q.Encode()
+
+	return &LogoutRedirect{RedirectURL: logoutURL.String()}
 }
 
 // authenticateWithAuthorizationCodeFlow is the entry point to handle OpenId authentication using the authorization
@@ -991,10 +1051,18 @@ func buildSessionPayload(openIdParams *openidFlowHelper) *oidcSessionPayload {
 		token = openIdParams.AccessToken
 	}
 
-	return &oidcSessionPayload{
-		Token:   token,
+	payload := &oidcSessionPayload{
 		Subject: openIdParams.Subject,
+		Token:   token,
 	}
+
+	// Only store IdToken separately when Token holds the access_token.
+	// When Token already is the id_token, storing it again would bloat the session cookie.
+	if openIdParams.UseAccessToken {
+		payload.IdToken = openIdParams.IdToken
+	}
+
+	return payload
 }
 
 // checkDomain verifies that the "hd" or the "email" claims in tokenClaims contain a domain
@@ -1237,11 +1305,12 @@ func getOpenIdMetadata(conf *config.Config) (*openIdMetadata, error) {
 		cfg := conf.Auth.OpenId
 
 		// Check if we have explicit endpoint configuration
-		var authEndpoint, tokenEndpoint, jwksUri, userInfoEndpoint string
+		var authEndpoint, endSessionEndpoint, tokenEndpoint, jwksUri, userInfoEndpoint string
 
 		// Use discovery_override for explicit endpoint configuration
 		if cfg.DiscoveryOverride.AuthorizationEndpoint != "" && cfg.DiscoveryOverride.TokenEndpoint != "" {
 			authEndpoint = cfg.DiscoveryOverride.AuthorizationEndpoint
+			endSessionEndpoint = cfg.DiscoveryOverride.EndSessionEndpoint
 			tokenEndpoint = cfg.DiscoveryOverride.TokenEndpoint
 			jwksUri = cfg.DiscoveryOverride.JwksUri
 			userInfoEndpoint = cfg.DiscoveryOverride.UserinfoEndpoint
@@ -1256,11 +1325,12 @@ func getOpenIdMetadata(conf *config.Config) (*openIdMetadata, error) {
 			log.Infof("Using explicit OpenID endpoints for restricted environment")
 
 			metadata := &openIdMetadata{
-				Issuer:      cfg.IssuerUri,
-				AuthURL:     authEndpoint,
-				TokenURL:    tokenEndpoint,
-				JWKSURL:     jwksUri,
-				UserInfoURL: userInfoEndpoint,
+				Issuer:        cfg.IssuerUri,
+				AuthURL:       authEndpoint,
+				EndSessionURL: endSessionEndpoint,
+				TokenURL:      tokenEndpoint,
+				JWKSURL:       jwksUri,
+				UserInfoURL:   userInfoEndpoint,
 				// Assume "code" is supported when explicit config is provided
 				ResponseTypesSupported: []string{"code"},
 			}

--- a/handlers/authentication/openid_auth_controller_test.go
+++ b/handlers/authentication/openid_auth_controller_test.go
@@ -2030,6 +2030,351 @@ func TestOpenIdCodeFlowShouldRejectMissingCodeVerifierCookie(t *testing.T) {
 // predate PKCE support (pre-2015), and forcing PKCE validation would break those installations. By always
 // sending PKCE parameters but not requiring provider validation, we provide enhanced security for modern
 // providers while maintaining compatibility with legacy systems.
+func TestBuildSessionPayloadAlwaysPreservesIdToken(t *testing.T) {
+	params := &openidFlowHelper{
+		IdToken:     "the-id-token",
+		AccessToken: "the-access-token",
+		Subject:     "user@example.com",
+	}
+
+	t.Run("id_token mode stores id_token only in Token to avoid cookie bloat", func(t *testing.T) {
+		params.UseAccessToken = false
+		payload := buildSessionPayload(params)
+		assert.Empty(t, payload.IdToken, "IdToken should be empty when Token already holds the id_token")
+		assert.Equal(t, "the-id-token", payload.Token)
+		assert.Equal(t, "user@example.com", payload.Subject)
+	})
+
+	t.Run("access_token mode stores access_token in Token but preserves id_token in IdToken", func(t *testing.T) {
+		params.UseAccessToken = true
+		payload := buildSessionPayload(params)
+		assert.Equal(t, "the-id-token", payload.IdToken)
+		assert.Equal(t, "the-access-token", payload.Token)
+		assert.Equal(t, "user@example.com", payload.Subject)
+	})
+}
+
+func TestTerminateSessionReturnsLogoutRedirect(t *testing.T) {
+	require := require.New(t)
+	cachedOpenIdMetadata.Store(nil)
+
+	var oidcMetadata []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.WriteHeader(200)
+			_, _ = w.Write(oidcMetadata)
+		}
+	}))
+	defer testServer.Close()
+
+	oidcMeta := openIdMetadata{
+		Issuer:                 testServer.URL,
+		AuthURL:                testServer.URL + "/auth",
+		EndSessionURL:          testServer.URL + "/logout",
+		TokenURL:               testServer.URL + "/token",
+		JWKSURL:                testServer.URL + "/jwks",
+		ResponseTypesSupported: []string{"code"},
+	}
+	oidcMetadata, err := json.Marshal(oidcMeta)
+	require.NoError(err)
+
+	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 3600
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+	conf.Auth.OpenId.IssuerUri = testServer.URL
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	config.Set(conf)
+
+	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
+	require.NoError(err)
+
+	controller := OpenIdAuthController{
+		SessionStore: store,
+		conf:         conf,
+	}
+
+	// Default id_token mode: IdToken is empty, Token holds the id_token.
+	// TerminateSession should fall back to Token for the id_token_hint.
+	sessionData, err := NewSessionData(conf.KubernetesConfig.ClusterName, config.AuthStrategyOpenId, clockTime.Add(time.Hour), &oidcSessionPayload{
+		Subject: "user@example.com",
+		Token:   "test-id-token-value",
+	})
+	require.NoError(err)
+
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	err = store.CreateSession(r, rr, *sessionData)
+	require.NoError(err)
+
+	logoutReq := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	for _, c := range rr.Result().Cookies() {
+		logoutReq.AddCookie(c)
+	}
+	logoutRR := httptest.NewRecorder()
+
+	result := controller.TerminateSession(logoutReq, logoutRR)
+
+	require.NotNil(result)
+	lr, ok := result.(*LogoutRedirect)
+	require.True(ok, "expected LogoutRedirect, got %T", result)
+
+	parsedURL, err := url.Parse(lr.RedirectURL)
+	require.NoError(err)
+	assert.True(t, strings.HasPrefix(lr.RedirectURL, testServer.URL+"/logout"))
+	assert.Equal(t, "test-id-token-value", parsedURL.Query().Get("id_token_hint"))
+	assert.Empty(t, parsedURL.Query().Get("client_id"), "client_id should not be sent when id_token_hint is present")
+	assert.NotEmpty(t, parsedURL.Query().Get("post_logout_redirect_uri"))
+}
+
+func TestTerminateSessionWithNoSessionStillBuildsLogoutURL(t *testing.T) {
+	require := require.New(t)
+	cachedOpenIdMetadata.Store(nil)
+
+	var oidcMetadata []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.WriteHeader(200)
+			_, _ = w.Write(oidcMetadata)
+		}
+	}))
+	defer testServer.Close()
+
+	oidcMeta := openIdMetadata{
+		Issuer:                 testServer.URL,
+		AuthURL:                testServer.URL + "/auth",
+		EndSessionURL:          testServer.URL + "/logout",
+		TokenURL:               testServer.URL + "/token",
+		JWKSURL:                testServer.URL + "/jwks",
+		ResponseTypesSupported: []string{"code"},
+	}
+	oidcMetadata, err := json.Marshal(oidcMeta)
+	require.NoError(err)
+
+	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+	conf.Auth.OpenId.IssuerUri = testServer.URL
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	config.Set(conf)
+
+	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
+	require.NoError(err)
+
+	controller := OpenIdAuthController{
+		SessionStore: store,
+		conf:         conf,
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	rr := httptest.NewRecorder()
+
+	result := controller.TerminateSession(r, rr)
+
+	require.NotNil(result)
+	lr, ok := result.(*LogoutRedirect)
+	require.True(ok, "expected LogoutRedirect even without a session")
+
+	parsedURL, err := url.Parse(lr.RedirectURL)
+	require.NoError(err)
+	assert.True(t, strings.HasPrefix(lr.RedirectURL, testServer.URL+"/logout"))
+	assert.Empty(t, parsedURL.Query().Get("id_token_hint"), "id_token_hint should be absent when there is no session")
+	assert.Equal(t, "kiali-client", parsedURL.Query().Get("client_id"))
+	assert.NotEmpty(t, parsedURL.Query().Get("post_logout_redirect_uri"))
+}
+
+func TestTerminateSessionFallsBackWhenNoEndSessionEndpoint(t *testing.T) {
+	require := require.New(t)
+	cachedOpenIdMetadata.Store(nil)
+
+	var oidcMetadata []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.WriteHeader(200)
+			_, _ = w.Write(oidcMetadata)
+		}
+	}))
+	defer testServer.Close()
+
+	oidcMeta := openIdMetadata{
+		Issuer:                 testServer.URL,
+		AuthURL:                testServer.URL + "/auth",
+		TokenURL:               testServer.URL + "/token",
+		JWKSURL:                testServer.URL + "/jwks",
+		ResponseTypesSupported: []string{"code"},
+	}
+	oidcMetadata, err := json.Marshal(oidcMeta)
+	require.NoError(err)
+
+	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 3600
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+	conf.Auth.OpenId.IssuerUri = testServer.URL
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	config.Set(conf)
+
+	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
+	require.NoError(err)
+
+	controller := OpenIdAuthController{
+		SessionStore: store,
+		conf:         conf,
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	rr := httptest.NewRecorder()
+
+	result := controller.TerminateSession(r, rr)
+	assert.Nil(t, result, "should return nil when end_session_endpoint is not available")
+}
+
+func TestTerminateSessionUsesIdTokenFieldInAccessTokenMode(t *testing.T) {
+	require := require.New(t)
+	cachedOpenIdMetadata.Store(nil)
+
+	var oidcMetadata []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.WriteHeader(200)
+			_, _ = w.Write(oidcMetadata)
+		}
+	}))
+	defer testServer.Close()
+
+	oidcMeta := openIdMetadata{
+		Issuer:                 testServer.URL,
+		AuthURL:                testServer.URL + "/auth",
+		EndSessionURL:          testServer.URL + "/logout",
+		TokenURL:               testServer.URL + "/token",
+		JWKSURL:                testServer.URL + "/jwks",
+		ResponseTypesSupported: []string{"code"},
+	}
+	oidcMetadata, err := json.Marshal(oidcMeta)
+	require.NoError(err)
+
+	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 3600
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+	conf.Auth.OpenId.IssuerUri = testServer.URL
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	config.Set(conf)
+
+	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
+	require.NoError(err)
+
+	controller := OpenIdAuthController{
+		SessionStore: store,
+		conf:         conf,
+	}
+
+	// Simulate access_token mode: IdToken holds the id_token, Token holds the access_token
+	sessionData, err := NewSessionData(conf.KubernetesConfig.ClusterName, config.AuthStrategyOpenId, clockTime.Add(time.Hour), &oidcSessionPayload{
+		IdToken: "the-real-id-token",
+		Subject: "user@example.com",
+		Token:   "the-access-token",
+	})
+	require.NoError(err)
+
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	err = store.CreateSession(r, rr, *sessionData)
+	require.NoError(err)
+
+	logoutReq := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	for _, c := range rr.Result().Cookies() {
+		logoutReq.AddCookie(c)
+	}
+	logoutRR := httptest.NewRecorder()
+
+	result := controller.TerminateSession(logoutReq, logoutRR)
+
+	require.NotNil(result)
+	lr, ok := result.(*LogoutRedirect)
+	require.True(ok, "expected LogoutRedirect, got %T", result)
+
+	parsedURL, err := url.Parse(lr.RedirectURL)
+	require.NoError(err)
+	assert.Equal(t, "the-real-id-token", parsedURL.Query().Get("id_token_hint"),
+		"should use IdToken (id_token) not Token (access_token) for id_token_hint")
+	assert.Empty(t, parsedURL.Query().Get("client_id"),
+		"client_id should not be sent when id_token_hint is present")
+}
+
+func TestTerminateSessionUsesDiscoveryOverrideEndSessionEndpoint(t *testing.T) {
+	require := require.New(t)
+	cachedOpenIdMetadata.Store(nil)
+
+	clockTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	util.Clock = util.ClockMock{Time: clockTime}
+
+	conf := config.NewConfig()
+	conf.LoginToken.SigningKey = "kiali67890123456"
+	conf.LoginToken.ExpirationSeconds = 3600
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+	conf.Auth.OpenId.IssuerUri = "https://idp.example.com"
+	conf.Auth.OpenId.ClientId = "kiali-client"
+	conf.Auth.OpenId.PostLogoutRedirectURI = "https://kiali.example.com/"
+	conf.Auth.OpenId.DiscoveryOverride = config.DiscoveryOverrideConfig{
+		AuthorizationEndpoint: "https://idp.example.com/auth",
+		EndSessionEndpoint:    "https://idp.example.com/logout",
+		TokenEndpoint:         "https://idp.example.com/token",
+	}
+	config.Set(conf)
+
+	store, err := NewCookieSessionPersistor[oidcSessionPayload](conf)
+	require.NoError(err)
+
+	controller := OpenIdAuthController{
+		SessionStore: store,
+		conf:         conf,
+	}
+
+	sessionData, err := NewSessionData(conf.KubernetesConfig.ClusterName, config.AuthStrategyOpenId, clockTime.Add(time.Hour), &oidcSessionPayload{
+		IdToken: "override-id-token",
+		Subject: "user@example.com",
+		Token:   "override-id-token",
+	})
+	require.NoError(err)
+
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	err = store.CreateSession(r, rr, *sessionData)
+	require.NoError(err)
+
+	logoutReq := httptest.NewRequest(http.MethodGet, "/api/logout", nil)
+	for _, c := range rr.Result().Cookies() {
+		logoutReq.AddCookie(c)
+	}
+	logoutRR := httptest.NewRecorder()
+
+	result := controller.TerminateSession(logoutReq, logoutRR)
+
+	require.NotNil(result)
+	lr, ok := result.(*LogoutRedirect)
+	require.True(ok, "expected LogoutRedirect, got %T", result)
+
+	parsedURL, err := url.Parse(lr.RedirectURL)
+	require.NoError(err)
+	assert.True(t, strings.HasPrefix(lr.RedirectURL, "https://idp.example.com/logout"))
+	assert.Equal(t, "override-id-token", parsedURL.Query().Get("id_token_hint"))
+	assert.Empty(t, parsedURL.Query().Get("client_id"), "client_id should not be sent when id_token_hint is present")
+	assert.Equal(t, "https://kiali.example.com/", parsedURL.Query().Get("post_logout_redirect_uri"))
+}
+
 func TestOpenIdPKCEWorksWithProviderThatIgnoresIt(t *testing.T) {
 	cachedOpenIdMetadata.Store(nil)
 	var oidcMetadata []byte

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -293,8 +293,9 @@ func TestStrategyHeaderOidcWithImpersonationAuthentication(t *testing.T) {
 }
 
 type fakeAuthController struct {
-	sessions authentication.UserSessions
-	err      error
+	sessions     authentication.UserSessions
+	err          error
+	terminateErr error
 }
 
 func (f *fakeAuthController) Authenticate(r *http.Request, w http.ResponseWriter) (*authentication.UserSessionData, error) {
@@ -302,7 +303,7 @@ func (f *fakeAuthController) Authenticate(r *http.Request, w http.ResponseWriter
 }
 
 func (f *fakeAuthController) TerminateSession(r *http.Request, w http.ResponseWriter) error {
-	return nil
+	return f.terminateErr
 }
 
 func (f *fakeAuthController) ValidateSession(r *http.Request, w http.ResponseWriter) (authentication.UserSessions, error) {
@@ -515,6 +516,41 @@ func TestHandleStripsImpersonationHeadersForOpenShift(t *testing.T) {
 	require.Empty(capturedHeaders.Get("Impersonate-User"), "Impersonate-User should be stripped")
 	require.Empty(capturedHeaders.Get("Impersonate-Group"), "Impersonate-Group should be stripped")
 	require.Empty(capturedHeaders.Get("Impersonate-Extra-Scopes"), "Impersonate-Extra-* should be stripped")
+}
+
+func TestLogoutHandlerReturnsRedirectWhenControllerReturnsLogoutRedirect(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+
+	controller := &fakeAuthController{
+		terminateErr: &authentication.LogoutRedirect{RedirectURL: "https://idp.example.com/logout?id_token_hint=abc"},
+	}
+
+	r := httptest.NewRequest("GET", "/api/logout", nil)
+	w := httptest.NewRecorder()
+	Logout(conf, controller)(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	var body map[string]string
+	err := json.NewDecoder(w.Result().Body).Decode(&body)
+	require.NoError(t, err)
+	assert.Equal(t, "https://idp.example.com/logout?id_token_hint=abc", body["redirect_url"])
+}
+
+func TestLogoutHandlerReturns204WhenNoRedirect(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Auth.Strategy = config.AuthStrategyOpenId
+
+	controller := &fakeAuthController{
+		terminateErr: nil,
+	}
+
+	r := httptest.NewRequest("GET", "/api/logout", nil)
+	w := httptest.NewRecorder()
+	Logout(conf, controller)(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
 }
 
 type rejectClient struct{ kubernetes.UserClientInterface }


### PR DESCRIPTION
Add support for redirecting users to the OpenID provider's end_session_endpoint during logout, ensuring both the Kiali session and the IdP session are properly terminated. Includes new end_session_endpoint and post_logout_redirect_uri configuration options, frontend redirect handling, and end-to-end molecule test coverage.

Fixes: https://github.com/kiali/kiali/issues/10095

Generated-by: Cursor