### PR TITLE
[2.27] Upgrade axios to 1.19.0 (CVE-2026-67313, CVE-2026-67314, CVE-2026-67320, CVE-2026-67321)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,7 +111,7 @@
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
     "@patternfly/react-topology": "^6.4.0",
-    "axios": "^1.17.0",
+    "axios": "^1.19.0",
     "bootstrap-slider-without-jquery": "10.0.0",
     "deep-freeze": "0.0.1",
     "eventemitter3": "4.0.7",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2853,7 +2853,7 @@ __metadata:
     "@types/react-redux": "npm:7.1.7"
     "@types/react-router-dom": "npm:^5.2.0"
     "@types/react-virtualized": "npm:9.x"
-    axios: "npm:^1.17.0"
+    axios: "npm:^1.19.0"
     axios-mock-adapter: "npm:^1.22.0"
     bootstrap-slider-without-jquery: "npm:10.0.0"
     cypress: "npm:^13.6.1"
@@ -6017,15 +6017,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "axios@npm:1.17.0"
+"axios@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "axios@npm:1.19.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
+    form-data: "npm:^4.0.6"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
+  checksum: 10c0/559fe7d51291787def61566a3db78b87510c8faf9c8a8c006d9d8b933808628ff0d8eca7756b40ae25e07da96d946c68c1ffba3da9075ed0b5d3661801d76869
   languageName: node
   linkType: hard
 
@@ -10128,7 +10128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5, form-data@npm:~4.0.4":
+"form-data@npm:^4.0.6, form-data@npm:~4.0.4":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:


### PR DESCRIPTION
## Summary
- Upgrade axios from 1.17.0 to 1.19.0 in `frontend/package.json` and regenerate `yarn.lock`
- Master already contains axios 1.19.0; this backport brings v2.27 into parity

## CVEs fixed
- CVE-2026-67313: DoS via uncontrolled recursion in formDataToJSON (fixed in 1.18.0)
- CVE-2026-67314: Outbound request tampering via prototype pollution in Basic Auth (<1.18.0)
- CVE-2026-67320: Information disclosure via prototype pollution in Node HTTP adapter (fixed in 1.18.0)
- CVE-2026-67321: DoS via object serialization bypass (<1.18.0)


Made with [Cursor](https://cursor.com)