### PR TITLE
Support installing OSSM Console without a Kiali server present ("lite mode")

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ KIALI_CR_FILE ?= ${ROOTDIR}/operator/deploy/kiali/kiali_cr_dev.yaml
 # When creating a OSSMConsole CR, these can customize it
 OSSMCONSOLE_CR_FILE ?= ${ROOTDIR}/operator/deploy/ossmconsole/ossmconsole_cr_dev.yaml
 OSSMCONSOLE_CR_SPEC_VERSION ?= default
+OSSMCONSOLE_CR_AUTO_DISCOVER ?= true
 
 # When ensuring the helm chart repo exists, by default the make infrastructure will pull the latest code from git.
 # If you do not want this to happen (i.e. if you want to retain the local copies of your helm charts), set this to false.

--- a/WORKING_WITH_OSSMC.md
+++ b/WORKING_WITH_OSSMC.md
@@ -1,33 +1,94 @@
 # OpenShift Service Mesh Console (OSSM Console)
 
-:information_source: There is a [Users Guide](https://github.com/kiali/openshift-servicemesh-plugin/blob/main/docs/users-guide.md).
+The OpenShift Service Mesh Console is a Webpack plugin that extends the OpenShift Console. The official title is "OpenShift Service Mesh Console"; you may also see it abbreviated as "OSSMC", "ossmconsole", or "OSSM Console".
 
-The OpenShift Service Mesh Console is a Webpack Plugin that integrates Kiali into the OpenShift Console. The official title of the project is "OpenShift Service Mesh Console" but you may see this abbreviated in documentation and code as "OSSMC", "ossmconsole", or "OSSM Console".
-
-The main component is a plugin based on OpenShift Console [Dynamic plugin-ins](https://docs.openshift.com/container-platform/4.13/web_console/dynamic-plugin/overview-dynamic-plugin.html) framework. Installing and enabling the plugin will add OpenShift Service Mesh support into the OpenShift Console. The new "Service Mesh" menu item and tabs allow you to interact with your mesh via the Kiali user interface. Note that OSSMC may also work with upstream Istio installed (as opposed to OpenShift Service Mesh).
+OSSMC is based on the OpenShift Console [dynamic plugins](https://docs.openshift.com/container-platform/latest/web_console/dynamic-plugin/dynamic-plugin-overview.html) framework. Installing the plugin adds a **Service Mesh** navigation category to the OpenShift Console. OSSMC may work with upstream Istio as well as OpenShift Service Mesh.
 
 The main installation mechanism is the Kiali Operator.
 
+## How it works
+
+OSSMC provides two layers of functionality:
+
+1. **Navigating multiple meshes** — The **Istio control planes** and **Kiali instances** pages list every Istio and Kiali CR on the cluster. They talk to the Kubernetes API directly, so they work even when no Kiali server is connected to the plugin. From **Kiali instances**, admins can **Connect** or **Disconnect** which Kiali server OSSMC uses for observability.
+
+2. **Kiali-powered observability** — When a Kiali instance is connected and reachable, OSSMC adds Overview, Traffic Graph, Mesh, Namespaces, Applications, Services, Workloads, Istio Config, and **Service Mesh** tabs on OpenShift resource detail pages. These pages proxy through the connected Kiali server configured on the OSSMConsole CR.
+
+When a Kiali server is connected, **Istio control planes** and **Kiali instances** appear at the bottom of the Service Mesh menu (below a separator). When no Kiali server is connected, those two pages are the Service Mesh menu.
+
+See the official documentation for details:
+
+- [OSSM Console integration overview](https://kiali.io/docs/integrations/ossm-console/)
+- [Navigating Multiple Meshes](https://kiali.io/docs/ossmc/navigating-multiple-meshes/)
+- [OSSMC User Guide](https://kiali.io/docs/ossmc/users-guide/) (Kiali-powered pages)
+- [The OSSMConsole CR](https://kiali.io/docs/installation/installation-guide/creating-updating-ossmconsole-cr/)
+
 ## Platform Setup
 
-These are the things you need before developers can start working with the OpenShift Service Mesh Console:
+These are the things you need before developers can start working with OSSMC:
 
-1. OpenShift cluster with OpenShift ServiceMesh or Istio installed.
-2. Kiali Server deployed in the cluster
-3. `oc` client available in the path
-4. `podman` or `docker` client available in the path
+1. OpenShift cluster with OpenShift Service Mesh or Istio installed
+2. `oc` client available in the path
+3. `podman` or `docker` client available in the path
 
-## Operator
+A Kiali Server is optional. You need one to develop or test Kiali-powered observability pages, but not to develop or test **Istio control planes** and **Kiali instances**.
 
-The OpenShift Service Mesh Console will be installed by end users using the Kiali Operator. More details can be found in the [Install Guild](https://github.com/kiali/openshift-servicemesh-plugin/blob/main/docs/install-guide.md). Developers can use the make targets found in the kiali repo (see below).
+## Operator (kiali repo make targets)
 
-#### Quick Summary
+OSSMC is installed by end users through the Kiali Operator. Developers working in this repo can use the make targets below. The operator source lives in the [kiali-operator](https://github.com/kiali/kiali-operator) repo; the plugin source lives in [openshift-servicemesh-plugin](https://github.com/kiali/openshift-servicemesh-plugin).
 
-Here is a summary for developers on how to get the Kiali Operator, Kiali Server, and OSSMC installed in your OpenShift cluster.
+### Quick install summary
 
-1. First run `make cluster-status` to expose the internal image registry and get the docker or podman command needed to log into the internal image registry.
-2. Run the podman or docker login command that will log into the internal image registry.
-3. Build and push the OSSMC plugin image. You must do this from within your local repo of https://github.com/kiali/openshift-servicemesh-plugin - so clone that repo locally, and from your clone's root directory on your local machine, run `make cluster-push` and that will do what needs to be done.
-4. Build, push, and deploy the operator, Kiali, and plugin by running `make cluster-push operator-create kiali-create ossmconsole-create`
+1. Run `make cluster-status` to expose the internal image registry and get the `podman` or `docker` login command.
+2. Log into the internal image registry.
+3. Build and push the OSSMC plugin image from your local [openshift-servicemesh-plugin](https://github.com/kiali/openshift-servicemesh-plugin) clone: `make cluster-push`.
+4. Build, push, and deploy the operator, Kiali, and plugin from this repo: `make cluster-push operator-create kiali-create ossmconsole-create`.
 
-When you are finished and you want to uninstall the operator, Kiali, and plugin, run `make operator-delete`.
+To uninstall the operator, Kiali, and plugin: `make operator-delete`.
+
+### OSSMConsole CR targets
+
+| Target | Description |
+|--------|-------------|
+| `ossmconsole-create` | Create an OSSMConsole CR (uses `operator/deploy/ossmconsole/ossmconsole_cr_dev.yaml` by default) |
+| `ossmconsole-delete` | Delete the OSSMConsole CR |
+| `ossmconsole-purge` | Remove OSSMC resources directly, without going through the operator |
+
+Environment variables for `ossmconsole-create`:
+
+- `OSSMCONSOLE_CR_FILE` — path to the CR template (default: `operator/deploy/ossmconsole/ossmconsole_cr_dev.yaml`)
+- `OSSMCONSOLE_CR_SPEC_VERSION` — `spec.version` value (default: `default`)
+- `OSSMCONSOLE_CR_AUTO_DISCOVER` — `spec.kiali.autoDiscover` value (default: `true`)
+- `OSSMCONSOLE_NAMESPACE` — namespace for the OSSMConsole CR (default: `ossmconsole`)
+
+### Other useful targets
+
+| Target | Description |
+|--------|-------------|
+| `run-operator-playbook-ossmconsole` | Run the operator ansible playbook locally against an OSSMConsole CR |
+| `run-operator` | Run the operator locally (watches Kiali and OSSMConsole CRs) |
+| `crd-create` / `crd-delete` | Install or remove the Kiali and OSSMConsole CRDs |
+
+### Molecule tests
+
+OSSMC operator behavior is covered by molecule tests under `kiali-operator/molecule/`. Relevant tests include `ossmconsole-config-values-test` and `ossmconsole-lite-test` (installing OSSMC without a connected Kiali server).
+
+Run molecule tests from this repo using `hack/run-molecule-tests.sh`. See the molecule testing instructions in the repo rules or `hack/run-molecule-tests.sh --help`.
+
+## Plugin development (openshift-servicemesh-plugin repo)
+
+Plugin UI work happens in [openshift-servicemesh-plugin](https://github.com/kiali/openshift-servicemesh-plugin). Common make targets there:
+
+| Target | Description |
+|--------|-------------|
+| `make cluster-push` | Build and push the plugin image to the cluster registry |
+| `make cluster-deploy` | Build, push, and deploy without the operator |
+| `make restart-plugin` | Restart the plugin pod after pushing a new image |
+| `make deploy-plugin` / `make enable-plugin` | Deploy and enable the `latest` image from quay.io (quick testing) |
+| `make start` | Start the webpack dev server for the plugin (run in one terminal) |
+| `make start-console` | Start a local OpenShift Console for plugin development (run in a second terminal; requires `make start`) |
+| `make lint` | Run eslint |
+| `make typecheck` | Run TypeScript type checking |
+| `make test` | Run all unit tests |
+
+See the [plugin README](https://github.com/kiali/openshift-servicemesh-plugin/blob/main/README.md) for full development setup (Node.js, corepack, Yarn 4).

--- a/WORKING_WITH_OSSMC.md
+++ b/WORKING_WITH_OSSMC.md
@@ -10,11 +10,11 @@ The main installation mechanism is the Kiali Operator.
 
 OSSMC provides two layers of functionality:
 
-1. **Navigating multiple meshes** — The **Istio control planes** and **Kiali instances** pages list every Istio and Kiali CR on the cluster. They talk to the Kubernetes API directly, so they work even when no Kiali server is connected to the plugin. From **Kiali instances**, admins can **Connect** or **Disconnect** which Kiali server OSSMC uses for observability.
+1. **Navigating multiple meshes** — The **Istios** and **Kialis** pages list every Istio and Kiali CR on the cluster. They talk to the Kubernetes API directly, so they work even when no Kiali server is connected to the plugin. From **Kialis**, admins can **Connect** or **Disconnect** which Kiali server OSSMC uses for observability.
 
 2. **Kiali-powered observability** — When a Kiali instance is connected and reachable, OSSMC adds Overview, Traffic Graph, Mesh, Namespaces, Applications, Services, Workloads, Istio Config, and **Service Mesh** tabs on OpenShift resource detail pages. These pages proxy through the connected Kiali server configured on the OSSMConsole CR.
 
-When a Kiali server is connected, **Istio control planes** and **Kiali instances** appear at the bottom of the Service Mesh menu (below a separator). When no Kiali server is connected, those two pages are the Service Mesh menu.
+When a Kiali server is connected, **Istios** and **Kialis** appear at the bottom of the Service Mesh menu (below a separator). When no Kiali server is connected, those two pages are the Service Mesh menu.
 
 See the official documentation for details:
 
@@ -31,7 +31,7 @@ These are the things you need before developers can start working with OSSMC:
 2. `oc` client available in the path
 3. `podman` or `docker` client available in the path
 
-A Kiali Server is optional. You need one to develop or test Kiali-powered observability pages, but not to develop or test **Istio control planes** and **Kiali instances**.
+A Kiali Server is optional. You need one to develop or test Kiali-powered observability pages, but not to develop or test **Istios** and **Kialis**.
 
 ## Operator (kiali repo make targets)
 

--- a/hack/run-molecule-tests.sh
+++ b/hack/run-molecule-tests.sh
@@ -181,9 +181,9 @@ ALL_TESTS=${ALL_TESTS:-$(cd "${KIALI_SRC_HOME}/operator/molecule" || exit; ls -d
 if [ "${CLUSTER_TYPE}" == "openshift" ]; then
   SKIP_TESTS="${SKIP_TESTS:-header-auth-test openid-test}"
 elif [ "${CLUSTER_TYPE}" == "minikube" ]; then
-  SKIP_TESTS="${SKIP_TESTS:-openid-openshift-test os-console-links-test ossmconsole-config-values-test tls-profile-test}"
+  SKIP_TESTS="${SKIP_TESTS:-openid-openshift-test os-console-links-test ossmconsole-config-values-test ossmconsole-lite-test tls-profile-test}"
 elif [ "${CLUSTER_TYPE}" == "kind" ]; then
-  SKIP_TESTS="${SKIP_TESTS:-openid-openshift-test os-console-links-test ossmconsole-config-values-test tls-profile-test}"
+  SKIP_TESTS="${SKIP_TESTS:-openid-openshift-test os-console-links-test ossmconsole-config-values-test ossmconsole-lite-test tls-profile-test}"
 fi
 
 # If you want to test the latest release from quay, set this to "false".

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -157,13 +157,14 @@ endif
 ## ossmconsole-create: Create a OSSMConsole CR to the cluster, informing the Kiali operator to install OSSMC.
 ossmconsole-create: .ensure-operator-repo-exists .prepare-cluster .create-plugin-pull-secret
 ifeq ($(CLUSTER_TYPE),openshift)
-	@while ! (${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running); do echo "Kiali needs to be installed and running before you can install OSSMC. Waiting for Kiali to start..."; sleep 2; done
+	@(${OC} get pods -l app.kubernetes.io/name=kiali --all-namespaces --no-headers 2>/dev/null | grep -q Running) || echo "Kiali is not yet installed and running, but continuing to install OSSMC anyway."
 	@echo Deploy OSSM Console using the settings found in ${OSSMCONSOLE_CR_FILE}
 	cat ${OSSMCONSOLE_CR_FILE} | \
 DEPLOYMENT_IMAGE_NAME="${CLUSTER_PLUGIN_INTERNAL_NAME}" \
 DEPLOYMENT_IMAGE_VERSION="${PLUGIN_CONTAINER_VERSION}" \
 PULL_SECRET_NAME="${PLUGIN_IMAGE_PULL_SECRET_NAME}" \
 OSSMCONSOLE_CR_SPEC_VERSION="${OSSMCONSOLE_CR_SPEC_VERSION}" \
+OSSMCONSOLE_CR_AUTO_DISCOVER="${OSSMCONSOLE_CR_AUTO_DISCOVER}" \
 envsubst | ${OC} apply -n "${OSSMCONSOLE_NAMESPACE}" -f -
 else
 	@echo "Will not create OSSMConsole CR on non-OpenShift environments."


### PR DESCRIPTION
skip the ossmconsole-lite test on non-openshift clusters fix make target since ossmc doesn't require kiali server now support autoDiscovery flag in ossmc cr