### PR TITLE
[v2.22] Remove duplicate plugins in volume/mount

### DIFF
--- a/hack/istio/perses/values.yaml
+++ b/hack/istio/perses/values.yaml
@@ -5,8 +5,6 @@ config:
   provisioning:
     interval: 1m
 volumes:
-- name: plugins
-  emptyDir: {}
 - name: provisioning
   projected:
     sources:
@@ -17,8 +15,6 @@ volumes:
     - configMap:
         name: perses-provisioning
 volumeMounts:
-- name: plugins
-  mountPath: /etc/perses/plugins
 - name: provisioning
   mountPath: /etc/perses/provisioning
   readOnly: true

--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -375,6 +375,7 @@ setup_kind_singlecluster() {
     kubectl apply -f "${SCRIPT_DIR}"/istio/perses/dashboard.yaml
 
     ${HELM} repo add perses https://perses.github.io/helm-charts
+    # Chart 0.23+ mounts /etc/perses/plugins itself; do not re-add that volume in values.yaml.
     ${HELM} install perses perses/perses -n istio-system -f "${SCRIPT_DIR}"/istio/perses/values.yaml
 
           PERSES_ARGS=(


### PR DESCRIPTION
## Summary
- Backport of #10157 to `v2.22`
- Fixes Perses Helm install failure caused by duplicate `plugins` volume/mount when using chart 0.23+
- Fixes #10158

## Test plan
- [ ] CI with Perses install (`--install-perses true` / jobs that deploy Perses) succeeds
- [ ] Confirm `hack/istio/perses/values.yaml` no longer defines the `plugins` volume/mount


Made with [Cursor](https://cursor.com)