### PR TITLE
[v2.27] Chatbot: Added support of Cluster Name in queries (#9927)

### DIFF
--- a/ai/mcp/get_action_ui/get_action_ui.go
+++ b/ai/mcp/get_action_ui/get_action_ui.go
@@ -162,7 +162,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	actions := make([]Action, 0)
 	switch resourceType {
 	case "graph":
-		actions = append(actions, getGraphAction(namespacesValue, graph, graphType))
+		actions = append(actions, getGraphAction(namespacesValue, graph, graphType, clusterName))
 	case "overview":
 		actions = append(actions, getOverviewAction())
 	case "namespaces":
@@ -189,7 +189,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 		if resourceName == "" && (namespaces == "" || namespaces == "all") {
 			nsForAction = namespaces
 		}
-		actions = append(actions, getResourceAction(nsForAction, resourceType, resourceName, tab))
+		actions = append(actions, getResourceAction(nsForAction, resourceType, resourceName, tab, clusterName))
 	}
 
 	return GetActionUIResponse{
@@ -198,7 +198,7 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	}, http.StatusOK
 }
 
-func getGraphAction(namespaces string, graph string, graphType string) Action {
+func getGraphAction(namespaces string, graph string, graphType string, clusterName string) Action {
 	if graphType == "" {
 		graphType = "versionedApp"
 	}
@@ -213,10 +213,14 @@ func getGraphAction(namespaces string, graph string, graphType string) Action {
 	if namespaces == "" {
 		namespacesLabel = " for all namespaces"
 	}
+	payload := "/graph/namespaces?namespaces=" + namespaces + "&graphType=" + graphType
+	if clusterName != "" {
+		payload += "&clusterName=" + clusterName
+	}
 	return Action{
 		Title:   "View Traffic Graph" + namespacesLabel,
 		Kind:    ActionKindNavigation,
-		Payload: "/graph/namespaces?namespaces=" + namespaces + "&graphType=" + graphType,
+		Payload: payload,
 	}
 }
 
@@ -236,7 +240,7 @@ func getNamespacesAction() Action {
 	}
 }
 
-func getResourceAction(namespaces string, resourceType string, resourceName string, tab string) Action {
+func getResourceAction(namespaces string, resourceType string, resourceName string, tab string, clusterName string) Action {
 	resourceLabel := "services"
 	switch resourceType {
 	case "workload":
@@ -255,10 +259,14 @@ func getResourceAction(namespaces string, resourceType string, resourceName stri
 			Payload: "/" + resourceLabel + queryNamespaces,
 		}
 	}
+	payload := "/namespaces/" + namespaces + "/" + resourceLabel + "/" + resourceName + "?tab=" + getTabLabel(tab, resourceType)
+	if clusterName != "" {
+		payload += "&clusterName=" + clusterName
+	}
 	return Action{
 		Title:   "View " + resourceType + " Details",
 		Kind:    ActionKindNavigation,
-		Payload: "/namespaces/" + namespaces + "/" + resourceLabel + "/" + resourceName + "?tab=" + getTabLabel(tab, resourceType),
+		Payload: payload,
 	}
 }
 
@@ -285,10 +293,8 @@ func getIstioAction(ctx context.Context, businessLayer *business.Layer, clusterN
 		var istioConfig *models.IstioConfigList
 		var err error
 		if len(strings.Split(namespace, ",")) > 1 {
-			// This means that we are listing all Istio configs for all namespaces
 			istioConfig, err = businessLayer.IstioConfig.GetIstioConfigList(ctx, clusterName, business.ParseIstioConfigCriteria("", "", ""))
 		} else {
-			// This means that we are listing all Istio configs for a specific namespace
 			istioConfig, err = businessLayer.IstioConfig.GetIstioConfigListForNamespace(
 				ctx, clusterName, namespace, business.ParseIstioConfigCriteria("", "", ""))
 		}
@@ -297,7 +303,7 @@ func getIstioAction(ctx context.Context, businessLayer *business.Layer, clusterN
 			return []Action{}, err
 		}
 		istioObjectsFiltered := filterIstioObjectsByName(istioConfig, resourceName)
-		actions = GetActionsForIstioObjects(istioObjectsFiltered)
+		actions = GetActionsForIstioObjects(istioObjectsFiltered, clusterName)
 	} else {
 		actions = append(actions, Action{
 			Title:   "View Istio List of Configs",

--- a/ai/mcp/get_action_ui/get_action_ui_test.go
+++ b/ai/mcp/get_action_ui/get_action_ui_test.go
@@ -141,7 +141,7 @@ func TestExecute(t *testing.T) {
 		resp := res.(GetActionUIResponse)
 		require.Len(t, resp.Actions, 1)
 		assert.Equal(t, "View workload Details", resp.Actions[0].Title)
-		assert.Equal(t, "/namespaces/bookinfo/workloads/details-v1?tab=logs", resp.Actions[0].Payload)
+		assert.Equal(t, "/namespaces/bookinfo/workloads/details-v1?tab=logs&clusterName=east", resp.Actions[0].Payload)
 	})
 
 	t.Run("Istio List Action", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestExecute(t *testing.T) {
 		resp := res.(GetActionUIResponse)
 		require.Len(t, resp.Actions, 1)
 		assert.Equal(t, "View service Details", resp.Actions[0].Title)
-		assert.Equal(t, "/namespaces/bookinfo/services/productpage?tab=metrics", resp.Actions[0].Payload)
+		assert.Equal(t, "/namespaces/bookinfo/services/productpage?tab=metrics&clusterName=east", resp.Actions[0].Payload)
 	})
 
 	t.Run("All Namespaces Action", func(t *testing.T) {
@@ -328,7 +328,7 @@ func TestExecute(t *testing.T) {
 		resp := res.(GetActionUIResponse)
 		require.Len(t, resp.Actions, 1)
 		assert.Equal(t, "View service Details", resp.Actions[0].Title)
-		assert.Equal(t, "/namespaces/bookinfo/services/productpage?tab=info", resp.Actions[0].Payload)
+		assert.Equal(t, "/namespaces/bookinfo/services/productpage?tab=info&clusterName=east", resp.Actions[0].Payload)
 	})
 
 	t.Run("Namespaces Action", func(t *testing.T) {

--- a/ai/mcp/get_action_ui/istio_objects_helper.go
+++ b/ai/mcp/get_action_ui/istio_objects_helper.go
@@ -191,22 +191,24 @@ func FilterByName[T runtime.Object](objects []T, name string) []T {
 
 // GetActionsForIstioObjects gets the actions for the Istio objects
 // It returns a list of actions that can be used to navigate to the Istio object details page.
-func GetActionsForIstioObjects(istioObjectsFiltered []runtime.Object) []Action {
+func GetActionsForIstioObjects(istioObjectsFiltered []runtime.Object, clusterName string) []Action {
 	actions := []Action{}
 	for _, istioObject := range istioObjectsFiltered {
 		o, err := meta.Accessor(istioObject)
-		// This shouldn't happen since we are using runtime.Object for T
-		// and all the API objects should implement meta.Object.
 		if err != nil {
 			continue
 		}
 		gvk := istioObject.GetObjectKind().GroupVersionKind()
 		kind := gvk.Kind
 		apiVersion := gvk.GroupVersion().String()
+		payload := "/namespaces/" + o.GetNamespace() + "/istio/" + apiVersion + "/" + kind + "/" + o.GetName()
+		if clusterName != "" {
+			payload += "?clusterName=" + clusterName
+		}
 		actions = append(actions, Action{
 			Title:   "View Istio " + o.GetName() + " Details",
 			Kind:    ActionKindNavigation,
-			Payload: "/namespaces/" + o.GetNamespace() + "/istio/" + apiVersion + "/" + kind + "/" + o.GetName(),
+			Payload: payload,
 		})
 	}
 

--- a/ai/mcp/list_clusters/list_clusters.go
+++ b/ai/mcp/list_clusters/list_clusters.go
@@ -1,0 +1,29 @@
+package list_clusters
+
+import (
+	"net/http"
+
+	"github.com/kiali/kiali/ai/mcputil"
+)
+
+type ClusterInfo struct {
+	IsHome bool   `json:"isHome"`
+	Name   string `json:"name"`
+}
+
+func Execute(ki *mcputil.KialiInterface, _ map[string]interface{}) (interface{}, int) {
+	clusters := ki.Discovery.Clusters()
+
+	result := make([]ClusterInfo, 0, len(clusters))
+	for _, c := range clusters {
+		if !c.Accessible {
+			continue
+		}
+		result = append(result, ClusterInfo{
+			IsHome: c.IsKialiHome,
+			Name:   c.Name,
+		})
+	}
+
+	return result, http.StatusOK
+}

--- a/ai/mcp/list_clusters/list_clusters_test.go
+++ b/ai/mcp/list_clusters/list_clusters_test.go
@@ -1,0 +1,85 @@
+package list_clusters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kiali/kiali/ai/mcputil"
+	"github.com/kiali/kiali/cache"
+	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/handlers/authentication"
+	"github.com/kiali/kiali/istio"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/kubernetes/kubetest"
+)
+
+func reqWithAuth(req *http.Request, conf *config.Config, token string) *http.Request {
+	authInfo := map[string]*api.AuthInfo{conf.KubernetesConfig.ClusterName: {Token: token}}
+	ctx := authentication.SetAuthInfoContext(req.Context(), authInfo)
+	return req.WithContext(ctx)
+}
+
+func TestExecute_ReturnsClusters(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("default"))
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{
+		conf.KubernetesConfig.ClusterName: k8s,
+	})
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/list_clusters", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+
+	res, code := Execute(&mcputil.KialiInterface{
+		Request:   req,
+		Conf:      conf,
+		Discovery: discovery,
+	}, map[string]interface{}{})
+
+	require.Equal(t, http.StatusOK, code)
+	clusters, ok := res.([]ClusterInfo)
+	require.True(t, ok)
+	require.NotEmpty(t, clusters)
+
+	found := false
+	for _, c := range clusters {
+		if c.Name == "east" {
+			found = true
+			assert.True(t, c.IsHome)
+		}
+	}
+	assert.True(t, found, "expected home cluster 'east' in results")
+}
+
+func TestExecute_ReturnsOKWithEmptyArgs(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "Kubernetes"
+	config.Set(conf)
+
+	k8s := kubetest.NewFakeK8sClient(kubetest.FakeNamespace("default"))
+	saClients := kubernetes.ConvertFromUserClients(map[string]kubernetes.UserClientInterface{
+		conf.KubernetesConfig.ClusterName: k8s,
+	})
+	kialiCache := cache.NewTestingCacheWithClients(t, saClients, *conf)
+	discovery := istio.NewDiscovery(saClients, kialiCache, conf)
+
+	req := httptest.NewRequest(http.MethodPost, "http://kiali/api/chat/mcp/list_clusters", nil)
+	req = reqWithAuth(req, conf, k8s.GetToken())
+
+	_, code := Execute(&mcputil.KialiInterface{
+		Request:   req,
+		Conf:      conf,
+		Discovery: discovery,
+	}, nil)
+
+	assert.Equal(t, http.StatusOK, code)
+}

--- a/ai/mcp/mcp_tools.go
+++ b/ai/mcp/mcp_tools.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kiali/kiali/ai/mcp/get_pod_performance"
 	"github.com/kiali/kiali/ai/mcp/get_referenced_docs"
 	"github.com/kiali/kiali/ai/mcp/get_trace_details"
+	"github.com/kiali/kiali/ai/mcp/list_clusters"
 	"github.com/kiali/kiali/ai/mcp/list_or_get_resources"
 	"github.com/kiali/kiali/ai/mcp/list_traces"
 	"github.com/kiali/kiali/ai/mcp/manage_istio_config"
@@ -178,6 +179,8 @@ func (t ToolDef) Call(kialiInterface *mcputil.KialiInterface, args map[string]in
 		return get_trace_details.Execute(kialiInterface, args)
 	case "get_logs":
 		return get_logs.Execute(kialiInterface, args)
+	case "list_clusters":
+		return list_clusters.Execute(kialiInterface, args)
 	case "get_pod_performance":
 		return get_pod_performance.Execute(kialiInterface, args)
 	case "manage_istio_config":

--- a/ai/mcp/tools/get_action_ui.yaml
+++ b/ai/mcp/tools/get_action_ui.yaml
@@ -5,6 +5,9 @@
     type: "object"
     required: ["resourceType"]
     properties:
+      clusterName:
+        type: "string"
+        description: "Optional cluster name for navigation. Defaults to the cluster name in the Kiali configuration (KubeConfig)."
       namespaces:
         type: "string"
         description: "Comma-separated list of namespaces. Use the 'page_namespaces' context if the user doesn't specify one. If empty, uses all accessible namespaces."

--- a/ai/mcp/tools/list_clusters.yaml
+++ b/ai/mcp/tools/list_clusters.yaml
@@ -1,0 +1,5 @@
+- name: "list_clusters"
+  description: "Returns the list of Kubernetes clusters that Kiali can access in the mesh. Each cluster includes its name and whether it is the home cluster (where Kiali is running). Use this tool to discover available cluster names before calling other tools that accept a clusterName parameter."
+  toolset: [default, mcp]
+  input_schema:
+    type: "object"

--- a/ai/providers/anthropic/anthropic_tools_test.go
+++ b/ai/providers/anthropic/anthropic_tools_test.go
@@ -45,6 +45,10 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetActionUI(t *testing.T) {
 			Description: param.NewOpt("Call this tool WHENEVER the user asks to navigate, view, show, open, or get a visual representation of resources (like graphs, lists, or details). This tool automatically redirects the user's Kiali UI. You do NOT need to analyze the output of this tool; simply call it and acknowledge to the user that you are taking them to the requested view."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				Properties: map[string]interface{}{
+					"clusterName": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional cluster name for navigation. Defaults to the cluster name in the Kiali configuration (KubeConfig).",
+					},
 					"namespaces": map[string]interface{}{
 						"type":        "string",
 						"description": "Comma-separated list of namespaces. Use the 'page_namespaces' context if the user doesn't specify one. If empty, uses all accessible namespaces.",
@@ -189,6 +193,27 @@ func TestConvertToolToAnthropic_FromToolDefinition_GetMeshStatus(t *testing.T) {
 		OfTool: &anthropic.ToolParam{
 			Name:        "get_mesh_status",
 			Description: param.NewOpt("Retrieves the high-level health, topology, and environment details of the Istio service mesh. Returns multi-cluster control plane status (istiod), data plane namespace health (including ambient mesh status), observability stack health (Prometheus, Grafana...), and component connectivity. Use this tool as the first step to diagnose mesh-wide issues, verify Istio/Kiali versions, or check overall health before drilling into specific workloads."),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				ExtraFields: map[string]any{
+					"additionalProperties": false,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, converted)
+}
+
+func TestConvertToolToAnthropic_FromToolDefinition_ListClusters(t *testing.T) {
+	tool, err := mcp.LoadToolDefinition(filepath.Join("..", "..", "mcp", "tools", "list_clusters.yaml"))
+	require.NoError(t, err)
+
+	converted := convertToolToAnthropic(tool)
+
+	expected := anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        "list_clusters",
+			Description: param.NewOpt("Returns the list of Kubernetes clusters that Kiali can access in the mesh. Each cluster includes its name and whether it is the home cluster (where Kiali is running). Use this tool to discover available cluster names before calling other tools that accept a clusterName parameter."),
 			InputSchema: anthropic.ToolInputSchemaParam{
 				ExtraFields: map[string]any{
 					"additionalProperties": false,

--- a/ai/providers/google/google_tools_test.go
+++ b/ai/providers/google/google_tools_test.go
@@ -41,6 +41,10 @@ func TestConvertToolToGoogle_FromToolDefinition_GetActionUI(t *testing.T) {
 	expected := &genai.Schema{
 		Type: genai.TypeObject,
 		Properties: map[string]*genai.Schema{
+			"clusterName": {
+				Type:        genai.TypeString,
+				Description: "Optional cluster name for navigation. Defaults to the cluster name in the Kiali configuration (KubeConfig).",
+			},
 			"namespaces": {
 				Type:        genai.TypeString,
 				Description: "Comma-separated list of namespaces. Use the 'page_namespaces' context if the user doesn't specify one. If empty, uses all accessible namespaces.",
@@ -156,6 +160,19 @@ func TestConvertToolToGoogle_FromToolDefinition_GetLogs(t *testing.T) {
 
 func TestConvertToolToGoogle_FromToolDefinition_GetMeshStatus(t *testing.T) {
 	tool, err := mcp.LoadToolDefinition(filepath.Join("..", "..", "mcp", "tools", "get_mesh_status.yaml"))
+	require.NoError(t, err)
+
+	converted := mapToGenAISchema(tool.GetDefinition())
+
+	expected := &genai.Schema{
+		Type: genai.TypeObject,
+	}
+
+	assert.Equal(t, expected, converted)
+}
+
+func TestConvertToolToGoogle_FromToolDefinition_ListClusters(t *testing.T) {
+	tool, err := mcp.LoadToolDefinition(filepath.Join("..", "..", "mcp", "tools", "list_clusters.yaml"))
 	require.NoError(t, err)
 
 	converted := mapToGenAISchema(tool.GetDefinition())

--- a/ai/providers/openai/openai_tools_test.go
+++ b/ai/providers/openai/openai_tools_test.go
@@ -46,6 +46,10 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetActionUI(t *testing.T) {
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"properties": map[string]interface{}{
+						"clusterName": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional cluster name for navigation. Defaults to the cluster name in the Kiali configuration (KubeConfig).",
+						},
 						"namespaces": map[string]interface{}{
 							"type":        "string",
 							"description": "Comma-separated list of namespaces. Use the 'page_namespaces' context if the user doesn't specify one. If empty, uses all accessible namespaces.",
@@ -204,6 +208,28 @@ func TestConvertToolToOpenAI_FromToolDefinition_GetMeshStatus(t *testing.T) {
 			Function: openai.FunctionDefinitionParam{
 				Name:        "get_mesh_status",
 				Description: openai.String("Retrieves the high-level health, topology, and environment details of the Istio service mesh. Returns multi-cluster control plane status (istiod), data plane namespace health (including ambient mesh status), observability stack health (Prometheus, Grafana...), and component connectivity. Use this tool as the first step to diagnose mesh-wide issues, verify Istio/Kiali versions, or check overall health before drilling into specific workloads."),
+				Parameters: openai.FunctionParameters{
+					"type": "object",
+				},
+			},
+		},
+	}
+
+	require.NotNil(t, converted.OfFunction)
+	assert.Equal(t, expected, converted)
+}
+
+func TestConvertToolToOpenAI_FromToolDefinition_ListClusters(t *testing.T) {
+	tool, err := mcp.LoadToolDefinition(filepath.Join("..", "..", "mcp", "tools", "list_clusters.yaml"))
+	require.NoError(t, err)
+
+	converted := convertToolToOpenAI(tool)
+
+	expected := openai.ChatCompletionToolUnionParam{
+		OfFunction: &openai.ChatCompletionFunctionToolParam{
+			Function: openai.FunctionDefinitionParam{
+				Name:        "list_clusters",
+				Description: openai.String("Returns the list of Kubernetes clusters that Kiali can access in the mesh. Each cluster includes its name and whether it is the home cluster (where Kiali is running). Use this tool to discover available cluster names before calling other tools that accept a clusterName parameter."),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 				},

--- a/ai/types/prompt.go
+++ b/ai/types/prompt.go
@@ -25,6 +25,9 @@ ALWAYS use this context to ground your answers, understand what the user is look
    - NEVER ask the user to confirm in the chat. 
    - Simply tell the user: "I have prepared the configuration in the attachment. You can review and apply it there."
 
+### MULTI-CLUSTER
+When Kiali manages multiple clusters, always include clusterName in tool calls when the user context specifies a cluster or when the user refers to one explicitly. If the cluster name is unknown, call list_clusters first to get the available cluster names, then re-invoke the requested tool.
+
 ### ACTION HANDLING
 You have tools that automatically navigate the user's UI ('get_action_ui') or surface documentation widgets ('get_referenced_docs'). When you call these tools, the system handles the UI updates automatically. Simply answer the user naturally (e.g., "I've pulled up the traffic graph for you" or "Here is the documentation on PeerAuthentication"). Do not wait for or analyze the system response from these UI tools.
 

--- a/frontend/src/components/ChatBot/PageContext.tsx
+++ b/frontend/src/components/ChatBot/PageContext.tsx
@@ -2,7 +2,8 @@ export const buildPageContext = (
   kind: string | undefined,
   name: string | undefined,
   namespace: string | undefined,
-  istio: string | undefined
+  istio: string | undefined,
+  clusterName?: string | undefined
 ): string | undefined => {
   if (!kind) {
     return undefined;
@@ -51,6 +52,10 @@ export const buildPageContext = (
         context += ` of namespace ${namespace}`;
       }
     }
+  }
+
+  if (clusterName) {
+    context += ` in cluster ${clusterName}`;
   }
 
   return context;

--- a/frontend/src/components/ChatBot/Prompt.tsx
+++ b/frontend/src/components/ChatBot/Prompt.tsx
@@ -34,13 +34,11 @@ export const Prompt = React.memo(({ scrollIntoView }: PromptProps) => {
 
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
-  const [kind, name, namespace, istio] = useLocationContext();
-  const pageContext = React.useMemo(() => buildPageContext(kind, name, namespace, istio), [
-    kind,
-    name,
-    namespace,
-    istio
-  ]);
+  const [kind, name, namespace, istio, clusterName] = useLocationContext();
+  const pageContext = React.useMemo(
+    () => buildPageContext(kind, name, namespace, istio, clusterName),
+    [kind, name, namespace, istio, clusterName]
+  );
   const onChange = React.useCallback(
     (_e: React.SyntheticEvent, value: string) => {
       if (value.trim().length > 0) {

--- a/frontend/src/components/ChatBot/__tests__/pageContext.test.ts
+++ b/frontend/src/components/ChatBot/__tests__/pageContext.test.ts
@@ -1,0 +1,92 @@
+import { buildPageContext } from '../PageContext';
+
+describe('buildPageContext', () => {
+  it('returns undefined when kind is not provided', () => {
+    expect(buildPageContext(undefined, undefined, undefined, undefined)).toBeUndefined();
+  });
+
+  describe('list views', () => {
+    it('returns mesh graph context', () => {
+      expect(buildPageContext('mesh', undefined, undefined, undefined)).toBe('User is seeing the mesh Graph');
+    });
+
+    it('returns traffic graph context', () => {
+      expect(buildPageContext('graph', undefined, undefined, undefined)).toBe('User is seeing the Traffic Graph');
+    });
+
+    it.each(['workloads', 'services', 'applications', 'namespaces'])('returns list context for %s', kind => {
+      expect(buildPageContext(kind, undefined, undefined, undefined)).toBe(`User is seeing the List of ${kind}`);
+    });
+
+    it('returns istio objects list context', () => {
+      expect(buildPageContext('istio', undefined, undefined, undefined)).toBe('User is seeing the istio objects list');
+    });
+
+    it('returns generic page context for unknown kind', () => {
+      expect(buildPageContext('overview', undefined, undefined, undefined)).toBe('User is seeing the overview page');
+    });
+
+    it('appends namespace to list view', () => {
+      expect(buildPageContext('workloads', undefined, 'bookinfo', undefined)).toBe(
+        'User is seeing the List of workloads for namespaces: bookinfo'
+      );
+    });
+  });
+
+  describe('detail views', () => {
+    it('returns istio object detail context', () => {
+      expect(buildPageContext('istio', 'my-vs', 'bookinfo', 'virtualservices')).toBe(
+        'User is seeing the istio object my-vs of namespace bookinfo that is type virtualservices'
+      );
+    });
+
+    it('defaults istio type to unknown when not provided', () => {
+      expect(buildPageContext('istio', 'my-vs', 'bookinfo', undefined)).toBe(
+        'User is seeing the istio object my-vs of namespace bookinfo that is type unknown'
+      );
+    });
+
+    it.each([
+      ['app', 'application'],
+      ['applications', 'application'],
+      ['wk', 'workload'],
+      ['workloads', 'workload'],
+      ['srv', 'service'],
+      ['services', 'service']
+    ])('maps kind %s to %s in detail view', (kind, expected) => {
+      expect(buildPageContext(kind, 'reviews', 'bookinfo', undefined)).toBe(
+        `User is seeing the information about ${expected} reviews of namespace bookinfo`
+      );
+    });
+
+    it('does not append namespace for namespace kind', () => {
+      expect(buildPageContext('namespace', 'bookinfo', 'bookinfo', undefined)).toBe(
+        'User is seeing the information about namespace bookinfo'
+      );
+    });
+  });
+
+  describe('cluster context', () => {
+    it('appends cluster to list view', () => {
+      expect(buildPageContext('workloads', undefined, 'bookinfo', undefined, 'east')).toBe(
+        'User is seeing the List of workloads for namespaces: bookinfo in cluster east'
+      );
+    });
+
+    it('appends cluster to detail view', () => {
+      expect(buildPageContext('app', 'reviews', 'bookinfo', undefined, 'west')).toBe(
+        'User is seeing the information about application reviews of namespace bookinfo in cluster west'
+      );
+    });
+
+    it('does not append cluster when undefined', () => {
+      const result = buildPageContext('workloads', undefined, undefined, undefined, undefined);
+      expect(result).not.toContain('in cluster');
+    });
+
+    it('does not append cluster when empty string', () => {
+      const result = buildPageContext('workloads', undefined, undefined, undefined, '');
+      expect(result).not.toContain('in cluster');
+    });
+  });
+});

--- a/frontend/src/components/ChatBot/hooks/useLocationContext.ts
+++ b/frontend/src/components/ChatBot/hooks/useLocationContext.ts
@@ -5,12 +5,14 @@ export const useLocationContext = (): [
   string | undefined,
   string | undefined,
   string | undefined,
+  string | undefined,
   string | undefined
 ] => {
   const [kind, setKind] = React.useState<string>();
   const [name, setName] = React.useState<string>();
   const [namespace, setNamespace] = React.useState<string>();
   const [istio, setIstio] = React.useState<string>();
+  const [clusterName, setClusterName] = React.useState<string>();
 
   const location = useLocation();
   const path = location?.pathname;
@@ -22,6 +24,7 @@ export const useLocationContext = (): [
     let newIstio = '';
 
     const searchParams = new URLSearchParams(location.search);
+    const newClusterName = searchParams.get('clusterName') || '';
     const nsParams = searchParams.getAll('namespace');
     const nssParams = searchParams.getAll('namespaces');
 
@@ -88,7 +91,8 @@ export const useLocationContext = (): [
     setName(newName || undefined);
     setNamespace(newNamespace || undefined);
     setIstio(newIstio || undefined);
+    setClusterName(newClusterName || undefined);
   }, [location.search, path]);
 
-  return [kind, name, namespace, istio];
+  return [kind, name, namespace, istio, clusterName];
 };

--- a/tests/integration/mcp_tools/list_clusters_test.go
+++ b/tests/integration/mcp_tools/list_clusters_test.go
@@ -1,0 +1,47 @@
+package mcp_tools
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListClusters_ReturnsOK(t *testing.T) {
+	resp, err := CallMCPToolEmptyBody("list_clusters")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestListClusters_ReturnsAtLeastOneCluster(t *testing.T) {
+	resp, err := CallMCPToolEmptyBody("list_clusters")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var clusters []map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &clusters))
+	require.NotEmpty(t, clusters, "expected at least one cluster")
+}
+
+func TestListClusters_HomeClusterPresent(t *testing.T) {
+	resp, err := CallMCPToolEmptyBody("list_clusters")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var clusters []map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &clusters))
+
+	hasHome := false
+	for _, c := range clusters {
+		name, hasName := c["name"]
+		assert.True(t, hasName, "cluster entry should have a 'name' field")
+		assert.NotEmpty(t, name)
+
+		if isHome, ok := c["isHome"].(bool); ok && isHome {
+			hasHome = true
+		}
+	}
+	assert.True(t, hasHome, "expected at least one cluster marked as home")
+}


### PR DESCRIPTION
Backport of #9927. Conflict in Prompt.tsx resolved without pulling master-only prompt category / MessageBar sync code.

(cherry picked from commit d8816a612547f106670de1d89de9c9dc1e599a10)

### Describe the change
This is needed for the MCP TP

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
