### PR TITLE
[v2.22] Fix KIA0201 false positives for disjoint wildcard DestinationRule hosts

### DIFF
--- a/business/checkers/destination_rules_checker.go
+++ b/business/checkers/destination_rules_checker.go
@@ -11,12 +11,11 @@ import (
 )
 
 type DestinationRulesChecker struct {
+	Cluster          string
 	Conf             *config.Config
 	DestinationRules []*networking_v1.DestinationRule
 	MTLSDetails      kubernetes.MTLSDetails
-	ServiceEntries   []*networking_v1.ServiceEntry
 	Namespaces       models.Namespaces
-	Cluster          string
 }
 
 func (in DestinationRulesChecker) Check() models.IstioValidations {
@@ -31,10 +30,8 @@ func (in DestinationRulesChecker) Check() models.IstioValidations {
 func (in DestinationRulesChecker) runGroupChecks() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	seHosts := kubernetes.ServiceEntryHostnames(in.ServiceEntries)
-
 	enabledDRCheckers := []GroupChecker{
-		destinationrules.MultiMatchChecker{Conf: in.Conf, Namespaces: in.Namespaces.GetNames(), ServiceEntries: seHosts, DestinationRules: in.DestinationRules, Cluster: in.Cluster},
+		destinationrules.MultiMatchChecker{Cluster: in.Cluster, Conf: in.Conf, DestinationRules: in.DestinationRules, Namespaces: in.Namespaces.GetNames()},
 	}
 
 	enabledDRCheckers = append(enabledDRCheckers, destinationrules.TrafficPolicyChecker{Conf: in.Conf, DestinationRules: in.DestinationRules, MTLSDetails: in.MTLSDetails, Cluster: in.Cluster})

--- a/business/checkers/destinationrules/multi_match_checker.go
+++ b/business/checkers/destinationrules/multi_match_checker.go
@@ -1,9 +1,6 @@
 package destinationrules
 
 import (
-	"fmt"
-	"strings"
-
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
 
 	"github.com/kiali/kiali/config"
@@ -16,7 +13,6 @@ type MultiMatchChecker struct {
 	Conf             *config.Config
 	DestinationRules []*networking_v1.DestinationRule
 	Namespaces       []string
-	ServiceEntries   map[string][]string
 }
 
 type subset struct {
@@ -34,7 +30,7 @@ type rule struct {
 func (m MultiMatchChecker) Check() models.IstioValidations {
 	validations := models.IstioValidations{}
 
-	// Equality search is: [fqdn.String()][subset] except for ServiceEntry targets which use [host][subset]
+	// Equality search is: [fqdn.String()][subset]
 	seenHostSubsets := make(map[string]map[string][]rule)
 
 	for _, dr := range m.DestinationRules {
@@ -42,36 +38,29 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 		destinationRulesNamespace := dr.Namespace
 		fqdn := kubernetes.GetHost(dr.Spec.Host, dr.Namespace, m.Namespaces, m.Conf)
 
-		// Skip DR validation if it enables mTLS either namespace or mesh-wide
-		if isNonLocalmTLSForServiceEnabled(dr, fqdn.String()) {
+		// Skip mesh-wide / namespace-wide mTLS DestinationRules (e.g. *.local, *.ns.svc...).
+		// These are intended to coexist with more specific DRs and must not drive multi-match.
+		if isNonLocalmTLSForServiceEnabled(dr, m.Conf) {
 			continue
 		}
 
 		foundSubsets := extractSubsets(dr, destinationRulesName, destinationRulesNamespace)
+		currentHost := fqdn.String()
 
-		if fqdn.IsWildcard() {
-			// We need to check the matching subsets from all hosts now
-			for _, h := range seenHostSubsets {
-				checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, h, m.Cluster)
+		// Only collide with previously seen hosts that actually overlap this one.
+		// Wildcard hosts must honor the namespace/domain suffix (e.g. *.vault... must not
+		// collide with *.istio-test3...); previously any wildcard was compared to all hosts.
+		for hostKey, existing := range seenHostSubsets {
+			if hostsOverlap(currentHost, hostKey) {
+				checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, existing, m.Cluster)
 			}
-			// We add * later
-		}
-		// Search "*" first and then exact name
-		if previous, found := seenHostSubsets[fmt.Sprintf("*.%s.%s", fqdn.Namespace, fqdn.Cluster)]; found {
-			// Need to check subsets of "*"
-			checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, previous, m.Cluster)
 		}
 
-		if previous, found := seenHostSubsets[fqdn.String()]; found {
-			// Host found, need to check underlying subsets
-			checkCollisions(validations, destinationRulesNamespace, destinationRulesName, foundSubsets, previous, m.Cluster)
-		}
-		// Nothing threw an error, so add these
-		if _, found := seenHostSubsets[fqdn.String()]; !found {
-			seenHostSubsets[fqdn.String()] = make(map[string][]rule)
+		if _, found := seenHostSubsets[currentHost]; !found {
+			seenHostSubsets[currentHost] = make(map[string][]rule)
 		}
 		for _, s := range foundSubsets {
-			seenHostSubsets[fqdn.String()][s.Name] = append(seenHostSubsets[fqdn.String()][s.Name], rule{destinationRulesName, destinationRulesNamespace})
+			seenHostSubsets[currentHost][s.Name] = append(seenHostSubsets[currentHost][s.Name], rule{destinationRulesName, destinationRulesNamespace})
 		}
 
 	}
@@ -79,8 +68,41 @@ func (m MultiMatchChecker) Check() models.IstioValidations {
 	return validations
 }
 
-func isNonLocalmTLSForServiceEnabled(dr *networking_v1.DestinationRule, service string) bool {
-	return strings.HasPrefix(service, "*") && ismTLSEnabled(dr)
+// hostsOverlap reports whether two DestinationRule host keys select the same traffic.
+// Exact matches overlap; a bare "*" overlaps everything; otherwise a wildcard overlaps
+// a host (or a more specific wildcard) when the non-wildcard/more-specific side falls
+// within the wildcard's domain suffix.
+func hostsOverlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if a == "*" || b == "*" {
+		return true
+	}
+	return kubernetes.HostWithinWildcardHost(b, a) || kubernetes.HostWithinWildcardHost(a, b)
+}
+
+// isNonLocalmTLSForServiceEnabled reports whether dr is a mesh-wide or namespace-wide
+// ISTIO_MUTUAL DestinationRule that should be ignored by multi-match / traffic-policy
+// overlap checks.
+//
+// Istio's recommended pattern for enabling mTLS uses hosts like "*.local" (mesh) or
+// "*.{namespace}.{identityDomain}" (namespace). Those DRs are meant to set a default
+// TLS mode and coexist with more specific DestinationRules, so treating them as
+// host collisions would produce false KIA0201 warnings.
+//
+// Only those exact host shapes qualify. A service-scoped wildcard such as
+// "*.vault.svc.cluster.local" with ISTIO_MUTUAL is still a normal DestinationRule and
+// must not be skipped for multi-match or treated as non-local for traffic-policy checks
+// (previously any host starting with "*" was treated as non-local).
+func isNonLocalmTLSForServiceEnabled(dr *networking_v1.DestinationRule, conf *config.Config) bool {
+	if enabled, _ := kubernetes.DestinationRuleHasMeshWideMTLSEnabled(dr); enabled {
+		return true
+	}
+	if enabled, _ := kubernetes.DestinationRuleHasNamespaceWideMTLSEnabled(dr.Namespace, dr, conf); enabled {
+		return true
+	}
+	return false
 }
 
 func ismTLSEnabled(dr *networking_v1.DestinationRule) bool {

--- a/business/checkers/destinationrules/multi_match_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_checker_test.go
@@ -200,6 +200,48 @@ func TestMultiHostMatchWildcardInvalid(t *testing.T) {
 	assert.Equal("rule2", validation.References[0].Name)
 }
 
+// OSSM-15084: disjoint namespace-scoped wildcards must not trigger KIA0201.
+func TestMultiHostMatchDisjointNamespaceWildcards(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "vault-no-tls", "*.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "test3-no-tls", "*.istio-test3.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		Conf:             config.Get(),
+		Namespaces:       []string{"istio-test1", "vault", "istio-test3"},
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.Empty(vals, "wildcard hosts targeting different namespaces must not overlap")
+}
+
+func TestMultiHostMatchSameNamespaceWildcardsStillConflict(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []*networking_v1.DestinationRule{
+		data.CreateTestDestinationRule("istio-test1", "rule1", "*.vault.svc.cluster.local"),
+		data.CreateTestDestinationRule("istio-test1", "rule2", "*.vault.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		Conf:             config.Get(),
+		Namespaces:       []string{"istio-test1", "vault"},
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+}
+
 func TestMultiHostMatchBothWildcardInvalid(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -293,6 +335,59 @@ func TestMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 	assert.Nil(validation)
 }
 
+// Service-scoped wildcard mTLS (e.g. *.vault) must still participate in multi-match;
+// only mesh-wide / namespace-wide mTLS DRs are skipped.
+func TestMultiHostMatchingServiceScopedMTLSWildcardStillConflicts(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	destinationRules := []*networking_v1.DestinationRule{
+		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+			data.CreateTestDestinationRule("istio-test1", "vault-mtls", "*.vault.svc.cluster.local")),
+		data.CreateTestDestinationRule("istio-test1", "vault-no-tls", "*.vault.svc.cluster.local"),
+	}
+
+	vals := MultiMatchChecker{
+		Conf:             config.Get(),
+		Namespaces:       []string{"istio-test1", "vault"},
+		DestinationRules: destinationRules,
+	}.Check()
+
+	assert.NotEmpty(vals)
+	assert.Equal(2, len(vals))
+}
+
+func TestHostsOverlap(t *testing.T) {
+	cases := []struct {
+		a, b     string
+		expected bool
+		reason   string
+	}{
+		{"*.svc.cluster.local", "*.test.svc.cluster.local", true, "broader wildcard contains narrower"},
+		{"*.test.svc.cluster.local", "*.svc.cluster.local", true, "reverse of above"},
+		{"*.wikipedia.org", "en.wikipedia.org", true, "non-cluster wildcard containing concrete"},
+		{"*.foo.com", "*.bar.com", false, "disjoint external wildcards"},
+		{"foo", "foo", true, "identity"},
+		{"*", "anything", true, "bare wildcard"},
+		{"anything", "*", true, "bare wildcard (reversed)"},
+		{"*.vault.svc.cluster.local", "*.istio-test3.svc.cluster.local", false, "disjoint namespace-scoped wildcards (OSSM-15084)"},
+		{"host1.test.svc.cluster.local", "*.test.svc.cluster.local", true, "concrete host within namespace wildcard"},
+		{"*.test.svc.cluster.local", "host1.test.svc.cluster.local", true, "reversed"},
+		{"host1.test.svc.cluster.local", "host1.test.svc.cluster.local", true, "exact match"},
+		{"host1.test.svc.cluster.local", "host2.test.svc.cluster.local", false, "different concrete hosts"},
+		{"*", "*", true, "bare wildcard identity"},
+		{"*.test.svc.cluster.local", "*.test.svc.cluster.local", true, "identical wildcards"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			assert.Equal(t, tc.expected, hostsOverlap(tc.a, tc.b), "%s vs %s", tc.a, tc.b)
+		})
+	}
+}
+
 func TestMultiHostMatchDifferentSubsets(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
@@ -371,16 +466,12 @@ func TestMultiServiceEntry(t *testing.T) {
 
 	assert := assert.New(t)
 
-	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
-	seB := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-b", "test", []string{"api.service_b.com"}))
-
 	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
 	drB := data.CreateEmptyDestinationRule("test", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
 		Conf:             config.Get(),
 		DestinationRules: []*networking_v1.DestinationRule{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{seA, seB}),
 	}.Check()
 
 	assert.Empty(vals)
@@ -392,15 +483,12 @@ func TestMultiServiceEntryInvalid(t *testing.T) {
 
 	assert := assert.New(t)
 
-	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
-
 	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
 	drB := data.CreateEmptyDestinationRule("test", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
 		Conf:             config.Get(),
 		DestinationRules: []*networking_v1.DestinationRule{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{seA}),
 	}.Check()
 
 	assert.NotEmpty(vals)

--- a/business/checkers/destinationrules/multi_match_exported_checker_test.go
+++ b/business/checkers/destinationrules/multi_match_exported_checker_test.go
@@ -444,7 +444,7 @@ func TestExportMultiHostMatchingNamespaceWideMTLSDestinationRule(t *testing.T) {
 
 	edr := []*networking_v1.DestinationRule{
 		data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
-			data.CreateTestDestinationRule("test2", "rule2", "*.test.svc.cluster.local")),
+			data.CreateTestDestinationRule("test2", "rule2", "*.test2.svc.cluster.local")),
 	}
 
 	vals := MultiMatchChecker{
@@ -542,16 +542,12 @@ func TestExportMultiServiceEntry(t *testing.T) {
 
 	assert := assert.New(t)
 
-	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
-	seB := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-b", "test2", []string{"api.service_b.com"}))
-
 	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
 	drB := data.CreateEmptyDestinationRule("test2", "service-b", "api.service_b.com")
 
 	vals := MultiMatchChecker{
 		Conf:             config.Get(),
 		DestinationRules: []*networking_v1.DestinationRule{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{seA, seB}),
 	}.Check()
 
 	assert.Empty(vals)
@@ -563,15 +559,12 @@ func TestExportMultiServiceEntryInvalid(t *testing.T) {
 
 	assert := assert.New(t)
 
-	seA := data.AddPortDefinitionToServiceEntry(data.CreateEmptyServicePortDefinition(443, "https", "TLS"), data.CreateEmptyMeshExternalServiceEntry("service-a", "test", []string{"api.service_a.com"}))
-
 	drA := data.CreateEmptyDestinationRule("test", "service-a", "api.service_a.com")
 	drB := data.CreateEmptyDestinationRule("test2", "service-a2", "api.service_a.com")
 
 	vals := MultiMatchChecker{
 		Conf:             config.Get(),
 		DestinationRules: []*networking_v1.DestinationRule{drA, drB},
-		ServiceEntries:   kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{seA}),
 	}.Check()
 
 	assert.NotEmpty(vals)

--- a/business/checkers/destinationrules/traffic_policy_checker.go
+++ b/business/checkers/destinationrules/traffic_policy_checker.go
@@ -56,8 +56,7 @@ func (t TrafficPolicyChecker) Check() models.IstioValidations {
 func (t TrafficPolicyChecker) drsWithNonLocalmTLSEnabled() []*networking_v1.DestinationRule {
 	mtlsDrs := make([]*networking_v1.DestinationRule, 0)
 	for _, dr := range t.MTLSDetails.DestinationRules {
-		fqdn := kubernetes.ParseHost(dr.Spec.Host, dr.Namespace, t.Conf)
-		if isNonLocalmTLSForServiceEnabled(dr, fqdn.String()) {
+		if isNonLocalmTLSForServiceEnabled(dr, t.Conf) {
 			mtlsDrs = append(mtlsDrs, dr)
 		}
 	}

--- a/business/checkers/destinationrules/traffic_policy_checker_test.go
+++ b/business/checkers/destinationrules/traffic_policy_checker_test.go
@@ -240,6 +240,25 @@ func TestCrossNamespaceServiceEntryProtection(t *testing.T) {
 	testValidationsNotAdded(t, destinationRules, mTLSDetails)
 }
 
+// Context: Service-scoped wildcard mTLS (e.g. *.vault), not mesh/ns-wide
+// Context: Another DestinationRule for that namespace has no trafficPolicy
+// It must not treat the service-scoped DR as non-local mTLS (no traffic-policy warning).
+func TestServiceScopedMTLSWildcardDoesNotDriveTrafficPolicy(t *testing.T) {
+	mTLSDetails := kubernetes.MTLSDetails{
+		DestinationRules: []*networking_v1.DestinationRule{
+			// Host targets vault services but DR lives in another namespace — not ns-wide for istio-test1.
+			data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+				data.CreateEmptyDestinationRule("istio-test1", "vault-mtls", "*.vault.svc.cluster.local")),
+		},
+	}
+
+	destinationRules := []*networking_v1.DestinationRule{
+		data.CreateEmptyDestinationRule("vault", "reviews", "reviews"),
+	}
+
+	testValidationsNotAdded(t, destinationRules, mTLSDetails)
+}
+
 func testValidationAdded(t *testing.T, destinationRules []*networking_v1.DestinationRule, mTLSDetails kubernetes.MTLSDetails) *models.IstioValidation {
 	assert := assert.New(t)
 

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -481,7 +481,7 @@ func (in *IstioValidationsService) getAllObjectCheckers(vInfo *validationInfo) [
 
 	return []checkers.ObjectChecker{
 		checkers.AuthorizationPolicyChecker{Conf: conf, AuthorizationPolicies: rbacDetails.AuthorizationPolicies, Namespaces: nsNames, ServiceEntries: istioConfigList.ServiceEntries, WorkloadsPerNamespace: workloadsPerNamespace, MtlsDetails: *mtlsDetails, VirtualServices: istioConfigList.VirtualServices, RegistryServices: registryServices, PolicyAllowAny: in.isPolicyAllowAny(vInfo.mesh), Cluster: cluster, ServiceAccounts: vInfo.saMap},
-		checkers.DestinationRulesChecker{Conf: conf, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: *mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries, Cluster: cluster},
+		checkers.DestinationRulesChecker{Conf: conf, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: *mtlsDetails, Cluster: cluster},
 		checkers.GatewayChecker{Conf: conf, Gateways: istioConfigList.Gateways, WorkloadsPerNamespace: workloadsPerNamespace, IsGatewayToNamespace: in.isGatewayToNamespace(vInfo.mesh), Cluster: cluster},
 		checkers.K8sGatewayChecker{K8sGateways: istioConfigList.K8sGateways, Cluster: cluster, GatewayClasses: in.kialiCache.GatewayAPIClasses(cluster)},
 		checkers.K8sGRPCRouteChecker{Conf: conf, K8sGRPCRoutes: istioConfigList.K8sGRPCRoutes, K8sGateways: istioConfigList.K8sGateways, K8sReferenceGrants: istioConfigList.K8sReferenceGrants, Namespaces: namespaces, RegistryServices: registryServices, Cluster: cluster},
@@ -608,7 +608,7 @@ func (in *IstioValidationsService) ValidateIstioObject(ctx context.Context, clus
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, virtualServiceChecker}
 		referenceChecker = references.VirtualServiceReferences{Conf: conf, Namespace: namespace, Namespaces: nsNames, VirtualServices: istioConfigList.VirtualServices, DestinationRules: istioConfigList.DestinationRules, AuthorizationPolicies: rbacDetails.AuthorizationPolicies}
 	case kubernetes.DestinationRules:
-		destinationRulesChecker := checkers.DestinationRulesChecker{Conf: conf, Cluster: cluster, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: *mtlsDetails, ServiceEntries: istioConfigList.ServiceEntries}
+		destinationRulesChecker := checkers.DestinationRulesChecker{Conf: conf, Cluster: cluster, Namespaces: namespaces, DestinationRules: istioConfigList.DestinationRules, MTLSDetails: *mtlsDetails}
 		objectCheckers = []checkers.ObjectChecker{noServiceChecker, destinationRulesChecker}
 		referenceChecker = references.DestinationRuleReferences{Conf: conf, Namespace: namespace, Namespaces: nsNames, DestinationRules: istioConfigList.DestinationRules, VirtualServices: istioConfigList.VirtualServices, WorkloadsPerNamespace: workloadsPerNamespace, ServiceEntries: istioConfigList.ServiceEntries, RegistryServices: registryServices}
 	case kubernetes.ServiceEntries:

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -247,11 +247,15 @@ func HasMatchingReferenceGrant(fromNamespace string, toNamespace string, fromKin
 }
 
 func HostWithinWildcardHost(subdomain, wildcardDomain string) bool {
-	if !strings.HasPrefix(wildcardDomain, "*") {
+	if wildcardDomain == "*" {
+		return true
+	}
+	// "*.suffix" only — require a DNS-label boundary so "*.test.svc..." does not
+	// match "...istio-test.svc..." (suffix of the namespace label).
+	if !strings.HasPrefix(wildcardDomain, "*.") {
 		return false
 	}
-
-	return len(wildcardDomain) > 2 && strings.HasSuffix(subdomain, wildcardDomain[2:])
+	return strings.HasSuffix(subdomain, wildcardDomain[1:])
 }
 
 func ParseGatewayAsHost(gateway, currentNamespace string, conf *config.Config) Host {

--- a/kubernetes/host_test.go
+++ b/kubernetes/host_test.go
@@ -27,6 +27,35 @@ func TestGatewayAsHost(t *testing.T) {
 	assert.Equal("mygateway.bookinfo.svc.cluster.local", ParseGatewayAsHost("mygateway.bookinfo.svc.cluster.local", "bookinfo", conf).String())
 }
 
+func TestHostWithinWildcardHost(t *testing.T) {
+	cases := []struct {
+		subdomain, wildcard string
+		expected            bool
+		reason              string
+	}{
+		{"host1.test.svc.cluster.local", "*.test.svc.cluster.local", true, "concrete host in namespace"},
+		{"*.test.svc.cluster.local", "*.test.svc.cluster.local", true, "identical wildcards"},
+		{"*.vault.svc.cluster.local", "*.local", true, "mesh-wide covers namespace wildcard"},
+		{"host.vault.svc.cluster.local", "*.local", true, "mesh-wide covers concrete host"},
+		{"en.wikipedia.org", "*.wikipedia.org", true, "external wildcard"},
+		{"*", "*", true, "bare wildcard"},
+		{"anything", "*", true, "bare wildcard matches all"},
+		{"svc.istio-test.svc.cluster.local", "*.test.svc.cluster.local", false, "ns suffix must not match across label boundary"},
+		{"*.istio-test.svc.cluster.local", "*.test.svc.cluster.local", false, "wildcard ns suffix must not match across label boundary"},
+		{"host.ntest.svc.cluster.local", "*.test.svc.cluster.local", false, "partial label suffix must not match"},
+		{"foo.mysvc.cluster.local", "*.svc.cluster.local", false, "partial domain label must not match"},
+		{"host1.test.svc.cluster.local", "host1.test.svc.cluster.local", false, "non-wildcard domain is not a wildcard"},
+		{"*.foo.com", "*.bar.com", false, "disjoint wildcards"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			assert.Equal(t, tc.expected, HostWithinWildcardHost(tc.subdomain, tc.wildcard),
+				"%s within %s", tc.subdomain, tc.wildcard)
+		})
+	}
+}
+
 func TestHasMatchingVirtualServices(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
### Describe the change

Backport of #10125 to `v2.22`.

Fixes KIA0201 false positives when DestinationRules use disjoint namespace-scoped wildcards (e.g. `*.vault.svc.cluster.local` vs `*.istio-test3.svc.cluster.local`). Also:
- Collide hosts only via real overlap (`hostsOverlap` / `HostWithinWildcardHost`)
- Require DNS-label boundary in `HostWithinWildcardHost`
- Skip only mesh/ns-wide mTLS DRs in multi-match / traffic-policy checks
- Drop unused `ServiceEntries` wiring from `MultiMatchChecker`

Adapted for v2.22: uses `Conf`-based host/mTLS helpers instead of `IdentityDomain`.

### Steps to test the PR

1. Apply two DestinationRules in the same NS with disjoint wildcard hosts (`*.vault...` and `*.istio-test3...`)
2. Confirm KIA0201 is **not** raised
3. Confirm same-host wildcards and mesh/ns-wide mTLS behavior still work as before

### Automation testing

Unit tests in `business/checkers/destinationrules` and `kubernetes` (hostsOverlap table, HostWithinWildcardHost label-boundary cases, service-scoped mTLS traffic-policy regression).

### Issue reference

Backport of https://github.com/kiali/kiali/pull/10125  
Jira: https://redhat.atlassian.net/browse/OSSM-15084


Made with [Cursor](https://cursor.com)