### PR TITLE
[Flake] Increment maxRetries waiting for the data in Ambient sidecar test

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -149,7 +149,7 @@ const waitForBookinfoWaypointTrafficGeneratedInGraph = (
 // Cross-ns curl clients produce 4 HTTP edges (client->service->workload x2). Ambient TCP
 // adds more for a full 8-edge graph. Wait for HTTP readiness and the full edge count.
 const waitForSidecarAmbientTrafficGeneratedInGraph = (
-  maxRetries = 60,
+  maxRetries = 90,
   retryCount = 0,
   lastEdgeCount = -1,
   lastHttpEdgeCount = -1
@@ -170,7 +170,7 @@ const waitForSidecarAmbientTrafficGeneratedInGraph = (
     method: 'GET',
     url: `${Cypress.config('baseUrl')}/api/namespaces/graph`,
     qs: {
-      duration: '300s',
+      duration: '600s',
       graphType: 'versionedApp',
       includeIdleEdges: false,
       injectServiceNodes: true,

--- a/hack/istio/install-testing-demos.sh
+++ b/hack/istio/install-testing-demos.sh
@@ -187,26 +187,28 @@ spec:
 EOF
   fi
   # Installed demos should be the exact same for both environments.
+  # Ambient demos do not depend on bookinfo. Install them first so Sidecar↔Ambient and
+  # waypoint traffic accumulate while bookinfo (and other demos) are still starting.
+  if [ "${AMBIENT_ENABLED}" == "true" ] && [ "${BOOKINFO_ONLY}" != "true" ]; then
+    echo "Deploying sidecar-ambient ..."
+    "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
+
+    echo "Deploying waypoint proxies ..."
+    "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
+  fi
+
   # Only the args passed to the scripts differ from each other.
   if [ "${IS_OPENSHIFT}" == "true" ]; then
     echo "Deploying bookinfo demo ..."
     "${SCRIPT_DIR}/install-bookinfo-demo.sh" -tg -in ${ISTIO_NAMESPACE} -a ${ARCH} ${gateway_yaml:+-g ${gateway_yaml}} ${AMBIENT_ARGS_BOOKINFO}
-    
+
     # Only install additional demos if not in bookinfo-only mode
     if [ "${BOOKINFO_ONLY}" != "true" ]; then
-      # Install just bookinfo for now for Ambient
       if [ "${AMBIENT_ENABLED}" != "true" ]; then
         echo "Deploying error rates demo ..."
         "${SCRIPT_DIR}/install-error-rates-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH} --install-beta ${INSTALL_ERRORRATES_BETA} ${AMBIENT_ARGS_ERROR_RATES}
       else
         ${CLIENT_EXE} apply -f "${SCRIPT_DIR}/ambient/resources/waypoint.yaml" -n bookinfo
-
-        # Install early so Sidecar↔Ambient traffic accumulates while other demos start.
-        echo "Deploying sidecar-ambient ..."
-        "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
-
-        echo "Deploying waypoint proxies ..."
-        "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
       fi
       echo "Deploying sleep demo ..."
       "${SCRIPT_DIR}/install-sleep-demo.sh" -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_BOOKINFO}
@@ -219,15 +221,8 @@ EOF
 
     # Only install additional demos if not in bookinfo-only mode
     if [ "${BOOKINFO_ONLY}" != "true" ]; then
-      # Install early so Sidecar↔Ambient traffic accumulates while other demos start.
-      echo "Deploying sidecar-ambient ..."
-      "${SCRIPT_DIR}/ambient/install-sidecars-ambient.sh" -c ${CLIENT_EXE} -a ${ARCH}
-
       echo "Deploying sleep demo ..."
       "${SCRIPT_DIR}/install-sleep-demo.sh" -c kubectl -in ${ISTIO_NAMESPACE} -a ${ARCH} ${AMBIENT_ARGS_BOOKINFO}
-
-      echo "Deploying waypoint proxies ..."
-      "${SCRIPT_DIR}/ambient/install-waypoints.sh" -c ${CLIENT_EXE} -a ${ARCH}
     fi
 
   else


### PR DESCRIPTION
### Describe the change

- Reduce Ambient Cypress flake in [Traffic] Sidecar Ambient traffic, which often stalled at 2 HTTP / 6 total edges (missing ambient→sidecar L7) before reaching 4 HTTP / 8 total.
- Install install-sidecars-ambient.sh and install-waypoints.sh before bookinfo so Sidecar↔Ambient and waypoint traffic accumulate while other demos start.
- Increase the sidecar-ambient graph wait to maxRetries=90 and query duration=600s so CI can pick up late L7 metrics.

### Steps to test the PR

Ambient frontend CI (frontend-ambient) passes, including [Traffic] Sidecar Ambient traffic

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
