### PR TITLE
Update tmp to 0.2.7 to address CVE-2026-44705

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14002,9 +14002,9 @@ __metadata:
   linkType: hard
 
 "tmp@npm:~0.2.4":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Update transitive dependency `tmp` from 0.2.5 to 0.2.7 to address CVE-2026-44705.

## CVE Details

**CVE-2026-44705** — Path traversal vulnerability in the `tmp` npm package (< 0.2.6) allows escaping the intended temporary directory when untrusted data flows into the prefix, postfix, or dir options.

## Changes

- Lockfile-only change (`frontend/yarn.lock`)
- `tmp` is a transitive dependency of Cypress (devDependency)


Made with [Cursor](https://cursor.com)