### PR TITLE
test: add K8sGateway details page validation diagnostic step

### DIFF
--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -33,6 +33,18 @@ When(
   }
 );
 
+Then('the details page does not include any error or warning', () => {
+  ensureKialiFinishedLoading();
+
+  cy.get('main').within(() => {
+    cy.get('[data-test="icon-error-validation"]').should('not.exist');
+    cy.get('[data-test="icon-warning-validation"]').should('not.exist');
+  });
+
+  cy.get('.pf-v6-c-alert.pf-m-danger').should('not.exist');
+  cy.get('.pf-v6-c-alert.pf-m-warning').should('not.exist');
+});
+
 When('user deletes k8sgateway named {string} and the resource is no longer available', (name: string) => {
   cy.exec(`kubectl delete gateways.gateway.networking.k8s.io ${name} -n bookinfo`, { failOnNonZeroExit: false });
   ensureKialiFinishedLoading();

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -362,6 +362,7 @@ Feature: Kiali Istio Config wizard
     When user is at the details page for the K8sGateway "gatewayapi-2" in the "bookinfo" namespace
     And choosing to delete it
     And user is at the details page for the K8sGateway "gatewayapi-1" in the "bookinfo" namespace
+    And the details page does not include any error or warning
     And user is at the "istio" page
     And user selects the "bookinfo" namespace
     Then the "K8sGateway" "gatewayapi-2" should not be listed in "bookinfo" namespace


### PR DESCRIPTION
## Summary

- Adds a Cypress step after visiting the `gatewayapi-1` K8sGateway details page (following deletion of the colliding `gatewayapi-2`) to assert the page shows no validation errors or warnings.
- This helps debug the flaky CI failure on `And the "gatewayapi-1" "K8sGateway" of the "bookinfo" namespace should have a "success"` by distinguishing whether validation state is stale on the details page vs. only on the list page.

## Test plan

- [ ] CI frontend core-2 suite runs the `wizard_istio_config.feature` gateway collision scenario
- [ ] If the new step fails in CI, inspect whether warnings/errors are still present on the details page immediately after deleting the colliding gateway
- [ ] If the new step passes but the list assertion still fails, the issue is likely list-page caching/refresh timing


Made with [Cursor](https://cursor.com)