### PR TITLE
[v2.22][OSSMC] Avoid PatternFly ToolbarFilter firstElementChild crash

### DIFF
--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -78,6 +78,7 @@
   "Circuit Breaker": "Interruptor de circuito",
   "Clear": "Limpiar",
   "Clear all": "Clear all",
+  "Clear all filters": "Clear all filters",
   "Clear message": "Clear message",
   "Click + Drag": "Clic + Arrastrar",
   "click here.": "haz clic aquí.",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -66,6 +66,7 @@
   "Circuit Breaker": "熔断",
   "Clear": "清除",
   "Clear all": "Clear all",
+  "Clear all filters": "Clear all filters",
   "Clear message": "Clear message",
   "Click + Drag": "Click + Drag",
   "click here.": "click here.",

--- a/frontend/src/components/Filters/StatefulFilters.tsx
+++ b/frontend/src/components/Filters/StatefulFilters.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import {
+  Button,
   Checkbox,
+  Label,
+  LabelGroup,
   TextInput,
   TextInputTypes,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
   ToolbarContent,
-  ToolbarFilter,
   Select,
   SelectList,
   SelectOption,
@@ -46,7 +48,7 @@ import { classes } from 'typestyle';
 
 const toolbarStyle = kialiStyle({
   padding: 0,
-  rowGap: "var(--pf-t--global--spacer--md)",
+  rowGap: 'var(--pf-t--global--spacer--md)',
   $nest: {
     '& > .pf-v6-c-toolbar__content': {
       paddingLeft: 0
@@ -55,7 +57,7 @@ const toolbarStyle = kialiStyle({
 });
 
 const bottomPadding = kialiStyle({
-  paddingBottom: "var(--pf-t--global--spacer--md)"
+  paddingBottom: 'var(--pf-t--global--spacer--md)'
 });
 
 const formSelectStyle = kialiStyle({
@@ -635,49 +637,34 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
         <Toolbar
           id="filter-selection"
           className={this.props.toolbarClass ? classes(toolbarStyle, this.props.toolbarClass) : toolbarStyle}
-          clearAllFilters={this.clearFilters}
         >
           {this.props.childrenFirst && this.renderChildren()}
           <ToolbarContent>
             <ToolbarGroup variant="filter-group">
-              {this.state.filterTypes.map((ft, i) => (
-                <ToolbarFilter
-                  key={`toolbar_filter-${ft.category}`}
-                  labels={activeFilters.filters
-                    .filter(af => af.category === ft.category)
-                    .map(af => ({
-                      key: af.value,
-                      node: t(af.value)
-                    }))}
-                  deleteLabel={this.removeFilter}
-                  categoryName={{ key: ft.category, name: t(ft.category) }}
+              <ToolbarItem>
+                <Select
+                  id="filter_select_type"
+                  onSelect={(_event, value) => this.selectFilterType(value as string)}
+                  onOpenChange={isFilterTypeOpen => this.setState({ isFilterTypeOpen })}
+                  toggle={filterTypeToggle}
+                  isOpen={this.state.isFilterTypeOpen}
+                  aria-label="Filter Select Type"
                 >
-                  {i === 0 && (
-                    <Select
-                      id="filter_select_type"
-                      onSelect={(_event, value) => this.selectFilterType(value as string)}
-                      onOpenChange={isFilterTypeOpen => this.setState({ isFilterTypeOpen })}
-                      toggle={filterTypeToggle}
-                      isOpen={this.state.isFilterTypeOpen}
-                      aria-label="Filter Select Type"
-                    >
-                      <SelectList>
-                        {this.state.filterTypes.map(option => (
-                          <SelectOption
-                            id={option.category}
-                            key={option.category}
-                            value={option.category}
-                            isSelected={option.category === currentFilterType.category}
-                          >
-                            {t(option.category)}
-                          </SelectOption>
-                        ))}
-                      </SelectList>
-                    </Select>
-                  )}
-                  {i === 0 && this.renderInput()}
-                </ToolbarFilter>
-              ))}
+                  <SelectList>
+                    {this.state.filterTypes.map(option => (
+                      <SelectOption
+                        id={option.category}
+                        key={option.category}
+                        value={option.category}
+                        isSelected={option.category === currentFilterType.category}
+                      >
+                        {t(option.category)}
+                      </SelectOption>
+                    ))}
+                  </SelectList>
+                </Select>
+              </ToolbarItem>
+              <ToolbarItem>{this.renderInput()}</ToolbarItem>
             </ToolbarGroup>
 
             <ToolbarGroup>
@@ -696,8 +683,6 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
                   </ToolbarItem>
                 ))}
             </ToolbarGroup>
-
-            {!this.props.childrenFirst && this.renderChildren()}
 
             {hasActiveFilters && (
               <ToolbarGroup>
@@ -739,7 +724,46 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
                 </ToolbarItem>
               </ToolbarGroup>
             )}
+
+            {!this.props.childrenFirst && this.renderChildren()}
           </ToolbarContent>
+
+          {activeFilters.filters.length > 0 && (
+            <ToolbarContent>
+              <ToolbarGroup>
+                <ToolbarItem>
+                  {this.state.filterTypes.map(ft => {
+                    const filtersForCategory = activeFilters.filters.filter(af => af.category === ft.category);
+                    if (filtersForCategory.length === 0) {
+                      return null;
+                    }
+                    return (
+                      <LabelGroup
+                        key={ft.category}
+                        categoryName={t(ft.category)}
+                        style={{ marginRight: 'var(--pf-t--global--spacer--md)' }}
+                      >
+                        {filtersForCategory.map(af => (
+                          <Label
+                            key={af.value}
+                            onClose={() => this.removeFilter(ft.category, af.value)}
+                            closeBtnProps={{ 'aria-label': `Close ${af.value}` }}
+                          >
+                            {t(af.value)}
+                          </Label>
+                        ))}
+                      </LabelGroup>
+                    );
+                  })}
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button variant="link" onClick={this.clearFilters}>
+                    {t('Clear all filters')}
+                  </Button>
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarContent>
+          )}
         </Toolbar>
         <div className={bottomPadding} />
       </>


### PR DESCRIPTION
### Describe the change

On PatternFly 6.4, `ToolbarFilter` chip/`labels` rendering can throw (Reproduced in OSSMC):
`Cannot read properties of null (reading 'firstElementChild')`

This was seen on first access to Overview (and other pages using `StatefulFilters`) in OSSM 3.3 / Kiali v2.22.

Stop using `ToolbarFilter` for active filter chips and render them with `LabelGroup`/`Label` instead (same approach already present on newer branches after the PF6 migration).

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes https://redhat.atlassian.net/browse/OSSM-15237 
