### PR TITLE
Honor Sidecar egress import scope in conflict validations

### DIFF
--- a/business/checkers/common/sidecar_import_scope.go
+++ b/business/checkers/common/sidecar_import_scope.go
@@ -1,0 +1,278 @@
+package common
+
+import (
+	"strings"
+
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/kubernetes"
+)
+
+// ImportScope models Sidecar egress import visibility for a client namespace.
+// A zero-value ImportScope is unrestricted (no Sidecar filtering), matching
+// Istio's default when no effective Sidecar limits imports.
+type ImportScope struct {
+	identityDomain string
+	namespaces     []string
+	workloadNS     string
+	egress         []egressEntry
+	limited        bool
+}
+
+type egressEntry struct {
+	DNSName   string
+	Exclude   bool
+	Namespace string // "." already expanded to workload namespace; "*" = any
+}
+
+// NewImportScope builds the effective Sidecar import scope for workloads in workloadNS.
+// Resolution matches Istio: selector-less Sidecar in the workload namespace, else
+// selector-less Sidecar in rootNS. Selector-only Sidecars are ignored (conservative).
+// Empty/missing egress on the effective Sidecar means unrestricted imports.
+func NewImportScope(workloadNS, rootNS string, sidecars []*networking_v1.Sidecar, namespaces []string, identityDomain string) ImportScope {
+	if workloadNS == "" {
+		return ImportScope{}
+	}
+
+	sc := EffectiveSidecar(workloadNS, rootNS, sidecars)
+	if sc == nil {
+		return ImportScope{}
+	}
+
+	entries := parseEgressEntries(sc, workloadNS)
+	if len(entries) == 0 {
+		// No egress listeners/hosts → Istio default is import all.
+		return ImportScope{}
+	}
+
+	return ImportScope{
+		limited:        true,
+		workloadNS:     workloadNS,
+		namespaces:     namespaces,
+		identityDomain: identityDomain,
+		egress:         entries,
+	}
+}
+
+// EffectiveSidecar returns the selector-less Sidecar that applies namespace-wide
+// to workloadNS, falling back to rootNS. Returns nil when unrestricted.
+func EffectiveSidecar(workloadNS, rootNS string, sidecars []*networking_v1.Sidecar) *networking_v1.Sidecar {
+	if sc := selectorLessSidecarIn(workloadNS, sidecars); sc != nil {
+		return sc
+	}
+	if rootNS != "" && rootNS != workloadNS {
+		return selectorLessSidecarIn(rootNS, sidecars)
+	}
+	return nil
+}
+
+func selectorLessSidecarIn(ns string, sidecars []*networking_v1.Sidecar) *networking_v1.Sidecar {
+	for _, sc := range sidecars {
+		if sc == nil || sc.Namespace != ns {
+			continue
+		}
+		if sc.Spec.WorkloadSelector != nil && len(sc.Spec.WorkloadSelector.Labels) > 0 {
+			continue
+		}
+		return sc
+	}
+	return nil
+}
+
+func parseEgressEntries(sc *networking_v1.Sidecar, workloadNS string) []egressEntry {
+	entries := make([]egressEntry, 0)
+	for _, listener := range sc.Spec.Egress {
+		if listener == nil {
+			continue
+		}
+		for _, host := range listener.Hosts {
+			if e, ok := parseEgressHost(host, workloadNS); ok {
+				entries = append(entries, e)
+			}
+		}
+	}
+	return entries
+}
+
+func parseEgressHost(host, workloadNS string) (egressEntry, bool) {
+	parts := strings.SplitN(host, "/", 2)
+	if len(parts) != 2 {
+		return egressEntry{}, false
+	}
+
+	nsPart, dnsPart := parts[0], parts[1]
+	exclude := false
+	if strings.HasPrefix(nsPart, "~") {
+		exclude = true
+		nsPart = strings.TrimPrefix(nsPart, "~")
+		// Istio: a bare "~" namespace is treated as wildcard "*", so "~/dnsName"
+		// (and "~/*") selects/excludes across all namespaces.
+		if nsPart == "" {
+			nsPart = "*"
+		}
+	}
+
+	switch nsPart {
+	case ".":
+		nsPart = workloadNS
+	}
+
+	return egressEntry{
+		Namespace: nsPart,
+		DNSName:   dnsPart,
+		Exclude:   exclude,
+	}, true
+}
+
+// IsLimited reports whether Sidecar egress filtering is active.
+func (s ImportScope) IsLimited() bool {
+	return s.limited
+}
+
+// ImportsHost reports whether the effective Sidecar imports the given config host.
+// hostName is the raw host from VS/DR/SE.
+// configNamespace is the object's namespace: used by kubernetes.GetHost for short names, and
+// as the namespace association for incomplete/external hosts (ServiceEntry hosts like
+// example.com) when matching against egress entries such as "ns/*".
+func (s ImportScope) ImportsHost(hostName, configNamespace string) bool {
+	if !s.limited {
+		return true
+	}
+	if hostName == "" {
+		return false
+	}
+
+	host := kubernetes.GetHost(hostName, configNamespace, s.namespaces, s.identityDomain)
+
+	included := false
+	for _, e := range s.egress {
+		if e.Exclude {
+			continue
+		}
+		if egressMatchesHost(e, host, hostName, configNamespace) {
+			included = true
+			break
+		}
+	}
+	if !included {
+		return false
+	}
+
+	for _, e := range s.egress {
+		if !e.Exclude {
+			continue
+		}
+		if egressMatchesHost(e, host, hostName, configNamespace) {
+			return false
+		}
+	}
+	return true
+}
+
+func egressMatchesHost(e egressEntry, host kubernetes.Host, rawHost, configNamespace string) bool {
+	if !namespaceMatches(e.Namespace, host, configNamespace) {
+		return false
+	}
+	return dnsMatches(e.DNSName, host, rawHost)
+}
+
+func namespaceMatches(egressNS string, host kubernetes.Host, configNamespace string) bool {
+	if egressNS == "*" {
+		return true
+	}
+	if host.CompleteInput {
+		return host.Namespace == egressNS
+	}
+	// External / incomplete hosts (typical ServiceEntry): associate with the config's namespace.
+	return configNamespace == egressNS
+}
+
+func dnsMatches(egressDNS string, host kubernetes.Host, rawHost string) bool {
+	if egressDNS == "*" {
+		return true
+	}
+	if egressDNS == rawHost {
+		return true
+	}
+	if host.CompleteInput {
+		fqdn := host.String()
+		short := host.Service
+		twoPart := host.Service + "." + host.Namespace
+		if egressDNS == fqdn || egressDNS == short || egressDNS == twoPart {
+			return true
+		}
+		// Egress is the pattern; config host must fall within it (Istio Sidecar matching).
+		if kubernetes.HostWithinWildcardHost(fqdn, egressDNS) || kubernetes.HostWithinWildcardHost(rawHost, egressDNS) {
+			return true
+		}
+		// Wildcard DestinationRule/VS host: include when it covers an imported egress host
+		// (the config applies to that service once Sidecar imports it).
+		if host.IsWildcard() && kubernetes.HostWithinWildcardHost(egressDNS, fqdn) {
+			return true
+		}
+		return false
+	}
+
+	if egressDNS == host.Service {
+		return true
+	}
+	return kubernetes.HostWithinWildcardHost(host.Service, egressDNS)
+}
+
+// FilterDestinationRulesByImport keeps DestinationRules whose host is imported by scope.
+// When scope is unrestricted, the input slice is returned unchanged.
+func FilterDestinationRulesByImport(drs []*networking_v1.DestinationRule, scope ImportScope) []*networking_v1.DestinationRule {
+	if !scope.IsLimited() {
+		return drs
+	}
+	out := make([]*networking_v1.DestinationRule, 0, len(drs))
+	for _, dr := range drs {
+		if dr == nil {
+			continue
+		}
+		if scope.ImportsHost(dr.Spec.Host, dr.Namespace) {
+			out = append(out, dr)
+		}
+	}
+	return out
+}
+
+// FilterVirtualServicesByImport keeps VirtualServices that have at least one imported host.
+func FilterVirtualServicesByImport(vss []*networking_v1.VirtualService, scope ImportScope) []*networking_v1.VirtualService {
+	if !scope.IsLimited() {
+		return vss
+	}
+	out := make([]*networking_v1.VirtualService, 0, len(vss))
+	for _, vs := range vss {
+		if vs == nil {
+			continue
+		}
+		for _, h := range vs.Spec.Hosts {
+			if scope.ImportsHost(h, vs.Namespace) {
+				out = append(out, vs)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// FilterServiceEntriesByImport keeps ServiceEntries that have at least one imported host.
+func FilterServiceEntriesByImport(ses []*networking_v1.ServiceEntry, scope ImportScope) []*networking_v1.ServiceEntry {
+	if !scope.IsLimited() {
+		return ses
+	}
+	out := make([]*networking_v1.ServiceEntry, 0, len(ses))
+	for _, se := range ses {
+		if se == nil {
+			continue
+		}
+		for _, h := range se.Spec.Hosts {
+			if scope.ImportsHost(h, se.Namespace) {
+				out = append(out, se)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/business/checkers/common/sidecar_import_scope_test.go
+++ b/business/checkers/common/sidecar_import_scope_test.go
@@ -1,0 +1,184 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/tests/data"
+)
+
+func TestImportScopeUnrestrictedWhenNoSidecar(t *testing.T) {
+	scope := NewImportScope("istio-test1", "istio-system", nil, []string{"istio-test1"}, "svc.cluster.local")
+	assert.False(t, scope.IsLimited())
+	assert.True(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeUnrestrictedWhenEmptyEgress(t *testing.T) {
+	sc := data.CreateSidecar("default", "istio-test1")
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, []string{"istio-test1"}, "svc.cluster.local")
+	assert.False(t, scope.IsLimited())
+}
+
+func TestImportScopeIgnoresSelectorOnlySidecar(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.AddSelectorToSidecar(map[string]string{
+		"app": "productpage",
+	}, data.CreateSidecar("selected", "istio-test1")))
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, []string{"istio-test1"}, "svc.cluster.local")
+	assert.False(t, scope.IsLimited(), "selector-only Sidecar must not limit namespace-wide import scope")
+}
+
+func TestImportScopeDotSlashStar(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"./*", "istio-system/*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "bookinfo", "istio-system", "vault"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.IsLimited())
+	assert.True(t, scope.ImportsHost("productpage.istio-test1.svc.cluster.local", "istio-test1"))
+	assert.True(t, scope.ImportsHost("productpage", "istio-test1"))
+	assert.True(t, scope.ImportsHost("istiod.istio-system.svc.cluster.local", "istio-system"))
+	assert.False(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("*.vault.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("*.istio-test3.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeRootNamespaceFallback(t *testing.T) {
+	rootSC := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-system"))
+	ns := []string{"istio-test1", "istio-system", "bookinfo"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{rootSC}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.IsLimited())
+	// "." expands to the workload namespace (istio-test1), not the Sidecar's namespace.
+	assert.True(t, scope.ImportsHost("productpage.istio-test1.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopePrefersNamespaceSidecarOverRoot(t *testing.T) {
+	nsSC := data.AddHostsToSidecar([]string{"bookinfo/*"}, data.CreateSidecar("default", "istio-test1"))
+	rootSC := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-system"))
+	ns := []string{"istio-test1", "istio-system", "bookinfo"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{nsSC, rootSC}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("productpage.istio-test1.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeSpecificHost(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{
+		"./*",
+		"bookinfo/reviews.bookinfo.svc.cluster.local",
+	}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "bookinfo"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("ratings.bookinfo.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeStarSlashStar(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"*/*"}, data.CreateSidecar("default", "istio-test1"))
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, []string{"istio-test1", "bookinfo"}, "svc.cluster.local")
+	assert.True(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeTildeSlashStarImportsNothing(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"~/*"}, data.CreateSidecar("default", "istio-test1"))
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, []string{"istio-test1"}, "svc.cluster.local")
+	assert.True(t, scope.IsLimited())
+	assert.False(t, scope.ImportsHost("productpage.istio-test1.svc.cluster.local", "istio-test1"))
+}
+
+func TestImportScopeExclusions(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"*/*", "~bookinfo/*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "bookinfo", "vault"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.ImportsHost("productpage.istio-test1.svc.cluster.local", "istio-test1"))
+	assert.False(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+	assert.True(t, scope.ImportsHost("*.vault.svc.cluster.local", "istio-test1"))
+}
+
+// Egress is the pattern: a specific egress host must not match an unrelated broader
+// config wildcard in a different namespace (unconditional reverse matching was wrong).
+func TestImportScopeEgressIsPatternNotReverse(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"bookinfo/reviews.bookinfo.svc.cluster.local"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "bookinfo", "vault"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.ImportsHost("reviews.bookinfo.svc.cluster.local", "istio-test1"))
+	// Wildcard DR that covers the imported egress host is relevant.
+	assert.True(t, scope.ImportsHost("*.bookinfo.svc.cluster.local", "istio-test1"))
+	// Unrelated namespace wildcard must not match via reverse wildcard logic.
+	assert.False(t, scope.ImportsHost("*.vault.svc.cluster.local", "istio-test1"))
+}
+
+// External ServiceEntry hosts associate with the SE's namespace for ns/* matching.
+func TestImportScopeExternalHostUsesConfigNamespace(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "external"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	assert.True(t, scope.ImportsHost("example.com", "istio-test1"), "SE in workload NS is imported by ./*")
+	assert.False(t, scope.ImportsHost("example.com", "external"), "SE in another NS is not imported by ./*")
+}
+
+func TestFilterDestinationRulesByImport(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "vault", "istio-test3"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	drs := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "local", "productpage.istio-test1.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "vault-no-tls", "*.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "test3-no-tls", "*.istio-test3.svc.cluster.local"),
+	}
+
+	filtered := FilterDestinationRulesByImport(drs, scope)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "local", filtered[0].Name)
+}
+
+func TestFilterVirtualServicesByImport(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "bookinfo"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	vss := []*networking_v1.VirtualService{
+		data.CreateEmptyVirtualService("local-vs", "istio-test1", []string{"productpage.istio-test1.svc.cluster.local"}),
+		data.CreateEmptyVirtualService("foreign-vs", "istio-test1", []string{"reviews.bookinfo.svc.cluster.local"}),
+	}
+
+	filtered := FilterVirtualServicesByImport(vss, scope)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "local-vs", filtered[0].Name)
+}
+
+func TestFilterServiceEntriesByImport(t *testing.T) {
+	sc := data.AddHostsToSidecar([]string{"external/*"}, data.CreateSidecar("default", "istio-test1"))
+	ns := []string{"istio-test1", "external"}
+	scope := NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, ns, "svc.cluster.local")
+
+	ses := []*networking_v1.ServiceEntry{
+		data.CreateEmptyMeshExternalServiceEntry("ext", "external", []string{"example.com"}),
+		data.CreateEmptyMeshExternalServiceEntry("local-ext", "istio-test1", []string{"other.example.com"}),
+	}
+
+	filtered := FilterServiceEntriesByImport(ses, scope)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "ext", filtered[0].Name)
+}
+
+func TestZeroValueImportScopeIsUnrestricted(t *testing.T) {
+	var scope ImportScope
+	assert.False(t, scope.IsLimited())
+	assert.True(t, scope.ImportsHost("anything", "ns"))
+	assert.Equal(t, 2, len(FilterDestinationRulesByImport([]*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("a", "r1", "h1"),
+		data.CreateTestDestinationRule("a", "r2", "h2"),
+	}, scope)))
+}

--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -15,6 +15,7 @@ type DestinationRulesChecker struct {
 	Conf             *config.Config
 	DestinationRules []*networking_v1.DestinationRule
 	IdentityDomain   string
+	ImportScope      common.ImportScope
 	MTLSDetails      kubernetes.MTLSDetails
 	Namespaces       models.Namespaces
 }
@@ -31,11 +32,16 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	// Conflict/override checks only consider hosts imported by the effective Sidecar.
+	conflictDRs := common.FilterDestinationRulesByImport(in.DestinationRules, in.ImportScope)
+
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{Cluster: in.Cluster, DestinationRules: in.DestinationRules, IdentityDomain: in.IdentityDomain, Namespaces: in.Namespaces.GetNames()},
+		destinationrules.MultiMatchChecker{Cluster: in.Cluster, DestinationRules: conflictDRs, IdentityDomain: in.IdentityDomain, Namespaces: in.Namespaces.GetNames()},
 	}
 
-	enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{Cluster: in.Cluster, DestinationRules: in.DestinationRules, IdentityDomain: in.IdentityDomain, MTLSDetails: in.MTLSDetails})
+	mtlsDetails := in.MTLSDetails
+	mtlsDetails.DestinationRules = common.FilterDestinationRulesByImport(mtlsDetails.DestinationRules, in.ImportScope)
+	enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{Cluster: in.Cluster, DestinationRules: conflictDRs, IdentityDomain: in.IdentityDomain, MTLSDetails: mtlsDetails})
 
 	for _, checker := range enabledDRCheckers {
 		validations = validations.MergeValidations(checker.Check())

--- a/business/checkers/service_entry_checker.go
+++ b/business/checkers/service_entry_checker.go
@@ -10,10 +10,11 @@ import (
 )
 
 type ServiceEntryChecker struct {
-	ServiceEntries  []*networking_v1.ServiceEntry
-	Namespaces      models.Namespaces
-	WorkloadEntries []*networking_v1.WorkloadEntry
 	Cluster         string
+	ImportScope     common.ImportScope
+	Namespaces      models.Namespaces
+	ServiceEntries  []*networking_v1.ServiceEntry
+	WorkloadEntries []*networking_v1.WorkloadEntry
 }
 
 func (s ServiceEntryChecker) Check() models.IstioValidations {
@@ -30,9 +31,11 @@ func (s ServiceEntryChecker) Check() models.IstioValidations {
 }
 
 func (s ServiceEntryChecker) runGroupChecks() models.IstioValidations {
+	// Multi-match (KIA1211/1212) only considers Sidecar-imported ServiceEntries.
+	conflictSEs := common.FilterServiceEntriesByImport(s.ServiceEntries, s.ImportScope)
 	return serviceentries.MultiMatchChecker{
 		Cluster:        s.Cluster,
-		ServiceEntries: s.ServiceEntries,
+		ServiceEntries: conflictSEs,
 	}.Check()
 }
 

--- a/business/checkers/sidecar_import_conflict_test.go
+++ b/business/checkers/sidecar_import_conflict_test.go
@@ -1,0 +1,253 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
+
+	"github.com/kiali/kiali/business/checkers/common"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/tests/data"
+)
+
+// Issue #10124: foreign-host DR multi-match must not warn under ./* Sidecar.
+func TestDestinationRulesCheckerSidecarImportSkipsForeignMultiMatch(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*", "istio-system/*"}, data.CreateSidecar("default", "istio-test1"))
+	nsNames := []string{"istio-test1", "vault", "istio-test3", "istio-system"}
+	scope := common.NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	drs := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "vault-no-tls", "*.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "test3-no-tls", "*.istio-test3.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "local-a", "productpage.istio-test1.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "local-b", "productpage.istio-test1.svc.cluster.local"),
+	}
+
+	vals := DestinationRulesChecker{
+		Cluster:          config.DefaultClusterID,
+		Conf:             conf,
+		DestinationRules: drs,
+		IdentityDomain:   "svc.cluster.local",
+		ImportScope:      scope,
+		MTLSDetails:      kubernetes.MTLSDetails{},
+		Namespaces: models.Namespaces{
+			{Name: "istio-test1"},
+			{Name: "vault"},
+			{Name: "istio-test3"},
+			{Name: "istio-system"},
+		},
+	}.Check()
+
+	vaultKey := models.BuildKey(kubernetes.DestinationRules, "vault-no-tls", "istio-test1", config.DefaultClusterID)
+	test3Key := models.BuildKey(kubernetes.DestinationRules, "test3-no-tls", "istio-test1", config.DefaultClusterID)
+	localAKey := models.BuildKey(kubernetes.DestinationRules, "local-a", "istio-test1", config.DefaultClusterID)
+	localBKey := models.BuildKey(kubernetes.DestinationRules, "local-b", "istio-test1", config.DefaultClusterID)
+
+	// Foreign hosts are outside Sidecar egress — no KIA0201 between them.
+	if v, ok := vals[vaultKey]; ok {
+		assert.False(hasCheckCode(v, "KIA0201"), "foreign DR should not get multi-match")
+	}
+	if v, ok := vals[test3Key]; ok {
+		assert.False(hasCheckCode(v, "KIA0201"), "foreign DR should not get multi-match")
+	}
+
+	// Local same-host DRs are imported — multi-match still applies.
+	assert.Contains(vals, localAKey)
+	assert.Contains(vals, localBKey)
+	assert.True(hasCheckCode(vals[localAKey], "KIA0201"))
+	assert.True(hasCheckCode(vals[localBKey], "KIA0201"))
+}
+
+// Same foreign host twice still must not multi-match when Sidecar does not import that host.
+func TestDestinationRulesCheckerSidecarImportSkipsSameForeignHostMultiMatch(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	nsNames := []string{"istio-test1", "vault"}
+	scope := common.NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	drs := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "vault-a", "echo.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "vault-b", "echo.vault.svc.cluster.local"),
+	}
+
+	vals := DestinationRulesChecker{
+		Cluster:          config.DefaultClusterID,
+		Conf:             conf,
+		DestinationRules: drs,
+		IdentityDomain:   "svc.cluster.local",
+		ImportScope:      scope,
+		MTLSDetails:      kubernetes.MTLSDetails{},
+		Namespaces:       models.Namespaces{{Name: "istio-test1"}, {Name: "vault"}},
+	}.Check()
+
+	for _, name := range []string{"vault-a", "vault-b"} {
+		key := models.BuildKey(kubernetes.DestinationRules, name, "istio-test1", config.DefaultClusterID)
+		if v, ok := vals[key]; ok {
+			assert.False(hasCheckCode(v, "KIA0201"), "%s should not get KIA0201 under ./* Sidecar", name)
+		}
+	}
+}
+
+// When Sidecar imports the foreign namespace, same-host multi-match still applies.
+func TestDestinationRulesCheckerSidecarImportKeepsImportedForeignMultiMatch(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*", "vault/*"}, data.CreateSidecar("default", "istio-test1"))
+	nsNames := []string{"istio-test1", "vault"}
+	scope := common.NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	drs := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "vault-a", "echo.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "vault-b", "echo.vault.svc.cluster.local"),
+	}
+
+	vals := DestinationRulesChecker{
+		Cluster:          config.DefaultClusterID,
+		Conf:             conf,
+		DestinationRules: drs,
+		IdentityDomain:   "svc.cluster.local",
+		ImportScope:      scope,
+		MTLSDetails:      kubernetes.MTLSDetails{},
+		Namespaces:       models.Namespaces{{Name: "istio-test1"}, {Name: "vault"}},
+	}.Check()
+
+	keyA := models.BuildKey(kubernetes.DestinationRules, "vault-a", "istio-test1", config.DefaultClusterID)
+	keyB := models.BuildKey(kubernetes.DestinationRules, "vault-b", "istio-test1", config.DefaultClusterID)
+	assert.True(hasCheckCode(vals[keyA], "KIA0201"))
+	assert.True(hasCheckCode(vals[keyB], "KIA0201"))
+}
+
+func TestDestinationRulesCheckerSidecarImportSkipsForeignTrafficPolicyOverride(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "bookinfo"))
+	nsNames := []string{"bookinfo", "vault"}
+	scope := common.NewImportScope("bookinfo", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	mtlsDR := data.AddTrafficPolicyToDestinationRule(
+		data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "vault-mtls", "*.vault.svc.cluster.local"),
+	)
+	noTLS := data.CreateEmptyDestinationRule("bookinfo", "vault-no-tls", "echo.vault.svc.cluster.local")
+
+	vals := DestinationRulesChecker{
+		Cluster:          config.DefaultClusterID,
+		Conf:             conf,
+		DestinationRules: []*networking_v1.DestinationRule{noTLS},
+		IdentityDomain:   "svc.cluster.local",
+		ImportScope:      scope,
+		MTLSDetails: kubernetes.MTLSDetails{
+			DestinationRules: []*networking_v1.DestinationRule{mtlsDR},
+		},
+		Namespaces: models.Namespaces{{Name: "bookinfo"}, {Name: "vault"}},
+	}.Check()
+
+	key := models.BuildKey(kubernetes.DestinationRules, "vault-no-tls", "bookinfo", config.DefaultClusterID)
+	if v, ok := vals[key]; ok {
+		assert.False(hasCheckCode(v, "KIA0204"), "foreign DR should not get traffic-policy override under ./*")
+	}
+}
+
+func TestVirtualServiceCheckerSidecarImportSkipsForeignSingleHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	nsNames := []string{"istio-test1", "bookinfo"}
+	scope := common.NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	vss := []*networking_v1.VirtualService{
+		data.CreateEmptyVirtualService("vs-a", "istio-test1", []string{"reviews.bookinfo.svc.cluster.local"}),
+		data.CreateEmptyVirtualService("vs-b", "istio-test1", []string{"reviews.bookinfo.svc.cluster.local"}),
+		data.CreateEmptyVirtualService("vs-local-a", "istio-test1", []string{"productpage.istio-test1.svc.cluster.local"}),
+		data.CreateEmptyVirtualService("vs-local-b", "istio-test1", []string{"productpage.istio-test1.svc.cluster.local"}),
+	}
+
+	vals := VirtualServiceChecker{
+		Cluster:         config.DefaultClusterID,
+		Conf:            conf,
+		IdentityDomain:  "svc.cluster.local",
+		ImportScope:     scope,
+		Namespaces:      models.Namespaces{{Name: "istio-test1"}, {Name: "bookinfo"}},
+		VirtualServices: vss,
+	}.Check()
+
+	foreignA := models.BuildKey(kubernetes.VirtualServices, "vs-a", "istio-test1", config.DefaultClusterID)
+	foreignB := models.BuildKey(kubernetes.VirtualServices, "vs-b", "istio-test1", config.DefaultClusterID)
+	localA := models.BuildKey(kubernetes.VirtualServices, "vs-local-a", "istio-test1", config.DefaultClusterID)
+	localB := models.BuildKey(kubernetes.VirtualServices, "vs-local-b", "istio-test1", config.DefaultClusterID)
+
+	if v, ok := vals[foreignA]; ok {
+		assert.False(hasCheckCode(v, "KIA1106"))
+	}
+	if v, ok := vals[foreignB]; ok {
+		assert.False(hasCheckCode(v, "KIA1106"))
+	}
+	assert.True(hasCheckCode(vals[localA], "KIA1106"))
+	assert.True(hasCheckCode(vals[localB], "KIA1106"))
+}
+
+func TestServiceEntryCheckerSidecarImportSkipsForeignMultiMatch(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	sc := data.AddHostsToSidecar([]string{"./*"}, data.CreateSidecar("default", "istio-test1"))
+	nsNames := []string{"istio-test1", "external"}
+	scope := common.NewImportScope("istio-test1", "istio-system", []*networking_v1.Sidecar{sc}, nsNames, "svc.cluster.local")
+
+	port := data.CreateEmptyServicePortDefinition(80, "http", "HTTP")
+	foreignA := data.AddPortDefinitionToServiceEntry(port, data.CreateEmptyMeshExternalServiceEntry("se-a", "external", []string{"example.com"}))
+	foreignB := data.AddPortDefinitionToServiceEntry(port, data.CreateEmptyMeshExternalServiceEntry("se-b", "external", []string{"example.com"}))
+	localA := data.AddPortDefinitionToServiceEntry(port, data.CreateEmptyMeshExternalServiceEntry("se-local-a", "istio-test1", []string{"local.example.com"}))
+	localB := data.AddPortDefinitionToServiceEntry(port, data.CreateEmptyMeshExternalServiceEntry("se-local-b", "istio-test1", []string{"local.example.com"}))
+
+	vals := ServiceEntryChecker{
+		Cluster:     config.DefaultClusterID,
+		ImportScope: scope,
+		Namespaces:  models.Namespaces{{Name: "istio-test1"}, {Name: "external"}},
+		ServiceEntries: []*networking_v1.ServiceEntry{
+			foreignA, foreignB, localA, localB,
+		},
+	}.Check()
+
+	for _, name := range []string{"se-a", "se-b"} {
+		key := models.BuildKey(kubernetes.ServiceEntries, name, "external", config.DefaultClusterID)
+		if v, ok := vals[key]; ok {
+			assert.False(hasCheckCode(v, "KIA1211"), "%s should not multi-match under ./*", name)
+		}
+	}
+
+	localKeyA := models.BuildKey(kubernetes.ServiceEntries, "se-local-a", "istio-test1", config.DefaultClusterID)
+	localKeyB := models.BuildKey(kubernetes.ServiceEntries, "se-local-b", "istio-test1", config.DefaultClusterID)
+	assert.True(hasCheckCode(vals[localKeyA], "KIA1211"))
+	assert.True(hasCheckCode(vals[localKeyB], "KIA1211"))
+}
+
+func hasCheckCode(v *models.IstioValidation, code string) bool {
+	if v == nil {
+		return false
+	}
+	for _, c := range v.Checks {
+		if c.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/business/checkers/sidecar_import_conflict_test.go
+++ b/business/checkers/sidecar_import_conflict_test.go
@@ -99,6 +99,34 @@ func TestDestinationRulesCheckerSidecarImportSkipsSameForeignHostMultiMatch(t *t
 	}
 }
 
+// Ambient namespaces use unrestricted ImportScope (buildImportScope skips Sidecar
+// filtering). Foreign same-host DRs must still multi-match when filtering is off.
+func TestDestinationRulesCheckerUnrestrictedImportKeepsForeignMultiMatch(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	drs := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "vault-a", "echo.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "vault-b", "echo.vault.svc.cluster.local"),
+	}
+
+	vals := DestinationRulesChecker{
+		Cluster:          config.DefaultClusterID,
+		Conf:             conf,
+		DestinationRules: drs,
+		IdentityDomain:   "svc.cluster.local",
+		ImportScope:      common.ImportScope{}, // unrestricted — Ambient / no Sidecar
+		MTLSDetails:      kubernetes.MTLSDetails{},
+		Namespaces:       models.Namespaces{{Name: "istio-test1"}, {Name: "vault"}},
+	}.Check()
+
+	keyA := models.BuildKey(kubernetes.DestinationRules, "vault-a", "istio-test1", config.DefaultClusterID)
+	keyB := models.BuildKey(kubernetes.DestinationRules, "vault-b", "istio-test1", config.DefaultClusterID)
+	assert.True(hasCheckCode(vals[keyA], "KIA0201"), "Ambient/unrestricted must keep KIA0201")
+	assert.True(hasCheckCode(vals[keyB], "KIA0201"), "Ambient/unrestricted must keep KIA0201")
+}
+
 // When Sidecar imports the foreign namespace, same-host multi-match still applies.
 func TestDestinationRulesCheckerSidecarImportKeepsImportedForeignMultiMatch(t *testing.T) {
 	conf := config.NewConfig()
@@ -161,6 +189,32 @@ func TestDestinationRulesCheckerSidecarImportSkipsForeignTrafficPolicyOverride(t
 	if v, ok := vals[key]; ok {
 		assert.False(hasCheckCode(v, "KIA0204"), "foreign DR should not get traffic-policy override under ./*")
 	}
+}
+
+// Ambient/unrestricted ImportScope must still report VS single-host multi-match.
+func TestVirtualServiceCheckerUnrestrictedImportKeepsForeignSingleHost(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	assert := assert.New(t)
+
+	vss := []*networking_v1.VirtualService{
+		data.CreateEmptyVirtualService("vs-a", "istio-test1", []string{"reviews.bookinfo.svc.cluster.local"}),
+		data.CreateEmptyVirtualService("vs-b", "istio-test1", []string{"reviews.bookinfo.svc.cluster.local"}),
+	}
+
+	vals := VirtualServiceChecker{
+		Cluster:         config.DefaultClusterID,
+		Conf:            conf,
+		IdentityDomain:  "svc.cluster.local",
+		ImportScope:     common.ImportScope{},
+		Namespaces:      models.Namespaces{{Name: "istio-test1"}, {Name: "bookinfo"}},
+		VirtualServices: vss,
+	}.Check()
+
+	keyA := models.BuildKey(kubernetes.VirtualServices, "vs-a", "istio-test1", config.DefaultClusterID)
+	keyB := models.BuildKey(kubernetes.VirtualServices, "vs-b", "istio-test1", config.DefaultClusterID)
+	assert.True(hasCheckCode(vals[keyA], "KIA1106"))
+	assert.True(hasCheckCode(vals[keyB], "KIA1106"))
 }
 
 func TestVirtualServiceCheckerSidecarImportSkipsForeignSingleHost(t *testing.T) {

--- a/business/checkers/virtual_service_checker.go
+++ b/business/checkers/virtual_service_checker.go
@@ -15,6 +15,7 @@ type VirtualServiceChecker struct {
 	Conf             *config.Config
 	DestinationRules []*networking_v1.DestinationRule
 	IdentityDomain   string
+	ImportScope      common.ImportScope
 	Namespaces       models.Namespaces
 	VirtualServices  []*networking_v1.VirtualService
 }
@@ -37,7 +38,9 @@ func (in VirtualServiceChecker) runIndividualChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
 	nsNames := in.Namespaces.GetNames()
-	drSubsets := in.prepareSubsetMap(nsNames)
+	// Subset presence (KIA1107) only considers Sidecar-imported DestinationRules.
+	conflictDRs := common.FilterDestinationRulesByImport(in.DestinationRules, in.ImportScope)
+	drSubsets := in.prepareSubsetMap(conflictDRs, nsNames)
 	for _, virtualService := range in.VirtualServices {
 		validations.MergeValidations(in.runChecks(virtualService, nsNames, drSubsets))
 	}
@@ -49,8 +52,10 @@ func (in VirtualServiceChecker) runIndividualChecks() models.IstioValidations {
 func (in VirtualServiceChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
+	// Multi-match (KIA1106) only considers Sidecar-imported VirtualServices.
+	conflictVSs := common.FilterVirtualServicesByImport(in.VirtualServices, in.ImportScope)
 	enabledCheckers := []GroupChecker{
-		virtualservices.SingleHostChecker{Cluster: in.Cluster, IdentityDomain: in.IdentityDomain, Namespaces: in.Namespaces.GetNames(), VirtualServices: in.VirtualServices},
+		virtualservices.SingleHostChecker{Cluster: in.Cluster, IdentityDomain: in.IdentityDomain, Namespaces: in.Namespaces.GetNames(), VirtualServices: conflictVSs},
 	}
 
 	for _, checker := range enabledCheckers {
@@ -67,7 +72,10 @@ func (in VirtualServiceChecker) runChecks(virtualService *networking_v1.VirtualS
 
 	enabledCheckers := []Checker{
 		virtualservices.RouteChecker{IdentityDomain: in.IdentityDomain, VirtualService: virtualService, Namespaces: nsNames},
-		virtualservices.SubsetPresenceChecker{DRSubsets: drSubsets, IdentityDomain: in.IdentityDomain, Namespaces: nsNames, VirtualService: virtualService},
+	}
+	// Subset presence only applies when at least one VS host is imported by Sidecar.
+	if virtualServiceImported(virtualService, in.ImportScope) {
+		enabledCheckers = append(enabledCheckers, virtualservices.SubsetPresenceChecker{DRSubsets: drSubsets, IdentityDomain: in.IdentityDomain, Namespaces: nsNames, VirtualService: virtualService})
 	}
 	if !in.Namespaces.IsNamespaceAmbient(virtualService.Namespace, in.Cluster) {
 		enabledCheckers = append(enabledCheckers, common.ExportToNamespaceChecker{ExportTo: virtualService.Spec.ExportTo, Namespaces: nsNames})
@@ -82,10 +90,22 @@ func (in VirtualServiceChecker) runChecks(virtualService *networking_v1.VirtualS
 	return models.IstioValidations{key: rrValidation}
 }
 
-func (in VirtualServiceChecker) prepareSubsetMap(namespaces []string) models.DestinationRuleSubsets {
+func virtualServiceImported(vs *networking_v1.VirtualService, scope common.ImportScope) bool {
+	if !scope.IsLimited() {
+		return true
+	}
+	for _, h := range vs.Spec.Hosts {
+		if scope.ImportsHost(h, vs.Namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+func (in VirtualServiceChecker) prepareSubsetMap(destinationRules []*networking_v1.DestinationRule, namespaces []string) models.DestinationRuleSubsets {
 	subsetMap := make(models.DestinationRuleSubsets)
 
-	for _, dr := range in.DestinationRules {
+	for _, dr := range destinationRules {
 		host := dr.Spec.Host
 		drHost := kubernetes.GetHost(host, dr.Namespace, namespaces, in.IdentityDomain)
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kiali/kiali/business/checkers"
+	"github.com/kiali/kiali/business/checkers/common"
 	"github.com/kiali/kiali/business/references"
 	"github.com/kiali/kiali/cache"
 	"github.com/kiali/kiali/config"
@@ -592,10 +593,11 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) (
 	}
 
 	identityDomain := vInfo.clusterInfo.identityDomain
+	importScope := in.buildImportScope(vInfo, nsNames, identityDomain)
 
 	return []checkers.ObjectChecker{
 		checkers.AuthorizationPolicyChecker{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, KnownTrustDomains: vInfo.knownTrustDomains, KubeServiceHosts: kubeServiceHosts, MtlsDetails: *mtlsDetails, Namespaces: nsNames, PolicyAllowAny: policyAllowAny, ServiceAccounts: vInfo.saMap, ServiceEntries: istioConfigList.ServiceEntries, Services: services, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace},
-		checkers.DestinationRulesChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, MTLSDetails: *mtlsDetails, Namespaces: namespaces},
+		checkers.DestinationRulesChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, ImportScope: importScope, MTLSDetails: *mtlsDetails, Namespaces: namespaces},
 		checkers.GatewayChecker{Cluster: cluster, Conf: conf, Gateways: istioConfigList.Gateways, IsGatewayToNamespace: gatewayToNamespace, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.K8sGatewayChecker{Cluster: cluster, GatewayClasses: in.kialiCache.GatewayAPIClasses(cluster), K8sGateways: istioConfigList.K8sGateways},
 		checkers.K8sGRPCRouteChecker{Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, K8sGateways: istioConfigList.K8sGateways, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, Services: services},
@@ -604,10 +606,10 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) (
 		checkers.NoServiceChecker{AuthorizationDetails: rbacDetails, Cluster: cluster, Conf: conf, IdentityDomain: identityDomain, IstioConfigList: istioConfigList, KubeServiceHosts: kubeServiceHosts, Namespaces: namespaces, PolicyAllowAny: policyAllowAny, Services: services, WorkloadsPerNamespace: workloadsPerNamespace},
 		checkers.NewPeerAuthenticationChecker(cluster, conf, identityDomain, vInfo.clusterInfo.rootNamespaces, *mtlsDetails, mtlsDetails.PeerAuthentications, workloadsPerNamespace),
 		checkers.RequestAuthenticationChecker{Cluster: cluster, RequestAuthentications: istioConfigList.RequestAuthentications, WorkloadsPerNamespace: workloadsPerNamespace},
-		checkers.ServiceEntryChecker{Cluster: cluster, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, WorkloadEntries: istioConfigList.WorkloadEntries},
+		checkers.ServiceEntryChecker{Cluster: cluster, ImportScope: importScope, Namespaces: namespaces, ServiceEntries: istioConfigList.ServiceEntries, WorkloadEntries: istioConfigList.WorkloadEntries},
 		checkers.NewSidecarChecker(cluster, conf, identityDomain, vInfo.clusterInfo.rootNamespaces, namespaces, kubeServiceHosts, istioConfigList.ServiceEntries, istioConfigList.Sidecars, workloadsPerNamespace),
 		checkers.TelemetryChecker{Namespaces: namespaces, Telemetries: istioConfigList.Telemetries},
-		checkers.VirtualServiceChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices},
+		checkers.VirtualServiceChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, ImportScope: importScope, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices},
 		checkers.TrafficExtensionChecker{Namespaces: namespaces, TrafficExtensions: istioConfigList.TrafficExtensions},
 		checkers.WasmPluginChecker{Namespaces: namespaces, WasmPlugins: istioConfigList.WasmPlugins},
 		checkers.NewWorkloadChecker(rbacDetails.AuthorizationPolicies, cluster, conf, vInfo.clusterInfo.rootNamespaces, namespaces, workloadsPerNamespace, services),
@@ -748,6 +750,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 	}
 
 	noServiceChecker := checkers.NoServiceChecker{Conf: conf, IdentityDomain: identityDomain, Cluster: cluster, Namespaces: namespaces, IstioConfigList: istioConfigList, WorkloadsPerNamespace: workloadsPerNamespace, AuthorizationDetails: rbacDetails, KubeServiceHosts: kubeServiceHosts, Services: services, PolicyAllowAny: policyAllowAny}
+	importScope := in.buildImportScope(vInfo, nsNames, identityDomain)
 
 	switch objectGVK {
 	case kubernetes.Gateways:
@@ -756,15 +759,15 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		}
 		referenceChecker = references.GatewayReferences{Conf: conf, Gateways: istioConfigList.Gateways, IdentityDomain: identityDomain, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.VirtualServices:
-		virtualServiceChecker := checkers.VirtualServiceChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices}
+		virtualServiceChecker := checkers.VirtualServiceChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, ImportScope: importScope, Namespaces: namespaces, VirtualServices: istioConfigList.VirtualServices}
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, virtualServiceChecker, newAmbientPolicyChecker(cluster, namespaces, workloadsPerNamespace, rbacDetails.AuthorizationPolicies, istioConfigList, services, identityDomain)}
 		referenceChecker = references.VirtualServiceReferences{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, Namespace: namespace, Namespaces: nsNames, VirtualServices: istioConfigList.VirtualServices}
 	case kubernetes.DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, MTLSDetails: *mtlsDetails, Namespaces: namespaces}
+		destinationRulesChecker := checkers.DestinationRulesChecker{Cluster: cluster, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, ImportScope: importScope, MTLSDetails: *mtlsDetails, Namespaces: namespaces}
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, destinationRulesChecker, newAmbientPolicyChecker(cluster, namespaces, workloadsPerNamespace, rbacDetails.AuthorizationPolicies, istioConfigList, services, identityDomain)}
 		referenceChecker = references.DestinationRuleReferences{Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, KubeServiceHosts: kubeServiceHosts, Namespace: namespace, Namespaces: nsNames, ServiceEntries: istioConfigList.ServiceEntries, Services: services, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace}
 	case kubernetes.ServiceEntries:
-		serviceEntryChecker := checkers.ServiceEntryChecker{Cluster: cluster, ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries}
+		serviceEntryChecker := checkers.ServiceEntryChecker{Cluster: cluster, ImportScope: importScope, ServiceEntries: istioConfigList.ServiceEntries, Namespaces: namespaces, WorkloadEntries: istioConfigList.WorkloadEntries}
 		objectCheckers = []checkers.ObjectChecker{serviceEntryChecker}
 		referenceChecker = references.ServiceEntryReferences{AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Conf: conf, DestinationRules: istioConfigList.DestinationRules, IdentityDomain: identityDomain, KubeServiceHosts: kubeServiceHosts, Namespace: namespace, Namespaces: nsNames, ServiceEntries: istioConfigList.ServiceEntries, Sidecars: istioConfigList.Sidecars}
 	case kubernetes.Sidecars:
@@ -972,6 +975,35 @@ func (in *IstioValidationsService) getServiceAccounts(
 		}
 	}
 	return slices.Collect(maps.Keys(serviceAccounts))
+}
+
+// buildImportScope returns the Sidecar egress import scope for the namespace under validation.
+// Ambient namespaces skip Sidecar filtering (Sidecar does not apply to ambient workloads).
+func (in *IstioValidationsService) buildImportScope(vInfo *validationInfo, nsNames []string, identityDomain string) common.ImportScope {
+	if vInfo.nsInfo == nil || vInfo.nsInfo.namespace == nil {
+		return common.ImportScope{}
+	}
+	namespace := vInfo.nsInfo.namespace.Name
+	cluster := vInfo.clusterInfo.cluster
+	if namespace == "" {
+		return common.ImportScope{}
+	}
+	if namespaces := vInfo.nsMap[cluster]; models.Namespaces(namespaces).IsNamespaceAmbient(namespace, cluster) {
+		return common.ImportScope{}
+	}
+
+	rootNS := ""
+	if vInfo.clusterInfo.rootNamespaces != nil {
+		rootNS = vInfo.clusterInfo.rootNamespaces[namespace]
+	}
+	// Use cluster-wide Sidecars so EffectiveSidecar can fall back to the root
+	// namespace Sidecar (nsInfo.Sidecars currently copies all cluster Sidecars, but
+	// clusterInfo is the authoritative source for cross-namespace resolution).
+	var sidecars []*networking_v1.Sidecar
+	if vInfo.clusterInfo.istioConfig != nil {
+		sidecars = vInfo.clusterInfo.istioConfig.Sidecars
+	}
+	return common.NewImportScope(namespace, rootNS, sidecars, nsNames, identityDomain)
 }
 
 // setNamespaceIstioConfig assumes the following are set:

--- a/tests/integration/assets/bookinfo-dr-sidecar-foreign-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-dr-sidecar-foreign-multimatch.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: kiali-test-sidecar-import
+spec:
+  egress:
+  - hosts:
+    - "./*"
+    - "istio-system/*"
+---
+# Two DestinationRules for the same foreign host. With Sidecar ./* these hosts
+# are not imported by bookinfo proxies, so KIA0201 must not be reported.
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: kiali-test-foreign-dr-a
+spec:
+  host: echo.default.svc.cluster.local
+  exportTo:
+  - "."
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: kiali-test-foreign-dr-b
+spec:
+  host: echo.default.svc.cluster.local
+  exportTo:
+  - "."
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_REQUEST

--- a/tests/integration/assets/bookinfo-dr-sidecar-foreign-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-dr-sidecar-foreign-multimatch.yaml
@@ -10,12 +10,13 @@ spec:
 ---
 # Two DestinationRules for the same foreign host. With Sidecar ./* these hosts
 # are not imported by bookinfo proxies, so KIA0201 must not be reported.
+# Use kubernetes.default (always present) so KIA0202 does not obscure the check.
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: kiali-test-foreign-dr-a
 spec:
-  host: echo.default.svc.cluster.local
+  host: kubernetes.default.svc.cluster.local
   exportTo:
   - "."
   trafficPolicy:
@@ -27,7 +28,7 @@ kind: DestinationRule
 metadata:
   name: kiali-test-foreign-dr-b
 spec:
-  host: echo.default.svc.cluster.local
+  host: kubernetes.default.svc.cluster.local
   exportTo:
   - "."
   trafficPolicy:

--- a/tests/integration/assets/bookinfo-dr-sidecar-imported-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-dr-sidecar-imported-multimatch.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: kiali-test-sidecar-import
+spec:
+  egress:
+  - hosts:
+    - "./*"
+    - "default/*"
+    - "istio-system/*"
+---
+# Same foreign host pair as the skip case, but Sidecar imports default/*, so
+# both DestinationRules are co-applied and KIA0201 is expected.
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: kiali-test-imported-dr-a
+spec:
+  host: echo.default.svc.cluster.local
+  exportTo:
+  - "."
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: kiali-test-imported-dr-b
+spec:
+  host: echo.default.svc.cluster.local
+  exportTo:
+  - "."
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_REQUEST

--- a/tests/integration/assets/bookinfo-dr-sidecar-imported-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-dr-sidecar-imported-multimatch.yaml
@@ -16,7 +16,7 @@ kind: DestinationRule
 metadata:
   name: kiali-test-imported-dr-a
 spec:
-  host: echo.default.svc.cluster.local
+  host: kubernetes.default.svc.cluster.local
   exportTo:
   - "."
   trafficPolicy:
@@ -28,7 +28,7 @@ kind: DestinationRule
 metadata:
   name: kiali-test-imported-dr-b
 spec:
-  host: echo.default.svc.cluster.local
+  host: kubernetes.default.svc.cluster.local
   exportTo:
   - "."
   trafficPolicy:

--- a/tests/integration/assets/bookinfo-se-sidecar-foreign-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-se-sidecar-foreign-multimatch.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: kiali-test-sidecar-import-se
+spec:
+  egress:
+  - hosts:
+    - "./*"
+    - "istio-system/*"
+---
+# Two ServiceEntries for the same foreign host. With Sidecar ./* these hosts
+# are not imported by bookinfo proxies, so KIA1211 must not be reported.
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: kiali-test-foreign-se-a
+spec:
+  hosts:
+  - kubernetes.default.svc.cluster.local
+  location: MESH_INTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: NONE
+  exportTo:
+  - "."
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: kiali-test-foreign-se-b
+spec:
+  hosts:
+  - kubernetes.default.svc.cluster.local
+  location: MESH_INTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: NONE
+  exportTo:
+  - "."

--- a/tests/integration/assets/bookinfo-vs-sidecar-foreign-multimatch.yaml
+++ b/tests/integration/assets/bookinfo-vs-sidecar-foreign-multimatch.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: kiali-test-sidecar-import-vs
+spec:
+  egress:
+  - hosts:
+    - "./*"
+    - "istio-system/*"
+---
+# Two VirtualServices for the same foreign host. With Sidecar ./* these hosts
+# are not imported by bookinfo proxies, so KIA1106 must not be reported.
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: kiali-test-foreign-vs-a
+spec:
+  hosts:
+  - kubernetes.default.svc.cluster.local
+  exportTo:
+  - "."
+  http:
+  - route:
+    - destination:
+        host: kubernetes.default.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: kiali-test-foreign-vs-b
+spec:
+  hosts:
+  - kubernetes.default.svc.cluster.local
+  exportTo:
+  - "."
+  http:
+  - route:
+    - destination:
+        host: kubernetes.default.svc.cluster.local

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -84,6 +84,42 @@ func TestDestinationRuleSidecarImportKeepsImportedForeignMultimatch(t *testing.T
 	assertConfigDetailsHasCode(*config, "KIA0201", require)
 }
 
+// TestVirtualServiceSidecarImportSkipsForeignMultimatch: Sidecar ./* means foreign-host
+// VirtualServices are not co-applied, so KIA1106 must not fire.
+func TestVirtualServiceSidecarImportSkipsForeignMultimatch(t *testing.T) {
+	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-vs-sidecar-foreign-multimatch.yaml")
+	require.True(utils.ApplyFileWithCleanup(t, filePath, kiali.BOOKINFO))
+
+	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-vs-a", kubernetes.VirtualServices, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA1106", require)
+
+	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-vs-b", kubernetes.VirtualServices, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA1106", require)
+}
+
+// TestServiceEntrySidecarImportSkipsForeignMultimatch: Sidecar ./* means foreign-host
+// ServiceEntries are not co-applied, so KIA1211 must not fire.
+func TestServiceEntrySidecarImportSkipsForeignMultimatch(t *testing.T) {
+	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-se-sidecar-foreign-multimatch.yaml")
+	require.True(utils.ApplyFileWithCleanup(t, filePath, kiali.BOOKINFO))
+
+	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-se-a", kubernetes.ServiceEntries, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA1211", require)
+
+	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-se-b", kubernetes.ServiceEntries, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA1211", require)
+}
+
 func TestDestinationRuleExportMultimatch(t *testing.T) {
 	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-destination-rule-export-multimatch.yaml")

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -72,15 +72,16 @@ func TestDestinationRuleSidecarImportKeepsImportedForeignMultimatch(t *testing.T
 	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-dr-sidecar-imported-multimatch.yaml")
 	require.True(utils.ApplyFileWithCleanup(t, filePath, kiali.BOOKINFO))
 
-	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-a", kubernetes.DestinationRules, false, require)
+	// Assert code presence (not Valid/Checks[0]): other DR checks may also appear.
+	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-a", kubernetes.DestinationRules, true, require)
 	require.NoError(err)
 	require.NotNil(config)
-	assertConfigDetailsValidations(*config, kiali.BOOKINFO, kubernetes.DestinationRules, "kiali-test-imported-dr-a", "KIA0201", true, require)
+	assertConfigDetailsHasCode(*config, "KIA0201", require)
 
-	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-b", kubernetes.DestinationRules, false, require)
+	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-b", kubernetes.DestinationRules, true, require)
 	require.NoError(err)
 	require.NotNil(config)
-	assertConfigDetailsValidations(*config, kiali.BOOKINFO, kubernetes.DestinationRules, "kiali-test-imported-dr-b", "KIA0201", true, require)
+	assertConfigDetailsHasCode(*config, "KIA0201", require)
 }
 
 func TestDestinationRuleExportMultimatch(t *testing.T) {
@@ -426,6 +427,19 @@ func assertConfigDetailsValidations(configDetails models.IstioConfigDetails, nam
 	require.Equal(valid, configDetails.IstioValidation.Valid)
 	require.NotEmpty(configDetails.IstioValidation.Checks)
 	require.Equal(code, configDetails.IstioValidation.Checks[0].Code)
+}
+
+func assertConfigDetailsHasCode(configDetails models.IstioConfigDetails, code string, require *require.Assertions) {
+	require.NotNil(configDetails.IstioValidation)
+	found := false
+	for _, check := range configDetails.IstioValidation.Checks {
+		if check.Code == code {
+			found = true
+			break
+		}
+	}
+	require.True(found, "expected validation code %s on %s/%s, got %+v",
+		code, configDetails.IstioValidation.Namespace, configDetails.IstioValidation.Name, configDetails.IstioValidation.Checks)
 }
 
 func assertConfigDetailsHasNoCode(configDetails models.IstioConfigDetails, code string, require *require.Assertions) {

--- a/tests/integration/tests/config_validations_test.go
+++ b/tests/integration/tests/config_validations_test.go
@@ -41,6 +41,48 @@ func TestDestinationRuleMultimatch(t *testing.T) {
 	assertConfigListValidations(*configList, kiali.BOOKINFO, kubernetes.DestinationRules, "all.googleapis.com2", "KIA0201", true, require)
 }
 
+// TestDestinationRuleSidecarImportSkipsForeignMultimatch verifies issue #10124:
+// with Sidecar egress limited to ./* (+ control plane), DestinationRules for a
+// foreign host are not co-applied by local proxies, so KIA0201 must not fire.
+func TestDestinationRuleSidecarImportSkipsForeignMultimatch(t *testing.T) {
+	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-dr-sidecar-foreign-multimatch.yaml")
+	require.True(utils.ApplyFileWithCleanup(t, filePath, kiali.BOOKINFO))
+
+	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-dr-a", kubernetes.DestinationRules, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA0201", require)
+
+	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-foreign-dr-b", kubernetes.DestinationRules, true, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsHasNoCode(*config, "KIA0201", require)
+
+	configList, err := kiali.IstioConfigsList(kiali.BOOKINFO)
+	require.NoError(err)
+	assertConfigListHasNoCode(*configList, kiali.BOOKINFO, "kiali-test-foreign-dr-a", "KIA0201", require)
+	assertConfigListHasNoCode(*configList, kiali.BOOKINFO, "kiali-test-foreign-dr-b", "KIA0201", require)
+}
+
+// TestDestinationRuleSidecarImportKeepsImportedForeignMultimatch: when Sidecar
+// imports the foreign namespace (default/*), same-host DRs still get KIA0201.
+func TestDestinationRuleSidecarImportKeepsImportedForeignMultimatch(t *testing.T) {
+	require := require.New(t)
+	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-dr-sidecar-imported-multimatch.yaml")
+	require.True(utils.ApplyFileWithCleanup(t, filePath, kiali.BOOKINFO))
+
+	config, err := getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-a", kubernetes.DestinationRules, false, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsValidations(*config, kiali.BOOKINFO, kubernetes.DestinationRules, "kiali-test-imported-dr-a", "KIA0201", true, require)
+
+	config, err = getConfigDetails(kiali.BOOKINFO, "kiali-test-imported-dr-b", kubernetes.DestinationRules, false, require)
+	require.NoError(err)
+	require.NotNil(config)
+	assertConfigDetailsValidations(*config, kiali.BOOKINFO, kubernetes.DestinationRules, "kiali-test-imported-dr-b", "KIA0201", true, require)
+}
+
 func TestDestinationRuleExportMultimatch(t *testing.T) {
 	require := require.New(t)
 	filePath := path.Join(cmd.KialiProjectRoot, kiali.ASSETS+"/bookinfo-destination-rule-export-multimatch.yaml")
@@ -384,4 +426,28 @@ func assertConfigDetailsValidations(configDetails models.IstioConfigDetails, nam
 	require.Equal(valid, configDetails.IstioValidation.Valid)
 	require.NotEmpty(configDetails.IstioValidation.Checks)
 	require.Equal(code, configDetails.IstioValidation.Checks[0].Code)
+}
+
+func assertConfigDetailsHasNoCode(configDetails models.IstioConfigDetails, code string, require *require.Assertions) {
+	require.NotNil(configDetails.IstioValidation)
+	for _, check := range configDetails.IstioValidation.Checks {
+		require.NotEqual(code, check.Code, "unexpected validation code %s on %s/%s", code, configDetails.IstioValidation.Namespace, configDetails.IstioValidation.Name)
+	}
+}
+
+func assertConfigListHasNoCode(configList models.IstioConfigList, namespace, objName, code string, require *require.Assertions) {
+	require.NotNil(configList.IstioValidations)
+	found := false
+	for key, validation := range configList.IstioValidations {
+		if key.Name != objName || key.Namespace != namespace {
+			continue
+		}
+		found = true
+		require.NotNil(validation)
+		for _, check := range validation.Checks {
+			require.NotEqual(code, check.Code, "unexpected validation code %s on %s/%s", code, namespace, objName)
+		}
+		break
+	}
+	require.True(found, "expected config %s/%s to appear in validations list", namespace, objName)
 }


### PR DESCRIPTION
### Describe the change

Fixes false-positive conflict validations (notably **KIA0201**) when a namespace Sidecar limits egress imports so that overlapping DestinationRules / VirtualServices / ServiceEntries are **not** co-applied by local proxies.

**Approach (Option B):** introduce a shared `ImportScope` helper that resolves the effective selector-less Sidecar (workload NS → root NS) and filters **conflict/override** checker inputs only. Individual existence checks are unchanged.

Covered conflict codes: KIA0201, KIA0204, KIA1106, KIA1107, KIA1211/KIA1212. Ambient namespaces skip Sidecar filtering. Empty/missing egress remains unrestricted (Istio default).

Fixes #10124

### Steps to test the PR

Use a cluster with Istio + bookinfo (or any mesh namespace). Apply the YAMLs below in that namespace (replace `bookinfo` if needed).

#### 1) Reproduce the false positive (before this PR) / confirm fixed (after)

Sidecar imports only local + control-plane hosts. Two DestinationRules target the same **foreign** host (`kubernetes.default...`). Proxies in the Sidecar namespace do **not** import those DRs together, so **KIA0201 must not appear**.

```yaml
apiVersion: networking.istio.io/v1
kind: Sidecar
metadata:
  name: kiali-test-sidecar-import
  namespace: bookinfo
spec:
  egress:
  - hosts:
    - "./*"
    - "istio-system/*"
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kiali-test-foreign-dr-a
  namespace: bookinfo
spec:
  host: kubernetes.default.svc.cluster.local
  exportTo:
  - "."
  trafficPolicy:
    loadBalancer:
      simple: ROUND_ROBIN
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kiali-test-foreign-dr-b
  namespace: bookinfo
spec:
  host: kubernetes.default.svc.cluster.local
  exportTo:
  - "."
  trafficPolicy:
    loadBalancer:
      simple: LEAST_REQUEST
```

Check in Kiali UI (Istio Config details for either DR) or API:

```bash
# expect no KIA0201 on these objects
curl -s "http://localhost:20001/kiali/api/namespaces/bookinfo/istio/destinationrules/kiali-test-foreign-dr-a" | jq '.validation.checks'
curl -s "http://localhost:20001/kiali/api/namespaces/bookinfo/istio/destinationrules/kiali-test-foreign-dr-b" | jq '.validation.checks'
```

**Before fix:** both DRs report `KIA0201` (More than one Destination Rule for the same host subset).  
**After fix:** neither DR reports `KIA0201`.

Cleanup:

```bash
kubectl -n bookinfo delete sidecar kiali-test-sidecar-import \
  destinationrule kiali-test-foreign-dr-a kiali-test-foreign-dr-b
```

#### 2) Confirm KIA0201 still fires when the host *is* imported

Same DR pair, but Sidecar also imports `default/*`. Both rules are co-applied → **KIA0201 is expected**.

```yaml
apiVersion: networking.istio.io/v1
kind: Sidecar
metadata:
  name: kiali-test-sidecar-import
  namespace: bookinfo
spec:
  egress:
  - hosts:
    - "./*"
    - "default/*"
    - "istio-system/*"
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kiali-test-imported-dr-a
  namespace: bookinfo
spec:
  host: kubernetes.default.svc.cluster.local
  exportTo:
  - "."
  trafficPolicy:
    loadBalancer:
      simple: ROUND_ROBIN
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kiali-test-imported-dr-b
  namespace: bookinfo
spec:
  host: kubernetes.default.svc.cluster.local
  exportTo:
  - "."
  trafficPolicy:
    loadBalancer:
      simple: LEAST_REQUEST
```

```bash
# expect KIA0201 on both
curl -s "http://localhost:20001/kiali/api/namespaces/bookinfo/istio/destinationrules/kiali-test-imported-dr-a" | jq '.validation.checks'
curl -s "http://localhost:20001/kiali/api/namespaces/bookinfo/istio/destinationrules/kiali-test-imported-dr-b" | jq '.validation.checks'
```

Cleanup:

```bash
kubectl -n bookinfo delete sidecar kiali-test-sidecar-import \
  destinationrule kiali-test-imported-dr-a kiali-test-imported-dr-b
```

**Note:** Removing egress hosts entirely (or omitting egress) makes import unrestricted again, so KIA0201 can return even for foreign hosts — that matches Istio’s default.

### Automation testing

- **Unit:** `business/checkers/common/sidecar_import_scope_test.go` (ImportScope / egress matching), `business/checkers/sidecar_import_conflict_test.go` (DR/VS/SE conflict filtering).
- **Integration:**
  - `TestDestinationRuleSidecarImportSkipsForeignMultimatch` — no KIA0201 with `./*` Sidecar + foreign host DRs.
  - `TestDestinationRuleSidecarImportKeepsImportedForeignMultimatch` — KIA0201 still present when `default/*` is imported.

```bash
make test
# with integration cluster + Kiali:
go test ./tests/integration/tests -run 'TestDestinationRuleSidecarImport' -v
```

### Issue reference

https://github.com/kiali/kiali/issues/10124