### PR TITLE
Fix Grafana Explore deep-link span tag key/value swap

### DIFF
--- a/frontend/src/utils/tracing/UrlProviders/Grafana.ts
+++ b/frontend/src/utils/tracing/UrlProviders/Grafana.ts
@@ -1,7 +1,8 @@
 import { map } from 'lodash-es';
-import { TracingUrlProvider, TEMPO } from 'types/Tracing';
-import { BoundsInMilliseconds } from 'types/Common';
-import { SpanData, TraceData } from 'types/TracingInfo';
+import type { BoundsInMilliseconds } from 'types/Common';
+import { TEMPO } from 'types/Tracing';
+import type { TracingUrlProvider } from 'types/Tracing';
+import type { SpanData, TraceData } from 'types/TracingInfo';
 
 function dec2hex(dec: number): string {
   return dec.toString(16).padStart(2, '0');
@@ -30,10 +31,10 @@ function base64ToHex(str: string): string {
 //
 // https://grafana.com/docs/grafana/v10.1/explore/#generating-explore-urls-from-external-tools
 export class GrafanaUrlProvider implements TracingUrlProvider {
-  private readonly datasourceUID: string;
-  private readonly orgID: string;
-  private readonly grafanaUrl: string | undefined;
   readonly valid: boolean = true;
+  private readonly datasourceUID: string;
+  private readonly grafanaUrl: string | undefined;
+  private readonly orgID: string;
 
   constructor(grafanaUrl: string, options: { datasource_uid: string; orgID?: string }) {
     this.datasourceUID = options.datasource_uid;
@@ -111,10 +112,11 @@ export class GrafanaUrlProvider implements TracingUrlProvider {
   }
 
   AppSearchUrl(app: string, bounds: BoundsInMilliseconds, tags: Record<string, string>): string {
-    const tagFilters = map(tags, (tag, value) => {
+    // lodash map on an object iterates as (value, key)
+    const tagFilters = map(tags, (value, key) => {
       return {
         id: generateId(5), // We need a random unique ID per filter
-        tag: tag,
+        tag: key,
         operator: '=',
         scope: 'span',
         value: [value],

--- a/frontend/src/utils/tracing/__tests__/GrafanaUrlProvider.test.ts
+++ b/frontend/src/utils/tracing/__tests__/GrafanaUrlProvider.test.ts
@@ -1,0 +1,98 @@
+import { GrafanaUrlProvider } from '../UrlProviders/Grafana';
+
+type ExploreFilter = {
+  operator: string;
+  scope: string;
+  tag: string;
+  value: string[];
+  valueType: string;
+};
+
+type ExplorePanes = {
+  a: {
+    queries: Array<{
+      filters: ExploreFilter[];
+    }>;
+  };
+};
+
+describe('GrafanaUrlProvider.AppSearchUrl', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'crypto', {
+      configurable: true,
+      value: {
+        getRandomValues: (arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) {
+            arr[i] = i;
+          }
+          return arr;
+        }
+      }
+    });
+  });
+
+  const provider = new GrafanaUrlProvider('http://grafana:3000', {
+    datasource_uid: 'tempo-uid',
+    orgID: '1'
+  });
+
+  const parsePanes = (url: string): ExplorePanes => {
+    const panesParam = new URL(url).searchParams.get('panes');
+    expect(panesParam).not.toBeNull();
+    return JSON.parse(decodeURIComponent(panesParam!));
+  };
+
+  it('keeps span tag keys and values in the correct order', () => {
+    const url = provider.AppSearchUrl('productpage', { from: 1000, to: 2000 }, { 'http.method': 'GET', error: 'true' });
+    const panes = parsePanes(url);
+    const filters = panes.a.queries[0].filters;
+
+    expect(filters[0]).toMatchObject({
+      tag: 'service.name',
+      value: ['productpage'],
+      scope: 'resource'
+    });
+
+    const tagFilters = filters.slice(1).map(({ tag, value, operator, scope, valueType }) => ({
+      tag,
+      value,
+      operator,
+      scope,
+      valueType
+    }));
+
+    expect(tagFilters).toEqual(
+      expect.arrayContaining([
+        {
+          tag: 'http.method',
+          operator: '=',
+          scope: 'span',
+          value: ['GET'],
+          valueType: 'string'
+        },
+        {
+          tag: 'error',
+          operator: '=',
+          scope: 'span',
+          value: ['true'],
+          valueType: 'string'
+        }
+      ])
+    );
+    expect(tagFilters).toHaveLength(2);
+  });
+
+  it('builds filters for the Errors only tag set', () => {
+    const url = provider.AppSearchUrl('reviews', { from: 1000, to: 2000 }, { error: 'true' });
+    const panes = parsePanes(url);
+    const errorFilter = panes.a.queries[0].filters.find(f => f.tag === 'error');
+
+    expect(errorFilter).toMatchObject({
+      tag: 'error',
+      operator: '=',
+      scope: 'span',
+      value: ['true'],
+      valueType: 'string'
+    });
+  });
+});


### PR DESCRIPTION
### Describe the change

`GrafanaUrlProvider.AppSearchUrl` used lodash `map` on a tags object with the iteratee args treated as `(tag, value)`, but lodash calls `(value, key)`. That swapped span tag keys and values in Grafana Explore deep-links (notably **Errors only** → `tag: "true"`, `value: ["error"]`).

Also cleans pre-commit lint on the touched file (`import type`, member ordering).

### Steps to test the PR

1. Configure Tempo with Grafana Explore URL format (`tempo_config.datasource_uid` set).
2. Open an app/workload **Traces** tab.
3. Enable **Show only traces with errors**.
4. Copy **View in Tracing** and decode the `panes` query param.
5. Confirm the error filter is `tag: "error"`, `value: ["true"]`.

### Automation testing

Unit tests in `GrafanaUrlProvider.test.ts` assert tag key/value order for multi-tag and Errors-only inputs.

### Issue reference

Fixes #10155


Made with [Cursor](https://cursor.com)