### PR TITLE
Fix workload annotations value editor Save/Cancel visibility

### DIFF
--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -15,6 +15,7 @@ import {
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { KialiIcon } from 'config/KialiIcon';
+import { PFSpacer } from 'styles/PfSpacer';
 import { kialiStyle } from 'styles/StyleUtils';
 import { t } from 'utils/I18nUtils';
 
@@ -65,7 +66,7 @@ const popoverTextAreaStyle = kialiStyle({
 
 const popoverFooterStyle = kialiStyle({
   display: 'flex',
-  gap: '0.25rem',
+  gap: PFSpacer.xs,
   justifyContent: 'flex-end'
 });
 
@@ -128,6 +129,10 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({
     onVisibleChange?.(visible);
   };
 
+  const valueAriaLabel = entryKey
+    ? t('Annotation value for {{key}}', { key: entryKey })
+    : t('Value');
+
   return (
     <Popover
       appendTo={() =>
@@ -136,7 +141,14 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({
       }
       headerContent={entryKey || t('Value')}
       bodyContent={
-        <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
+        <TextArea
+          aria-label={valueAriaLabel}
+          className={popoverTextAreaStyle}
+          data-test="annotation-value-input"
+          id={id}
+          onChange={(_event, v) => setDraft(v)}
+          value={draft}
+        />
       }
       footerContent={
         <div className={popoverFooterStyle}>

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -65,15 +65,28 @@ const popoverTextAreaStyle = kialiStyle({
   width: '100%'
 });
 
+const annotationValuePopoverStyle = kialiStyle({
+  $nest: {
+    '.pf-v6-c-popover__title': {
+      width: '100%'
+    },
+    '.pf-v6-c-popover__title-text': {
+      display: 'block',
+      width: '100%'
+    }
+  }
+});
+
 const popoverHeaderStyle = kialiStyle({
   alignItems: 'center',
   display: 'flex',
   gap: PFSpacer.md,
-  justifyContent: 'space-between',
   width: '100%'
 });
 
 const popoverHeaderTitleStyle = kialiStyle({
+  flex: '1 1 auto',
+  minWidth: 0,
   overflowWrap: 'anywhere',
   wordBreak: 'break-word'
 });
@@ -81,7 +94,8 @@ const popoverHeaderTitleStyle = kialiStyle({
 const popoverHeaderActionsStyle = kialiStyle({
   display: 'flex',
   flexShrink: 0,
-  gap: PFSpacer.xs
+  gap: PFSpacer.xs,
+  marginLeft: 'auto'
 });
 
 const toEntries = (record: Record<string, string>): Entry[] => {
@@ -182,6 +196,7 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({
 
   return (
     <Popover
+      className={annotationValuePopoverStyle}
       appendTo={() =>
         (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
         document.body

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -58,16 +58,9 @@ const valueDisplayStyle = kialiStyle({
 const popoverTextAreaStyle = kialiStyle({
   fontFamily: 'var(--pf-t--global--font--family--mono)',
   fontSize: 'var(--pf-t--global--font--size--sm)',
-  // Keep the editor short enough to fit when opened from the first annotation row.
-  maxHeight: '30vh',
-  minHeight: '8rem',
+  minHeight: '20rem',
   width: '100%',
   resize: 'vertical'
-});
-
-const popoverHeaderStyle = kialiStyle({
-  overflowWrap: 'anywhere',
-  wordBreak: 'break-word'
 });
 
 const popoverFooterStyle = kialiStyle({
@@ -110,6 +103,8 @@ const disabledEditorStyle = kialiStyle({
 });
 
 interface EditValuePopoverProps {
+  // First Controller Annotations row sits near the modal top; left-start keeps the Value header on-screen.
+  alignStart?: boolean;
   entryKey: string;
   id: string;
   onChange: (value: string) => void;
@@ -117,7 +112,14 @@ interface EditValuePopoverProps {
   value: string;
 }
 
-const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, onVisibleChange, value }) => {
+const EditValuePopover: React.FC<EditValuePopoverProps> = ({
+  alignStart = false,
+  entryKey,
+  id,
+  onChange,
+  onVisibleChange,
+  value
+}) => {
   const [draft, setDraft] = React.useState(value);
   const [isVisible, setIsVisible] = React.useState(false);
 
@@ -128,9 +130,11 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
 
   return (
     <Popover
-      // Append to body so the value editor is not clipped by Modal overflow.
-      appendTo={() => document.body}
-      headerContent={<div className={popoverHeaderStyle}>{entryKey || t('Value')}</div>}
+      appendTo={() =>
+        (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
+        document.body
+      }
+      headerContent={entryKey || t('Value')}
       bodyContent={
         <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
       }
@@ -165,10 +169,7 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
         </div>
       }
       elementToFocus={`#${id}`}
-      enableFlip
-      // Prefer top-aligned left placement so the first-row editor is not cut off above the modal.
-      // Flip to left-end near the bottom of the viewport.
-      flipBehavior={['left-start', 'left-end', 'right-start', 'right-end', 'bottom', 'top']}
+      enableFlip={!alignStart}
       hideOnOutsideClick={false}
       isVisible={isVisible}
       shouldOpen={() => {
@@ -179,11 +180,10 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
         setDraft(value);
         setVisible(false);
       }}
-      minWidth="30rem"
-      position="left-start"
+      minWidth="40rem"
+      position={alignStart ? 'left-start' : 'left'}
       showClose={false}
       withFocusTrap
-      zIndex={10000}
     >
       <Button
         aria-label={t('Edit value')}
@@ -251,6 +251,7 @@ const AnnotationSection: React.FC<SectionProps> = ({
               </Th>
               <Th>
                 <EditValuePopover
+                  alignStart={sectionId === 'controller' && index === 0}
                   entryKey={key}
                   id={`${sectionId}_popover_value_${index}`}
                   onChange={v => onChange(index, [key, v])}

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -59,15 +59,29 @@ const valueDisplayStyle = kialiStyle({
 const popoverTextAreaStyle = kialiStyle({
   fontFamily: 'var(--pf-t--global--font--family--mono)',
   fontSize: 'var(--pf-t--global--font--size--sm)',
-  minHeight: '20rem',
-  width: '100%',
-  resize: 'vertical'
+  maxHeight: '20rem',
+  overflowY: 'auto',
+  resize: 'none',
+  width: '100%'
 });
 
-const popoverFooterStyle = kialiStyle({
+const popoverHeaderStyle = kialiStyle({
+  alignItems: 'center',
   display: 'flex',
-  gap: PFSpacer.xs,
-  justifyContent: 'flex-end'
+  gap: PFSpacer.md,
+  justifyContent: 'space-between',
+  width: '100%'
+});
+
+const popoverHeaderTitleStyle = kialiStyle({
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word'
+});
+
+const popoverHeaderActionsStyle = kialiStyle({
+  display: 'flex',
+  flexShrink: 0,
+  gap: PFSpacer.xs
 });
 
 const toEntries = (record: Record<string, string>): Entry[] => {
@@ -133,13 +147,51 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({
     ? t('Annotation value for {{key}}', { key: entryKey })
     : t('Value');
 
+  const title = entryKey || t('Value');
+
+  const headerActions = (
+    <div className={popoverHeaderActionsStyle}>
+      <Tooltip content={t('Save')} trigger="mouseenter">
+        <Button
+          aria-label={t('Save')}
+          data-test="annotation-value-save"
+          variant="plain"
+          size="sm"
+          icon={<KialiIcon.Check />}
+          onClick={() => {
+            onChange(draft);
+            setVisible(false);
+          }}
+        />
+      </Tooltip>
+      <Tooltip content={t('Cancel')} trigger="mouseenter">
+        <Button
+          aria-label={t('Cancel')}
+          data-test="annotation-value-cancel"
+          variant="plain"
+          size="sm"
+          icon={<KialiIcon.Close />}
+          onClick={() => {
+            setDraft(value);
+            setVisible(false);
+          }}
+        />
+      </Tooltip>
+    </div>
+  );
+
   return (
     <Popover
       appendTo={() =>
         (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
         document.body
       }
-      headerContent={entryKey || t('Value')}
+      headerContent={
+        <div className={popoverHeaderStyle}>
+          <span className={popoverHeaderTitleStyle}>{title}</span>
+          {headerActions}
+        </div>
+      }
       bodyContent={
         <TextArea
           aria-label={valueAriaLabel}
@@ -147,38 +199,9 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({
           data-test="annotation-value-input"
           id={id}
           onChange={(_event, v) => setDraft(v)}
+          rows={10}
           value={draft}
         />
-      }
-      footerContent={
-        <div className={popoverFooterStyle}>
-          <Tooltip content={t('Save')} trigger="mouseenter">
-            <Button
-              aria-label={t('Save')}
-              data-test="annotation-value-save"
-              variant="plain"
-              size="sm"
-              icon={<KialiIcon.Check />}
-              onClick={() => {
-                onChange(draft);
-                setVisible(false);
-              }}
-            />
-          </Tooltip>
-          <Tooltip content={t('Cancel')} trigger="mouseenter">
-            <Button
-              aria-label={t('Cancel')}
-              data-test="annotation-value-cancel"
-              variant="plain"
-              size="sm"
-              icon={<KialiIcon.Close />}
-              onClick={() => {
-                setDraft(value);
-                setVisible(false);
-              }}
-            />
-          </Tooltip>
-        </div>
       }
       elementToFocus={`#${id}`}
       enableFlip={!alignStart}

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -15,7 +15,6 @@ import {
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { KialiIcon } from 'config/KialiIcon';
-import { PFSpacer } from 'styles/PfSpacer';
 import { kialiStyle } from 'styles/StyleUtils';
 import { t } from 'utils/I18nUtils';
 
@@ -64,6 +63,12 @@ const popoverTextAreaStyle = kialiStyle({
   resize: 'vertical'
 });
 
+const popoverFooterStyle = kialiStyle({
+  display: 'flex',
+  gap: '0.25rem',
+  justifyContent: 'flex-end'
+});
+
 const toEntries = (record: Record<string, string>): Entry[] => {
   const entries = Object.entries(record);
   return entries.length > 0 ? entries : [['', '']];
@@ -105,14 +110,6 @@ interface EditValuePopoverProps {
   value: string;
 }
 
-const popoverActionsStyle = kialiStyle({
-  display: 'flex',
-  gap: '0.25rem',
-  position: 'absolute',
-  top: PFSpacer.sm,
-  right: PFSpacer.md
-});
-
 const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onChange, onVisibleChange, value }) => {
   const [draft, setDraft] = React.useState(value);
   const [isVisible, setIsVisible] = React.useState(false);
@@ -130,33 +127,37 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
       }
       headerContent={entryKey || t('Value')}
       bodyContent={
-        <>
-          <div className={popoverActionsStyle}>
-            <Tooltip content={t('Save')} trigger="mouseenter">
-              <Button
-                variant="plain"
-                size="sm"
-                icon={<KialiIcon.Check />}
-                onClick={() => {
-                  onChange(draft);
-                  setVisible(false);
-                }}
-              />
-            </Tooltip>
-            <Tooltip content={t('Cancel')} trigger="mouseenter">
-              <Button
-                variant="plain"
-                size="sm"
-                icon={<KialiIcon.Close />}
-                onClick={() => {
-                  setDraft(value);
-                  setVisible(false);
-                }}
-              />
-            </Tooltip>
-          </div>
-          <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
-        </>
+        <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
+      }
+      footerContent={
+        <div className={popoverFooterStyle}>
+          <Tooltip content={t('Save')} trigger="mouseenter">
+            <Button
+              aria-label={t('Save')}
+              data-test="annotation-value-save"
+              variant="plain"
+              size="sm"
+              icon={<KialiIcon.Check />}
+              onClick={() => {
+                onChange(draft);
+                setVisible(false);
+              }}
+            />
+          </Tooltip>
+          <Tooltip content={t('Cancel')} trigger="mouseenter">
+            <Button
+              aria-label={t('Cancel')}
+              data-test="annotation-value-cancel"
+              variant="plain"
+              size="sm"
+              icon={<KialiIcon.Close />}
+              onClick={() => {
+                setDraft(value);
+                setVisible(false);
+              }}
+            />
+          </Tooltip>
+        </div>
       }
       elementToFocus={`#${id}`}
       hideOnOutsideClick={false}
@@ -174,7 +175,13 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
       showClose={false}
       withFocusTrap
     >
-      <Button variant="plain" icon={<KialiIcon.PencilAlt />} size="sm" />
+      <Button
+        aria-label={t('Edit value')}
+        data-test="annotation-value-edit"
+        variant="plain"
+        icon={<KialiIcon.PencilAlt />}
+        size="sm"
+      />
     </Popover>
   );
 };

--- a/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
+++ b/frontend/src/components/IstioWizards/WorkloadAnnotationsWizard.tsx
@@ -58,9 +58,16 @@ const valueDisplayStyle = kialiStyle({
 const popoverTextAreaStyle = kialiStyle({
   fontFamily: 'var(--pf-t--global--font--family--mono)',
   fontSize: 'var(--pf-t--global--font--size--sm)',
-  minHeight: '20rem',
+  // Keep the editor short enough to fit when opened from the first annotation row.
+  maxHeight: '30vh',
+  minHeight: '8rem',
   width: '100%',
   resize: 'vertical'
+});
+
+const popoverHeaderStyle = kialiStyle({
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word'
 });
 
 const popoverFooterStyle = kialiStyle({
@@ -121,11 +128,9 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
 
   return (
     <Popover
-      appendTo={() =>
-        (document.querySelector('[aria-labelledby="workload-annotations-wizard-title"]') as HTMLElement) ||
-        document.body
-      }
-      headerContent={entryKey || t('Value')}
+      // Append to body so the value editor is not clipped by Modal overflow.
+      appendTo={() => document.body}
+      headerContent={<div className={popoverHeaderStyle}>{entryKey || t('Value')}</div>}
       bodyContent={
         <TextArea className={popoverTextAreaStyle} id={id} onChange={(_event, v) => setDraft(v)} value={draft} />
       }
@@ -160,6 +165,10 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
         </div>
       }
       elementToFocus={`#${id}`}
+      enableFlip
+      // Prefer top-aligned left placement so the first-row editor is not cut off above the modal.
+      // Flip to left-end near the bottom of the viewport.
+      flipBehavior={['left-start', 'left-end', 'right-start', 'right-end', 'bottom', 'top']}
       hideOnOutsideClick={false}
       isVisible={isVisible}
       shouldOpen={() => {
@@ -170,10 +179,11 @@ const EditValuePopover: React.FC<EditValuePopoverProps> = ({ entryKey, id, onCha
         setDraft(value);
         setVisible(false);
       }}
-      minWidth="40rem"
-      position="left"
+      minWidth="30rem"
+      position="left-start"
       showClose={false}
       withFocusTrap
+      zIndex={10000}
     >
       <Button
         aria-label={t('Edit value')}

--- a/frontend/src/components/IstioWizards/__tests__/WorkloadAnnotationsWizard.test.tsx
+++ b/frontend/src/components/IstioWizards/__tests__/WorkloadAnnotationsWizard.test.tsx
@@ -102,4 +102,24 @@ describe('WorkloadAnnotationsWizard', () => {
     expect(screen.getByText('Close')).toBeInTheDocument();
     expect(screen.queryByTestId('save-button')).not.toBeInTheDocument();
   });
+
+  it('shows Save and Cancel when editing an annotation value', () => {
+    render(<WorkloadAnnotationsWizard {...defaultProps} />);
+    fireEvent.click(screen.getAllByTestId('annotation-value-edit')[0]);
+    expect(screen.getByTestId('annotation-value-save')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-value-cancel')).toBeInTheDocument();
+  });
+
+  it('saves edited annotation value from the popover', () => {
+    render(<WorkloadAnnotationsWizard {...defaultProps} />);
+    fireEvent.click(screen.getAllByTestId('annotation-value-edit')[0]);
+    const textArea = screen.getByDisplayValue('1');
+    fireEvent.change(textArea, { target: { value: '2' } });
+    fireEvent.click(screen.getByTestId('annotation-value-save'));
+    fireEvent.click(screen.getByTestId('save-button'));
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      { 'deployment.kubernetes.io/revision': '2' },
+      { 'proxy.istio.io/config': 'tracing: {}' }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Move Save/Cancel actions in `WorkloadAnnotationsWizard` value popover from an absolutely positioned overlay into PatternFly `footerContent`, so the `TextArea` no longer covers them.
- Add unit tests covering popover open and save behavior.

Fixes #10182

## Test plan
- [x] Open a workload Overview (e.g. bookinfo / details-v1)
- [x] Open the Annotations editor
- [x] Click the pencil on a controller or pod-template annotation value
- [x] Confirm Save (check) and Cancel (close) are visible below the textarea
- [x] Edit a value, Save in the popover, then Save the wizard and confirm the value persisted
- [x] `yarn test src/components/IstioWizards/__tests__/WorkloadAnnotationsWizard.test.tsx`


Made with [Cursor](https://cursor.com)