### PR TITLE
[CI] Remove duplicate plugins in volume/mount

### DIFF
--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -5,8 +5,6 @@ config:
   provisioning:
     interval: 1m
 volumes:
-- name: plugins
-  emptyDir: {}
 - name: provisioning
   projected:
     sources:
@@ -17,8 +15,6 @@ volumes:
     - configMap:
         name: perses-provisioning
 volumeMounts:
-- name: plugins
-  mountPath: /etc/perses/plugins
 - name: provisioning
   mountPath: /etc/perses/provisioning
   readOnly: true

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -494,6 +494,7 @@ setup_kind_singlecluster() {
     kubectl apply -f "${SCRIPT_DIR}"/istio/perses/dashboard.yaml
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
+    # Chart 0.23+ mounts /etc/perses/plugins itself; do not re-add that volume in values.yaml.
     ${HELM} install perses perses/perses -n istio-system -f "${SCRIPT_DIR}"/istio/perses/values.yaml
 
           PERSES_ARGS=(


### PR DESCRIPTION
### Describe the change
Ref. https://github.com/kiali/kiali/actions/runs/30893206500/job/91963673326

Fix for issue: 

```
"perses" has been added to your repositories
Error: INSTALLATION FAILED: 1 error occurred:
	* StatefulSet.apps "perses" is invalid: [spec.template.spec.volumes[4].name: Duplicate value: "plugins", spec.template.spec.containers[0].volumeMounts[4].mountPath: Invalid value: "/etc/perses/plugins": must be unique]


```
### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes https://github.com/kiali/kiali/issues/10158 
