### PR TITLE
Fix CI race condition when labels are added to PRs

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -19,7 +19,6 @@ permissions: read-all
 
 jobs:
   initialize:
-    if: github.event.action != 'labeled' || github.event.label.name == 'ci-full'
     permissions:
       contents: read
     name: Initialize


### PR DESCRIPTION
## Summary

- Remove the conditional gate on the `initialize` job that skipped CI for non-`ci-full` labeled events
- Fixes a race condition where adding any label (e.g. `backport needed`) shortly after PR creation would cancel the running CI and leave it in a permanently skipped state

## Details

The `labeled` event type in the CI workflow shared the same concurrency group as `opened`/`synchronize` with `cancel-in-progress: true`. The `initialize` job had this condition:

```yaml
if: github.event.action != 'labeled' || github.event.label.name == 'ci-full'
```

When a label was added while CI was running:
1. The new `labeled` run cancelled the in-progress CI run
2. The new run then evaluated the condition — since the label wasn't `ci-full`, all jobs were skipped
3. Result: CI cancelled with no way to recover automatically

With this fix, any `labeled` event triggers a normal CI run. The Wave 2 gate (`ci-full` label must be present on the PR) is unaffected.

## Test plan

- [x] Verify Wave 2 gate still requires `ci-full` label (line 145 unchanged)
- [ ] Create a test PR, add a non-`ci-full` label while CI is running, confirm CI restarts and completes


Made with [Cursor](https://cursor.com)