### PR TITLE
fix: show bootstrap-slider tooltips above toolbar dropdowns

### DIFF
--- a/frontend/src/components/IstioWizards/Slider/SliderStyle.ts
+++ b/frontend/src/components/IstioWizards/Slider/SliderStyle.ts
@@ -24,11 +24,6 @@ export const sliderStyle = (maxWidth?: string): string =>
         backgroundImage: `radial-gradient(${PFColors.Color200}, ${PFColors.Color200} 2px, transparent 0) !important`,
         '-webkit-box-shadow': 'none',
         boxShadow: 'none'
-      },
-
-      // Make sure slider tooltips are below datepicker popper but above secondary masthead
-      '& .tooltip': {
-        zIndex: 10
       }
     }
   });


### PR DESCRIPTION
## Summary

Remove the stale `zIndex: 10` override on bootstrap-slider tooltips in `SliderStyle.ts` so the module's `z-index: 1070` applies. This fixes tooltips rendering behind PatternFly toolbar dropdowns on the Graph Replay slider.

Fixes #10214

## Test plan

- [x] Graph → Replay → hover/drag slider; tooltip visible above toolbar dropdowns
- [x] Replay → custom start time → open calendar popover; tooltip still below the calendar
- [ ] TCP/HTTP traffic-shifting wizards: slider tooltips behave correctly in modals

Made with [Cursor](https://cursor.com)