### PR TITLE
[Ambient] Improvements in Ambient validations

### DIFF
--- a/business/checkers/ambient/ambient_workload_checker.go
+++ b/business/checkers/ambient/ambient_workload_checker.go
@@ -134,6 +134,10 @@ func (awc AmbientWorkloadChecker) hasAuthPolicyAndNoWaypoint() bool {
 	if awc.workload.IsWaypoint() || awc.workload.IsGateway() {
 		return false
 	}
+	// Explicit workload opt-out of Ambient dataplane — never KIA1317 (even if IsAmbient is stale).
+	if awc.workload.Labels[config.IstioAmbientNamespaceLabel] == config.WaypointNone {
+		return false
+	}
 	// KIA1317 is Ambient-only: L7 AuthPolicies need a waypoint. Sidecar and out-of-mesh
 	// workloads do not — sidecars enforce L7, and out-of-mesh ignores these policies.
 	if !awc.workload.IsAmbient && !awc.hasAmbientLabel() {

--- a/business/checkers/ambient/ambient_workload_checker_test.go
+++ b/business/checkers/ambient/ambient_workload_checker_test.go
@@ -317,6 +317,72 @@ func TestWorkloadHasAuthPolicyAndNoWaypoint_Sidecar_NoWarning(t *testing.T) {
 	assert.True(valid)
 }
 
+func TestWorkloadHasAuthPolicyAndNoWaypoint_WorkloadOptOut_NoWarning(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	// Namespace Ambient + workload dataplane-mode=none must not get KIA1317.
+	nsLabels := map[string]string{
+		config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+	}
+	workload := data.CreateWorkload(ns1, "reviews-v1", map[string]string{
+		"app":                             "reviews",
+		config.IstioAmbientNamespaceLabel: config.WaypointNone,
+	})
+	workload.IsAmbient = false
+	workload.WaypointWorkloads = make([]models.WorkloadReferenceInfo, 0)
+	l7Policy := data.CreateAuthorizationPolicy([]string{"bookinfo"}, []string{"GET"}, []string{"reviews"}, map[string]string{"app": "reviews"})
+	l7Policy.Namespace = ns1
+
+	vals, valid := NewAmbientWorkloadChecker(
+		conf.KubernetesConfig.ClusterName,
+		conf,
+		workload,
+		ns1,
+		models.Namespaces{models.Namespace{Name: ns1, Labels: nsLabels, IsAmbient: true}},
+		[]*security_v1.AuthorizationPolicy{l7Policy},
+		nil,
+	).Check()
+
+	assert.Empty(vals)
+	assert.True(valid)
+}
+
+func TestWorkloadHasAuthPolicyAndNoWaypoint_WorkloadOptOut_StaleIsAmbient_NoWarning(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	// Explicit dataplane-mode=none wins even when IsAmbient is incorrectly true.
+	nsLabels := map[string]string{
+		config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+	}
+	workload := data.CreateWorkload(ns1, "reviews-v1", map[string]string{
+		"app":                             "reviews",
+		config.IstioAmbientNamespaceLabel: config.WaypointNone,
+	})
+	workload.IsAmbient = true
+	workload.WaypointWorkloads = make([]models.WorkloadReferenceInfo, 0)
+	l7Policy := data.CreateAuthorizationPolicy([]string{"bookinfo"}, []string{"GET"}, []string{"reviews"}, map[string]string{"app": "reviews"})
+	l7Policy.Namespace = ns1
+
+	vals, valid := NewAmbientWorkloadChecker(
+		conf.KubernetesConfig.ClusterName,
+		conf,
+		workload,
+		ns1,
+		models.Namespaces{models.Namespace{Name: ns1, Labels: nsLabels, IsAmbient: true}},
+		[]*security_v1.AuthorizationPolicy{l7Policy},
+		nil,
+	).Check()
+
+	assert.Empty(vals)
+	assert.True(valid)
+}
+
 func TestWorkloadHasL7AuthPolicyForOtherWorkload_NoWarning(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/ambient_policy_checker.go
+++ b/business/checkers/ambient_policy_checker.go
@@ -3,6 +3,7 @@ package checkers
 import (
 	"fmt"
 
+	api_v1beta1 "istio.io/api/type/v1beta1"
 	extensions_v1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 	security_v1 "istio.io/client-go/pkg/apis/security/v1"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kiali/kiali/business/checkers/ambient"
+	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 )
@@ -90,7 +92,7 @@ func (c AmbientPolicyChecker) Check() models.IstioValidations {
 		if ap.Spec.Selector != nil {
 			matchLabels = ap.Spec.Selector.MatchLabels
 		}
-		if c.selectorNeedsWarning(matchLabels, ap.Namespace, nsByName[ap.Namespace], nsStatus) {
+		if c.enrollmentNeedsWarning(ap.Spec.TargetRef, ap.Spec.TargetRefs, matchLabels, ap.Namespace, nsByName[ap.Namespace], nsStatus) {
 			validations.MergeValidations(c.buildCheck(ap.Name, ap.Namespace, kubernetes.AuthorizationPolicies, "authorizationpolicy.ambient.l7nowaypoint", ""))
 		}
 	}
@@ -108,7 +110,7 @@ func (c AmbientPolicyChecker) Check() models.IstioValidations {
 		if ra.Spec.Selector != nil {
 			matchLabels = ra.Spec.Selector.MatchLabels
 		}
-		if c.selectorNeedsWarning(matchLabels, ra.Namespace, nsByName[ra.Namespace], nsStatus) {
+		if c.enrollmentNeedsWarning(ra.Spec.TargetRef, ra.Spec.TargetRefs, matchLabels, ra.Namespace, nsByName[ra.Namespace], nsStatus) {
 			validations.MergeValidations(c.buildCheck(ra.Name, ra.Namespace, kubernetes.RequestAuthentications, "requestauthentication.ambient.l7nowaypoint", ""))
 		}
 	}
@@ -155,7 +157,7 @@ func (c AmbientPolicyChecker) Check() models.IstioValidations {
 		if wp.Spec.Selector != nil {
 			matchLabels = wp.Spec.Selector.MatchLabels
 		}
-		if c.selectorNeedsWarning(matchLabels, wp.Namespace, nsByName[wp.Namespace], nsStatus) {
+		if c.enrollmentNeedsWarning(wp.Spec.TargetRef, wp.Spec.TargetRefs, matchLabels, wp.Namespace, nsByName[wp.Namespace], nsStatus) {
 			check := models.Build("wasmplugin.ambient.l7nowaypoint", "")
 			validation.Checks = append(validation.Checks, &check)
 			validation.Valid = false
@@ -181,7 +183,7 @@ func (c AmbientPolicyChecker) Check() models.IstioValidations {
 			if tel.Spec.Selector != nil {
 				matchLabels = tel.Spec.Selector.MatchLabels
 			}
-			if c.selectorNeedsWarning(matchLabels, tel.Namespace, nsByName[tel.Namespace], nsStatus) {
+			if c.enrollmentNeedsWarning(tel.Spec.TargetRef, tel.Spec.TargetRefs, matchLabels, tel.Namespace, nsByName[tel.Namespace], nsStatus) {
 				check := models.Build("telemetry.ambient.l7nowaypoint", "")
 				validation.Checks = append(validation.Checks, &check)
 				validation.Valid = false
@@ -287,9 +289,75 @@ func ambientHostPath(gvk schema.GroupVersionKind, hostIdx int) string {
 	return fmt.Sprintf("spec/hosts[%d]", hostIdx)
 }
 
+// enrollmentNeedsWarning reports whether L7 policy attachment targets are missing waypoint enrollment.
+// Service targetRefs take precedence: a Service with use-waypoint=none must warn even when the
+// namespace is enrolled (selector/ns fallback alone would miss that opt-out).
+func (c AmbientPolicyChecker) enrollmentNeedsWarning(
+	targetRef *api_v1beta1.PolicyTargetReference,
+	targetRefs []*api_v1beta1.PolicyTargetReference,
+	matchLabels map[string]string,
+	namespace string,
+	ns *models.Namespace,
+	nsStatus ambient.NamespaceAmbientStatus,
+) bool {
+	if checked, needsWarning := c.serviceTargetRefsNeedWarning(targetRef, targetRefs, namespace, ns); checked {
+		return needsWarning
+	}
+	return c.selectorNeedsWarning(matchLabels, namespace, ns, nsStatus)
+}
+
+// serviceTargetRefsNeedWarning checks enrollment for Service targetRefs.
+// Returns checked=false when there are no resolvable Service targetRefs (caller should fall back).
+func (c AmbientPolicyChecker) serviceTargetRefsNeedWarning(
+	targetRef *api_v1beta1.PolicyTargetReference,
+	targetRefs []*api_v1beta1.PolicyTargetReference,
+	namespace string,
+	ns *models.Namespace,
+) (checked bool, needsWarning bool) {
+	refs := make([]*api_v1beta1.PolicyTargetReference, 0, len(targetRefs)+1)
+	if targetRef != nil {
+		refs = append(refs, targetRef)
+	}
+	refs = append(refs, targetRefs...)
+
+	var nsLabels map[string]string
+	if ns != nil {
+		nsLabels = ns.Labels
+	}
+
+	resolvedAny := false
+	for _, ref := range refs {
+		if ref == nil || ref.Kind != "Service" || (ref.Group != "" && ref.Group != "core") {
+			continue
+		}
+		svc := c.findService(namespace, ref.Name)
+		if svc == nil {
+			continue
+		}
+		resolvedAny = true
+		if !ambient.IsEnrolledForWaypoint(svc.Labels, nsLabels) {
+			return true, true
+		}
+	}
+	if resolvedAny {
+		return true, false
+	}
+	return false, false
+}
+
+func (c AmbientPolicyChecker) findService(namespace, name string) *core_v1.Service {
+	for i := range c.Services {
+		if c.Services[i].Namespace == namespace && c.Services[i].Name == name {
+			return &c.Services[i]
+		}
+	}
+	return nil
+}
+
 // selectorNeedsWarning returns true when L7 config targets workloads/namespace that are not enrolled.
 // Namespace-wide (empty selector): warn if namespace is not enrolled.
-// With selector: warn if any matched workload is not enrolled (workload label, else namespace).
+// With selector: warn if any matched Ambient workload is not enrolled (workload label, else namespace).
+// Workloads opted out of Ambient (istio.io/dataplane-mode=none) are ignored, consistent with KIA1317.
 func (c AmbientPolicyChecker) selectorNeedsWarning(matchLabels map[string]string, namespace string, ns *models.Namespace, nsStatus ambient.NamespaceAmbientStatus) bool {
 	var nsLabels map[string]string
 	if ns != nil {
@@ -302,22 +370,32 @@ func (c AmbientPolicyChecker) selectorNeedsWarning(matchLabels map[string]string
 
 	selector := labels.Set(matchLabels).AsSelector()
 	workloads := c.WorkloadsPerNamespace[namespace]
-	matched := false
+	matchedAmbient := false
+	matchedOptedOutOnly := false
 	for _, wl := range workloads {
 		if wl == nil || wl.IsWaypoint() {
 			continue
 		}
-		if selector.Matches(labels.Set(wl.Labels)) {
-			matched = true
-			if !ambient.IsEnrolledForWaypoint(wl.Labels, nsLabels) {
-				return true
-			}
+		if !selector.Matches(labels.Set(wl.Labels)) {
+			continue
+		}
+		if wl.Labels[config.IstioAmbientNamespaceLabel] == config.WaypointNone {
+			matchedOptedOutOnly = true
+			continue
+		}
+		matchedAmbient = true
+		if !ambient.IsEnrolledForWaypoint(wl.Labels, nsLabels) {
+			return true
 		}
 	}
-	if !matched {
-		return ambient.NeedsWaypointWarning(nsStatus, true)
+	if matchedAmbient {
+		return false
 	}
-	return false
+	if matchedOptedOutOnly {
+		// Selector only hits workloads opted out of Ambient — no waypoint enrollment warning.
+		return false
+	}
+	return ambient.NeedsWaypointWarning(nsStatus, true)
 }
 
 func (c AmbientPolicyChecker) buildCheck(name, namespace string, gvk schema.GroupVersionKind, checkID, path string) models.IstioValidations {

--- a/business/checkers/ambient_policy_checker_test.go
+++ b/business/checkers/ambient_policy_checker_test.go
@@ -334,6 +334,102 @@ func TestAmbientPolicyChecker_NonAmbientNamespace_NoWarning(t *testing.T) {
 	assert.Empty(t, vals)
 }
 
+func TestAmbientPolicyChecker_RequestAuthentication_NonAmbientNamespace_NoWarning(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+	ns := "sidecar-ns"
+
+	ra := &security_v1.RequestAuthentication{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "jwt", Namespace: ns},
+		Spec:       security_v1_api.RequestAuthentication{},
+	}
+
+	vals := AmbientPolicyChecker{
+		Cluster: cluster,
+		Namespaces: models.Namespaces{
+			{Name: ns, Cluster: cluster, IsAmbient: false},
+		},
+		RequestAuthentications: []*security_v1.RequestAuthentication{ra},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			ns: {data.CreateWorkload(ns, "app", map[string]string{})},
+		},
+	}.Check()
+
+	assert.Empty(t, vals)
+}
+
+func TestAmbientPolicyChecker_SelectorMatchesOnlyOptedOutWorkload_NoEnrollmentWarning(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+	ns := "ambient-ns"
+
+	ap := data.CreateAuthorizationPolicy([]string{"bookinfo"}, []string{"GET"}, []string{"reviews"}, map[string]string{"app": "reviews"})
+	ap.Namespace = ns
+
+	vals := AmbientPolicyChecker{
+		AuthorizationPolicies: []*security_v1.AuthorizationPolicy{ap},
+		Cluster:               cluster,
+		IdentityDomain:        conf.ExternalServices.Istio.IstioIdentityDomain,
+		Namespaces: models.Namespaces{
+			{Name: ns, Cluster: cluster, IsAmbient: true, Labels: map[string]string{
+				config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+			}},
+		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			ns: {data.CreateWorkload(ns, "reviews-v1", map[string]string{
+				"app":                             "reviews",
+				config.IstioAmbientNamespaceLabel: config.WaypointNone,
+			})},
+		},
+	}.Check()
+
+	key := models.BuildKey(kubernetes.AuthorizationPolicies, ap.Name, ns, cluster)
+	validation, ok := vals[key]
+	require.True(t, ok, "missing targetRefs still warns")
+	require.Len(t, validation.Checks, 1)
+	assert.NoError(t, validations.ConfirmIstioCheckMessage("authorizationpolicy.ambient.l7notargetrefs", validation.Checks[0]))
+}
+
+func TestAmbientPolicyChecker_TargetRefsServiceOptOut_WarnsDespiteNsEnrollment(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	cluster := conf.KubernetesConfig.ClusterName
+	ns := "ambient-ns"
+
+	ap := data.CreateAuthorizationPolicyWithTargetRefs("reviews-l7-deny-get", ns, "reviews", []string{"GET"})
+
+	vals := AmbientPolicyChecker{
+		AuthorizationPolicies: []*security_v1.AuthorizationPolicy{ap},
+		Cluster:               cluster,
+		IdentityDomain:        conf.ExternalServices.Istio.IstioIdentityDomain,
+		Namespaces: models.Namespaces{
+			{Name: ns, Cluster: cluster, IsAmbient: true, Labels: map[string]string{
+				config.WaypointUseLabel: "waypoint",
+			}},
+		},
+		Services: []core_v1.Service{
+			{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "reviews",
+					Namespace: ns,
+					Labels:    map[string]string{config.WaypointUseLabel: config.WaypointNone},
+				},
+			},
+		},
+		WorkloadsPerNamespace: map[string]models.Workloads{
+			ns: {data.CreateWorkload(ns, "reviews-v1", map[string]string{"app": "reviews"})},
+		},
+	}.Check()
+
+	key := models.BuildKey(kubernetes.AuthorizationPolicies, ap.Name, ns, cluster)
+	validation, ok := vals[key]
+	require.True(t, ok, "expected warning when Service has use-waypoint:none despite ns enrollment")
+	require.Len(t, validation.Checks, 1)
+	assert.NoError(t, validations.ConfirmIstioCheckMessage("authorizationpolicy.ambient.l7nowaypoint", validation.Checks[0]))
+}
+
 func TestAmbientPolicyChecker_VirtualServiceCrossNamespace_Warns(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -626,8 +626,8 @@ Then('the workload description card has no config issues', () => {
   cy.get('[data-test=workload-details-card]').should('be.visible').and('not.contain', 'Config Issues');
 });
 
-// Ambient L7 validation codes from AmbientPolicyChecker (issue #7900).
-// Baseline bookinfo + waypoint enrollment should not produce these warnings.
+// Ambient L7 validation codes from AmbientPolicyChecker / AmbientWorkloadChecker (issues #7900, #10113).
+// Baseline bookinfo (sidecar or enrolled Ambient) should not produce these warnings.
 const ambientL7ValidationCodes = new Set([
   'KIA0109',
   'KIA0110',
@@ -642,41 +642,50 @@ const ambientL7ValidationCodes = new Set([
   'KIA1114',
   'KIA1115',
   'KIA1116',
-  'KIA1117'
+  'KIA1117',
+  'KIA1317'
 ]);
+
+const collectAmbientL7Warnings = (validations: Record<string, any> | undefined): string[] => {
+  const found: string[] = [];
+  Object.keys(validations ?? {}).forEach(gvk => {
+    const byName = validations?.[gvk] ?? {};
+    Object.keys(byName).forEach(nameKey => {
+      const entry = byName[nameKey];
+      const checks = entry?.checks ?? [];
+      checks.forEach((check: { code?: string; message?: string }) => {
+        if (check.code && ambientL7ValidationCodes.has(check.code)) {
+          found.push(`${gvk}/${nameKey}: ${check.code} ${check.message ?? ''}`.trim());
+        }
+      });
+    });
+  });
+  return found;
+};
 
 Then('Ambient L7 validation warnings are not present in the {string} namespace', (namespace: string) => {
   cy.request({ url: `/api/namespaces/${namespace}/istio?validate=true` }).then(response => {
     expect(response.status).to.eq(200);
-    // API shape: validations[gvk][name.namespace] = { checks: [...] }
-    const validations = response.body?.validations ?? {};
-    const found: string[] = [];
-
-    // TODO: /api/namespaces/{ns}/istio?validate=true still returns cluster-wide validations
-    // (resources are namespaced; validations map is not). Filter client-side until the handler
-    // uses GetValidationsForNamespace. Track in a follow-up issue.
-    Object.keys(validations).forEach(gvk => {
-      const byName = validations[gvk] ?? {};
-      Object.keys(byName).forEach(nameKey => {
-        const entry = byName[nameKey];
-        if (entry?.namespace && entry.namespace !== namespace) {
-          return;
-        }
-        if (!entry?.namespace && !nameKey.endsWith(`.${namespace}`)) {
-          return;
-        }
-        const checks = entry?.checks ?? [];
-        checks.forEach((check: { code?: string; message?: string }) => {
-          if (check.code && ambientL7ValidationCodes.has(check.code)) {
-            found.push(`${gvk}/${nameKey}: ${check.code} ${check.message ?? ''}`.trim());
-          }
-        });
-      });
-    });
-
+    // Namespace-scoped API returns validations for that namespace only.
+    const found = collectAmbientL7Warnings(response.body?.validations);
     expect(found, `unexpected Ambient L7 validation warnings in ${namespace}`).to.deep.equal([]);
   });
 });
+
+Then(
+  'Ambient L7 validation warnings are not present for the {string} workload in the {string} namespace',
+  (workload: string, namespace: string) => {
+    cy.request({
+      url: `/api/namespaces/${namespace}/workloads/${workload}?validate=true&rateInterval=60s&health=true`
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      const found = collectAmbientL7Warnings(response.body?.validations);
+      expect(found, `unexpected Ambient L7 validation warnings for workload ${namespace}/${workload}`).to.deep.equal(
+        []
+      );
+    });
+  }
+);
 
 Then('the user sees the L7 {string} link', (waypoint: string) => {
   cy.get('[data-test=workload-resources-card]').should('contain', 'L7');

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -23,6 +23,12 @@ Feature: Kiali Istio Config page
     And user sees Type information for Istio objects
     And user sees Configuration information for Istio objects
 
+  @bookinfo-app
+  @core-1
+  Scenario: Sidecar bookinfo has no Ambient L7 validation warnings
+    Then Ambient L7 validation warnings are not present in the "bookinfo" namespace
+    And Ambient L7 validation warnings are not present for the "reviews-v1" workload in the "bookinfo" namespace
+
   # There is no Configuration column for offline mode because the istio API is disabled
   # so you don't get validations.
   @offline

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -127,6 +127,7 @@ Feature: Kiali Waypoint related features
     Given user is at the "istio" page
     And user selects the "bookinfo" namespace
     Then Ambient L7 validation warnings are not present in the "bookinfo" namespace
+    And Ambient L7 validation warnings are not present for the "reviews-v1" workload in the "bookinfo" namespace
 
   Scenario: [Namespaces] Namespace is labeled with the waypoint labels
     Given user is at the "namespaces" list page


### PR DESCRIPTION
### Describe the change

- selectorNeedsWarning: ignore workloads with `istio.io/dataplane-mode=none` (aligned with KIA1317)
- enrollmentNeedsWarning: with targetRefs in a Service, respect `use-waypoint=none` even the namespace is enrolled (false negative)
- KIA1317: opt-out explicit from the workload even IsAmbient is not updated

<img width="882" height="626" alt="image" src="https://github.com/user-attachments/assets/20bdb992-5bef-4b52-9d8c-6716ce918e3b" />


Unit tests
- Workload opt-out → no KIA1317
- RA in no-Ambient ns → no KIA1110/KIA1115
- Selector just over workloads opted-out → no enrollment warning
- AP with targetRefs + Service `use-waypoint=none` → KIA0109

Cypress
- KIA1317 in the Ambient L7 sets
- TODO removed, handler already using GetValidationsForNamespace
- Assert also in workload reviews-v1
- New @core-1 in sidecar bookinfo

### Steps to test the PR

Some manual tests (In Ambient ns and Bookinfo in Ambient): 

#### A) Workload opt-out: no KIA1317

```bash
kubectl patch deploy reviews-v1 -n bookinfo --type='json' -p='[{"op":"add","path":"/spec/template/metadata/labels/istio.io~1dataplane-mode","value":"none"}]'
# + L7 AuthorizationPolicy selecting app=reviews
```

**Expect:** Workloads → `reviews-v1` → no KIA1317 (policy may still show KIA0110).

#### B) Service `use-waypoint=none` + `targetRefs` — enrollment warning

```bash
kubectl label svc reviews -n bookinfo istio.io/use-waypoint=none --overwrite
# + AuthorizationPolicy with targetRefs → Service/reviews
```

**Expect:** Istio Config → policy → KIA0109.

#### C) Positive KIA1317 — no waypoint on workload

> Do **not** use `kubectl label deploy … use-waypoint=none` (Deployment metadata only). Patch the **pod template** (or label the Service).

```bash
kubectl patch deploy reviews-v1 -n bookinfo --type='json' -p='[{"op":"add","path":"/spec/template/metadata/labels/istio.io~1use-waypoint","value":"none"}]'
kubectl rollout status deploy/reviews-v1 -n bookinfo
# + L7 AuthorizationPolicy selecting app=reviews
```

**Expect:** Workloads → `reviews-v1` → KIA1317 (`waypointWorkloads` must be empty).

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10113 
