### PR TITLE
Fix nested scrollbars in Mesh target panel YAML editor

### DIFF
--- a/frontend/src/pages/Mesh/target/TargetPanelEditor.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelEditor.tsx
@@ -15,46 +15,58 @@ interface TargetPanelEditorProps {
   targetName: string;
 }
 
-const editorStyle = kialiStyle({
+const editorContainerStyle = kialiStyle({
+  backgroundColor: PFColors.BackgroundColor100,
   marginTop: '0.5rem',
-  backgroundColor: PFColors.BackgroundColor100
+  overflow: 'hidden',
+  $nest: {
+    '& > section': {
+      overflow: 'hidden'
+    }
+  }
 });
 
 const editorOptions: editor.IStandaloneEditorConstructionOptions = {
-  automaticLayout: true,
   folding: false,
   lineNumbers: 'off',
   minimap: { enabled: false },
   overviewRulerLanes: 0,
   renderLineHighlight: 'none',
   scrollBeyondLastLine: false,
+  scrollbar: {
+    alwaysConsumeMouseWheel: false,
+    handleMouseWheel: false,
+    horizontal: 'hidden',
+    vertical: 'hidden'
+  },
   wordWrap: 'on'
 };
 
-export const TargetPanelEditor: React.FC<TargetPanelEditorProps> = (props: TargetPanelEditorProps) => {
+export const TargetPanelEditor: React.FC<TargetPanelEditorProps> = ({ configData, includeTitle, targetName }) => {
   const darkTheme = useKialiTheme() === Theme.DARK;
   const [editorHeight, setEditorHeight] = React.useState<string>('200px');
 
   let yaml = '';
   try {
-    yaml = dump(props.configData || 'N/A', yamlDumpOptions);
+    yaml = dump(configData || 'N/A', yamlDumpOptions);
   } catch {
     yaml = 'N/A';
   }
 
+  const updateEditorHeight = (ed: editor.IStandaloneCodeEditor): void => {
+    setEditorHeight(`${ed.getContentHeight()}px`);
+  };
+
   const onEditorDidMount = (ed: editor.IStandaloneCodeEditor): void => {
-    const lineHeight = ed.getOption(editor.EditorOption.lineHeight);
-    const padding = ed.getOption(editor.EditorOption.padding);
-    const lineCount = ed.getModel()?.getLineCount() ?? yaml.split('\n').length;
-    const totalPadding = (padding.top ?? 0) + (padding.bottom ?? 0);
-    setEditorHeight(`${lineCount * lineHeight + totalPadding}px`);
+    updateEditorHeight(ed);
+    ed.onDidContentSizeChange(() => updateEditorHeight(ed));
   };
 
   return (
     <>
-      <ConfigButtonsTargetPanel copyText={yaml} includeTitle={props.includeTitle} targetName={props.targetName} />
+      <ConfigButtonsTargetPanel copyText={yaml} includeTitle={includeTitle} targetName={targetName} />
 
-      <div className={editorStyle} data-test="target-panel-editor">
+      <div className={editorContainerStyle} data-test="target-panel-editor">
         <Editor
           value={yaml}
           language="yaml"

--- a/frontend/src/pages/Mesh/target/TargetPanelEditor.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelEditor.tsx
@@ -27,6 +27,7 @@ const editorContainerStyle = kialiStyle({
 });
 
 const editorOptions: editor.IStandaloneEditorConstructionOptions = {
+  automaticLayout: true,
   folding: false,
   lineNumbers: 'off',
   minimap: { enabled: false },

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
@@ -1,25 +1,42 @@
-import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { TargetPanelEditor } from '../TargetPanelEditor';
 
 const mockOnDidContentSizeChange = rstest.fn();
 const mockGetContentHeight = rstest.fn(() => 480);
+let contentSizeChangeCallback: (() => void) | undefined;
 
-rstest.mock('@monaco-editor/react', () => ({
-  default: ({
+rstest.mock('@monaco-editor/react', () => {
+  const MonacoEditorMock = ({
     height,
-    onMount
+    onMount,
+    options
   }: {
     height: string;
     onMount: (ed: { getContentHeight: () => number; onDidContentSizeChange: (cb: () => void) => void }) => void;
+    options?: Record<string, unknown>;
   }) => {
-    onMount({
-      getContentHeight: mockGetContentHeight,
-      onDidContentSizeChange: mockOnDidContentSizeChange
-    });
+    React.useEffect(() => {
+      onMount({
+        getContentHeight: mockGetContentHeight,
+        onDidContentSizeChange: (cb: () => void) => {
+          contentSizeChangeCallback = cb;
+          mockOnDidContentSizeChange(cb);
+        }
+      });
+    }, [onMount]);
 
-    return <div data-test="monaco-editor-mock" data-height={height} />;
-  }
-}));
+    return (
+      <div
+        data-test="monaco-editor-mock"
+        data-height={height}
+        data-automatic-layout={String(options?.automaticLayout)}
+      />
+    );
+  };
+
+  return { default: MonacoEditorMock };
+});
 
 rstest.mock('utils/ThemeUtils', () => ({
   useKialiTheme: () => 'Light'
@@ -32,14 +49,44 @@ rstest.mock('components/Mesh/ConfigButtonsTargetPanel', () => ({
 describe('TargetPanelEditor', () => {
   beforeEach(() => {
     rstest.clearAllMocks();
+    contentSizeChangeCallback = undefined;
+    mockGetContentHeight.mockReturnValue(480);
   });
 
-  it('sizes the editor to Monaco content height and listens for content size changes', () => {
+  it('sizes the editor to Monaco content height and listens for content size changes', async () => {
     render(<TargetPanelEditor configData={{ mesh: { trustDomain: 'cluster.local' } }} targetName="istiod" />);
 
     expect(screen.getByTestId('target-panel-editor')).toBeInTheDocument();
-    expect(mockGetContentHeight).toHaveBeenCalled();
-    expect(mockOnDidContentSizeChange).toHaveBeenCalled();
-    expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-height', '480px');
+
+    await waitFor(() => {
+      expect(mockGetContentHeight).toHaveBeenCalled();
+      expect(mockOnDidContentSizeChange).toHaveBeenCalled();
+      expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-height', '480px');
+    });
+  });
+
+  it('updates editor height when Monaco reports a content size change', async () => {
+    render(<TargetPanelEditor configData={{ mesh: { trustDomain: 'cluster.local' } }} targetName="istiod" />);
+
+    await waitFor(() => {
+      expect(contentSizeChangeCallback).toBeDefined();
+      expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-height', '480px');
+    });
+
+    mockGetContentHeight.mockReturnValue(560);
+
+    act(() => {
+      contentSizeChangeCallback?.();
+    });
+
+    expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-height', '560px');
+  });
+
+  it('enables automaticLayout so wrapped content reflows on container resize', async () => {
+    render(<TargetPanelEditor configData={{ mesh: { trustDomain: 'cluster.local' } }} targetName="istiod" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-automatic-layout', 'true');
+    });
   });
 });

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
@@ -24,7 +24,7 @@ rstest.mock('@monaco-editor/react', () => {
           mockOnDidContentSizeChange(cb);
         }
       });
-    }, [onMount]);
+    }, []);
 
     return (
       <div

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { TargetPanelEditor } from '../TargetPanelEditor';
 
@@ -13,12 +12,10 @@ rstest.mock('@monaco-editor/react', () => ({
     height: string;
     onMount: (ed: { getContentHeight: () => number; onDidContentSizeChange: (cb: () => void) => void }) => void;
   }) => {
-    React.useEffect(() => {
-      onMount({
-        getContentHeight: mockGetContentHeight,
-        onDidContentSizeChange: mockOnDidContentSizeChange
-      });
-    }, [onMount]);
+    onMount({
+      getContentHeight: mockGetContentHeight,
+      onDidContentSizeChange: mockOnDidContentSizeChange
+    });
 
     return <div data-test="monaco-editor-mock" data-height={height} />;
   }

--- a/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
+++ b/frontend/src/pages/Mesh/target/__tests__/TargetPanelEditor.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TargetPanelEditor } from '../TargetPanelEditor';
+
+const mockOnDidContentSizeChange = rstest.fn();
+const mockGetContentHeight = rstest.fn(() => 480);
+
+rstest.mock('@monaco-editor/react', () => ({
+  default: ({
+    height,
+    onMount
+  }: {
+    height: string;
+    onMount: (ed: { getContentHeight: () => number; onDidContentSizeChange: (cb: () => void) => void }) => void;
+  }) => {
+    React.useEffect(() => {
+      onMount({
+        getContentHeight: mockGetContentHeight,
+        onDidContentSizeChange: mockOnDidContentSizeChange
+      });
+    }, [onMount]);
+
+    return <div data-test="monaco-editor-mock" data-height={height} />;
+  }
+}));
+
+rstest.mock('utils/ThemeUtils', () => ({
+  useKialiTheme: () => 'Light'
+}));
+
+rstest.mock('components/Mesh/ConfigButtonsTargetPanel', () => ({
+  ConfigButtonsTargetPanel: () => <div data-test="config-buttons" />
+}));
+
+describe('TargetPanelEditor', () => {
+  beforeEach(() => {
+    rstest.clearAllMocks();
+  });
+
+  it('sizes the editor to Monaco content height and listens for content size changes', () => {
+    render(<TargetPanelEditor configData={{ mesh: { trustDomain: 'cluster.local' } }} targetName="istiod" />);
+
+    expect(screen.getByTestId('target-panel-editor')).toBeInTheDocument();
+    expect(mockGetContentHeight).toHaveBeenCalled();
+    expect(mockOnDidContentSizeChange).toHaveBeenCalled();
+    expect(screen.getByTestId('monaco-editor-mock')).toHaveAttribute('data-height', '480px');
+  });
+});


### PR DESCRIPTION
Size the Monaco editor to its content height, hide internal scrollbars, and let the side panel be the single scroll context.

Fixes kiali#10180
