### PR TITLE
Fix several UI/navigation bugs found in Kiali frontend

### DIFF
--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -80,7 +80,7 @@ export const NavigationComponent: React.FC<NavigationProps> = (props: Navigation
     }
 
     const resetDrawerScroll = (): void => {
-      document.querySelectorAll('.pf-v6-c-page__drawer .pf-v6-c-drawer__main').forEach(el => {
+      document.querySelectorAll('.pf-v6-c-page__drawer > .pf-v6-c-drawer > .pf-v6-c-drawer__main').forEach(el => {
         (el as HTMLElement).scrollLeft = 0;
       });
     };

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -80,7 +80,7 @@ export const NavigationComponent: React.FC<NavigationProps> = (props: Navigation
     }
 
     const resetDrawerScroll = (): void => {
-      document.querySelectorAll('.pf-v6-c-drawer__main').forEach(el => {
+      document.querySelectorAll('.pf-v6-c-page__drawer .pf-v6-c-drawer__main').forEach(el => {
         (el as HTMLElement).scrollLeft = 0;
       });
     };

--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { KialiDispatch } from 'types/Redux';
+import type { KialiDispatch } from 'types/Redux';
 import { RenderPage } from './RenderPage';
 import { MastheadItems } from './Masthead/Masthead';
 import {
@@ -20,11 +20,11 @@ import {
 
 import { kialiStyle } from 'styles/StyleUtils';
 import { homeCluster, kialiLogoDark, kialiLogoLight, serverConfig } from '../../config';
-import { KialiAppState } from '../../store/Store';
+import type { KialiAppState } from '../../store/Store';
 import { UserSettingsThunkActions } from '../../actions/UserSettingsThunkActions';
 import { Menu } from './Menu';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
-import { ExternalServiceInfo } from '../../types/StatusState';
+import type { ExternalServiceInfo } from '../../types/StatusState';
 import { Theme } from 'types/Common';
 import { useKialiTranslation } from 'utils/I18nUtils';
 import { isKiosk } from '../Kiosk/KioskActions';
@@ -71,6 +71,24 @@ export const NavigationComponent: React.FC<NavigationProps> = (props: Navigation
 
     document.title = pageTitle;
   }, []);
+
+  // Keep page content aligned when the notification drawer is collapsed. Focus or
+  // automation can scroll drawer__main horizontally into the reserved panel slot.
+  React.useEffect(() => {
+    if (props.showNotificationCenter) {
+      return;
+    }
+
+    const resetDrawerScroll = (): void => {
+      document.querySelectorAll('.pf-v6-c-drawer__main').forEach(el => {
+        (el as HTMLElement).scrollLeft = 0;
+      });
+    };
+
+    resetDrawerScroll();
+    const id = requestAnimationFrame(resetDrawerScroll);
+    return () => cancelAnimationFrame(id);
+  }, [props.showNotificationCenter, pathname]);
 
   const isGraph = (): boolean => {
     return pathname.startsWith('/graph') || pathname.startsWith('/mesh');

--- a/frontend/src/components/Table/SimpleTable.tsx
+++ b/frontend/src/components/Table/SimpleTable.tsx
@@ -1,21 +1,6 @@
 import * as React from 'react';
-import {
-  ActionsColumn,
-  IAction,
-  InnerScrollContainer,
-  IRow,
-  IRowData,
-  ISortBy,
-  OnSort,
-  Table,
-  TableVariant,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  ThProps,
-  Tr
-} from '@patternfly/react-table';
+import type { IAction, IRow, IRowData, ISortBy, OnSort, TableVariant, ThProps } from '@patternfly/react-table';
+import { ActionsColumn, InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 
 const stickyWrapperStyle = kialiStyle({
@@ -109,7 +94,7 @@ export const SimpleTable: React.FC<SimpleTableProps> = (props: SimpleTableProps)
               info={column.info}
               className={column.className}
             >
-              {'headerContent' in column ? column.headerContent ?? column.title : column.title}
+              {'headerContent' in column ? (column.headerContent ?? column.title) : column.title}
             </Th>
           ))}
         </Tr>
@@ -119,11 +104,22 @@ export const SimpleTable: React.FC<SimpleTableProps> = (props: SimpleTableProps)
         {props.rows.length > 0 ? (
           props.rows.map((row, rowIndex) => (
             <Tr key={row.key ?? `row_${rowIndex}`} className={row.className}>
-              {row.cells?.map((cell: React.ReactNode, colIndex: number) => (
-                <Td key={`cell_${rowIndex}_${colIndex}`} dataLabel={props.columns[colIndex].title} className={tdStyle}>
-                  {cell}
-                </Td>
-              ))}
+              {row.cells?.map((cell, colIndex: number) => {
+                const cellContent =
+                  typeof cell === 'object' && cell !== null && 'title' in cell
+                    ? (cell as { title: React.ReactNode }).title
+                    : (cell as React.ReactNode);
+
+                return (
+                  <Td
+                    key={`cell_${rowIndex}_${colIndex}`}
+                    dataLabel={props.columns[colIndex].title}
+                    className={tdStyle}
+                  >
+                    {cellContent}
+                  </Td>
+                );
+              })}
 
               {getActionToggle(row, rowIndex)}
             </Tr>

--- a/frontend/src/pages/Graph/GraphHelpTour.tsx
+++ b/frontend/src/pages/Graph/GraphHelpTour.tsx
@@ -1,5 +1,5 @@
 import { PopoverPosition } from '@patternfly/react-core';
-import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
+import type { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
 import { t } from 'utils/I18nUtils';
 import { GraphShortcuts } from './GraphToolbar/GraphShortcuts';
 
@@ -65,7 +65,7 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   },
   Shortcuts: {
     name: t('Shortcuts'),
-    htmlDescription: GraphShortcuts,
+    htmlDescription: GraphShortcuts(),
     position: PopoverPosition.leftStart
   },
   SidePanel: {

--- a/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { KialiAppState } from '../../../store/Store';
+import type { KialiAppState } from '../../../store/Store';
 import {
   activeNamespacesSelector,
   edgeLabelsSelector,
@@ -21,10 +21,18 @@ import {
 } from '../../../store/Selectors';
 import { GraphToolbarActions } from '../../../actions/GraphToolbarActions';
 import { GraphSettings } from './GraphSettings';
-import { GraphType, NodeParamsType, EdgeLabelMode, SummaryData, TrafficRate, RankMode } from '../../../types/Graph';
+import type {
+  GraphType,
+  NodeParamsType,
+  EdgeLabelMode,
+  SummaryData,
+  TrafficRate,
+  RankMode
+} from '../../../types/Graph';
 import { router, HistoryManager, URLParam, location } from '../../../app/History';
-import { Namespace, namespacesFromString, namespacesToString } from '../../../types/Namespace';
-import { KialiDispatch } from '../../../types/Redux';
+import type { Namespace } from '../../../types/Namespace';
+import { namespacesFromString, namespacesToString } from '../../../types/Namespace';
+import type { KialiDispatch } from '../../../types/Redux';
 import { NamespaceActions } from '../../../actions/NamespaceAction';
 import { GraphActions } from '../../../actions/GraphActions';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
@@ -37,7 +45,7 @@ import { INITIAL_USER_SETTINGS_STATE } from 'reducers/UserSettingsState';
 import { GraphReset } from './GraphReset';
 import { GraphFind } from './GraphFind';
 import { isParentKiosk, kioskNavigateAction } from 'components/Kiosk/KioskActions';
-import { GraphElement } from '@patternfly/react-topology';
+import type { GraphElement } from '@patternfly/react-topology';
 import { t } from 'utils/I18nUtils';
 
 type ReduxStateProps = {
@@ -192,17 +200,21 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
   }
 
   render(): React.ReactNode {
+    // Prefer URL over Redux for first paint: setNode runs in GraphPage.componentDidMount,
+    // so Redux can lag one frame behind a node-graph route.
+    const isNodeGraph = !!this.props.node || location.getPathname().includes('/graph/node');
+
     return (
       <>
         <GraphSecondaryMasthead
           disabled={this.props.disabled}
           graphType={this.props.graphType}
-          isNodeGraph={!!this.props.node}
+          isNodeGraph={isNodeGraph}
           onGraphTypeChange={this.props.setGraphType}
         />
         <Toolbar style={{ paddingTop: '1rem', width: '100%' }}>
           <ToolbarGroup aria-label="graph settings" style={{ margin: 0, alignItems: 'flex-start' }}>
-            {this.props.node && (
+            {isNodeGraph && (
               <ToolbarItem style={{ margin: 0 }}>
                 <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content={t('Back to full graph')}>
                   <Button variant={ButtonVariant.link} onClick={this.handleNamespaceReturn}>

--- a/frontend/src/pages/Graph/MiniGraphCard.tsx
+++ b/frontend/src/pages/Graph/MiniGraphCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import type { MenuToggleElement } from '@patternfly/react-core';
 import {
   Card,
   CardBody,
@@ -9,46 +10,39 @@ import {
   DropdownItem,
   DropdownList,
   MenuToggle,
-  MenuToggleElement,
   ToolbarItem
 } from '@patternfly/react-core';
-import { Edge, EdgeModel, Node, NodeModel } from '@patternfly/react-topology';
+import type { Edge, EdgeModel, Node, NodeModel } from '@patternfly/react-topology';
 import { URLParam, location, router } from '../../app/History';
-import { GraphDataSource } from '../../services/GraphDataSource';
-import {
-  DecoratedGraphElements,
-  EdgeMode,
-  SummaryData,
-  GraphLayout,
-  GraphType,
-  NodeType,
-  UNKNOWN
-} from '../../types/Graph';
-import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
+import type { GraphDataSource } from '../../services/GraphDataSource';
+import type { DecoratedGraphElements, SummaryData } from '../../types/Graph';
+import { EdgeMode, GraphLayout, GraphType, NodeType, UNKNOWN } from '../../types/Graph';
+import type { GraphUrlParams } from 'components/Nav/NavUtils';
+import { makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
 import { store } from 'store/ConfigStore';
-import { TimeInMilliseconds } from '../../types/Common';
-import { ServiceDetailsInfo } from '../../types/ServiceInfo';
-import { KialiAppState } from '../../store/Store';
+import type { TimeInMilliseconds } from '../../types/Common';
+import type { ServiceDetailsInfo } from '../../types/ServiceInfo';
+import type { KialiAppState } from '../../store/Store';
 import { Graph } from './Graph';
-import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
+import type { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
 import { isKiosk, isParentKiosk, kioskNavigateAction } from 'components/Kiosk/KioskActions';
 import { ServiceWizardActionsDropdownGroup } from 'components/IstioWizards/ServiceWizardActionsDropdownGroup';
 import { toRangeString } from 'components/Time/Utils';
 import { KioskElement } from 'components/Kiosk/KioskElement';
 import { TimeDurationIndicator } from 'components/Time/TimeDurationIndicator';
 import { TimeDurationModal } from 'components/Time/TimeDurationModal';
-import { KialiDispatch } from 'types/Redux';
+import type { KialiDispatch } from 'types/Redux';
 import { bindActionCreators } from 'redux';
 import { GraphActions } from 'actions/GraphActions';
-import { NodeData } from './GraphElems';
+import type { NodeData } from './GraphElems';
 import { elems, selectAnd } from 'helpers/GraphHelpers';
 import { KialiIcon } from 'config/KialiIcon';
 import { kebabToggleStyle } from 'styles/DropdownStyles';
 import { WorkloadWizardActionsDropdownGroup } from 'components/IstioWizards/WorkloadWizardActionsDropdownGroup';
-import { Workload } from 'types/Workload';
-import { NamespaceAction } from 'pages/Namespaces/NamespaceActions';
+import type { Workload } from 'types/Workload';
+import type { NamespaceAction } from 'pages/Namespaces/NamespaceActions';
 import { NamespaceActionsDropdownGroup } from 'pages/Namespaces/NamespaceActionsDropdownGroup';
-import { GraphRefs } from './GraphPage';
+import type { GraphRefs } from './GraphPage';
 import { EmptyGraphLayout } from 'pages/Graph/EmptyGraphLayout';
 import { kialiStyle } from 'styles/StyleUtils';
 import { t } from 'utils/I18nUtils';
@@ -123,10 +117,6 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     this.props.dataSource.removeListener('fetchSuccess', this.refresh);
     this.props.dataSource.removeListener('fetchError', this.refresh);
   }
-
-  private refresh = (): void => {
-    this.setState({ graphData: this.props.dataSource.graphData, isLoading: this.props.dataSource.isLoading });
-  };
 
   render(): React.ReactNode {
     const hasNode =
@@ -296,6 +286,10 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     );
   }
 
+  private refresh = (): void => {
+    this.setState({ graphData: this.props.dataSource.graphData, isLoading: this.props.dataSource.isLoading });
+  };
+
   private handleReady = (refs: GraphRefs | undefined, isReady: boolean): void => {
     this.setState({ graphRefs: refs, isReady: isReady });
   };
@@ -364,7 +358,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
         }
       }
 
-      router.navigate(`${location.getPathname()}?&{urlParams.toString()}`, { replace: true });
+      router.navigate(`${location.getPathname()}?${urlParams.toString()}`, { replace: true });
     }
   };
 
@@ -401,8 +395,8 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
     (node as any).selected = false;
 
     // Redirect to the details page of the tapped node.
-    let resource = data[eNodeType];
-    let resourceType: string = eNodeType === NodeType.APP ? 'application' : eNodeType;
+    const resource = data[eNodeType];
+    const resourceType: string = eNodeType === NodeType.APP ? 'application' : eNodeType;
 
     let href = `/namespaces/${data.namespace}/${resourceType}s/${resource}`;
 

--- a/frontend/src/pages/Graph/styles/styleGroup.tsx
+++ b/frontend/src/pages/Graph/styles/styleGroup.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { CubesIcon } from '@patternfly/react-icons';
-import {
-  DefaultGroup,
-  Node,
-  observer,
-  Rect,
-  ScaleDetailsLevel,
-  ShapeProps,
-  WithSelectionProps
-} from '@patternfly/react-topology';
+import type { Node, Rect, ShapeProps, WithSelectionProps } from '@patternfly/react-topology';
+import { DefaultGroup, observer, ScaleDetailsLevel } from '@patternfly/react-topology';
 import { useDetailsLevel } from '@patternfly/react-topology';
 import { PFColors } from 'components/Pf/PfColors';
 import { kialiStyle } from 'styles/StyleUtils';
@@ -108,16 +101,17 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
 
   const boxRef = React.useRef<Rect | null>(null);
   boxRef.current = element.getBounds();
+  const boxBounds = boxRef.current;
 
   return (
     <g style={{ opacity: opacity }} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      {data.isFocus && (
+      {data.isFocus && boxBounds && (
         <rect
           className={focusOverlayStyle}
-          x={boxRef.current.x}
-          y={boxRef.current.y}
-          width={boxRef.current.width}
-          height={boxRef.current.height}
+          x={boxBounds.x}
+          y={boxBounds.y}
+          width={boxBounds.width}
+          height={boxBounds.height}
         />
       )}
       <DefaultGroup

--- a/frontend/src/pages/Mesh/MeshHelpTour.tsx
+++ b/frontend/src/pages/Mesh/MeshHelpTour.tsx
@@ -1,5 +1,5 @@
 import { PopoverPosition } from '@patternfly/react-core';
-import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
+import type { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
 import { MeshShortcuts } from './toolbar/MeshShortcuts';
 import { t } from 'utils/I18nUtils';
 
@@ -42,7 +42,7 @@ export const MeshTourStops: { [name: string]: TourStopInfo } = {
   },
   Shortcuts: {
     name: t('Shortcuts'),
-    htmlDescription: MeshShortcuts,
+    htmlDescription: MeshShortcuts(),
     position: PopoverPosition.leftStart
   },
   TargetPanel: {

--- a/frontend/src/pages/Overview/DataPlaneStats.tsx
+++ b/frontend/src/pages/Overview/DataPlaneStats.tsx
@@ -18,8 +18,10 @@ import { t } from 'utils/I18nUtils';
 import { useNamespaces } from 'hooks/namespaces';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { getNamespaceDetailUrl } from 'utils/NamespaceUtils';
-import { DEGRADED, FAILURE, HEALTHY, HealthStatusId, NA, NOT_READY, statusFromString } from 'types/Health';
-import { NamespaceWithHealthStatus, useDataPlanes } from 'hooks/dataPlanes';
+import type { HealthStatusId } from 'types/Health';
+import { DEGRADED, FAILURE, HEALTHY, NA, NOT_READY, statusFromString } from 'types/Health';
+import type { NamespaceWithHealthStatus } from 'hooks/dataPlanes';
+import { useDataPlanes } from 'hooks/dataPlanes';
 import {
   cardBodyStyle,
   cardStyle,
@@ -159,6 +161,9 @@ export const DataPlaneStats: React.FC = () => {
   const unhealthyCount = failureCount + degradedCount + notReadyCount;
   const isCardLoading = isNamespacesLoading || isHealthLoading;
   const isCardError = isNamespacesError || isError;
+  // Keep the footer during health-only refreshes so the link is not detached mid-click.
+  // Hide only while namespaces are still loading or the card is in error.
+  const showFooter = !isCardError && !isNamespacesLoading && (total > 0 || !isHealthLoading);
 
   const unhealthyNamespaces: NamespaceWithHealthStatus[] = React.useMemo(() => {
     const severity = (s: HealthStatusId): number => {
@@ -287,7 +292,7 @@ export const DataPlaneStats: React.FC = () => {
           </div>
         )}
       </CardBody>
-      {!isCardLoading && !isCardError && (
+      {showFooter && (
         <CardFooter>
           <KialiLink
             to={buildDataPlanesUrl()}

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -45,6 +45,28 @@ export const globalStyle = kialiStyle({
     },
 
     /**
+     * Collapse the closed notification drawer panel so it cannot steal horizontal
+     * scroll. PatternFly reserves FlexBasis (e.g. 28.125rem) for the panel while
+     * collapsed; focus/automation can set scrollLeft on drawer__main and shift the
+     * page content under the sidebar, clipping toolbar controls and table headers.
+     */
+    '& .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
+      flexBasis: '0 !important',
+      margin: '0 !important',
+      maxWidth: '0 !important',
+      minWidth: '0 !important',
+      overflow: 'hidden',
+      padding: '0 !important',
+      transform: 'none !important',
+      visibility: 'hidden',
+      width: '0 !important'
+    },
+
+    '& .pf-v6-c-drawer__main': {
+      overflowX: 'hidden'
+    },
+
+    /**
      * Reduce padding of menu group title
      */
     '& .pf-v6-c-menu__group-title': {

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -50,7 +50,7 @@ export const globalStyle = kialiStyle({
      * collapsed; focus/automation can set scrollLeft on drawer__main and shift the
      * page content under the sidebar, clipping toolbar controls and table headers.
      */
-    '& .pf-v6-c-page__drawer .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
+    '& .pf-v6-c-page__drawer > .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
       flexBasis: '0 !important',
       margin: '0 !important',
       maxWidth: '0 !important',
@@ -62,7 +62,7 @@ export const globalStyle = kialiStyle({
       width: '0 !important'
     },
 
-    '& .pf-v6-c-page__drawer .pf-v6-c-drawer__main': {
+    '& .pf-v6-c-page__drawer > .pf-v6-c-drawer > .pf-v6-c-drawer__main': {
       overflowX: 'hidden'
     },
 

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -50,7 +50,7 @@ export const globalStyle = kialiStyle({
      * collapsed; focus/automation can set scrollLeft on drawer__main and shift the
      * page content under the sidebar, clipping toolbar controls and table headers.
      */
-    '& .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
+    '& .pf-v6-c-page__drawer .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
       flexBasis: '0 !important',
       margin: '0 !important',
       maxWidth: '0 !important',
@@ -62,7 +62,7 @@ export const globalStyle = kialiStyle({
       width: '0 !important'
     },
 
-    '& .pf-v6-c-drawer__main': {
+    '& .pf-v6-c-page__drawer .pf-v6-c-drawer__main': {
       overflowX: 'hidden'
     },
 


### PR DESCRIPTION
Fixes a handful of small, unrelated bugs found while working on other changes elsewhere in the codebase:

- MiniGraphCard: fixed a query-string typo that produced a literal `?&{urlParams...}` in the URL instead of interpolating the params.
- SimpleTable: cells shaped as `{ title }` objects now render their title instead of `[object Object]`.
- DataPlaneStats: the "view data planes" footer link now stays visible during health-only refreshes instead of disappearing mid-click.
- Navigation/GlobalStyle: the collapsed notification drawer no longer steals horizontal scroll and clips toolbar/table content.
- GraphHelpTour/MeshHelpTour: the Shortcuts tour stop now renders the shortcuts content instead of a stray function reference.
- GraphToolbar: the node-graph toolbar no longer briefly renders as the full graph on first paint, by preferring the URL over Redux state.
- styleGroup: added a null check to avoid a possible crash when a group node's bounds aren't yet available.

fixes: https://github.com/kiali/kiali/issues/10151

Generated-by: Cursor