### PR TITLE
[CI] Use external route for corepack

### DIFF
--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -27,6 +27,12 @@ WORKDIR $HOME
 RUN mkdir .cache
 ENV CYPRESS_CACHE_FOLDER=$HOME/.cache
 
+# Corepack stores Yarn as yarn.js under COREPACK_HOME (default: $HOME/.cache/node/corepack).
+# With HOME == project dir and package.json "type":"module", Node loads that yarn.js as ESM
+# and fails with: Dynamic require of "util" is not supported.
+# Keep the Corepack cache outside the project tree (see yarnpkg/berry#5831, issue #10123).
+ENV COREPACK_HOME=/tmp/corepack
+
 # Enable corepack to use the Yarn version specified in package.json
 RUN corepack enable
 
@@ -34,8 +40,8 @@ RUN corepack enable
 RUN yarn install --immutable
 
 # Set required permissions for OpenShift usage
-RUN chgrp -R 0 $HOME && \
-    chmod -R g=u $HOME
+RUN chgrp -R 0 $HOME $COREPACK_HOME && \
+    chmod -R g=u $HOME $COREPACK_HOME
 
 ENV TEST_GROUP="not @multi-cluster"
 

--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -33,6 +33,9 @@ ENV CYPRESS_CACHE_FOLDER=$HOME/.cache
 # Keep the Corepack cache outside the project tree (see yarnpkg/berry#5831, issue #10123).
 ENV COREPACK_HOME=/tmp/corepack
 
+# Ensure COREPACK_HOME exists (corepack enable doesn't create it)
+RUN mkdir -p $COREPACK_HOME
+
 # Enable corepack to use the Yarn version specified in package.json
 RUN corepack enable
 


### PR DESCRIPTION
### Describe the change

- Fix Cypress image build failure caused by Corepack caching Yarn under the project HOME when package.json has "type": "module".
- Set COREPACK_HOME=/tmp/corepack so Yarn is loaded as CommonJS again

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10123 
