### PR TITLE
Add React keys to graph/mesh shortcut tour items

### DIFF
--- a/frontend/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
+++ b/frontend/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
@@ -20,7 +20,7 @@ const shortcuts: Shortcut[] = [
 
 const makeShortcut = (shortcut: Shortcut): React.ReactNode => {
   return (
-    <div style={{ display: 'flex', marginBottom: '10px' }}>
+    <div key={shortcut.shortcut} style={{ display: 'flex', marginBottom: '10px' }}>
       <div style={{ flex: '45%' }}>
         <Label variant="outline">{shortcut.shortcut}</Label>
       </div>
@@ -32,10 +32,8 @@ const makeShortcut = (shortcut: Shortcut): React.ReactNode => {
 
 export const GraphShortcuts = (): React.ReactNode => (
   <>
-    {shortcuts.map(
-      (s: Shortcut): React.ReactNode => {
-        return makeShortcut(s);
-      }
-    )}
+    {shortcuts.map((s: Shortcut): React.ReactNode => {
+      return makeShortcut(s);
+    })}
   </>
 );

--- a/frontend/src/pages/Mesh/toolbar/MeshShortcuts.tsx
+++ b/frontend/src/pages/Mesh/toolbar/MeshShortcuts.tsx
@@ -18,7 +18,7 @@ const shortcuts: Shortcut[] = [
 
 const makeShortcut = (shortcut: Shortcut): React.ReactNode => {
   return (
-    <div style={{ display: 'flex', marginBottom: '10px' }}>
+    <div key={shortcut.shortcut} style={{ display: 'flex', marginBottom: '10px' }}>
       <div style={{ flex: '40%' }}>
         <Label variant="outline">{t(shortcut.shortcut)}</Label>
       </div>
@@ -29,10 +29,8 @@ const makeShortcut = (shortcut: Shortcut): React.ReactNode => {
 
 export const MeshShortcuts = (): React.ReactNode => (
   <>
-    {shortcuts.map(
-      (s: Shortcut): React.ReactNode => {
-        return makeShortcut(s);
-      }
-    )}
+    {shortcuts.map((s: Shortcut): React.ReactNode => {
+      return makeShortcut(s);
+    })}
   </>
 );


### PR DESCRIPTION
## Summary

- Add `key` props to mapped shortcut rows in `GraphShortcuts` and `MeshShortcuts`
- Fixes OSSMC local dev crash when loading pages that import `GraphHelpTour` after kiali/kiali#10150

## Context

kiali/kiali#10150 changed the Shortcuts tour stop to call `GraphShortcuts()` / `MeshShortcuts()` at module load time. In OSSMC's Module Federation setup, missing React keys on the mapped shortcut rows can crash the plugin during module evaluation with:

```
TypeError: Cannot read properties of undefined (reading 'setExtraStackFrame')
```

Fixes kiali/openshift-servicemesh-plugin#803

## Test plan

- [ ] Open Graph help tour → Shortcuts stop renders the shortcut list
- [ ] Open Mesh help tour → Shortcuts stop renders the shortcut list
- [ ] Sync OSSMC frontend and verify Overview loads in local dev without `setExtraStackFrame` error

Made with [Cursor](https://cursor.com)