### PR TITLE
[Validations] Fix sticky KIA1313 false positive from stale empty waypoint cache

### DIFF
--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -219,6 +219,11 @@ func (in *IstioValidationsService) NewValidationInfo(ctx context.Context, cluste
 	}
 	vInfo.mesh = mesh
 
+	// Always refresh waypoints before building the workload map used by checkers. Otherwise a
+	// waypointStore miss that cached an empty list (TTL defaults to 4m) can produce KIA1313 and,
+	// without a tracked change after the cache refreshes, leave that false positive stuck forever.
+	in.workload.cache.ClearWaypoints()
+
 	// gather base info, mapped by cluster
 	for _, cluster := range clusters {
 		namespaces, err := in.namespace.GetClusterNamespaces(ctx, cluster)
@@ -257,7 +262,12 @@ func (in *IstioValidationsService) NewValidationInfo(ctx context.Context, cluste
 		}
 		changeDetected = changeMap.update("validation-num-namespaces", strconv.Itoa(numNamespaces), vInfo.reportChange) || changeDetected
 
-		// loop through workloads, looking for label/serviceAccount changes that affect validations
+		// Track the resolved waypoint set itself. Waypoint appearance/disappearance is not
+		// otherwise visible via namespace/workload label keys alone once enrollment is stable.
+		waypoints := in.workload.GetWaypoints(ctx)
+		changeDetected = changeMap.update("validation-waypoints", waypointWorkloadsValidationDigest(waypoints), vInfo.reportChange) || changeDetected
+
+		// loop through workloads, looking for label/serviceAccount/waypoint changes that affect validations
 		numWorkloads := 0
 		for _, workloadsMap := range vInfo.wlMap {
 			for _, workloads := range workloadsMap {

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -263,6 +263,130 @@ func TestAmbientNamespaceWaypointDoesNotTriggerWaypointNotFound(t *testing.T) {
 	assert.False(hasWaypointNotFound, "namespace waypoint should resolve without KIA1313")
 }
 
+func TestStaleEmptyWaypointCacheDoesNotStickKIA1313(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	namespaceLabels := map[string]string{
+		config.IstioAmbientNamespaceLabel: config.IstioAmbientNamespaceLabelValue,
+		config.WaypointUseLabel:           "waypoint",
+	}
+
+	objects := []runtime.Object{
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "Namespace", Labels: namespaceLabels}},
+		&core_v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: "istio-system"}},
+		&core_v1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: "istio", Namespace: "istio-system"}},
+	}
+
+	for _, pod := range FakeWaypointPod() {
+		p := pod
+		objects = append(objects, &p)
+	}
+	for _, pod := range FakeWaypointNamespaceEnrolledPods(conf, false) {
+		p := pod
+		objects = append(objects, &p)
+	}
+	objects = append(objects, &apps_v1.Deployment{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: kubernetes.Deployments.GroupVersion().String(),
+			Kind:       kubernetes.Deployments.Kind,
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "waypoint",
+			Namespace: "Namespace",
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Template: core_v1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"gateway.istio.io/managed":               "istio.io-mesh-controller",
+						"gateway.networking.k8s.io/gateway-name": "waypoint",
+					},
+				},
+			},
+		},
+	})
+
+	mesh := models.Mesh{
+		ControlPlanes: []models.ControlPlane{{
+			Cluster:    &models.KubeCluster{IsKialiHome: true},
+			MeshConfig: models.NewMeshConfig(),
+			ManagedNamespaces: []models.Namespace{
+				{Name: "Namespace"},
+				{Name: "istio-system"},
+			},
+		}},
+	}
+
+	vs := fakeValidationMeshServiceWithMesh(t, *conf, mesh, objects...)
+
+	// Simulate Kiali having cached an empty waypoint list before the waypoint existed.
+	vs.kialiCache.SetWaypoints(models.Workloads{})
+
+	changeMap := ValidationChangeMap{}
+	vInfo, err := vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
+	require.NoError(err)
+	assert.Contains(changeMap, "validation-waypoints")
+	assert.NotEmpty(changeMap["validation-waypoints"], "fresh waypoint discovery should populate the tracked digest")
+
+	var detailsWorkload *models.Workload
+	for _, workload := range vInfo.wlMap[conf.KubernetesConfig.ClusterName]["Namespace"] {
+		if workload.Name == "details" {
+			detailsWorkload = workload
+			break
+		}
+	}
+	require.NotNil(detailsWorkload)
+	require.Len(detailsWorkload.WaypointWorkloads, 1)
+
+	validationPerformed, allValidations, err := vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	require.NoError(err)
+	assert.True(validationPerformed)
+
+	key := models.IstioValidationKey{
+		ObjectGVK: schema.GroupVersionKind{Group: "", Version: "", Kind: "workload"},
+		Namespace: "Namespace",
+		Name:      "details",
+		Cluster:   conf.KubernetesConfig.ClusterName,
+	}
+	require.Contains(allValidations, key)
+
+	for _, check := range allValidations[key].Checks {
+		assert.NotEqual("KIA1313", check.Code, "stale empty waypoint cache must not produce KIA1313")
+	}
+
+	// A second pass with no cluster changes should skip checkers (change detection still works).
+	vInfo, err = vs.NewValidationInfo(context.Background(), []string{conf.KubernetesConfig.ClusterName}, changeMap)
+	require.NoError(err)
+	assert.False(vInfo.hasBaseChange)
+	validationPerformed, _, err = vs.Validate(context.Background(), conf.KubernetesConfig.ClusterName, vInfo)
+	require.NoError(err)
+	assert.False(validationPerformed)
+}
+
+func TestWaypointRefsValidationDigest(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Empty(waypointRefsValidationDigest(nil))
+
+	a := waypointRefsValidationDigest([]models.WorkloadReferenceInfo{
+		{Cluster: "c", Namespace: "ns", Name: "wp-b", Type: "service"},
+		{Cluster: "c", Namespace: "ns", Name: "wp-a", Type: "service"},
+	})
+	b := waypointRefsValidationDigest([]models.WorkloadReferenceInfo{
+		{Cluster: "c", Namespace: "ns", Name: "wp-a", Type: "service"},
+		{Cluster: "c", Namespace: "ns", Name: "wp-b", Type: "service"},
+	})
+	assert.Equal(a, b, "digest must be order-independent")
+	assert.NotEmpty(a)
+	assert.NotEqual(
+		waypointRefsValidationDigest([]models.WorkloadReferenceInfo{{Name: "wp-a"}}),
+		waypointRefsValidationDigest([]models.WorkloadReferenceInfo{{Name: "wp-b"}}),
+	)
+}
+
 func TestGetIstioObjectValidations(t *testing.T) {
 	assert := assert.New(t)
 	conf := config.NewConfig()

--- a/business/workloads.go
+++ b/business/workloads.go
@@ -1732,7 +1732,9 @@ func (in *WorkloadService) fetchWorkloadsFromCluster(ctx context.Context, cluste
 
 			w.ServiceAccountNames = w.Pods.ServiceAccounts()
 			slices.Sort(w.ServiceAccountNames)
-			w.ValidationVersion = fmt.Sprintf("%v:%v:%v", w.Labels, w.ServiceAccountNames, w.Annotations[models.IgnoreValidationsAnnotation])
+			// Include resolved waypoints so a stale empty waypoint cache that later refreshes
+			// is treated as a validation-relevant change (avoids sticky KIA1313 false positives).
+			w.ValidationVersion = fmt.Sprintf("%v:%v:%v:%s", w.Labels, w.ServiceAccountNames, w.Annotations[models.IgnoreValidationsAnnotation], waypointRefsValidationDigest(w.WaypointWorkloads))
 
 			// Set SpireInfo if workload is SPIRE-managed or is a SPIRE server
 			spireMatches := w.SpireManagedIdentity()
@@ -2524,6 +2526,32 @@ func (in *WorkloadService) GetWaypoints(ctx context.Context) models.Workloads {
 	}
 	in.cache.SetWaypoints(waypoints)
 	return waypoints
+}
+
+// waypointRefsValidationDigest returns a stable digest of resolved waypoint references for change detection.
+func waypointRefsValidationDigest(refs []models.WorkloadReferenceInfo) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	parts := make([]string, len(refs))
+	for i, ref := range refs {
+		parts[i] = strings.Join([]string{ref.Cluster, ref.Namespace, ref.Name, ref.Type}, "/")
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, ",")
+}
+
+// waypointWorkloadsValidationDigest returns a stable digest of discovered waypoint workloads for change detection.
+func waypointWorkloadsValidationDigest(waypoints models.Workloads) string {
+	if len(waypoints) == 0 {
+		return ""
+	}
+	parts := make([]string, len(waypoints))
+	for i, wp := range waypoints {
+		parts[i] = strings.Join([]string{wp.Cluster, wp.Namespace, wp.Name}, "/")
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, ",")
 }
 
 // getCapturingWaypoints returns waypoint references that capture the workload. Only the active waypoint is returned unless <all>

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -97,6 +97,8 @@ type KialiCache interface {
 	// GetNamespaces returns all namespaces for the cluster/cacheKey from the in memory cache.
 	GetNamespaces(cluster string, cacheKey string) ([]models.Namespace, bool)
 
+	// ClearWaypoints removes the cached waypoint list so the next GetWaypoints refreshes from the cluster.
+	ClearWaypoints()
 	GetWaypoints() (models.Workloads, bool)
 	SetWaypoints(models.Workloads)
 
@@ -712,6 +714,11 @@ func (c *kialiCacheImpl) GatewayAPIClasses(cluster string) []config.GatewayAPICl
 	}
 
 	return result
+}
+
+// ClearWaypoints removes the cached waypoint list so the next GetWaypoints refreshes from the cluster.
+func (c *kialiCacheImpl) ClearWaypoints() {
+	c.waypointStore.Remove(kialiCacheWaypointsKey)
 }
 
 // GetWaypoints Returns a list of waypoint proxies by cluster and namespace

--- a/models/workload.go
+++ b/models/workload.go
@@ -177,7 +177,8 @@ type WorkloadListItem struct {
 	ValidationKey string
 
 	// ValidationVersion is a pre-calculated string representing the workload "version", basically
-	// the workload information that, if changed, requires re-validation (including per-object ignore rules).
+	// the workload information that, if changed, requires re-validation (including per-object ignore
+	// rules and resolved waypoint references used by ambient checkers such as KIA1313).
 	ValidationVersion string
 }
 


### PR DESCRIPTION
### Describe the change

- Clear the waypoint cache before each validation pass so checkers do not run against a stale empty `waypointStore` list (TTL default 4m).
- Include resolved waypoint references in `ValidationVersion` and track a `validation-waypoints` digest in the change map, so waypoint appearance/disappearance forces revalidation.
- Add a regression test that seeds an empty waypoint cache and asserts KIA1313 is not raised when the waypoint exists.

When Kiali starts before a waypoint exists, `GetWaypoints()` can cache an empty list. Labeling a namespace with `istio.io/use-waypoint` triggers revalidation while that cache is still empty, so KIA1313 is stored. After the waypoint cache refreshes, change detection did not see a tracked change, so the false positive persisted indefinitely. Workload detail could show KIA1313 while `waypointWorkloads` in the same response was already resolved.

## Test plan
- [x] Unit: `TestStaleEmptyWaypointCacheDoesNotStickKIA1313`
- [x] Unit: `TestWaypointRefsValidationDigest`
- [x] Unit: existing ambient waypoint validation tests
- [ ] Manual: delete waypoint + restart Kiali (empty cache), recreate waypoint + enroll namespace within TTL; detail should **not** show KIA1313 once validation reconciles
- [ ] Manual: label `istio.io/use-waypoint` to a missing name (or delete waypoint while keeping the label); detail should show **real** KIA1313 with empty `waypointWorkloads`

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10144 
