### PR TITLE
Fix flaky K8sGateway collision wizard test

### DIFF
--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -103,32 +103,14 @@ When('user checks validation of the hostname {string} input', (id: string) => {
   cy.inputValidation(id, 'HOST.com', false); // capital letters are not allowed
 });
 
-When('user checks validation of the gateway address {string} input', (id: string) => {
-  const typeId = id.replace('addValue', 'addType');
-
+When('user checks validation of the gateway IP address {string} input', (id: string) => {
   cy.inputValidation(id, 'invalid', false);
   cy.inputValidation(id, '192.168.1.1', true);
+});
 
-  cy.get('body').then($body => {
-    if ($body.find(`select[id="${typeId}"]`).length > 0) {
-      cy.get(`select[id="${typeId}"]`).select('Hostname');
-    } else {
-      cy.get(`button[id="${typeId}-toggle"]`).click();
-      cy.get('.pf-v6-c-menu__list-item').contains('Hostname').click();
-    }
-  });
-
+When('user checks validation of the gateway hostname address {string} input', (id: string) => {
   cy.inputValidation(id, 'bookinfo-istio-system', false);
   cy.inputValidation(id, 'example.com', true);
-
-  cy.get('body').then($body => {
-    if ($body.find(`select[id="${typeId}"]`).length > 0) {
-      cy.get(`select[id="${typeId}"]`).select('IPAddress');
-    } else {
-      cy.get(`button[id="${typeId}-toggle"]`).click();
-      cy.get('.pf-v6-c-menu__list-item').contains('IPAddress').click();
-    }
-  });
 });
 
 When('user adds a server to a server list', () => {

--- a/frontend/cypress/integration/common/wizard_istio_config.ts
+++ b/frontend/cypress/integration/common/wizard_istio_config.ts
@@ -103,6 +103,34 @@ When('user checks validation of the hostname {string} input', (id: string) => {
   cy.inputValidation(id, 'HOST.com', false); // capital letters are not allowed
 });
 
+When('user checks validation of the gateway address {string} input', (id: string) => {
+  const typeId = id.replace('addValue', 'addType');
+
+  cy.inputValidation(id, 'invalid', false);
+  cy.inputValidation(id, '192.168.1.1', true);
+
+  cy.get('body').then($body => {
+    if ($body.find(`select[id="${typeId}"]`).length > 0) {
+      cy.get(`select[id="${typeId}"]`).select('Hostname');
+    } else {
+      cy.get(`button[id="${typeId}-toggle"]`).click();
+      cy.get('.pf-v6-c-menu__list-item').contains('Hostname').click();
+    }
+  });
+
+  cy.inputValidation(id, 'bookinfo-istio-system', false);
+  cy.inputValidation(id, 'example.com', true);
+
+  cy.get('body').then($body => {
+    if ($body.find(`select[id="${typeId}"]`).length > 0) {
+      cy.get(`select[id="${typeId}"]`).select('IPAddress');
+    } else {
+      cy.get(`button[id="${typeId}-toggle"]`).click();
+      cy.get('.pf-v6-c-menu__list-item').contains('IPAddress').click();
+    }
+  });
+});
+
 When('user adds a server to a server list', () => {
   cy.get('button[name="addServer"]').should('be.visible').click();
 });

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -92,7 +92,10 @@ Feature: Kiali Istio Config wizard
     And user types "website.com" in the "addHostname_0" input
     And user types "8080" in the "addPort_0" input
     And user adds a hostname
-    And user checks validation of the gateway address "addValue_0" input
+    And user checks validation of the gateway IP address "addValue_0" input
+    And user chooses "Hostname" mode from the "addType_0" select
+    And user checks validation of the gateway hostname address "addValue_0" input
+    And user chooses "IPAddress" mode from the "addType_0" select
     And user types "192.168.1.1" in the "addValue_0" input
     And user previews the configuration
     Then "192.168.1.1" should be in preview

--- a/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/wizard_istio_config.feature
@@ -82,6 +82,27 @@ Feature: Kiali Istio Config wizard
   @gateway-api
   @bookinfo-app
   @core-2
+  Scenario: Create a K8s Gateway with an address
+    When user deletes k8sgateway named "k8sgwaddress" and the resource is no longer available
+    And user clicks in the "K8sGateway" Istio config actions
+    And user sees the "Create K8sGateway" config wizard
+    And user adds listener
+    And user types "k8sgwaddress" in the "name" input
+    And user types "default" in the "addName_0" input
+    And user types "website.com" in the "addHostname_0" input
+    And user types "8080" in the "addPort_0" input
+    And user adds a hostname
+    And user checks validation of the gateway address "addValue_0" input
+    And user types "192.168.1.1" in the "addValue_0" input
+    And user previews the configuration
+    Then "192.168.1.1" should be in preview
+    And user creates the istio config
+    Then the "K8sGateway" "k8sgwaddress" should be listed in "bookinfo" namespace
+    And user deletes k8sgateway named "k8sgwaddress" and the resource is no longer available
+
+  @gateway-api
+  @bookinfo-app
+  @core-2
   Scenario: Create a K8s Reference Grant scenario
     When user deletes k8sreferencegrant named "k8srefgrant" and the resource is no longer available
     And user clicks in the "K8sReferenceGrant" Istio config actions
@@ -336,9 +357,6 @@ Feature: Kiali Istio Config wizard
     And user types "default" in the "addName_0" input
     And user types "bookinfo-istio-system.apps.ocp4-kqe1.maistra.upshift.redhat.com" in the "addHostname_0" input
     And user types "80" in the "addPort_0" input
-    And user adds a hostname
-    And user chooses "Hostname" mode from the "addType_0" select
-    And user types "google.com" in the "addValue_0" input
     And user previews the configuration
     And user creates the istio config
     And user clicks in the "K8sGateway" Istio config actions
@@ -348,13 +366,14 @@ Feature: Kiali Istio Config wizard
     And user types "default" in the "addName_0" input
     And user types "bookinfo-istio-system.apps.ocp4-kqe1.maistra.upshift.redhat.com" in the "addHostname_0" input
     And user types "80" in the "addPort_0" input
-    And user adds a hostname
-    And user chooses "Hostname" mode from the "addType_0" select
-    And user types "google.com" in the "addValue_0" input
     And user previews the configuration
     And user creates the istio config
     Then the "K8sGateway" "gatewayapi-1" should be listed in "bookinfo" namespace
     And the "K8sGateway" "gatewayapi-2" should be listed in "bookinfo" namespace
+    And user is at the details page for the K8sGateway "gatewayapi-1" in the "bookinfo" namespace
+    And user is at the details page for the K8sGateway "gatewayapi-2" in the "bookinfo" namespace
+    And user is at the "istio" page
+    And user selects the "bookinfo" namespace
     And the "gatewayapi-1" "K8sGateway" of the "bookinfo" namespace should have a "warning"
     And the "gatewayapi-2" "K8sGateway" of the "bookinfo" namespace should have a "warning"
     When viewing the detail for "gatewayapi-1"


### PR DESCRIPTION
### Describe the change

Fixes a flaky Cypress failure in the K8sGateway collision wizard scenario (`wizard_istio_config.feature`).

The collision test was creating both gateways with a `google.com` hostname address. In KinD CI this leaves a persistent GWAPI `AddressNotUsable` / GWA101 warning (`Programmed=False`) even after the colliding gateway is deleted, so `gatewayapi-1` never reaches `success`.

Changes:
- Remove address steps from the listener collision scenario (KIA1501 is what it exercises; KIA1502 is covered in `istio_config.feature`).
- Add a dedicated wizard scenario that exercises address UI validation (IPAddress and Hostname modes) and creates a gateway with an `IPAddress` value.
- Refresh the istio list before status assertions after creating both gateways.

### Steps to test the PR

```bash
cd frontend
CYPRESS_BASE_URL=http://localhost:20001 npx cypress run \
  --spec "cypress/integration/featureFiles/wizard_istio_config.feature" \
  -e TAGS="@gateway-api"
```

Or run the full `@core-2` frontend suite in CI.

### Automation testing

- Cypress: updated `wizard_istio_config.feature` collision scenario
- Cypress: new scenario `Create a K8s Gateway with an address`
- Cypress: new step `user checks validation of the gateway address` in `wizard_istio_config.ts`

### Issue reference

Related to flaky CI on the K8sGateway collision wizard test (e.g. PR #10225 / branch `issue10189`).

Made with [Cursor](https://cursor.com)