### PR TITLE
Consistent use of lodash library (#6339)

### DIFF
--- a/STYLE_GUIDE.adoc
+++ b/STYLE_GUIDE.adoc
@@ -75,6 +75,10 @@ instance := &MyStruct{
 
 By default, we try to follow community conventions. link:https://github.com/basarat/typescript-book/blob/master/docs/styleguide/styleguide.md[Basarat's Style Guide] is used as a reference, with a few exceptions that are listed below:
 
+==== Imports
+
+Prefer named imports from `lodash-es` (ex: `import { cloneDeep } from 'lodash-es';`) instead of importing from `lodash` or using default/namespace imports (ex: `import _ from 'lodash';`). `lodash-es` is tree-shakeable, which keeps bundle size down, and named imports make dependencies on specific utilities explicit. This is enforced by the `no-restricted-imports` ESLint rule.
+
 ==== File names
 
 Most files are named after the main type / class / interface it's exporting. For instance, `ServiceList.ts` is named after the `ServiceList` interface that it's exporting. Which means that, unlike in Basarat's guide, we often use `PascalCase`.

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -36,6 +36,13 @@ export default tseslint.config(
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       'import-x/no-default-export': 'error',
       'no-case-declarations': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [{ name: 'lodash', message: "Use named imports from 'lodash-es' instead." }],
+          patterns: [{ group: ['lodash/*'], message: "Use named imports from 'lodash-es' instead." }]
+        }
+      ],
       'no-console': 'off',
       'no-extra-boolean-cast': 'off',
       'no-prototype-builtins': 'off',

--- a/frontend/src/components/Charts/Dashboard.tsx
+++ b/frontend/src/components/Charts/Dashboard.tsx
@@ -9,7 +9,7 @@ import { Overlay } from 'types/Overlay';
 import { KChart } from './KChart';
 import { LineInfo, RawOrBucket } from 'types/VictoryChartInfo';
 import { BrushHandlers } from './Container';
-import { isArray } from 'lodash';
+import { isArray } from 'lodash-es';
 import { kialiStyle } from 'styles/StyleUtils';
 import { ResizeHeightObserver } from 'utils/ResizeHeightObserver';
 

--- a/frontend/src/components/Dropdown/NamespaceDropdown.tsx
+++ b/frontend/src/components/Dropdown/NamespaceDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
-import _ from 'lodash';
+import { difference } from 'lodash-es';
 import { kialiStyle } from 'styles/StyleUtils';
 import {
   Button,
@@ -105,7 +105,7 @@ class NamespaceDropdownComponent extends React.PureComponent<NamespaceDropdownPr
     const urlNamespaces = (HistoryManager.getParam(URLParam.NAMESPACES) || '').split(',').filter(Boolean);
     if (
       urlNamespaces.length > 0 &&
-      _.difference(
+      difference(
         urlNamespaces,
         this.props.activeNamespaces.map(item => item.name)
       )

--- a/frontend/src/components/FilterList/FilterHelper.ts
+++ b/frontend/src/components/FilterList/FilterHelper.ts
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import { camelCase } from 'lodash-es';
 import { URLParam, HistoryManager, router, location } from '../../app/History';
 import { config } from '../../config';
 import {

--- a/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
+++ b/frontend/src/components/IstioConfigPreview/IstioConfigPreview.tsx
@@ -29,9 +29,8 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { KialiIcon } from '../../config/KialiIcon';
 import { yamlDumpOptions } from '../../types/IstioConfigDetails';
 import { EditResources } from './EditResources';
-import { cloneDeep } from 'lodash';
 import { PFColors } from '../Pf/PfColors';
-import _ from 'lodash';
+import { cloneDeep, isEqual, uniq } from 'lodash-es';
 import { download } from 'utils/Common';
 import { t } from 'utils/I18nUtils';
 import { dump } from 'js-yaml';
@@ -108,7 +107,7 @@ export class IstioConfigPreview extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props): void {
-    if (!_.isEqual(prevProps.items, this.props.items) || prevProps.isOpen !== this.props.isOpen) {
+    if (!isEqual(prevProps.items, this.props.items) || prevProps.isOpen !== this.props.isOpen) {
       this.setStateValues(this.props.items);
     }
   }
@@ -192,7 +191,7 @@ export class IstioConfigPreview extends React.Component<Props, State> {
   };
 
   groupItems = (list: ConfigPreviewItem[] = this.state.items): ConfigPreviewItem[] => {
-    const gvks = _.uniq(list.map(item => item.objectGVK));
+    const gvks = uniq(list.map(item => item.objectGVK));
 
     const itemsGrouped: ConfigPreviewItem[] = gvks.map(gvk => {
       const filtered = list.filter(it => getGVKTypeString(it.objectGVK) === getGVKTypeString(gvk));

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -68,7 +68,7 @@ import {
 import { kialiStyle } from 'styles/StyleUtils';
 import { RequestTimeouts, TimeoutRetryRoute } from './RequestTimeouts';
 import { CircuitBreaker, CircuitBreakerState } from './CircuitBreaker';
-import _ from 'lodash';
+import { isEqual } from 'lodash-es';
 import { ConfigPreviewItem, IstioConfigPreview } from 'components/IstioConfigPreview/IstioConfigPreview';
 import { ApiResponse } from 'types/Api';
 import { t } from 'utils/I18nUtils';
@@ -386,7 +386,7 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
     }
 
     for (let i = 0; i < prev.length; i++) {
-      if (!current.some(w => _.isEqual(w, prev[i]))) {
+      if (!current.some(w => isEqual(w, prev[i]))) {
         return false;
       }
     }

--- a/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/frontend/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -11,7 +11,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash-es';
 import { location, router, URLParam } from '../../app/History';
 import { MetricsSettings, Quantiles, allQuantiles, LabelsSettings } from './MetricsSettings';
 import {

--- a/frontend/src/components/Nav/Menu.tsx
+++ b/frontend/src/components/Nav/Menu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import _ from 'lodash';
+import { filter } from 'lodash-es';
 import { Link, useLocation, useNavigate, matchPath } from 'react-router-dom-v5-compat';
 import { Divider, Nav, NavList, NavItem } from '@patternfly/react-core';
 import { navMenuItems } from '../../routes';
@@ -67,7 +67,7 @@ export const Menu: React.FC<MenuProps> = (props: MenuProps) => {
       let isRoute = matchPath({ path: item.to }, pathname) ? true : false;
 
       if (!isRoute && item.pathsActive) {
-        isRoute = _.filter(item.pathsActive, path => path.test(pathname)).length > 0;
+        isRoute = filter(item.pathsActive, path => path.test(pathname)).length > 0;
       }
 
       return isRoute;

--- a/frontend/src/components/SummaryPanel/ResponseFlagsTable.tsx
+++ b/frontend/src/components/SummaryPanel/ResponseFlagsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import _ from 'lodash';
+import { keys } from 'lodash-es';
 import { Responses } from '../../types/Graph';
 import { responseFlags } from '../../utils/ResponseFlags';
 import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
@@ -29,8 +29,8 @@ interface Row {
 export const ResponseFlagsTable: React.FC<ResponseFlagsTableProps> = (props: ResponseFlagsTableProps) => {
   const getRows = (responses: Responses): Row[] => {
     const rows: Row[] = [];
-    _.keys(responses).forEach(code => {
-      _.keys(responses[code].flags).forEach(f => {
+    keys(responses).forEach(code => {
+      keys(responses[code].flags).forEach(f => {
         rows.push({ key: `${code} ${f}`, code: code, flags: f, val: responses[code].flags[f] });
       });
     });

--- a/frontend/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/frontend/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import _ from 'lodash';
+import { keys } from 'lodash-es';
 import { kialiStyle } from 'styles/StyleUtils';
 import { Responses } from '../../types/Graph';
 import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
@@ -36,8 +36,8 @@ interface Row {
 export const ResponseHostsTable: React.FC<ResponseHostsTableProps> = (props: ResponseHostsTableProps) => {
   const getRows = (responses: Responses): Row[] => {
     const rows: Row[] = [];
-    _.keys(responses).forEach(code => {
-      _.keys(responses[code].hosts).forEach(h => {
+    keys(responses).forEach(code => {
+      keys(responses[code].hosts).forEach(h => {
         rows.push({ key: `${code} ${h}`, code: code, host: h, val: responses[code].hosts[h] });
       });
     });

--- a/frontend/src/components/Time/Replay.tsx
+++ b/frontend/src/components/Time/Replay.tsx
@@ -15,7 +15,7 @@ import { toString } from './Utils';
 import { serverConfig } from 'config';
 import { PFColors } from 'components/Pf/PfColors';
 import { DateTimePicker } from './DateTimePicker';
-import _ from 'lodash';
+import { mapValues } from 'lodash-es';
 import { HistoryManager, URLParam, location } from 'app/History';
 
 type ReduxStateProps = {
@@ -86,7 +86,7 @@ const replayIntervals = {
   1800000: '30 minutes'
 };
 
-const replayLastIntervals = _.mapValues(replayIntervals, i => `Last ${i}`);
+const replayLastIntervals = mapValues(replayIntervals, i => `Last ${i}`);
 
 // key represents speed in milliseconds (i.e. how long to wait before refreshing-the-frame (fetching new data)
 const replaySpeeds: ReplaySpeed[] = [

--- a/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/StatsComparison.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { InfoAltIcon } from '@patternfly/react-icons';
-import _round from 'lodash/round';
+import { round } from 'lodash-es';
 import { HeatMap, healthColorMap } from 'components/HeatMap/HeatMap';
 import { MetricsStats } from 'types/Metrics';
 import { PFColors } from 'components/Pf/PfColors';
@@ -44,7 +44,7 @@ const renderHeatMap = (item: RichSpanData, stats: StatsWithIntervalIndex[], isCo
       colorMap={healthColorMap}
       dataRange={{ from: -10, to: 10 }}
       colorUndefined={PFColors.ColorLight200}
-      valueFormat={v => `${v > 0 ? '+' : ''}${_round(v, 1)}`}
+      valueFormat={v => `${v > 0 ? '+' : ''}${round(v, 1)}`}
       tooltip={(x, y, v) => {
         // Build explanation tooltip
         const slowOrFast = v > 0 ? 'slower' : 'faster';
@@ -63,7 +63,7 @@ const renderHeatMap = (item: RichSpanData, stats: StatsWithIntervalIndex[], isCo
         const thisObj = statsCompareKind === 'app' ? item.app : item.workload;
         const peer = statsPerPeer ? `${rev} ${info.peer}` : '';
 
-        return `This request has been ${_round(Math.abs(v), 2)}ms ${slowOrFast} than the ${stat} of all ${
+        return `This request has been ${round(Math.abs(v), 2)}ms ${slowOrFast} than the ${stat} of all ${
           info.direction
         } requests ${dir} ${thisObj} ${peer} in the last ${interval}`;
       }}
@@ -122,14 +122,14 @@ export const renderTraceHeatMap = (matrix: StatsMatrix, isCompact: boolean): Rea
       colorMap={healthColorMap}
       dataRange={{ from: -10, to: 10 }}
       colorUndefined={PFColors.ColorLight200}
-      valueFormat={v => `${v > 0 ? '+' : ''}${_round(v, 1)}`}
+      valueFormat={v => `${v > 0 ? '+' : ''}${round(v, 1)}`}
       tooltip={(x, y, v) => {
         // Build explanation tooltip
         const slowOrFast = v > 0 ? 'slower' : 'faster';
         const stat = statToText[quantilesWithAvg[x]]?.long || quantilesWithAvg[x];
         const interval = intervals[y];
 
-        return `Trace requests have been, in average, ${_round(
+        return `Trace requests have been, in average, ${round(
           Math.abs(v),
           2
         )}ms ${slowOrFast} than the ${stat} of the requests involving the same services in the last ${interval}`;

--- a/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
+++ b/frontend/src/components/TracingIntegration/TracingResults/TraceDetails.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { KialiDispatch } from 'types/Redux';
-import _round from 'lodash/round';
 import { Button, ButtonVariant, Card, CardBody, Grid, GridItem, Tooltip } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
 import { tabCardStyle } from 'styles/FlexStyles';
@@ -30,7 +29,7 @@ import { renderTraceHeatMap } from './StatsComparison';
 import { HeatMap, healthColorMap } from 'components/HeatMap/HeatMap';
 import { formatDuration, isWaypointProxySpan, sameSpans } from 'utils/tracing/TracingHelper';
 import { TracingUrlProvider } from 'types/Tracing';
-import _ from 'lodash';
+import { map, round } from 'lodash-es';
 
 type ReduxProps = {
   loadMetricsStats: (queries: MetricsStatsQuery[], isCompact: boolean, cluster?: string) => void;
@@ -163,11 +162,11 @@ class TraceDetailsComponent extends React.Component<Props> {
         colorMap={healthColorMap}
         dataRange={{ from: -10, to: 10 }}
         colorUndefined={PFColors.ColorLight200}
-        valueFormat={v => `${v > 0 ? '+' : ''}${_round(v, 1)}`}
+        valueFormat={v => `${v > 0 ? '+' : ''}${round(v, 1)}`}
         tooltip={(x, _, v) => {
           // Build explanation tooltip
           const slowOrFast = v > 0 ? 'slower' : 'faster';
-          const diff = _round(Math.abs(v), 2);
+          const diff = round(Math.abs(v), 2);
           const versus =
             x === similarTracesToShow.length
               ? 'the mean of all similar traces on chart'
@@ -194,7 +193,7 @@ class TraceDetailsComponent extends React.Component<Props> {
 
     const comparisonLink =
       similarTraces.length > 0
-        ? this.props.tracingURLProvider?.ComparisonUrl(trace.traceID, ..._.map(similarTraces, t => t.traceID))
+        ? this.props.tracingURLProvider?.ComparisonUrl(trace.traceID, ...map(similarTraces, t => t.traceID))
         : undefined;
 
     return (

--- a/frontend/src/config/ServerConfig.ts
+++ b/frontend/src/config/ServerConfig.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { isEmpty, mapValues, reject } from 'lodash-es';
 import { RunMode, ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
 import { MeshCluster } from '../types/Mesh';
@@ -22,7 +22,7 @@ function getHomeCluster(cfg: ServerConfig): MeshCluster | undefined {
 }
 
 export const humanDurations = (cfg: ComputedServerConfig, prefix?: string, suffix?: string): Durations =>
-  _.mapValues(cfg.durations, v => _.reject([prefix, v, suffix], _.isEmpty).join(' '));
+  mapValues(cfg.durations, v => reject([prefix, v, suffix], isEmpty).join(' '));
 
 const toDurations = (tupleArray: [number, string][]): Durations => {
   const obj: Durations = {};

--- a/frontend/src/pages/Graph/EmptyGraphLayout.tsx
+++ b/frontend/src/pages/Graph/EmptyGraphLayout.tsx
@@ -8,7 +8,7 @@ import {
   EmptyStateFooter
 } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
-import * as _ from 'lodash';
+import { isEmpty, isEqual } from 'lodash-es';
 import { Namespace } from '../../types/Namespace';
 import { KialiIcon } from '../../config/KialiIcon';
 import { DecoratedGraphElements } from '../../types/Graph';
@@ -43,8 +43,8 @@ const emptyStateStyle = kialiStyle({
 
 export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps> {
   shouldComponentUpdate(nextProps: EmptyGraphLayoutProps): boolean {
-    const currentIsEmpty = this.props.elements === undefined || _.isEmpty(this.props.elements.nodes);
-    const nextIsEmpty = nextProps.elements === undefined || _.isEmpty(nextProps.elements.nodes);
+    const currentIsEmpty = this.props.elements === undefined || isEmpty(this.props.elements.nodes);
+    const nextIsEmpty = nextProps.elements === undefined || isEmpty(nextProps.elements.nodes);
 
     // Update if we have elements and we are not loading
     if (!nextProps.isLoading && !nextIsEmpty) {
@@ -56,7 +56,7 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps> {
       return true;
     }
     // Do not update if we have elements and the namespace didn't change, as this means we are refreshing
-    return !(!nextIsEmpty && _.isEqual(this.props.namespaces, nextProps.namespaces));
+    return !(!nextIsEmpty && isEqual(this.props.namespaces, nextProps.namespaces));
   }
 
   namespacesText(): React.ReactElement | null {

--- a/frontend/src/pages/Graph/GraphElems.tsx
+++ b/frontend/src/pages/Graph/GraphElems.tsx
@@ -30,7 +30,7 @@ import {
 } from 'types/Graph';
 import { DEGRADED, FAILURE } from 'types/Health';
 import { Namespace } from 'types/Namespace';
-import _ from 'lodash';
+import { keys } from 'lodash-es';
 import { PFColors } from 'components/Pf/PfColors';
 import { Span } from 'types/TracingInfo';
 import { IconType } from 'config/Icons';
@@ -500,7 +500,7 @@ const getEdgeLabel = (edge: EdgeModel, nodeMap: NodeMap, settings: GraphSettings
   if (data.hasTraffic && data.responses) {
     if (nodeMap.get(edge.target!)?.data?.hasCB) {
       const responses = data.responses;
-      for (let code of _.keys(responses)) {
+      for (let code of keys(responses)) {
         // TODO: Not 100% sure we want "UH" code here ("no healthy upstream hosts") but based on timing I have
         // seen this code returned and not "UO". "UO" is returned only when the circuit breaker is caught open.
         // But if open CB is responsible for removing possible destinations the "UH" code seems preferred.

--- a/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -34,7 +34,7 @@ import { isValid } from 'utils/Common';
 import { EdgeData, NodeData } from 'pages/Graph/GraphElems';
 import { elems, SelectAnd, SelectExp, selectOr, SelectOr, setObserved, toSafeFieldName } from 'helpers/GraphHelpers';
 import { descendents } from 'helpers/GraphHelpers';
-import { isArray } from 'lodash';
+import { isArray } from 'lodash-es';
 import { graphLayout } from 'pages/Graph/Graph';
 import { TimeInMilliseconds } from 'types/Common';
 

--- a/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -6,7 +6,7 @@ import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from '../GraphHelpTour';
 import { ToolbarDropdown } from 'components/Dropdown/ToolbarDropdown';
 import { GraphType } from 'types/Graph';
-import * as _ from 'lodash';
+import { capitalize, findKey, mapValues, startCase } from 'lodash-es';
 import { TimeDurationComponent } from '../../../components/Time/TimeDurationComponent';
 import { GraphTraffic } from './GraphTraffic';
 
@@ -37,7 +37,7 @@ const rightToolbarStyle = kialiStyle({
  *
  *  Example:  GraphType => {'APP': 'App', 'VERSIONED_APP': 'VersionedApp'}
  */
-const GRAPH_TYPES = _.mapValues(GraphType, val => `${_.capitalize(_.startCase(val))} graph`);
+const GRAPH_TYPES = mapValues(GraphType, val => `${capitalize(startCase(val))} graph`);
 
 export const GraphSecondaryMasthead: React.FC<GraphSecondaryMastheadProps> = (props: GraphSecondaryMastheadProps) => {
   const setGraphType = (type: string): void => {
@@ -47,7 +47,7 @@ export const GraphSecondaryMasthead: React.FC<GraphSecondaryMastheadProps> = (pr
     }
   };
 
-  const graphTypeKey = _.findKey(GraphType, val => val === props.graphType)!;
+  const graphTypeKey = findKey(GraphType, val => val === props.graphType)!;
 
   return (
     <SecondaryMasthead>

--- a/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphTraffic.tsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { KialiAppState } from '../../../store/Store';
 import { GraphToolbarActions } from '../../../actions/GraphToolbarActions';
 import { TrafficRate, isAmbientRate, isGrpcRate, isHttpRate, isTcpRate } from '../../../types/Graph';
-import * as _ from 'lodash';
+import { startCase } from 'lodash-es';
 import { trafficRatesSelector } from 'store/Selectors';
 import {
   BoundingClientAwareComponent,
@@ -55,7 +55,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
     const trafficRateOptions: TrafficRateOptionType[] = [
       {
         id: TrafficRate.AMBIENT_GROUP,
-        labelText: _.startCase(TrafficRate.AMBIENT_GROUP),
+        labelText: startCase(TrafficRate.AMBIENT_GROUP),
         isChecked: trafficRates.includes(TrafficRate.AMBIENT_GROUP),
         isHidden: !serverConfig.ambientEnabled,
         tooltip: (
@@ -67,7 +67,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
       },
       {
         id: TrafficRate.GRPC_GROUP,
-        labelText: _.startCase(TrafficRate.GRPC_GROUP),
+        labelText: startCase(TrafficRate.GRPC_GROUP),
         isChecked: trafficRates.includes(TrafficRate.GRPC_GROUP),
         tooltip: (
           <div style={{ textAlign: 'left' }}>
@@ -78,7 +78,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
       },
       {
         id: TrafficRate.HTTP_GROUP,
-        labelText: _.startCase(TrafficRate.HTTP_GROUP),
+        labelText: startCase(TrafficRate.HTTP_GROUP),
         isChecked: trafficRates.includes(TrafficRate.HTTP_GROUP),
         tooltip: (
           <div style={{ textAlign: 'left' }}>
@@ -89,7 +89,7 @@ const GraphTrafficComponent: React.FC<GraphTrafficProps> = (props: GraphTrafficP
       },
       {
         id: TrafficRate.TCP_GROUP,
-        labelText: _.startCase(TrafficRate.TCP_GROUP),
+        labelText: startCase(TrafficRate.TCP_GROUP),
         isChecked: trafficRates.includes(TrafficRate.TCP_GROUP),
         tooltip: (
           <div style={{ textAlign: 'left' }}>

--- a/frontend/src/pages/Mesh/EmptyMeshLayout.tsx
+++ b/frontend/src/pages/Mesh/EmptyMeshLayout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateVariant, EmptyStateFooter } from '@patternfly/react-core';
 import { kialiStyle } from 'styles/StyleUtils';
-import * as _ from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { KialiIcon } from '../../config/KialiIcon';
 import { DecoratedMeshElements } from 'types/Mesh';
 import { ManualRefreshEmptyState } from 'components/Refresh/ManualRefreshEmptyState';
@@ -30,8 +30,8 @@ const emptyStateStyle = kialiStyle({
 
 export class EmptyMeshLayout extends React.Component<EmptyMeshLayoutProps> {
   shouldComponentUpdate(nextProps: EmptyMeshLayoutProps): boolean {
-    const currentIsEmpty = this.props.elements === undefined || _.isEmpty(this.props.elements.nodes);
-    const nextIsEmpty = nextProps.elements === undefined || _.isEmpty(nextProps.elements.nodes);
+    const currentIsEmpty = this.props.elements === undefined || isEmpty(this.props.elements.nodes);
+    const nextIsEmpty = nextProps.elements === undefined || isEmpty(nextProps.elements.nodes);
 
     // Update if we have elements and we are not loading
     if (!nextProps.isLoading && !nextIsEmpty) {

--- a/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshFind.tsx
@@ -36,7 +36,7 @@ import {
   descendents,
   toSafeFieldName
 } from 'helpers/GraphHelpers';
-import { isArray } from 'lodash';
+import { isArray } from 'lodash-es';
 import { MeshAttr, MeshEdgeData, MeshInfraType, MeshNodeData } from 'types/Mesh';
 import { MeshToolbarActions } from 'actions/MeshToolbarActions';
 import { MeshFindOptions } from './MeshFindOptions';

--- a/frontend/src/pages/Namespaces/NamespaceHealthStatus.tsx
+++ b/frontend/src/pages/Namespaces/NamespaceHealthStatus.tsx
@@ -22,7 +22,7 @@ import { naTextStyle } from 'styles/HealthStyle';
 import { classes } from 'typestyle';
 import { Paths } from 'config';
 import { URLParam } from 'app/History';
-import { camelCase } from 'lodash';
+import { camelCase } from 'lodash-es';
 import { healthFilter } from 'components/Filters/CommonFilters';
 import { FilterSelected } from 'components/Filters/StatefulFilters';
 import { KialiLink } from 'components/Link/KialiLink';

--- a/frontend/src/pages/Overview/LinkBuilder.ts
+++ b/frontend/src/pages/Overview/LinkBuilder.ts
@@ -1,5 +1,5 @@
 import { URLParam } from '../../app/History';
-import { camelCase } from 'lodash';
+import { camelCase } from 'lodash-es';
 import { categoryFilter, healthFilter, modeFilter, NamespaceCategory } from '../Namespaces/Filters';
 import { isMultiCluster, Paths } from '../../config';
 import { DEGRADED, FAILURE, HealthStatusId, NOT_READY } from '../../types/Health';

--- a/frontend/src/reducers/NotificationCenter.ts
+++ b/frontend/src/reducers/NotificationCenter.ts
@@ -5,7 +5,7 @@ import { getType } from 'typesafe-actions';
 import { NotificationCenterActions } from '../actions/NotificationCenterActions';
 import { updateState } from '../utils/Reducer';
 import { LoginActions } from '../actions/LoginActions';
-import _ from 'lodash';
+import { filter } from 'lodash-es';
 
 export const INITIAL_NOTIFICATION_CENTER_STATE: NotificationCenterState = {
   // predefined groups are specifically ordered by status
@@ -100,7 +100,7 @@ export const NotificationCenterReducer = (
           });
 
           // remove the old message from the list
-          const filteredArray = _.filter(group.messages, message => {
+          const filteredArray = filter(group.messages, message => {
             return message.content !== content;
           });
 

--- a/frontend/src/utils/IstioConfigUtils.ts
+++ b/frontend/src/utils/IstioConfigUtils.ts
@@ -9,7 +9,7 @@ import {
   StatusCondition,
   Validations
 } from '../types/IstioObjects';
-import _ from 'lodash';
+import { isObject, mergeWith } from 'lodash-es';
 import { dicTypeToGVK, gvkType, IstioConfigItem } from 'types/IstioConfigList';
 
 // Guard against prototype pollution via crafted keys in deep-merged objects.
@@ -26,12 +26,12 @@ export const mergeJsonPatch = (objectModified: object, object?: object): object 
     if (!objValue) {
       return null;
     }
-    if (_.isObject(objValue) && _.isObject(srcValue)) {
-      _.mergeWith(objValue, srcValue, customizer);
+    if (isObject(objValue) && isObject(srcValue)) {
+      mergeWith(objValue, srcValue, customizer);
     }
     return objValue;
   };
-  _.mergeWith(objectModified, object, customizer);
+  mergeWith(objectModified, object, customizer);
   return objectModified;
 };
 

--- a/frontend/src/utils/TrafficRate.ts
+++ b/frontend/src/utils/TrafficRate.ts
@@ -1,5 +1,5 @@
 import { GraphElement } from '@patternfly/react-topology';
-import _ from 'lodash';
+import { reduce } from 'lodash-es';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
 
 const safeRate = (rate: any) => (isNaN(rate) ? 0.0 : Number(rate));
@@ -40,7 +40,7 @@ export const getTrafficRateGrpc = (element: any, trafficType: TRAFFIC_GRPC = NOD
 };
 
 export const getAccumulatedTrafficRateGrpc = (elements: any): TrafficRateGrpc => {
-  return _.reduce(
+  return reduce(
     elements,
     (r: TrafficRateGrpc, element): TrafficRateGrpc => {
       const elementTrafficRate = getTrafficRateGrpc(element, EDGE_GRPC);
@@ -95,7 +95,7 @@ export const getTrafficRateHttp = (element: any, trafficType: TRAFFIC_HTTP = NOD
 };
 
 export const getAccumulatedTrafficRateHttp = (elements): TrafficRateHttp => {
-  return _.reduce(
+  return reduce(
     elements,
     (r: TrafficRateHttp, element): TrafficRateHttp => {
       const elementTrafficRate = getTrafficRateHttp(element, EDGE_HTTP);
@@ -132,7 +132,7 @@ export const getTrafficRateTcp = (element: any, trafficType: TRAFFIC_TCP = NODE_
 };
 
 export const getAccumulatedTrafficRateTcp = (elements: any): TrafficRateTcp => {
-  return _.reduce(
+  return reduce(
     elements,
     (r: TrafficRateTcp, element): TrafficRateTcp => {
       const elementTrafficRate = getTrafficRateTcp(element, EDGE_TCP);

--- a/frontend/src/utils/tracing/TraceTransform.ts
+++ b/frontend/src/utils/tracing/TraceTransform.ts
@@ -1,4 +1,4 @@
-import _isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash-es';
 import { KeyValuePair, Span, SpanData, JaegerTrace, TraceData, RichSpanData } from 'types/TracingInfo';
 import { extractSpanInfo, getAppFromSpan, getWorkloadFromSpan, isWaypointProxySpan } from './TracingHelper';
 
@@ -183,7 +183,7 @@ export function transformTraceData(data: TraceData<SpanData>, cluster?: string):
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
       console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
-      if (_isEqual(span, spanMap.get(spanID))) {
+      if (isEqual(span, spanMap.get(spanID))) {
         console.warn('\t two spans with same ID have `isEqual(...) === true`');
       }
       spanIdCounts.set(spanID, idCount + 1);

--- a/frontend/src/utils/tracing/TracingHelper.ts
+++ b/frontend/src/utils/tracing/TracingHelper.ts
@@ -1,4 +1,4 @@
-import _round from 'lodash/round';
+import { round } from 'lodash-es';
 import moment from 'moment';
 import {
   EnvoySpanInfo,
@@ -389,7 +389,7 @@ export function formatDuration(micros: number): string {
     unit = 's';
     d /= 1000;
   }
-  return _round(d, 2) + unit;
+  return round(d, 2) + unit;
 }
 
 const TODAY = 'Today';

--- a/frontend/src/utils/tracing/UrlProviders/Grafana.ts
+++ b/frontend/src/utils/tracing/UrlProviders/Grafana.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import { map } from 'lodash-es';
 import { TracingUrlProvider, TEMPO } from 'types/Tracing';
 import { BoundsInMilliseconds } from 'types/Common';
 import { SpanData, TraceData } from 'types/TracingInfo';
@@ -111,7 +111,7 @@ export class GrafanaUrlProvider implements TracingUrlProvider {
   }
 
   AppSearchUrl(app: string, bounds: BoundsInMilliseconds, tags: Record<string, string>): string {
-    const tagFilters = _.map(tags, (tag, value) => {
+    const tagFilters = map(tags, (tag, value) => {
       return {
         id: generateId(5), // We need a random unique ID per filter
         tag: tag,


### PR DESCRIPTION
## What this PR does

Fixes #6339 - standardizes all lodash imports across the frontend on a single, consistent pattern:

```
import { fn } from 'lodash-es';
```

replacing the three previously mixed styles called out in the issue:

```
import _ from 'lodash';
import { isArray } from 'lodash';
import _isEqual from 'lodash/isEqual';
```

## Why lodash-es

`lodash-es` ships as ES modules, which allows bundlers to tree-shake and only include the specific functions actually used, unlike importing the default `lodash` CJS build (whether via the `_` namespace import or a `lodash/fn` subpath import). The project already depends on `lodash-es` and uses it in several files, so this just extends that pattern everywhere.

## Scope

This is a mechanical, behavior-preserving change only:

- `import _ from 'lodash'` / `import * as _ from 'lodash'` -> `import { usedFn1, usedFn2, ... } from 'lodash-es'`, with all `_.fn(...)` call sites updated to the bare `fn(...)` name.
- `import { fn } from 'lodash'` -> `import { fn } from 'lodash-es'` (no call-site changes needed).
- `import alias from 'lodash/fn'` (e.g. `import _round from 'lodash/round'`, `import _isEqual from 'lodash/isEqual'`) -> `import { fn } from 'lodash-es'`, with call sites renamed to the real function name.
- Merged import statements where a file previously had two separate `lodash`/`lodash-es` import lines into one.

No logic was changed - every replacement is a like-for-like call to the same lodash function.

## Testing

- `tsc -p . --noEmit` - clean, no new type errors.
- `eslint` on all changed files - 0 errors; only pre-existing warnings unrelated to this change remain (verified identical on `master`).
- Full frontend test suite (`yarn rstest run`) - same pass/fail counts as `master` (2 pre-existing snapshot failures unrelated to this change, caused by CRLF line-ending differences in checked-out SVG assets on this environment, reproduced identically on unmodified `master`).
