### PR TITLE
Fix P0 Istio validation false positives (AuthZ, mTLS, appProtocol, GWAPI)

### DIFF
--- a/business/checkers/authorization/namespace_method_checker.go
+++ b/business/checkers/authorization/namespace_method_checker.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	api_security_v1 "istio.io/api/security/v1"
@@ -11,8 +10,6 @@ import (
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/util/httputil"
 )
-
-var methodMatcher = regexp.MustCompile(`^((\/[a-zA-Z\.]+)+)(\/[a-zA-Z]+)$`)
 
 type NamespaceMethodChecker struct {
 	AuthorizationPolicy *security_v1.AuthorizationPolicy
@@ -106,21 +103,46 @@ func (ap NamespaceMethodChecker) validateToField(ruleIdx int, to []*api_security
 
 func validMethod(m string) bool {
 	method := strings.TrimSpace(m)
+	if method == "" {
+		return false
+	}
 
-	// Istio AuthorizationPolicy string fields support presence match ("*"):
+	// Istio AuthorizationPolicy string fields support Exact / Prefix / Suffix / Presence:
 	// https://istio.io/latest/docs/reference/config/security/authorization-policy/
+	// Presence match: "*" matches when the HTTP method header is not empty.
 	if method == "*" {
 		return true
 	}
 
-	if methodMatcher.MatchString(method) {
-		return true
+	// Prefix match: "GET*" ; Suffix match: "*ET" (wildcard only at start or end, not both).
+	prefixMatch := strings.HasSuffix(method, "*") && !strings.HasPrefix(method, "*")
+	suffixMatch := strings.HasPrefix(method, "*") && !strings.HasSuffix(method, "*")
+
+	var pattern string
+	switch {
+	case prefixMatch:
+		pattern = strings.ToUpper(strings.TrimSuffix(method, "*"))
+	case suffixMatch:
+		pattern = strings.ToUpper(strings.TrimPrefix(method, "*"))
+	default:
+		pattern = strings.ToUpper(method)
 	}
 
-	upper := strings.ToUpper(method)
+	// methods is the HTTP method (for gRPC this is always POST). gRPC FQNs belong in paths.
 	for _, httpMethod := range httputil.HttpMethods() {
-		if upper == httpMethod {
-			return true
+		switch {
+		case prefixMatch:
+			if pattern != "" && strings.HasPrefix(httpMethod, pattern) {
+				return true
+			}
+		case suffixMatch:
+			if pattern != "" && strings.HasSuffix(httpMethod, pattern) {
+				return true
+			}
+		default:
+			if httpMethod == pattern {
+				return true
+			}
 		}
 	}
 

--- a/business/checkers/authorization/namespace_method_checker_test.go
+++ b/business/checkers/authorization/namespace_method_checker_test.go
@@ -47,10 +47,11 @@ func TestSourceNamespaceNotFound(t *testing.T) {
 func TestToMethodWrongHTTP(t *testing.T) {
 	assert := assert.New(t)
 
+	// gRPC FQNs belong in paths, not methods — they must be flagged here.
 	vals, valid := NamespaceMethodChecker{
 		AuthorizationPolicy: toMethodsAuthPolicy([]string{
-			"GET", "/grpc.package/method", "/grpc.package/subpackage/subpackage/method",
-			"GOT", "WRONG", "/grpc.pkg/hello.method", "grpc.pkg/noinitialslash",
+			"GET", "POST",
+			"GOT", "WRONG", "/grpc.package/method", "grpc.pkg/noinitialslash",
 		}),
 		Namespaces: []string{"bookinfo"},
 	}.Check()
@@ -58,7 +59,7 @@ func TestToMethodWrongHTTP(t *testing.T) {
 	assert.True(valid)
 	assert.NotEmpty(vals)
 	assert.Len(vals, 4)
-	for i, m := range []int{3, 4, 5, 6} {
+	for i, m := range []int{2, 3, 4, 5} {
 		assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", vals[i]))
 		assert.Equal(vals[i].Severity, models.WarningSeverity)
 		assert.Equal(vals[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))
@@ -77,17 +78,29 @@ func TestToMethodWildcardPresenceMatch(t *testing.T) {
 	assert.Empty(vals)
 }
 
-func TestToMethodWildcardWithInvalidStillFlags(t *testing.T) {
+func TestToMethodWildcardPrefixAndSuffix(t *testing.T) {
 	assert := assert.New(t)
 
 	vals, valid := NamespaceMethodChecker{
-		AuthorizationPolicy: toMethodsAuthPolicy([]string{"*", "GOT", "WRONG"}),
+		AuthorizationPolicy: toMethodsAuthPolicy([]string{"GET*", "G*", "*ET", "*POST"}),
 		Namespaces:          []string{"bookinfo"},
 	}.Check()
 
 	assert.True(valid)
-	assert.Len(vals, 2)
-	for i, m := range []int{1, 2} {
+	assert.Empty(vals)
+}
+
+func TestToMethodWildcardWithInvalidStillFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	vals, valid := NamespaceMethodChecker{
+		AuthorizationPolicy: toMethodsAuthPolicy([]string{"*", "GOT", "WRONG", "GOT*", "*WRONG", "*BAD*"}),
+		Namespaces:          []string{"bookinfo"},
+	}.Check()
+
+	assert.True(valid)
+	assert.Len(vals, 5)
+	for i, m := range []int{1, 2, 3, 4, 5} {
 		assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.to.wrongmethod", vals[i]))
 		assert.Equal(vals[i].Severity, models.WarningSeverity)
 		assert.Equal(vals[i].Path, fmt.Sprintf("spec/rules[0]/to[0]/operation/methods[%d]", m))

--- a/business/checkers/authorization/no_host_checker.go
+++ b/business/checkers/authorization/no_host_checker.go
@@ -2,6 +2,8 @@ package authorization
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	api_security_v1 "istio.io/api/security/v1"
 	networking_v1 "istio.io/client-go/pkg/apis/networking/v1"
@@ -68,6 +70,12 @@ func (n NoHostChecker) validateHost(ruleIdx int, to []*api_security_v1.Rule_To) 
 		}
 
 		for hostIdx, h := range t.Operation.Hosts {
+			// Istio matches operation.hosts against the HTTP Host/Authority header
+			// (Exact/Prefix/Suffix/Presence), not the service registry. Skip registry
+			// checks for wildcards and external DNS Host headers.
+			if isHTTPHostHeaderMatcher(h, namespace, n.Namespaces) {
+				continue
+			}
 			fqdn := kubernetes.GetHost(h, namespace, n.Namespaces, n.IdentityDomain)
 			if !n.hasMatchingService(fqdn, namespace) {
 				path := fmt.Sprintf("spec/rules[%d]/to[%d]/operation/hosts[%d]", ruleIdx, toIdx, hostIdx)
@@ -108,5 +116,31 @@ func (n NoHostChecker) hasMatchingService(host kubernetes.Host, itemNamespace st
 		return true
 	}
 
+	return false
+}
+
+// isHTTPHostHeaderMatcher reports whether host is an Istio AuthZ Host-header matcher that
+// should not be validated against the service registry.
+func isHTTPHostHeaderMatcher(host, policyNamespace string, clusterNamespaces []string) bool {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		return false
+	}
+	if h == "*" {
+		return true
+	}
+	if strings.HasPrefix(h, "*") || strings.HasSuffix(h, "*") {
+		return true
+	}
+	if strings.Count(h, ".") >= 2 {
+		return true
+	}
+	if strings.Count(h, ".") == 1 {
+		parts := strings.SplitN(h, ".", 2)
+		// Registry-check only known service.namespace shorthand (namespace is the policy
+		// namespace or a cluster namespace). All other single-dot hosts (api.info, app.tech,
+		// wrong.org) are treated as HTTP Host headers and are not registry-validated.
+		return parts[1] != policyNamespace && !slices.Contains(clusterNamespaces, parts[1])
+	}
 	return false
 }

--- a/business/checkers/authorization/no_host_checker_test.go
+++ b/business/checkers/authorization/no_host_checker_test.go
@@ -47,13 +47,74 @@ func TestNonExistingService(t *testing.T) {
 		PolicyAllowAny:      true,
 	}.Check()
 
-	// Wrong host is not present
+	// Short-name typo is still flagged (soft registry lint)
 	assert.False(valid)
 	assert.NotEmpty(vals)
 	assert.Len(vals, 1)
 	assert.Equal(models.WarningSeverity, vals[0].Severity)
 	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
 	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", vals[0].Path)
+}
+
+func TestNonExistingServiceNamespaceShorthand(t *testing.T) {
+	assert := assert.New(t)
+
+	fakeServices := data.CreateFakeMultiServices([]string{"details.bookinfo.svc.cluster.local"}, "bookinfo")
+
+	vals, valid := NoHostChecker{
+		IdentityDomain:      "svc.cluster.local",
+		AuthorizationPolicy: authPolicyWithHost([]string{"missing.bookinfo"}),
+		Namespaces:          []string{"bookinfo"},
+		ServiceEntries:      map[string][]string{},
+		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices, "svc.cluster.local"),
+		PolicyAllowAny:      true,
+	}.Check()
+
+	// service.namespace shorthand is registry-checked when the namespace is known
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.WarningSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
+}
+
+func TestHTTPHostHeaderSkipped(t *testing.T) {
+	assert := assert.New(t)
+
+	fakeServices := data.CreateFakeMultiServices([]string{"details.bookinfo.svc.cluster.local"}, "bookinfo")
+
+	for _, host := range []string{"api.example.com", "wrong.org", "myservice.test", "api.info", "app.tech"} {
+		vals, valid := NoHostChecker{
+			IdentityDomain:      "svc.cluster.local",
+			AuthorizationPolicy: authPolicyWithHost([]string{host}),
+			Namespaces:          []string{"bookinfo"},
+			ServiceEntries:      map[string][]string{},
+			KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices, "svc.cluster.local"),
+			PolicyAllowAny:      true,
+		}.Check()
+
+		assert.True(valid, "host %q should not be registry-validated", host)
+		assert.Empty(vals, "host %q should not produce KIA0104", host)
+	}
+}
+
+func TestNonExistingServiceErrorSeverity(t *testing.T) {
+	assert := assert.New(t)
+
+	fakeServices := data.CreateFakeMultiServices([]string{"details.bookinfo.svc.cluster.local"}, "bookinfo")
+
+	vals, valid := NoHostChecker{
+		IdentityDomain:      "svc.cluster.local",
+		AuthorizationPolicy: authPolicyWithHost([]string{"wrong"}),
+		Namespaces:          []string{"bookinfo"},
+		ServiceEntries:      map[string][]string{},
+		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices, "svc.cluster.local"),
+		PolicyAllowAny:      false,
+	}.Check()
+
+	assert.False(valid)
+	assert.Len(vals, 1)
+	assert.Equal(models.ErrorSeverity, vals[0].Severity)
+	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
 }
 
 func TestWildcardHost(t *testing.T) {
@@ -69,7 +130,7 @@ func TestWildcardHost(t *testing.T) {
 		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices, "svc.cluster.local"),
 	}.Check()
 
-	// Well configured object
+	// Host-header wildcards are valid Istio AuthZ matchers
 	assert.True(valid)
 	assert.Empty(vals)
 }
@@ -87,15 +148,9 @@ func TestWildcardHostOutsideNamespace(t *testing.T) {
 		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices, "svc.cluster.local"),
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 2)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
-	assert.Equal(models.ErrorSeverity, vals[1].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[1]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[1]", vals[1].Path)
+	// Wildcard Host-header matchers are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestServiceEntryPresent(t *testing.T) {
@@ -161,13 +216,9 @@ func TestExportedExternalServiceEntryFail(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{serviceEntry}),
 	}.Check()
 
-	// www.wrong.com host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestWildcardExportedInternalServiceEntryPresent(t *testing.T) {
@@ -199,13 +250,9 @@ func TestWildcardExportedInternalServiceEntryFail(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{serviceEntry}),
 	}.Check()
 
-	// details.bookinfo3.svc.cluster.local host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
@@ -220,13 +267,9 @@ func TestExportedNonFQDNInternalServiceEntryFail(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{serviceEntry}),
 	}.Check()
 
-	// details.bookinfo2.svc.cluster.local host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestServiceEntryNotPresent(t *testing.T) {
@@ -240,13 +283,9 @@ func TestServiceEntryNotPresent(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{serviceEntry}),
 	}.Check()
 
-	// Wrong.org host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestExportedInternalServiceEntryNotPresent(t *testing.T) {
@@ -260,13 +299,9 @@ func TestExportedInternalServiceEntryNotPresent(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{serviceEntry}),
 	}.Check()
 
-	// Wrong.org host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestVirtualServicePresent(t *testing.T) {
@@ -297,13 +332,9 @@ func TestVirtualServiceNotPresent(t *testing.T) {
 		VirtualServices:     []*networking_v1.VirtualService{&virtualService},
 	}.Check()
 
-	// Wrong.org host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.ErrorSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	// Dotted Host-header values are not registry-validated
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func TestWildcardServiceEntryHost(t *testing.T) {
@@ -318,11 +349,10 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 		ServiceEntries:      kubernetes.ServiceEntryHostnames([]*networking_v1.ServiceEntry{&serviceEntry}),
 	}.Check()
 
-	// Well configured object
 	assert.True(valid)
 	assert.Empty(vals)
 
-	// Not matching
+	// Non-matching dotted Host header is still not registry-validated
 	vals, valid = NoHostChecker{
 		IdentityDomain:      "svc.cluster.local",
 		AuthorizationPolicy: authPolicyWithHost([]string{"maps.apple.com"}),
@@ -331,13 +361,8 @@ func TestWildcardServiceEntryHost(t *testing.T) {
 		PolicyAllowAny:      true,
 	}.Check()
 
-	// apple.com host is not present
-	assert.False(valid)
-	assert.NotEmpty(vals)
-	assert.Len(vals, 1)
-	assert.Equal(models.WarningSeverity, vals[0].Severity)
-	assert.NoError(validations.ConfirmIstioCheckMessage("authorizationpolicy.nodest.matchingregistry", vals[0]))
-	assert.Equal("spec/rules[0]/to[0]/operation/hosts[0]", vals[0].Path)
+	assert.True(valid)
+	assert.Empty(vals)
 }
 
 func authPolicyWithHost(hostList []string) *security_v1.AuthorizationPolicy {
@@ -350,14 +375,15 @@ func authPolicyWithHost(hostList []string) *security_v1.AuthorizationPolicy {
 func TestValidServiceRegistry(t *testing.T) {
 	assert := assert.New(t)
 
+	// Dotted FQDNs are Host-header matchers and skip registry validation
 	validations, valid := NoHostChecker{
 		IdentityDomain:      "svc.cluster.local",
 		AuthorizationPolicy: authPolicyWithHost([]string{"ratings.mesh2-bookinfo.svc.mesh1-imports.local"}),
 		Namespaces:          []string{"outside", "bookinfo"},
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.True(valid)
+	assert.Empty(validations)
 
 	conf := config.NewConfig()
 	conf.ExternalServices.Istio.IstioIdentityDomain = "svc.mesh1-imports.local"
@@ -385,8 +411,8 @@ func TestValidServiceRegistry(t *testing.T) {
 		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices2, id),
 	}.Check()
 
-	assert.False(valid)
-	assert.NotEmpty(validations)
+	assert.True(valid)
+	assert.Empty(validations)
 
 	config.Set(config.NewConfig())
 	fakeServices3 := data.CreateFakeMultiServices([]string{"ratings.bookinfo.svc.cluster.local"}, "bookinfo")
@@ -401,13 +427,12 @@ func TestValidServiceRegistry(t *testing.T) {
 	assert.True(valid)
 	assert.Empty(validations)
 
-	fakeServices4 := data.CreateFakeMultiServices([]string{"ratings.bookinfo.svc.cluster.local"}, "bookinfo")
-
+	// Short names remain registry-validated
 	validations, valid = NoHostChecker{
 		IdentityDomain:      "svc.cluster.local",
-		AuthorizationPolicy: authPolicyWithHost([]string{"ratings2.bookinfo.svc.cluster.local"}),
+		AuthorizationPolicy: authPolicyWithHost([]string{"ratings2"}),
 		Namespaces:          []string{"outside", "bookinfo"},
-		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices4, "svc.cluster.local"),
+		KubeServiceHosts:    kubernetes.KubeServiceFQDNs(fakeServices3, "svc.cluster.local"),
 	}.Check()
 
 	assert.False(valid)

--- a/business/checkers/destinationrules/meshwide_mtls_checker.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker.go
@@ -20,6 +20,12 @@ func (m MeshWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, true
 	}
 
+	// With auto-mTLS, Istio encrypts without requiring an explicit PeerAuthentication
+	// (same escape hatch as KIA0401 / MeshMtlsChecker).
+	if m.MTLSDetails.EnabledAutoMtls {
+		return validations, true
+	}
+
 	// otherwise, check among MeshPeerAuthentications for a rule enabling mesh-wide mTLS
 	for _, mp := range m.MTLSDetails.MeshPeerAuthentications {
 		if enabled, _ := kubernetes.PeerAuthnHasMTLSEnabled(mp); enabled {

--- a/business/checkers/destinationrules/meshwide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/meshwide_mtls_checker_test.go
@@ -106,6 +106,21 @@ func TestMTLSDRDisabledWithMeshPolicy(t *testing.T) {
 	testNoValidationsFound(t, destinationRule, mTlsDetails)
 }
 
+// Context: DestinationRule enables mesh-wide mTLS
+// Context: auto-mTLS is enabled and no MeshPolicy exists
+// It doesn't return any validation
+func TestMTLSMeshWideDREnabledWithAutoMtls(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("istio-system", "dr-mtls", "*.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		EnabledAutoMtls:         true,
+		MeshPeerAuthentications: []*security_v1.PeerAuthentication{},
+	}
+
+	testNoValidationsFound(t, destinationRule, mTlsDetails)
+}
+
 // Context: DestinationRule not enabling mTLS
 // Context: There is one MeshPolicy not enabling mTLS
 // It doesn't return any validation

--- a/business/checkers/destinationrules/namespacewide_mtls_checker.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker.go
@@ -23,6 +23,12 @@ func (m NamespaceWideMTLSChecker) Check() ([]*models.IstioCheck, bool) {
 		return validations, true
 	}
 
+	// With auto-mTLS, Istio encrypts without requiring an explicit PeerAuthentication
+	// (same escape hatch as KIA0501 / NamespaceMtlsChecker).
+	if m.MTLSDetails.EnabledAutoMtls {
+		return validations, true
+	}
+
 	// otherwise, check among PeerAuthentications for a rule enabling ns-wide mTLS
 	for _, mp := range m.MTLSDetails.PeerAuthentications {
 		if enabled, _ := kubernetes.PeerAuthnHasMTLSEnabled(mp); enabled {

--- a/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
+++ b/business/checkers/destinationrules/namespacewide_mtls_checker_test.go
@@ -92,7 +92,7 @@ func TestMTLSNsWideDREnabledWithMeshPolicy(t *testing.T) {
 
 // Context: DestinationRule enables namespace-wide mTLS
 // Context: There isn't any policy enabling mTLS
-// It doesn't return any validation
+// It returns a validation
 func TestMTLSNsWideDREnabledWithoutPolicy(t *testing.T) {
 	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
 		data.CreateEmptyDestinationRule("bookinfo", "dr-mtls", "*.bookinfo.svc.cluster.local"))
@@ -116,4 +116,27 @@ func TestMTLSNsWideDREnabledWithoutPolicy(t *testing.T) {
 	assert.Equal(models.ErrorSeverity, validation.Severity)
 	assert.Equal("spec/trafficPolicy/tls/mode", validation.Path)
 	assert.NoError(validations.ConfirmIstioCheckMessage("destinationrules.mtls.nspolicymissing", validation))
+}
+
+// Context: DestinationRule enables namespace-wide mTLS
+// Context: auto-mTLS is enabled and no PeerAuthentication exists
+// It doesn't return any validation
+func TestMTLSNsWideDREnabledWithAutoMtls(t *testing.T) {
+	destinationRule := data.AddTrafficPolicyToDestinationRule(data.CreateMTLSTrafficPolicyForDestinationRules(),
+		data.CreateEmptyDestinationRule("bookinfo", "dr-mtls", "*.bookinfo.svc.cluster.local"))
+
+	mTlsDetails := kubernetes.MTLSDetails{
+		EnabledAutoMtls: true,
+	}
+
+	assert := assert.New(t)
+
+	vals, valid := NamespaceWideMTLSChecker{
+		IdentityDomain:  "svc.cluster.local",
+		DestinationRule: destinationRule,
+		MTLSDetails:     mTlsDetails,
+	}.Check()
+
+	assert.Empty(vals)
+	assert.True(valid)
 }

--- a/business/checkers/k8sgateways/status_checker.go
+++ b/business/checkers/k8sgateways/status_checker.go
@@ -23,7 +23,8 @@ const GwAPICheckerCode string = "GWAPI"
 // K8sGatewayConditionStatus maps Gateway-level condition types to the status value that
 // indicates a problem. Maps include GEP-1364 conditions (Accepted, Programmed) and legacy
 // types (Scheduled, Ready) so both modern and older controllers are covered.
-// Programmed=False is only flagged when the reason is not benign (see isBenignProgrammedReason).
+// Programmed=False is only flagged when the reason is not benign (see
+// isBenignPositiveConditionFalse).
 var K8sGatewayConditionStatus = map[string]string{
 	"Accepted":   "False",
 	"Programmed": "False",
@@ -79,18 +80,25 @@ func isProblematicCondition(c metav1.Condition, problematicStatus map[string]str
 	if !ok || string(c.Status) != expectedStatus {
 		return false
 	}
-	if c.Type == "Programmed" && c.Status == metav1.ConditionFalse {
-		return !isBenignProgrammedReason(c.Reason)
+	if isBenignPositiveConditionFalse(c.Type, c.Status, c.Reason) {
+		return false
 	}
 	return true
 }
 
-// isBenignProgrammedReason reports Gateway API Programmed=False reasons that reflect
-// controller progress or missing routes, not invalid Gateway spec. Other reasons
-// (Invalid, NoResources, etc.) are surfaced as GWAPI warnings.
-func isBenignProgrammedReason(reason string) bool {
+// isBenignPositiveConditionFalse reports positive-polarity conditions set to False for
+// transitional controller states (no routes yet, listeners skipped, etc.), not spec errors.
+func isBenignPositiveConditionFalse(condType string, status metav1.ConditionStatus, reason string) bool {
+	if status != metav1.ConditionFalse {
+		return false
+	}
+	switch condType {
+	case "Accepted", "Programmed", "Ready", "ResolvedRefs", "Scheduled":
+	default:
+		return false
+	}
 	switch reason {
-	case "Pending", "ListenersNotValid":
+	case "Pending", "ListenersNotValid", "ListenerSetsNotValid":
 		return true
 	default:
 		return false

--- a/business/checkers/k8sgateways/status_checker.go
+++ b/business/checkers/k8sgateways/status_checker.go
@@ -2,6 +2,7 @@ package k8sgateways
 
 import (
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -80,7 +81,7 @@ func isProblematicCondition(c metav1.Condition, problematicStatus map[string]str
 	if !ok || string(c.Status) != expectedStatus {
 		return false
 	}
-	if isBenignPositiveConditionFalse(c.Type, c.Status, c.Reason) {
+	if isBenignPositiveConditionFalse(c.Type, c.Status, c.Reason, c.Message) {
 		return false
 	}
 	return true
@@ -88,7 +89,7 @@ func isProblematicCondition(c metav1.Condition, problematicStatus map[string]str
 
 // isBenignPositiveConditionFalse reports positive-polarity conditions set to False for
 // transitional controller states (no routes yet, listeners skipped, etc.), not spec errors.
-func isBenignPositiveConditionFalse(condType string, status metav1.ConditionStatus, reason string) bool {
+func isBenignPositiveConditionFalse(condType string, status metav1.ConditionStatus, reason, message string) bool {
 	if status != metav1.ConditionFalse {
 		return false
 	}
@@ -100,6 +101,11 @@ func isBenignPositiveConditionFalse(condType string, status metav1.ConditionStat
 	switch reason {
 	case "Pending", "ListenersNotValid", "ListenerSetsNotValid":
 		return true
+	case "AddressNotAssigned":
+		// Istio often reports gateway-level address assignment as in-progress ("address pending")
+		// while listeners are already Programmed=True. That is operational, not a spec error.
+		// Manual status patches for demos/tests can still surface GWAPI with other messages.
+		return strings.Contains(strings.ToLower(message), "address pending")
 	default:
 		return false
 	}

--- a/business/checkers/k8sgateways/status_checker.go
+++ b/business/checkers/k8sgateways/status_checker.go
@@ -3,6 +3,7 @@ package k8sgateways
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/models"
@@ -19,16 +20,25 @@ type K8sGatewayStatus struct {
 
 const GwAPICheckerCode string = "GWAPI"
 
-// K8sGatewayConditionStatus represents the status failures for a Condition in a K8sGateway
+// K8sGatewayConditionStatus maps Gateway-level condition types to the status value that
+// indicates a problem. Maps include GEP-1364 conditions (Accepted, Programmed) and legacy
+// types (Scheduled, Ready) so both modern and older controllers are covered.
+// Programmed=False is only flagged when the reason is not benign (see isBenignProgrammedReason).
 var K8sGatewayConditionStatus = map[string]string{
-	"Scheduled": "False",
-	"Ready":     "False",
+	"Accepted":   "False",
+	"Programmed": "False",
+	"Ready":      "False",
+	"Scheduled":  "False",
 }
 
-// K8sGatewayConditionStatus represents the status failures for a Condition in a K8sGateway
+// K8sGatewayListenersStatus maps Listener condition types to problematic values. Includes
+// GEP-1364 conditions (Accepted, Programmed, ResolvedRefs, Conflicted) and legacy types
+// (Detached, Ready). Programmed=False uses the same benign-reason filter as gateway-level.
 var K8sGatewayListenersStatus = map[string]string{
+	"Accepted":     "False",
 	"Conflicted":   "True",
 	"Detached":     "True",
+	"Programmed":   "False",
 	"Ready":        "False",
 	"ResolvedRefs": "False",
 }
@@ -38,7 +48,7 @@ func (m StatusChecker) Check() ([]*models.IstioCheck, bool) {
 	validations := make([]*models.IstioCheck, 0)
 
 	for i, c := range m.K8sGateway.Status.Conditions {
-		if K8sGatewayConditionStatus[c.Type] == string(c.Status) {
+		if isProblematicGatewayCondition(c) {
 			check := createGwChecker(fmt.Sprintf("%s. GWAPI errors should be changed in the spec.", c.Message), fmt.Sprintf("status/conditions[%d]/reason/%s", i, c.Reason))
 			validations = append(validations, &check)
 		}
@@ -46,7 +56,7 @@ func (m StatusChecker) Check() ([]*models.IstioCheck, bool) {
 
 	for i, l := range m.K8sGateway.Status.Listeners {
 		for _, c := range l.Conditions {
-			if K8sGatewayListenersStatus[c.Type] == string(c.Status) {
+			if isProblematicListenerCondition(c) {
 				check := createGwChecker(fmt.Sprintf("%s. GWAPI errors should be changed in the spec.", c.Message), fmt.Sprintf("status/conditions[%d]/type/%s", i, c.Reason))
 				validations = append(validations, &check)
 			}
@@ -54,6 +64,37 @@ func (m StatusChecker) Check() ([]*models.IstioCheck, bool) {
 	}
 
 	return validations, len(validations) == 0
+}
+
+func isProblematicGatewayCondition(c metav1.Condition) bool {
+	return isProblematicCondition(c, K8sGatewayConditionStatus)
+}
+
+func isProblematicListenerCondition(c metav1.Condition) bool {
+	return isProblematicCondition(c, K8sGatewayListenersStatus)
+}
+
+func isProblematicCondition(c metav1.Condition, problematicStatus map[string]string) bool {
+	expectedStatus, ok := problematicStatus[c.Type]
+	if !ok || string(c.Status) != expectedStatus {
+		return false
+	}
+	if c.Type == "Programmed" && c.Status == metav1.ConditionFalse {
+		return !isBenignProgrammedReason(c.Reason)
+	}
+	return true
+}
+
+// isBenignProgrammedReason reports Gateway API Programmed=False reasons that reflect
+// controller progress or missing routes, not invalid Gateway spec. Other reasons
+// (Invalid, NoResources, etc.) are surfaced as GWAPI warnings.
+func isBenignProgrammedReason(reason string) bool {
+	switch reason {
+	case "Pending", "ListenersNotValid":
+		return true
+	default:
+		return false
+	}
 }
 
 // Create checker for GW validation (Gateway status)

--- a/business/checkers/k8sgateways/status_checker_test.go
+++ b/business/checkers/k8sgateways/status_checker_test.go
@@ -168,6 +168,26 @@ func TestIncorrectK8sGatewaysProgrammedNoResourcesStatus(t *testing.T) {
 	assert.Equal("No gateway pods. GWAPI errors should be changed in the spec.", check[0].Message)
 }
 
+func TestIncorrectK8sGatewaysProgrammedAddressNotAssignedStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Programmed", Status: "False", Reason: "AddressNotAssigned", Message: "demo Programmed=False"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("demo Programmed=False. GWAPI errors should be changed in the spec.", check[0].Message)
+	assert.Equal(models.WarningSeverity, check[0].Severity)
+}
+
 func TestIncorrectK8sGatewaysScheduledStatus(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/k8sgateways/status_checker_test.go
+++ b/business/checkers/k8sgateways/status_checker_test.go
@@ -149,6 +149,29 @@ func TestK8sGatewayListenerAcceptedPendingNotFlagged(t *testing.T) {
 	assert.Empty(check)
 }
 
+func TestK8sGatewaysProgrammedAddressPendingMessageNotFlagged(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{
+			Type:    "Programmed",
+			Status:  "False",
+			Reason:  "AddressNotAssigned",
+			Message: "Assigned to service(s) gw-istio.bookinfo.svc.cluster.local:80, but failed to assign to all requested addresses: address pending for hostname \"gw-istio.bookinfo.svc.cluster.local\"",
+		})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.True(isValid)
+	assert.Empty(check)
+}
+
 func TestIncorrectK8sGatewaysProgrammedNoResourcesStatus(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/k8sgateways/status_checker_test.go
+++ b/business/checkers/k8sgateways/status_checker_test.go
@@ -107,6 +107,48 @@ func TestK8sGatewaysProgrammedPendingNotFlagged(t *testing.T) {
 	assert.Empty(check)
 }
 
+func TestK8sGatewaysAcceptedListenersNotValidNotFlagged(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Accepted", Status: "False", Reason: "ListenersNotValid", Message: "Listeners have no routes"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.True(isValid)
+	assert.Empty(check)
+}
+
+func TestK8sGatewayListenerAcceptedPendingNotFlagged(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.AddListenerToK8sGateway(data.CreateListener("http", "example.com", 80, "HTTP"),
+		data.CreateEmptyK8sGateway("validk8sgateway", "test"))
+	k8sgwObject.Status.Listeners = []k8s_networking_v1.ListenerStatus{
+		{
+			Conditions: []metav1.Condition{
+				{Type: "Accepted", Status: "False", Reason: "Pending", Message: "Waiting for controller"},
+			},
+		},
+	}
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.True(isValid)
+	assert.Empty(check)
+}
+
 func TestIncorrectK8sGatewaysProgrammedNoResourcesStatus(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/business/checkers/k8sgateways/status_checker_test.go
+++ b/business/checkers/k8sgateways/status_checker_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s_networking_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/models"
@@ -46,4 +48,173 @@ func TestIncorrectK8sGatewaysStatus(t *testing.T) {
 	assert.NotEmpty(check)
 	assert.Equal("Fake msg. GWAPI errors should be changed in the spec.", check[0].Message)
 	assert.Equal(models.WarningSeverity, check[0].Severity)
+}
+
+func TestIncorrectK8sGatewaysAcceptedStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Accepted", Status: "False", Reason: "Invalid", Message: "Not accepted"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("Not accepted. GWAPI errors should be changed in the spec.", check[0].Message)
+	assert.Equal(models.WarningSeverity, check[0].Severity)
+}
+
+func TestIncorrectK8sGatewaysProgrammedStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Programmed", Status: "False", Reason: "Invalid", Message: "Not programmed"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("Not programmed. GWAPI errors should be changed in the spec.", check[0].Message)
+}
+
+func TestK8sGatewaysProgrammedPendingNotFlagged(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Programmed", Status: "False", Reason: "Pending", Message: "Waiting for controller"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.True(isValid)
+	assert.Empty(check)
+}
+
+func TestIncorrectK8sGatewaysProgrammedNoResourcesStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Programmed", Status: "False", Reason: "NoResources", Message: "No gateway pods"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("No gateway pods. GWAPI errors should be changed in the spec.", check[0].Message)
+}
+
+func TestIncorrectK8sGatewaysScheduledStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.CreateEmptyK8sGateway("validk8sgateway", "test")
+	k8sgwObject.Status.Conditions = append(k8sgwObject.Status.Conditions,
+		metav1.Condition{Type: "Scheduled", Status: "False", Reason: "Invalid", Message: "Not scheduled"})
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("Not scheduled. GWAPI errors should be changed in the spec.", check[0].Message)
+}
+
+func TestIncorrectK8sGatewayListenerDetachedStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.AddListenerToK8sGateway(data.CreateListener("http", "example.com", 80, "HTTP"),
+		data.CreateEmptyK8sGateway("validk8sgateway", "test"))
+	k8sgwObject.Status.Listeners = []k8s_networking_v1.ListenerStatus{
+		{
+			Conditions: []metav1.Condition{
+				{Type: "Detached", Status: "True", Reason: "Invalid", Message: "Listener detached"},
+			},
+		},
+	}
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("Listener detached. GWAPI errors should be changed in the spec.", check[0].Message)
+}
+
+func TestIncorrectK8sGatewayListenerProgrammedStatus(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.AddListenerToK8sGateway(data.CreateListener("http", "example.com", 80, "HTTP"),
+		data.CreateEmptyK8sGateway("validk8sgateway", "test"))
+	k8sgwObject.Status.Listeners = []k8s_networking_v1.ListenerStatus{
+		{
+			Conditions: []metav1.Condition{
+				{Type: "Programmed", Status: "False", Reason: "Invalid", Message: "Listener not programmed"},
+			},
+		},
+	}
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.False(isValid)
+	assert.Len(check, 1)
+	assert.Equal("Listener not programmed. GWAPI errors should be changed in the spec.", check[0].Message)
+}
+
+func TestK8sGatewayListenerProgrammedPendingNotFlagged(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+
+	assert := assert.New(t)
+
+	k8sgwObject := data.AddListenerToK8sGateway(data.CreateListener("http", "example.com", 80, "HTTP"),
+		data.CreateEmptyK8sGateway("validk8sgateway", "test"))
+	k8sgwObject.Status.Listeners = []k8s_networking_v1.ListenerStatus{
+		{
+			Conditions: []metav1.Condition{
+				{Type: "Programmed", Status: "False", Reason: "Pending", Message: "Waiting for routes"},
+			},
+		},
+	}
+
+	k8sgws := StatusChecker{k8sgwObject}
+
+	check, isValid := k8sgws.Check()
+
+	assert.True(isValid)
+	assert.Empty(check)
 }

--- a/business/checkers/k8shttproutes/no_host_checker_test.go
+++ b/business/checkers/k8shttproutes/no_host_checker_test.go
@@ -7,6 +7,7 @@ import (
 	k8s_networking_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/models"
 	"github.com/kiali/kiali/tests/data"
 	"github.com/kiali/kiali/tests/testutils/validations"
@@ -24,6 +25,31 @@ func TestValidRefHost(t *testing.T) {
 	vals, valid := NoHostChecker{
 		Services:           fakeServices,
 		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")},
+		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
+	}.Check()
+
+	assert.True(valid)
+	assert.Empty(vals)
+}
+
+func TestValidRefHostMultiToGrant(t *testing.T) {
+	c := config.Get()
+	c.ExternalServices.Istio.IstioIdentityDomain = "svc.cluster.local"
+	config.Set(c)
+
+	assert := assert.New(t)
+
+	fakeServices := data.CreateFakeMultiServices([]string{"other.bookinfo.svc.cluster.local", "reviews.bookinfo.svc.cluster.local"}, "bookinfo")
+
+	grant := data.CreateReferenceGrant("grant", "bookinfo", "bookinfo2")
+	grant.Spec.To = []k8s_networking_v1beta1.ReferenceGrantTo{
+		{Kind: "Secret"},
+		{Kind: kubernetes.ServiceType},
+	}
+
+	vals, valid := NoHostChecker{
+		Services:           fakeServices,
+		K8sReferenceGrants: []*k8s_networking_v1beta1.ReferenceGrant{grant},
 		K8sHTTPRoute:       data.AddServiceParentRefToHTTPRoute("reviews", "bookinfo", data.AddBackendRefToHTTPRoute("reviews", "bookinfo", data.CreateHTTPRoute("route", "bookinfo2", "gatewayapi", []string{"bookinfo"}))),
 	}.Check()
 

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -22,6 +22,17 @@ When('viewing the detail for {string}', (object: string) => {
   cy.get(linkSelector()).contains(object).should('be.visible').click();
 });
 
+When(
+  'user is at the details page for the K8sGateway {string} in the {string} namespace',
+  (name: string, namespace: string) => {
+    cy.visit({
+      url: `${Cypress.config('baseUrl')}/console/namespaces/${namespace}/istio/gateway.networking.k8s.io/v1/Gateway/${name}`,
+      qs: { refresh: '0' }
+    });
+    ensureKialiFinishedLoading();
+  }
+);
+
 When('user deletes k8sgateway named {string} and the resource is no longer available', (name: string) => {
   cy.exec(`kubectl delete gateways.gateway.networking.k8s.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
   ensureKialiFinishedLoading();

--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -173,7 +173,7 @@ Feature: Kiali Istio Config page
   Scenario: KIA0104 validation
     Given there is not a "bookinfo" "VirtualService" in the "bookinfo" namespace
     Given a "foo" AuthorizationPolicy in the "bookinfo" namespace
-    And the AuthorizationPolicy has a to-operation rule with "missing.hostname" host
+    And the AuthorizationPolicy has a to-operation rule with "missing.bookinfo" host
     When the user refreshes the page
     And user selects the "bookinfo" namespace
     Then the AuthorizationPolicy should have a "warning"

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -56,6 +56,7 @@ Feature: Kiali Istio Config wizard
     And user previews the configuration
     And user creates the istio config
     Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
+    And user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
 
   @gateway-api
   @bookinfo-app
@@ -76,6 +77,7 @@ Feature: Kiali Istio Config wizard
     And user previews the configuration
     And user creates the istio config
     Then the "K8sGateway" "k8sapigateway" should be listed in "bookinfo" namespace
+    And user deletes k8sgateway named "k8sapigateway" and the resource is no longer available
 
   @gateway-api
   @bookinfo-app

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -359,9 +359,9 @@ Feature: Kiali Istio Config wizard
     And the "gatewayapi-2" "K8sGateway" of the "bookinfo" namespace should have a "warning"
     When viewing the detail for "gatewayapi-1"
     Then "gatewayapi-2" should be referenced
-    When user is at the "istio" page
-    And viewing the detail for "gatewayapi-2"
+    When user is at the details page for the K8sGateway "gatewayapi-2" in the "bookinfo" namespace
     And choosing to delete it
+    And user is at the details page for the K8sGateway "gatewayapi-1" in the "bookinfo" namespace
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace

--- a/kubernetes/host.go
+++ b/kubernetes/host.go
@@ -219,15 +219,27 @@ func HasMatchingVirtualServices(host Host, virtualServices []*networking_v1.Virt
 	return false
 }
 
-// HasMatchingReferenceGrant returns true when the From matches to given fromNamespace and fromKind and To matched given toNamespace and toKind.
+// HasMatchingReferenceGrant returns true when any From entry matches fromNamespace/fromKind
+// and any To entry matches toKind for a ReferenceGrant in toNamespace.
 func HasMatchingReferenceGrant(fromNamespace string, toNamespace string, fromKind string, toKind string, referenceGrants []*k8s_networking_v1beta1.ReferenceGrant) bool {
 	for _, rGrant := range referenceGrants {
-		if len(rGrant.Spec.From) > 0 && len(rGrant.Spec.To) > 0 &&
-			string(rGrant.Spec.From[0].Namespace) == fromNamespace &&
-			rGrant.Namespace == toNamespace &&
-			string(rGrant.Spec.From[0].Kind) == fromKind &&
-			string(rGrant.Spec.To[0].Kind) == toKind {
-			return true
+		if rGrant == nil || rGrant.Namespace != toNamespace {
+			continue
+		}
+		fromMatch := false
+		for _, from := range rGrant.Spec.From {
+			if string(from.Namespace) == fromNamespace && string(from.Kind) == fromKind {
+				fromMatch = true
+				break
+			}
+		}
+		if !fromMatch {
+			continue
+		}
+		for _, to := range rGrant.Spec.To {
+			if string(to.Kind) == toKind {
+				return true
+			}
 		}
 	}
 	return false

--- a/kubernetes/host_test.go
+++ b/kubernetes/host_test.go
@@ -108,6 +108,14 @@ func TestHasMatchingReferenceGrant(t *testing.T) {
 		Namespace: k8s_networking_v1.Namespace("bookinfo"),
 	})
 	assert.True(HasMatchingReferenceGrant("bookinfo", "default", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{multiFrom}))
+
+	// Match the second To entry (previously only Spec.To[0] was checked)
+	multiTo := createReferenceGrant("multi-to", "default", "bookinfo")
+	multiTo.Spec.To = []k8s_networking_v1beta1.ReferenceGrantTo{
+		{Kind: "Secret"},
+		{Kind: ServiceType},
+	}
+	assert.True(HasMatchingReferenceGrant("bookinfo", "default", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{multiTo}))
 }
 
 func createVirtualService(namespace string, hosts []string) *networking_v1.VirtualService {

--- a/kubernetes/host_test.go
+++ b/kubernetes/host_test.go
@@ -99,6 +99,15 @@ func TestHasMatchingReferenceGrant(t *testing.T) {
 	assert.True(HasMatchingReferenceGrant("bookinfo", "default", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{createReferenceGrant("test", "default", "bookinfo"), createReferenceGrant("test", "bookinfo2", "bookinfo")}))
 	assert.False(HasMatchingReferenceGrant("bookinfo", "test", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{createReferenceGrant("test", "default", "bookinfo"), createReferenceGrant("test", "bookinfo2", "bookinfo")}))
 	assert.False(HasMatchingReferenceGrant("default", "bookinfo", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{createReferenceGrant("test", "default", "bookinfo"), createReferenceGrant("test", "bookinfo2", "bookinfo")}))
+
+	// Match the second From entry (previously only Spec.From[0] was checked)
+	multiFrom := createReferenceGrant("multi", "default", "other")
+	multiFrom.Spec.From = append(multiFrom.Spec.From, k8s_networking_v1beta1.ReferenceGrantFrom{
+		Kind:      k8s_networking_v1beta1.Kind(K8sHTTPRoutes.Kind),
+		Group:     k8s_networking_v1beta1.GroupName,
+		Namespace: k8s_networking_v1.Namespace("bookinfo"),
+	})
+	assert.True(HasMatchingReferenceGrant("bookinfo", "default", K8sHTTPRouteType, ServiceType, []*k8s_networking_v1beta1.ReferenceGrant{multiFrom}))
 }
 
 func createVirtualService(namespace string, hosts []string) *networking_v1.VirtualService {

--- a/kubernetes/istio.go
+++ b/kubernetes/istio.go
@@ -382,12 +382,26 @@ func MatchPortNameWithValidProtocols(portName string) bool {
 	return false
 }
 
+// kubernetesAppProtocols are Kubernetes-standard appProtocol values that Istio recognizes
+// for protocol selection (see istio pkg/config/kube/conversion.go).
+var kubernetesAppProtocols = [...]string{
+	"kubernetes.io/h2c",
+	"kubernetes.io/ws",
+	"kubernetes.io/wss",
+}
+
 func MatchPortAppProtocolWithValidProtocols(appProtocol *string) bool {
 	if appProtocol == nil || *appProtocol == "" {
 		return false
 	}
+	proto := strings.ToLower(*appProtocol)
 	for _, protocol := range portProtocols {
-		if strings.ToLower(*appProtocol) == protocol {
+		if proto == protocol {
+			return true
+		}
+	}
+	for _, protocol := range kubernetesAppProtocols {
+		if proto == protocol {
 			return true
 		}
 	}

--- a/kubernetes/istio_internal_test.go
+++ b/kubernetes/istio_internal_test.go
@@ -96,9 +96,15 @@ func TestValidPortAppProtocolMatcher(t *testing.T) {
 	s1 := "http"
 	s2 := "mysql"
 	s3 := "grpc-web"
+	s4 := "kubernetes.io/h2c"
+	s5 := "kubernetes.io/ws"
+	s6 := "kubernetes.io/wss"
 	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s1))
 	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s2))
 	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s3))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s4))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s5))
+	assert.True(t, MatchPortAppProtocolWithValidProtocols(&s6))
 }
 
 func TestInvalidPortAppProtocolMatcher(t *testing.T) {

--- a/models/istio_validation.go
+++ b/models/istio_validation.go
@@ -179,7 +179,7 @@ var checkDescriptors = map[string]IstioCheck{
 	},
 	"authorizationpolicy.to.wrongmethod": {
 		Code:     "KIA0102",
-		Message:  "Only HTTP methods, wildcards, and fully-qualified gRPC names are allowed",
+		Message:  "Only HTTP methods and Istio wildcards are allowed",
 		Severity: WarningSeverity,
 	},
 	"authorizationpolicy.nodest.matchingregistry": {


### PR DESCRIPTION
### Describe the change

Fixes high-priority Istio / Gateway API validation false positives tracked in #10188:

- **KIA0104** — treat AuthZ `operation.hosts` as HTTP Host-header matchers (skip registry for `*`, prefix/suffix `*`, and dotted hostnames); keep short-name registry lint
- **KIA0102** — accept HTTP method prefix/suffix wildcards (`GET*`, `G*`, `*ET`, `*POST`); stop treating gRPC FQNs as valid `methods` (belong in `paths`); update message
- **KIA0205 / KIA0206** — skip missing-PeerAuthentication errors when auto-mTLS is enabled (same escape hatch as KIA0401/0501)
- **KIA0602** — allow `kubernetes.io/h2c`, `kubernetes.io/ws`, `kubernetes.io/wss` appProtocols
- **KIA1402** — match any ReferenceGrant `From`/`To` entry (not only `[0]`)
- **GWAPI status** — prefer modern `Accepted` / `Programmed` (keep `Ready` for older controllers)

### Steps to test the PR

Prereqs: Istio + Kiali from this branch, namespace `bookinfo` (Bookinfo demo optional). Open the named object in Kiali Istio Config / Services and check validations.

**Important for KIA0104:** stock Bookinfo VS uses `hosts: ["*"]`, which masks registry misses. Patch it first:

```bash
kubectl patch virtualservice bookinfo -n bookinfo --type=json \
  -p='[{"op":"replace","path":"/spec/hosts","value":["bookinfo.example.com"]}]'
```

#### 1) KIA0104 — AuthZ Host-header hosts (should be clean after fix)

```bash
kubectl apply -f - <<'EOF'
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: kia0104-host-header
  namespace: bookinfo
spec:
  action: ALLOW
  rules:
  - to:
    - operation:
        hosts:
        - kia0104-unique.notindns.test
        - "*.kia0104-repro.test"
        methods: ["GET"]
EOF
```

#### 2) KIA0102 — method wildcards clean; gRPC-in-methods still warned

```bash
kubectl apply -f - <<'EOF'
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: kia0102-method-wildcards
  namespace: bookinfo
spec:
  action: ALLOW
  rules:
  - to:
    - operation:
        methods: ["GET*", "G*", "*ET", "*POST", "*"]
---
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: kia0102-grpc-in-methods
  namespace: bookinfo
spec:
  action: ALLOW
  rules:
  - to:
    - operation:
        methods: ["/my.package.Service/Method"]
EOF
```

#### 3) KIA0205 / KIA0206 — ISTIO_MUTUAL DR with auto-mTLS, no PeerAuth (should be clean)

```bash
kubectl apply -f - <<'EOF'
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kia0205-mesh-mtls
  namespace: istio-system
spec:
  host: "*.local"
  trafficPolicy:
    tls:
      mode: ISTIO_MUTUAL
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: kia0206-ns-mtls
  namespace: bookinfo
spec:
  host: "*.bookinfo.svc.cluster.local"
  trafficPolicy:
    tls:
      mode: ISTIO_MUTUAL
EOF
```

Note: if bookinfo already has a STRICT PeerAuthentication, KIA0206 will also be clean for that reason.

#### 4) KIA0602 — kubernetes.io appProtocol (should be clean)

```bash
kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Service
metadata:
  name: kia0602-h2c
  namespace: bookinfo
spec:
  selector:
    app: productpage
  ports:
  - name: http
    port: 9080
    targetPort: 9080
    appProtocol: kubernetes.io/h2c
EOF
```

#### 5) KIA1402 — multi-from ReferenceGrant (HTTPRoute in bookinfo; should be clean after fix)

Requires Gateway API CRDs.

```bash
kubectl create ns kia1402-backend --dry-run=client -o yaml | kubectl apply -f -
kubectl create ns kia1402-other --dry-run=client -o yaml | kubectl apply -f -
kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Service
metadata:
  name: kia1402-svc
  namespace: kia1402-backend
spec:
  ports:
  - name: http
    port: 9080
    targetPort: 9080
  selector:
    app: kia1402-backend
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: ReferenceGrant
metadata:
  name: kia1402-multi-from
  namespace: kia1402-backend
spec:
  from:
  - group: gateway.networking.k8s.io
    kind: HTTPRoute
    namespace: kia1402-other
  - group: gateway.networking.k8s.io
    kind: HTTPRoute
    namespace: bookinfo
  to:
  - group: ""
    kind: Service
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kia1402-gw
  namespace: bookinfo
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: Same
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: kia1402-route
  namespace: bookinfo
spec:
  parentRefs:
  - name: kia1402-gw
    namespace: bookinfo
  rules:
  - backendRefs:
    - name: kia1402-svc
      namespace: kia1402-backend
      port: 9080
EOF
```

#### 6) GWAPI status — Programmed=False should surface a warning

```bash
kubectl apply -f - <<'EOF'
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kia-gwapi-status
  namespace: bookinfo
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    port: 80
    protocol: HTTP
    hostname: demo.example.com
EOF
# If status stays healthy, force Programmed=False for the demo:
kubectl patch gateway kia-gwapi-status -n bookinfo --subresource=status --type=merge -p '{"status":{"conditions":[{"type":"Programmed","status":"False","reason":"AddressNotAssigned","message":"demo Programmed=False","lastTransitionTime":"2026-01-01T00:00:00Z"}]}}'
```

#### Cleanup

```bash
kubectl delete authorizationpolicy kia0104-host-header kia0102-method-wildcards kia0102-grpc-in-methods -n bookinfo --ignore-not-found
kubectl delete destinationrule kia0205-mesh-mtls -n istio-system --ignore-not-found
kubectl delete destinationrule kia0206-ns-mtls -n bookinfo --ignore-not-found
kubectl delete svc kia0602-h2c -n bookinfo --ignore-not-found
kubectl delete httproute kia1402-route gateway kia1402-gw kia-gwapi-status -n bookinfo --ignore-not-found
kubectl delete referencegrant kia1402-multi-from -n kia1402-backend --ignore-not-found
kubectl delete ns kia1402-backend kia1402-other --ignore-not-found
kubectl patch virtualservice bookinfo -n bookinfo --type=json \
  -p='[{"op":"replace","path":"/spec/hosts","value":["*"]}]' || true
```

### Automation testing

Unit tests updated/added for:

- AuthZ method wildcards / gRPC-in-methods
- AuthZ host-header matcher skip vs short-name registry lint
- Mesh/ns DestinationRule auto-mTLS skip
- `kubernetes.io/*` appProtocols
- ReferenceGrant multi-From
- Gateway Accepted=False status

### Issue reference

Fixes #10188
