### PR TITLE
Add React key to replay speed button fragments

### DIFF
--- a/frontend/src/components/Time/Replay.tsx
+++ b/frontend/src/components/Time/Replay.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { KialiDispatch } from 'types/Redux';
-import { KialiAppState } from 'store/Store';
+import type { KialiDispatch } from 'types/Redux';
+import type { KialiAppState } from 'store/Store';
 import { replayQueryTimeSelector, durationSelector } from 'store/Selectors';
 import { Tooltip, ButtonVariant, Button, Content } from '@patternfly/react-core';
-import { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds } from 'types/Common';
+import type { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds } from 'types/Common';
 import { ToolbarDropdown } from 'components/Dropdown/ToolbarDropdown';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
 import { Slider } from 'components/IstioWizards/Slider/Slider';
@@ -155,20 +155,6 @@ const vrStyle = kialiStyle({
 });
 
 class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
-  static getFrameCount = (elapsedTime: IntervalInMilliseconds): number => {
-    return elapsedTime > 0 ? Math.floor(elapsedTime / frameInterval) : 0;
-  };
-
-  static queryTimeToFrame = (replayQueryTime: TimeInMilliseconds, replayStartTime: TimeInMilliseconds): number => {
-    const elapsedTime: IntervalInMilliseconds = replayQueryTime - replayStartTime;
-    const frame: number = ReplayComponent.getFrameCount(elapsedTime);
-    return frame;
-  };
-
-  static frameToQueryTime = (frame: number, replayWindow: ReplayWindow): TimeInMilliseconds => {
-    return replayWindow.startTime + frame * frameInterval;
-  };
-
   constructor(props: ReplayProps) {
     super(props);
 
@@ -201,6 +187,20 @@ class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
       status: 'initialized'
     };
   }
+
+  static getFrameCount = (elapsedTime: IntervalInMilliseconds): number => {
+    return elapsedTime > 0 ? Math.floor(elapsedTime / frameInterval) : 0;
+  };
+
+  static queryTimeToFrame = (replayQueryTime: TimeInMilliseconds, replayStartTime: TimeInMilliseconds): number => {
+    const elapsedTime: IntervalInMilliseconds = replayQueryTime - replayStartTime;
+    const frame: number = ReplayComponent.getFrameCount(elapsedTime);
+    return frame;
+  };
+
+  static frameToQueryTime = (frame: number, replayWindow: ReplayWindow): TimeInMilliseconds => {
+    return replayWindow.startTime + frame * frameInterval;
+  };
 
   componentDidUpdate(_prevProps: ReplayProps, prevState: ReplayState): void {
     const isCustomStartChange = this.state.isCustomStartTime !== prevState.isCustomStartTime;
@@ -456,9 +456,8 @@ class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
       return;
     }
 
-    let refresherRef: number | undefined = undefined;
-    refresherRef = window.setInterval(this.handleRefresh, this.state.replaySpeed);
-    this.setState({ refresherRef: refresherRef });
+    const refresherRef = window.setInterval(this.handleRefresh, this.state.replaySpeed);
+    this.setState({ refresherRef });
   };
 
   private handleRefresh = (): void => {
@@ -476,7 +475,7 @@ class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
     const isActive = this.state.replaySpeed === replaySpeed.speed;
 
     return (
-      <>
+      <React.Fragment key={`speed-${replaySpeed.text}`}>
         <Button
           icon={
             <Content component="p" className={isActive ? speedActiveStyle : undefined}>
@@ -484,7 +483,6 @@ class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
             </Content>
           }
           data-test={`speed-${replaySpeed.text}`}
-          key={`speed-${replaySpeed.text}`}
           className={speedStyle}
           variant={ButtonVariant.plain}
           isClicked={isActive}
@@ -492,7 +490,7 @@ class ReplayComponent extends React.PureComponent<ReplayProps, ReplayState> {
         />
 
         {!isLast && <div className={vrStyle} />}
-      </>
+      </React.Fragment>
     );
   };
 }


### PR DESCRIPTION
## Summary

- Add `key` to mapped replay speed button fragments in `Replay`
- Fixes OSSMC local dev crash when opening Replay on the Traffic Graph page

## Context

After kiali/kiali#10150, OSSMC can crash with `Cannot read properties of undefined (reading 'setExtraStackFrame')` when React's dev JSX runtime validates mapped children without keys in the Module Federation setup.

Clicking **Replay** mounts the `Replay` component, which maps `replaySpeeds` via `speedButton()`. Each mapped item returned a fragment without a `key` (the key was incorrectly placed on the inner `Button`).

Fixes kiali/openshift-servicemesh-plugin#803

## Test plan

- [ ] Open Traffic Graph → click **Replay** → speed buttons (slow/medium/fast) render
- [ ] Play/pause replay and scrub the slider
- [ ] Sync OSSMC frontend and verify Replay works without `setExtraStackFrame` error

Made with [Cursor](https://cursor.com)