### PR TITLE
[CI] Increase timeout for tracing in Ambient frontend-multi-primary 

### DIFF
--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -433,7 +433,7 @@ const waitForWaypointTracesInApi = (
   namespace: string,
   workload: string,
   clusterName?: string,
-  maxRetries = 10,
+  maxRetries = 30,
   retryCount = 0
 ): void => {
   if (retryCount >= maxRetries) {


### PR DESCRIPTION
### Describe the change

Tested locally and works as expected, so probably is another timing issue (Time out waiting for traces to be populated)
<img width="1904" height="796" alt="image" src="https://github.com/user-attachments/assets/aa21da29-d285-4805-b534-9d3af23a0a8e" />


### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

Fixes #10175 
