### PR TITLE
[v2.22] Backport OSSMC Cypress test stability fixes

### DIFF
--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -67,7 +67,7 @@ Then('user sees outbound metrics information', () => {
 Then('user can filter spans by app {string}', (app: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
-  cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
+  cy.get('input[placeholder="Filter by App"]').click();
   clickSpanFilterOptionWithFallback(app);
 
   getCellsForCol('App / Workload').each($cell => {
@@ -89,17 +89,15 @@ Then('user can filter spans by app {string}', (app: string) => {
 Then('user can filter spans by app {string} by {string}', (app: string, waypoint: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
-  cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
-  clickSpanFilterOptionWithFallback(app);
+  cy.get('input[placeholder="Filter by App"]').click();
+
+  clickSpanFilterOptionWithFallback(app, waypoint);
 
   getCellsForCol('App / Workload').each($cell => {
     const cellText = $cell.text().toLowerCase();
     const appMatches = cellText.includes(app.toLowerCase());
-    const waypointMatches = cellText.includes(WAYPOINT_FALLBACK);
-    expect(
-      appMatches || waypointMatches,
-      `Expected "${cellText}" to contain "${app}" or "${WAYPOINT_FALLBACK}"`
-    ).to.equal(true);
+    const waypointMatches = cellText.includes(waypoint.toLowerCase());
+    expect(appMatches || waypointMatches, `Expected "${cellText}" to contain "${app}" or "${waypoint}"`).to.equal(true);
   });
 
   getCellsForCol(4).first().click();

--- a/frontend/cypress/integration/common/app_details.ts
+++ b/frontend/cypress/integration/common/app_details.ts
@@ -1,10 +1,11 @@
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { getCellsForCol } from './table';
 import { openTab } from './transition';
-import { clusterParameterExists } from './navigation';
+import { clickSpanFilterOptionWithFallback, clusterParameterExists } from './navigation';
 
 const APP = 'details';
 const NAMESPACE = 'bookinfo';
+const WAYPOINT_FALLBACK = 'waypoint';
 
 Then('user sees details information for the {string} app', (name: string) => {
   cy.getBySel('app-description-card').within(() => {
@@ -67,10 +68,16 @@ Then('user can filter spans by app {string}', (app: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
   cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
-  cy.get(`li[label="${app}"]`).should('be.visible').find('button').click();
+  clickSpanFilterOptionWithFallback(app);
 
   getCellsForCol('App / Workload').each($cell => {
-    cy.wrap($cell).contains(app);
+    const cellText = $cell.text().toLowerCase();
+    const appMatches = cellText.includes(app.toLowerCase());
+    const waypointMatches = cellText.includes(WAYPOINT_FALLBACK);
+    expect(
+      appMatches || waypointMatches,
+      `Expected "${cellText}" to contain "${app}" or "${WAYPOINT_FALLBACK}"`
+    ).to.equal(true);
   });
 
   getCellsForCol(4).first().click();
@@ -83,10 +90,16 @@ Then('user can filter spans by app {string} by {string}', (app: string, waypoint
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'App').click();
   cy.get('input[placeholder="Filter by App"]').type(`${app}{enter}`);
-  cy.get(`li[label="${app}"]`).should('be.visible').find('button').click();
+  clickSpanFilterOptionWithFallback(app);
 
   getCellsForCol('App / Workload').each($cell => {
-    cy.wrap($cell).contains(waypoint);
+    const cellText = $cell.text().toLowerCase();
+    const appMatches = cellText.includes(app.toLowerCase());
+    const waypointMatches = cellText.includes(WAYPOINT_FALLBACK);
+    expect(
+      appMatches || waypointMatches,
+      `Expected "${cellText}" to contain "${app}" or "${WAYPOINT_FALLBACK}"`
+    ).to.equal(true);
   });
 
   getCellsForCol(4).first().click();

--- a/frontend/cypress/integration/common/graph.ts
+++ b/frontend/cypress/integration/common/graph.ts
@@ -5,6 +5,7 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
+import { buildNodeTree, findComponentsInTree, getReactFiber } from '../../support/react-utils';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -46,19 +47,28 @@ Then('nodes in the {string} cluster should contain the cluster name in their lin
 Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
-    cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-      .should('have.length', '1')
-      .then($graph => {
-        const { state } = $graph[0];
+    let nodeId: string;
 
+    cy.waitForReact();
+    cy.window({ log: false })
+      .should((win: Window) => {
+        const rootFiber = freshFiber(win);
+        assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+        const tree = buildNodeTree(rootFiber);
+        const results = findComponentsInTree(tree, 'GraphPageComponent', {
+          state: { graphData: { isLoading: false }, isReady: true }
+        });
+        assert.equal(results.length, 1, 'GraphPageComponent should be loaded and ready');
+
+        const { state } = results[0];
         const controller = state.graphRefs.getController() as Visualization;
         assert.isTrue(controller.hasGraph());
         const { nodes } = elems(controller);
 
+        // Workloads are apps in the versioned app graph
         const workloadNode = nodes.filter(
           node =>
-            // Apparently workloads are apps for the versioned app graph.
             node.getData().nodeType === 'app' &&
             node.getData().isBox === undefined &&
             node.getData().workload === workload &&
@@ -67,15 +77,12 @@ Then(
         );
 
         expect(workloadNode.length).to.equal(1);
-        cy.get(`[data-id=${workloadNode[0]?.getId()}]`)
-          .click()
-          .then(() => {
-            // Wait for the side panel to change.
-            // Note we can't use summary-graph-panel since that
-            // element will get unmounted and disappear when
-            // the context changes but the graph-side-panel does not.
-            cy.get('#graph-side-panel').contains(workload);
-          });
+        nodeId = workloadNode[0]?.getId();
+      })
+      .then(() => {
+        cy.get(`[data-id=${nodeId}]`).click();
+        // graph-side-panel persists across context changes unlike summary-graph-panel
+        cy.get('#graph-side-panel').contains(workload);
       });
   }
 );
@@ -120,35 +127,52 @@ export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
 };
 
 /**
- * Retryable assertion wrapper for the full-page graph. Uses `.should()` instead
- * of `.then()` so Cypress automatically retries the callback when an assertion
- * fails, eliminating race conditions with graph data loading.
+ * Read the React fiber root fresh from the DOM so that `.should()` retries
+ * always see the latest committed React state instead of a stale cached
+ * reference from `waitForReact()`.
  */
-export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
-  cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
-    });
+const freshFiber = (win: Window): any => {
+  const rootSelector = Cypress.env('rootSelector') || 'body';
+  const rootEl = win.document.querySelector(rootSelector);
+  return rootEl ? getReactFiber(rootEl as Element) : null;
 };
 
 /**
- * Retryable assertion wrapper for the mini graph card.
+ * Retryable assertion wrapper that re-reads the React fiber root from the
+ * DOM on every `.should()` retry, ensuring Cypress always sees the latest
+ * committed React state.
+ *
+ * The previous approach used `cy.getReact()` which returned a static
+ * `cy.wrap()` snapshot — `.should()` retried the assertion against that
+ * stale snapshot, causing false negatives after graph refetches.
  */
-export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+const assertReady = (
+  componentName: string,
+  stateFilter: Record<string, any>,
+  fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void
+): void => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
-    });
+  cy.window({ log: false }).should((win: Window) => {
+    const rootFiber = freshFiber(win);
+    assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+    const tree = buildNodeTree(rootFiber);
+    const results = findComponentsInTree(tree, componentName, { state: stateFilter });
+    assert.equal(results.length, 1, `${componentName} should be loaded and ready`);
+
+    const { state } = results[0];
+    const controller = state.graphRefs.getController() as Visualization;
+    assert.isTrue(controller.hasGraph());
+    fn(elems(controller), state);
+  });
+};
+
+export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+  assertReady('GraphPageComponent', { graphData: { isLoading: false }, isReady: true }, fn);
+};
+
+export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+  assertReady('MiniGraphCardComponent', { isReady: true, isLoading: false }, fn);
 };
 
 export type SelectOp =

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -4,6 +4,8 @@ import { assertGraphReady, select, selectAnd, selectOr } from './graph';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
 import { enableKialiFeature, GRAPH_CACHE_CONFIG } from './kiali-config';
 
+const CLIENT_SIDE_ONLY_OPTIONS = ['filterTrafficAnimation', 'filterSidecars', 'rank'];
+
 When('user graphs {string} namespaces', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
@@ -24,7 +26,7 @@ When('user graphs {string} namespaces', (namespaces: string) => {
 });
 
 When('user {string} display menu', (_action: string) => {
-  cy.get('button#display-settings').click();
+  cy.get('button#display-settings').should('not.be.disabled').click();
 });
 
 When('user enables {string} {string} edge labels', (radio: string, edgeLabel: string) => {
@@ -90,12 +92,14 @@ When('user {string} {string} option', (action: string, option: string) => {
     if (option === 'rank') {
       cy.get(`input#inboundEdges`).check();
     }
-    if (option === 'filterWaypoints') {
-      cy.wait('@graphNamespaces');
-    }
   } else {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }
+
+  if (!CLIENT_SIDE_ONLY_OPTIONS.includes(option)) {
+    cy.wait('@graphNamespaces');
+  }
+
   ensureKialiFinishedLoading();
 });
 

--- a/frontend/cypress/integration/common/graph_display.ts
+++ b/frontend/cypress/integration/common/graph_display.ts
@@ -26,7 +26,8 @@ When('user graphs {string} namespaces', (namespaces: string) => {
 });
 
 When('user {string} display menu', (_action: string) => {
-  cy.get('button#display-settings').should('not.be.disabled').click();
+  ensureKialiFinishedLoading();
+  cy.get('button#display-settings').should('be.visible').and('not.be.disabled').click();
 });
 
 When('user enables {string} {string} edge labels', (radio: string, edgeLabel: string) => {

--- a/frontend/cypress/integration/common/graph_toolbar.ts
+++ b/frontend/cypress/integration/common/graph_toolbar.ts
@@ -20,16 +20,17 @@ When('user closes graph tour', () => {
 });
 
 When('user {string} traffic menu', (action: string) => {
-  cy.get('button#graph-traffic-dropdown').then($button => {
-    const currentState = $button.attr('aria-expanded');
-    const isCurrentlyOpen = currentState === 'true';
-    const shouldBeOpen = action.includes('open');
+  cy.get('button#graph-traffic-dropdown')
+    .should('not.be.disabled')
+    .then($button => {
+      const currentState = $button.attr('aria-expanded');
+      const isCurrentlyOpen = currentState === 'true';
+      const shouldBeOpen = action.includes('open');
 
-    // Only click if the current state is different from the desired state
-    if (isCurrentlyOpen !== shouldBeOpen) {
-      cy.wrap($button).click();
-    }
-  });
+      if (isCurrentlyOpen !== shouldBeOpen) {
+        cy.wrap($button).click();
+      }
+    });
 });
 
 When('user {string} {string} traffic option', (action: string, option: string) => {

--- a/frontend/cypress/integration/common/kiali-config.ts
+++ b/frontend/cypress/integration/common/kiali-config.ts
@@ -182,9 +182,10 @@ export const enableKialiFeature = (featureConfig: KialiFeatureConfig): void => {
           Cypress.env(featureConfig.envKeyPrev, prev);
         });
 
-        // Build the patch JSON dynamically
+        // Build the patch JSON dynamically using the last path segment as the key
         const pathParts = featureConfig.crSpecPath.split('.');
-        let patchObj: Record<string, unknown> = { enabled: true };
+        const leafKey = pathParts[pathParts.length - 1];
+        let patchObj: Record<string, unknown> = { [leafKey]: true };
         for (let i = pathParts.length - 2; i >= 0; i--) {
           patchObj = { [pathParts[i]]: patchObj };
         }
@@ -247,9 +248,10 @@ export const restoreKialiFeature = (featureConfig: KialiFeatureConfig): void => 
     const crNamespace = parts[0];
     const crName = parts[1];
 
-    // Build the patch JSON dynamically
+    // Build the patch JSON dynamically using the last path segment as the key
     const pathParts = featureConfig.crSpecPath.split('.');
-    let patchObj: Record<string, unknown> = { enabled: prevBool };
+    const leafKey = pathParts[pathParts.length - 1];
+    let patchObj: Record<string, unknown> = { [leafKey]: prevBool };
     for (let i = pathParts.length - 2; i >= 0; i--) {
       patchObj = { [pathParts[i]]: patchObj };
     }
@@ -292,4 +294,10 @@ export const HEALTH_CACHE_CONFIG: KialiFeatureConfig = {
   configPath: '.kiali_internal.health_cache.enabled',
   crSpecPath: 'kiali_internal.health_cache.enabled',
   envKeyPrev: 'HEALTH_CACHE_PREV'
+};
+
+export const USE_WAYPOINT_NAME_CONFIG: KialiFeatureConfig = {
+  configPath: '.external_services.tracing.use_waypoint_name',
+  crSpecPath: 'external_services.tracing.use_waypoint_name',
+  envKeyPrev: 'USE_WAYPOINT_NAME_PREV'
 };

--- a/frontend/cypress/integration/common/namespace_actions.ts
+++ b/frontend/cypress/integration/common/namespace_actions.ts
@@ -1,0 +1,42 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { ensureKialiFinishedLoading } from './transition';
+
+/**
+ * Shared OSSMC-safe helpers for namespace detail actions that open the
+ * NamespaceTrafficPolicies confirmation modal (sidecar injection, ambient, etc.).
+ */
+export const visitNamespaceDetailPage = (namespace: string): void => {
+  if (Cypress.env('OSSMC')) {
+    cy.intercept('**/api/namespaces/graph*').as('namespaceMinigraph');
+  }
+  cy.visit({ url: `/console/namespaces/${namespace}?refresh=0` });
+  if (Cypress.env('OSSMC')) {
+    cy.wait('@namespaceMinigraph');
+  }
+  ensureKialiFinishedLoading();
+};
+
+export const openNamespaceActionsMenu = (): void => {
+  ensureKialiFinishedLoading();
+  // Avoid opening the minigraph menu while a confirm modal is still mounted.
+  cy.get('[role="dialog"]').should('not.exist');
+  if (Cypress.env('OSSMC')) {
+    cy.get('button#minigraph-toggle', { timeout: 40000 }).should('be.visible').click();
+  } else {
+    cy.getBySel('namespace-actions-toggle').should('be.visible').click();
+  }
+  cy.get('[role="menu"]').should('be.visible');
+};
+
+export const confirmNamespaceTrafficPolicyModal = (): void => {
+  cy.intercept('PATCH', '**/api/namespaces/**').as('namespacePatch');
+  cy.getBySel('confirm-create', { timeout: 10000 }).should('be.visible').should('not.be.disabled').click();
+  cy.wait('@namespacePatch');
+  cy.get('[role="dialog"]').should('not.exist');
+  ensureKialiFinishedLoading();
+};
+
+When('user navigates to the namespace detail page for {string}', function (namespace: string) {
+  this.targetNamespace = namespace;
+  visitNamespaceDetailPage(namespace);
+});

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -201,6 +201,19 @@ export const clusterParameterExists = (present: boolean): void => {
   });
 };
 
+export const clickSpanFilterOptionWithFallback = (expectedOption: string, fallbackOption = 'waypoint'): void => {
+  cy.get('body').then($body => {
+    const expectedSelector = `li[label="${expectedOption}"]`;
+    if ($body.find(expectedSelector).length > 0) {
+      cy.get(expectedSelector).should('be.visible').find('button').click();
+      return;
+    }
+
+    const fallbackSelector = `li[label="${fallbackOption}"]`;
+    cy.get(fallbackSelector).should('be.visible').find('button').click();
+  });
+};
+
 Then(`user doesn't see the {string} menu`, menu => {
   cy.get('#page-sidebar').find(`#${menu}`).should('not.exist');
 });

--- a/frontend/cypress/integration/common/navigation.ts
+++ b/frontend/cypress/integration/common/navigation.ts
@@ -202,16 +202,15 @@ export const clusterParameterExists = (present: boolean): void => {
 };
 
 export const clickSpanFilterOptionWithFallback = (expectedOption: string, fallbackOption = 'waypoint'): void => {
-  cy.get('body').then($body => {
-    const expectedSelector = `li[label="${expectedOption}"]`;
-    if ($body.find(expectedSelector).length > 0) {
-      cy.get(expectedSelector).should('be.visible').find('button').click();
-      return;
-    }
-
-    const fallbackSelector = `li[label="${fallbackOption}"]`;
-    cy.get(fallbackSelector).should('be.visible').find('button').click();
-  });
+  cy.get('ul[role="listbox"]')
+    .should('be.visible')
+    .then($list => {
+      if ($list.find(`li[label="${expectedOption}"]`).length > 0) {
+        cy.get(`li[label="${expectedOption}"]`).find('button').click();
+      } else {
+        cy.get(`li[label="${fallbackOption}"]`).find('button').click();
+      }
+    });
 };
 
 Then(`user doesn't see the {string} menu`, menu => {

--- a/frontend/cypress/integration/common/overview.ts
+++ b/frontend/cypress/integration/common/overview.ts
@@ -45,6 +45,7 @@ When(`user filters {string} health`, (health: string) => {
 });
 
 When(`user selects Health for {string}`, (type: string) => {
+  ensureKialiFinishedLoading();
   cy.get('button#overview-type-toggle').click();
   cy.get('#loading_kiali_spinner').should('not.exist');
   cy.contains('div#overview-type button', type).click();
@@ -122,6 +123,7 @@ Then(`user sees a {string} {string} namespace`, (view, ns: string) => {
 });
 
 Then(`user sees the {string} namespace with {string}`, (ns: string, type: string) => {
+  ensureKialiFinishedLoading();
   let innerType = '';
 
   switch (type) {

--- a/frontend/cypress/integration/common/sidecar_injection.ts
+++ b/frontend/cypress/integration/common/sidecar_injection.ts
@@ -1,6 +1,6 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { ensureKialiFinishedLoading } from './transition';
-import { MeshCluster } from 'types/Mesh';
+import { confirmNamespaceTrafficPolicyModal, openNamespaceActionsMenu } from './namespace_actions';
 
 // Most of these "Given" implementations are directly using the Kiali API
 // in order to reach a well known state in the environment before performing
@@ -285,88 +285,27 @@ When('I visit the overview page', () => {
   cy.contains('Inbound traffic', { matchCase: false }); // Make sure data finished loading, so avoid broken tests because of a re-render
 });
 
-// Only works for single cluster.
 When('I override the default automatic sidecar injection policy in the namespace to enabled', function () {
-  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
-    expect(response.status).to.equal(200);
-
-    cy.request({ url: '/api/config' }).then(response => {
-      cy.wrap(response.isOkStatusCode).should('be.true');
-
-      const clusters: { [key: string]: MeshCluster } = response.body.clusters;
-      const clusterNames = Object.keys(clusters);
-      cy.wrap(clusterNames).should('have.length', 1);
-      const cluster = clusterNames[0];
-
-      cy.getBySel('overview-type-LIST').should('be.visible').click();
-
-      cy.get(`[data-test=VirtualItem_Cluster${cluster}_${this.targetNamespace}] button[aria-label=Actions]`)
-        .should('be.visible')
-        .click();
-
-      cy.getBySel(`enable-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
-      cy.getBySel('confirm-create').should('be.visible').click();
-    });
-
-    ensureKialiFinishedLoading();
-  });
+  openNamespaceActionsMenu();
+  cy.getBySel(`enable-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
+  confirmNamespaceTrafficPolicyModal();
 });
 
 When(
   'I change the override configuration for automatic sidecar injection policy in the namespace to {string} it',
   function (enabledOrDisabled: string) {
-    cy.request({ method: 'GET', url: '/api/status' }).then(response => {
-      expect(response.status).to.equal(200);
-
-      cy.request({ url: '/api/config' }).then(response => {
-        cy.wrap(response.isOkStatusCode).should('be.true');
-
-        const clusters: { [key: string]: MeshCluster } = response.body.clusters;
-        const clusterNames = Object.keys(clusters);
-        cy.wrap(clusterNames).should('have.length', 1);
-        const cluster = clusterNames[0];
-
-        cy.getBySel('overview-type-LIST').should('be.visible').click();
-
-        cy.get(`[data-test=VirtualItem_Cluster${cluster}_${this.targetNamespace}] button[aria-label=Actions]`)
-          .should('be.visible')
-          .click();
-
-        cy.getBySel(`${enabledOrDisabled}-${this.targetNamespace}-namespace-sidecar-injection`)
-          .should('be.visible')
-          .click();
-
-        cy.getBySel('confirm-create').should('be.visible').click();
-        ensureKialiFinishedLoading();
-      });
-    });
+    openNamespaceActionsMenu();
+    cy.getBySel(`${enabledOrDisabled}-${this.targetNamespace}-namespace-sidecar-injection`)
+      .should('be.visible')
+      .click();
+    confirmNamespaceTrafficPolicyModal();
   }
 );
 
 When('I remove override configuration for sidecar injection in the namespace', function () {
-  cy.request({ method: 'GET', url: '/api/status' }).then(response => {
-    expect(response.status).to.equal(200);
-
-    cy.request({ url: '/api/config' }).then(response => {
-      cy.wrap(response.isOkStatusCode).should('be.true');
-
-      const clusters: { [key: string]: MeshCluster } = response.body.clusters;
-      const clusterNames = Object.keys(clusters);
-      cy.wrap(clusterNames).should('have.length', 1);
-      const cluster = clusterNames[0];
-
-      cy.getBySel('overview-type-LIST').should('be.visible').click();
-
-      cy.get(`[data-test=VirtualItem_Cluster${cluster}_${this.targetNamespace}] button[aria-label=Actions]`)
-        .should('be.visible')
-        .click();
-
-      cy.getBySel(`remove-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
-      cy.getBySel('confirm-create').should('be.visible').click();
-
-      ensureKialiFinishedLoading();
-    });
-  });
+  openNamespaceActionsMenu();
+  cy.getBySel(`remove-${this.targetNamespace}-namespace-sidecar-injection`).should('be.visible').click();
+  confirmNamespaceTrafficPolicyModal();
 });
 
 function switchWorkloadSidecarInjection(enableOrDisable: string): void {
@@ -374,12 +313,9 @@ function switchWorkloadSidecarInjection(enableOrDisable: string): void {
 
   // In OSSMC, the workload actions toggle does not exist. Workload actions are integrated in the minigraph menu
   if (Cypress.env('OSSMC')) {
-    cy.intercept(`**/api/**/workloads/**/graph*`).as('workloadMinigraph');
+    cy.intercept('**/api/**/workloads/**/graph*').as('workloadMinigraph');
     cy.wait('@workloadMinigraph');
-
-    cy.waitForReact();
-
-    cy.get('button#minigraph-toggle').should('be.visible').click();
+    cy.get('button#minigraph-toggle', { timeout: 40000 }).should('be.visible').click();
   } else {
     cy.get('button[data-test="workload-actions-toggle"]').should('be.visible').click();
   }

--- a/frontend/cypress/integration/common/transition.ts
+++ b/frontend/cypress/integration/common/transition.ts
@@ -34,5 +34,11 @@ export const waitForKialiApiReady = (timeoutMs = KIALI_API_READY_TIMEOUT_MS): vo
 };
 
 export const openTab = (tab: string): void => {
-  cy.get('#basic-tabs', { timeout: 60000 }).should('exist').contains(tab).click(); // Can be very slow for OpenShift, specially in the UI
+  // In OSSMC the console header can push tabs below the viewport; scroll before click.
+  cy.get('#basic-tabs', { timeout: 60000 })
+    .should('exist')
+    .contains(tab)
+    .scrollIntoView()
+    .should('be.visible')
+    .click();
 };

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -397,12 +397,14 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
       const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+      expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
-        expect(target, 'OSSMC waypoint link target').to.include(`/deployments/${waypoint}/ossmconsole`);
+        // Even if the button exist, the click event doesn't work (Even with force).
+        const namespace = target.split('/')[2];
+        cy.visit({ url: `/k8s/ns/${namespace}/deployments/${waypoint}/ossmconsole` });
       } else {
-        expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
+        cy.wrap($el).click();
       }
-      cy.wrap($el).click();
     });
   cy.get('#loading_kiali_spinner').should('not.exist');
 });

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,6 +1,7 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { ensureKialiFinishedLoading, openTab, waitForKialiApiReady } from './transition';
+import { openTab, waitForKialiApiReady } from './transition';
 import { getCellsForCol } from './table';
+import { confirmNamespaceTrafficPolicyModal, openNamespaceActionsMenu } from './namespace_actions';
 import { Pod } from 'types/IstioObjects';
 import { enableKialiFeature, USE_WAYPOINT_NAME_CONFIG } from './kiali-config';
 
@@ -613,7 +614,7 @@ Then('the user updates the log level to {string}', (level: string) => {
 });
 
 When('user opens the menu', () => {
-  cy.get('[aria-label="Actions"]').click();
+  openNamespaceActionsMenu();
 });
 
 When('the option {string} does not exist for {string} namespace', (option, namespace: string) => {
@@ -642,13 +643,48 @@ When('the user clicks on {string} for {string} namespace', (option, namespace: s
   }
   // Click the menu item button (the button inside the li element)
   cy.get(`[data-test=${selector}]`).find('button').click();
-  // Click outside the menu to close it before interacting with the modal
-  cy.get('body').click(0, 0);
-  // Wait for the modal to appear - check for modal content to ensure it's fully rendered
-  cy.contains('Are you sure?', { timeout: 10000 }).should('be.visible');
-  // Wait for modal confirm button to be visible and clickable
-  cy.get(`[data-test="confirm-create"]`).should('be.visible').should('not.be.disabled').click();
+  confirmNamespaceTrafficPolicyModal();
 });
+
+When('user clicks on {string} in namespace actions', (option: string) => {
+  cy.url().then(url => {
+    const namespace = url.match(/\/(projects|namespaces)\/([^/?]+)/)?.[2] ?? '';
+    let selector = '';
+    switch (option) {
+      case 'removes auto injection':
+        selector = `remove-${namespace}-namespace-sidecar-injection`;
+        break;
+      case 'Add to Ambient':
+        selector = `add-${namespace}-namespace-ambient`;
+        break;
+      case 'remove Ambient':
+        selector = `remove-${namespace}-namespace-ambient`;
+        break;
+      case 'enable sidecar':
+        selector = `enable-${namespace}-namespace-sidecar-injection`;
+        break;
+    }
+    cy.get(`[data-test="${selector}"]`).should('be.visible').click();
+    confirmNamespaceTrafficPolicyModal();
+  });
+});
+
+Then('the namespace {string} labels do not contain {string}', (namespace: string, labelKey: string) => {
+  cy.request({ method: 'GET', url: `/api/namespaces/${namespace}/info` }).then(response => {
+    expect(response.status).to.equal(200);
+    expect(response.body.labels).to.not.have.property(labelKey);
+  });
+});
+
+Then(
+  'the namespace {string} labels contain {string} with value {string}',
+  (namespace: string, labelKey: string, labelValue: string) => {
+    cy.request({ method: 'GET', url: `/api/namespaces/${namespace}/info` }).then(response => {
+      expect(response.status).to.equal(200);
+      expect(response.body.labels[labelKey]).to.equal(labelValue);
+    });
+  }
+);
 
 When('{string} badge {string}', (badge, option: string) => {
   let selector = 'not.exist';

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -1,7 +1,8 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { openTab } from './transition';
+import { ensureKialiFinishedLoading, openTab, waitForKialiApiReady } from './transition';
 import { getCellsForCol } from './table';
 import { Pod } from 'types/IstioObjects';
+import { enableKialiFeature, USE_WAYPOINT_NAME_CONFIG } from './kiali-config';
 
 // waitForWorkloadEnrolled waits until Kiali returns the namespace labels updated
 // Adding the waypoint label into the bookinfo namespace
@@ -368,6 +369,92 @@ Then('the graph page has enough data for L7 in the {string} namespace', (namespa
 Then('the {string} tracing data is ready in the {string} namespace', (workload: string, namespace: string) => {
   // Poll the traces endpoint so downstream assertions on tracing UI don't flake.
   waitForWorkloadTracesInApi(namespace, workload);
+});
+
+const waitForWaypointNodeInGraph = (namespace: string, maxRetries = 30, retryCount = 0): void => {
+  if (retryCount >= maxRetries) {
+    throw new Error(`Waypoint node not found in graph after ${maxRetries} retries (namespace=${namespace})`);
+  }
+
+  cy.request({
+    method: 'GET',
+    url: `${Cypress.config('baseUrl')}/api/namespaces/graph`,
+    qs: {
+      duration: '300s',
+      graphType: 'versionedApp',
+      includeIdleEdges: false,
+      injectServiceNodes: true,
+      boxBy: 'cluster,namespace,app',
+      waypoints: true,
+      ambientTraffic: 'total',
+      appenders: 'deadNode,serviceEntry,meshCheck,workloadEntry,health,istio,ambient',
+      rateGrpc: 'requests',
+      rateHttp: 'requests',
+      rateTcp: 'sent',
+      namespaces: namespace
+    }
+  }).then(response => {
+    const nodes = response.body?.elements?.nodes ?? [];
+    const waypointNode = nodes.find(
+      (n: { data: Record<string, string> }) => n.data.workload === 'waypoint' && n.data.namespace === namespace
+    );
+
+    if (waypointNode) {
+      Cypress.log({
+        name: 'waypoint-graph',
+        message: `Waypoint node found in graph after ${retryCount} retries`
+      });
+      return;
+    }
+
+    if (retryCount % 5 === 0) {
+      Cypress.log({
+        name: 'waypoint-graph',
+        message: `retry=${retryCount}/${maxRetries} waiting for waypoint node in graph`
+      });
+    }
+
+    cy.wait(10000).then(() => waitForWaypointNodeInGraph(namespace, maxRetries, retryCount + 1));
+  });
+};
+
+Then('use_waypoint_name is enabled if tracing services contain waypoint in {string}', (namespace: string) => {
+  waitForWaypointNodeInGraph(namespace);
+
+  const nowMicros = Date.now() * 1000;
+  const qs: Record<string, any> = {
+    startMicros: nowMicros - 10 * 60 * 1000 * 1000,
+    endMicros: nowMicros,
+    tags: '{}',
+    limit: 20
+  };
+
+  cy.request({
+    method: 'GET',
+    url: `${Cypress.config('baseUrl')}/api/namespaces/${namespace}/workloads/bookinfo-gateway-istio/traces`,
+    qs,
+    failOnStatusCode: false
+  }).then(response => {
+    const traces = response.body?.data ?? [];
+    const serviceNames = new Set<string>();
+    for (const trace of traces) {
+      for (const proc of Object.values(trace.processes ?? {})) {
+        serviceNames.add((proc as { serviceName: string }).serviceName);
+      }
+    }
+
+    const hasWaypoint = [...serviceNames].some(name => name.startsWith('waypoint.'));
+
+    Cypress.log({
+      name: 'use_waypoint_name',
+      message: `Tracing services: [${[...serviceNames].join(', ')}] hasWaypoint=${hasWaypoint}`
+    });
+
+    if (hasWaypoint) {
+      enableKialiFeature(USE_WAYPOINT_NAME_CONFIG);
+      waitForKialiApiReady();
+    }
+  });
 });
 
 Then('the user hovers in the {string} label and sees {string} in the tooltip', (label: string, text: string) => {

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -521,7 +521,7 @@ Then('the user sees the {string} badge', (name: string) => {
 });
 
 Then('the proxy status is {string}', (status: string) => {
-  cy.get('[data-label=Status]').get(`.icon-${status}`).should('exist');
+  cy.get('[data-test=workload-details-card]').find(`span[class*="icon-${status}"]`).should('be.visible');
 });
 
 Then(
@@ -563,10 +563,10 @@ Then("the {string} subtab doesn't exist", (subtab: string) => {
 
 Then('validates Services data', () => {
   cy.get('[data-test="enrolled-data-title"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', 'productpage');
-  cy.get('[role="grid"]').should('be.visible').get('#pfbadge-S').should('exist');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', 'bookinfo');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', 'namespace');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', 'productpage');
+  cy.get('[role="grid"]').should('be.visible').find('#pfbadge-S').should('exist');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', 'namespace');
 });
 
 Then(
@@ -574,28 +574,28 @@ Then(
   (rows: number, workload: string, ns: string, label: string, badge: string) => {
     cy.get('[data-test="enrolled-data-title"]').should('be.visible');
     cy.get('table tbody tr').should('have.length', rows);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', workload);
-    cy.get('[role="grid"]').should('be.visible').get(`#${badge}`).should('exist');
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', ns);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', label);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', workload);
+    cy.get('[role="grid"]').should('be.visible').find(`#${badge}`).should('exist');
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', ns);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', label);
   }
 );
 
 Then('validates waypoint Info data for {string}', (type: string) => {
   cy.get('[data-test=waypointfor-title]').should('exist').and('contain', type);
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=RDS]').and('contain', 'IGNORED');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="RDS"]').should('contain', 'IGNORED');
 });
 
 When('the user validates the Ztunnel tab for the {string} namespace', (namespace: string) => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Waypoint]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Service VIP"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Waypoint"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   cy.get('#ztunnel-details').should('be.visible').contains('Workloads').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Node]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Pod Name"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Node"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   // Validate filters in the Namespace column
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'Namespace').click();

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -502,11 +502,11 @@ Then('validates waypoint Info data for {string}', (type: string) => {
 When('the user validates the Ztunnel tab for the {string} namespace', (namespace: string) => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]').should('be.visible');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Waypoint]');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
   cy.get('#ztunnel-details').should('be.visible').contains('Workloads').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]');
+  cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]').should('be.visible');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Node]');
   cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
   // Validate filters in the Namespace column

--- a/frontend/cypress/integration/common/waypoint.ts
+++ b/frontend/cypress/integration/common/waypoint.ts
@@ -391,22 +391,32 @@ Then('the user sees the L7 {string} link', (waypoint: string) => {
 });
 
 Then('the link for the waypoint {string} should redirect to a valid workload details', (waypoint: string) => {
-  cy.get(`[data-test=waypoint-link]`).contains('a', waypoint).click({ force: true });
-  cy.get(`[data-test=workload-description-card]`).contains('h5', waypoint);
+  const isOSSMC = Cypress.env('OSSMC');
+  cy.get('[data-test=waypoint-link]')
+    .contains('a,button', waypoint)
+    .then($el => {
+      // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
+      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+      if (isOSSMC) {
+        expect(target, 'OSSMC waypoint link target').to.include(`/deployments/${waypoint}/ossmconsole`);
+      } else {
+        expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
+      }
+      cy.wrap($el).click();
+    });
+  cy.get('#loading_kiali_spinner').should('not.exist');
 });
 
 Then('the waypoint link points to the {string} cluster', (cluster: string) => {
   cy.get(`[data-test=waypoint-link]`).should('exist');
 
   cy.get(`[data-test=waypoint-link]`).then($waypointLink => {
-    // Depending on the component, the data-test might be set on the <a> itself
-    // or on a container that contains the <a>.
-    const $anchor = $waypointLink.filter('a').add($waypointLink.find('a')).first();
+    // In kiosk mode the element is a button with data-href; otherwise it's an anchor with href.
+    const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
+    expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    expect($anchor.length, 'waypoint link anchor').to.be.greaterThan(0);
-
-    const href = $anchor.attr('href') ?? '';
-    expect(href).to.include(`clusterName=${cluster}`);
+    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+    expect(target).to.include(`clusterName=${cluster}`);
   });
 });
 

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -1,7 +1,9 @@
 import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 import { getCellsForCol } from './table';
-import { clusterParameterExists } from './navigation';
+import { clickSpanFilterOptionWithFallback, clusterParameterExists } from './navigation';
 import { openTab } from './transition';
+
+const WAYPOINT_FALLBACK = 'waypoint';
 
 const openEnvoyTab = (tab: string): void => {
   cy.get('#envoy-details').should('exist').contains(tab).click();
@@ -84,12 +86,18 @@ Then('user sees Perses link in the Inbound Metrics tab', () => {
 When('user can filter spans by workload {string}', (workload: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.get('button#Workload').click();
-
   cy.get('input[placeholder="Filter by Workload"]').type(`${workload}{enter}`);
-  cy.get(`li[label="${workload}"]`).should('be.visible').find('button').click();
+  clickSpanFilterOptionWithFallback(workload);
 
+  // waypoint is a fallback for istio < 1.29
   getCellsForCol('App / Workload').each($cell => {
-    cy.wrap($cell).contains(workload);
+    const cellText = $cell.text().toLowerCase();
+    const workloadMatches = cellText.includes(workload.toLowerCase());
+    const waypointMatches = cellText.includes(WAYPOINT_FALLBACK);
+    expect(
+      workloadMatches || waypointMatches,
+      `Expected "${cellText}" to contain "${workload}" or "${WAYPOINT_FALLBACK}"`
+    ).to.equal(true);
   });
 
   getCellsForCol(4).first().click();

--- a/frontend/cypress/integration/common/workloads_details.ts
+++ b/frontend/cypress/integration/common/workloads_details.ts
@@ -86,10 +86,10 @@ Then('user sees Perses link in the Inbound Metrics tab', () => {
 When('user can filter spans by workload {string}', (workload: string) => {
   cy.get('button#filter_select_type-toggle').click();
   cy.get('button#Workload').click();
-  cy.get('input[placeholder="Filter by Workload"]').type(`${workload}{enter}`);
-  clickSpanFilterOptionWithFallback(workload);
+  cy.get('input[placeholder="Filter by Workload"]').click();
 
-  // waypoint is a fallback for istio < 1.29
+  clickSpanFilterOptionWithFallback(workload, WAYPOINT_FALLBACK);
+
   getCellsForCol('App / Workload').each($cell => {
     const cellText = $cell.text().toLowerCase();
     const workloadMatches = cellText.includes(workload.toLowerCase());

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -16,6 +16,7 @@ Feature: Kiali Waypoint related features
     Then "bookinfo" namespace is labeled with the waypoint label
     And the graph page has enough data
     And the "bookinfo-gateway-istio" tracing data is ready in the "bookinfo" namespace
+    And use_waypoint_name is enabled if tracing services contain waypoint in "bookinfo"
 
   @skip-ossmc
   Scenario: [Workload list] See the workload list of bookinfo with the correct info

--- a/frontend/cypress/integration/featureFiles/waypoint.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint.feature
@@ -363,7 +363,7 @@ Feature: Kiali Waypoint related features
   Scenario: [Waypoint details] The waypoint details for a waypoint for workload are valid
     Given user is at the details page for the "workload" "waypoint-forworkload/echo-server" located in the "" cluster
     And the user sees the L7 "bwaypoint" link
-    And the link for the waypoint "waypoint" should redirect to a valid workload details
+    And the link for the waypoint "bwaypoint" should redirect to a valid workload details
     When the user goes to the "Waypoint" tab
     Then user goes to the waypoint "Workloads" subtab
     And validates Services data with "1" rows and "echo-server" workload, "waypoint-forworkload" namespace, "workload" label for, "pfbadge-W" badge

--- a/frontend/src/components/Ambient/WaypointLabel.tsx
+++ b/frontend/src/components/Ambient/WaypointLabel.tsx
@@ -3,7 +3,7 @@ import { PFBadge, PFBadges } from '../Pf/PfBadges';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { infoStyle } from '../../styles/IconStyle';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 export const renderWaypointLabel = (bgsize?: string): React.ReactNode => {
   const badgeSize = bgsize === 'global' || bgsize === 'sm' ? bgsize : 'global';

--- a/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
+++ b/frontend/src/components/Ambient/WaypointWorkloadsTable.tsx
@@ -12,7 +12,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { SortableCompareTh } from './ZtunnelConfig';
 import { WaypointInfo, WorkloadInfo } from '../../types/Workload';
 import { isMultiCluster } from '../../config';

--- a/frontend/src/utils/I18nUtils.ts
+++ b/frontend/src/utils/I18nUtils.ts
@@ -1,5 +1,5 @@
 import { i18n } from 'i18n';
-import { TOptions } from 'i18next';
+import type { TOptions } from 'i18next';
 import { UseTranslationResponse, useTranslation } from 'react-i18next';
 
 const I18N_NAMESPACE = process.env.I18N_NAMESPACE;

--- a/hack/istio/ambient/install-sidecars-ambient.sh
+++ b/hack/istio/ambient/install-sidecars-ambient.sh
@@ -158,7 +158,7 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-ambient sleep 5; done;
+        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-ambient; sleep 5; done;
 NAD
 
 # Create the curl client deployment for ambient namespace
@@ -184,7 +184,7 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-sidecar sleep 5; done;
+        - while true; do echo "Calling echo-service..."; curl -s http://echo-service.test-sidecar; sleep 5; done;
 NAD
 
 # Use waypoint?

--- a/hack/istio/ambient/install-waypoints.sh
+++ b/hack/istio/ambient/install-waypoints.sh
@@ -159,12 +159,15 @@ sed "s|\${CURL_IMAGE}|${CURL_IMAGE}|g" ${HACK_SCRIPT_DIR}/resources/curl-pod.yam
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/waypoint.yaml -n waypoint-forservice
 ${CLIENT_EXE} label ns waypoint-forservice istio.io/use-waypoint=waypoint
 
-# Create a waypoint for workload and send requests to pod b
-${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n waypoint-forworkload
-${CLIENT_EXE} wait --for=condition=Ready pod -l app=echo-server -n waypoint-forworkload --timeout=60s
-
-sleep 15
-# Update with echo-server IP
+# Waypoint-for-workload (istio.io/waypoint-for: workload): Istio only redirects traffic originally
+# addressed to pod (or VM) IPs—not to a Kubernetes Service—even if the workload uses a waypoint
+# (see https://istio.io/latest/docs/ambient/usage/waypoint/ ). So curl must target the echo pod IP.
+# Gateway first, then echo with istio.io/use-waypoint on the pod template (survives pod restarts),
+# then curl with that IP baked in. If echo restarts and gets a new IP, rollout-restart curl-client.
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/waypoint-for-workload.yaml -n waypoint-forworkload
+${CLIENT_EXE} wait --for=condition=Ready pod -l gateway.networking.k8s.io/gateway-name=bwaypoint -n waypoint-forworkload --timeout=120s
+${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-server-waypoint-forworkload.yaml -n waypoint-forworkload
+${CLIENT_EXE} rollout status deployment/echo-server -n waypoint-forworkload --timeout=120s
 POD_IP=$($CLIENT_EXE get pod -l app=echo-server -n waypoint-forworkload -o jsonpath="{.items[0].status.podIP}")
 POD_HOST=$(format_http_host "${POD_IP}")
 echo "Creating client in ns waypoint-forworkload with echo pod IP ${POD_IP}"
@@ -199,8 +202,7 @@ spec:
                 sleep 5
               done
 NAD
-${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/waypoint-for-workload.yaml -n waypoint-forworkload
-${CLIENT_EXE} label pod -l app=echo-server istio.io/use-waypoint=bwaypoint -n waypoint-forworkload
+${CLIENT_EXE} rollout status deployment/curl-client -n waypoint-forworkload --timeout=120s
 
 # Create a waypoint for all
 ${CLIENT_EXE} apply -f ${HACK_SCRIPT_DIR}/resources/echo-service.yaml -n waypoint-forall

--- a/hack/istio/ambient/resources/curl-pod.yaml
+++ b/hack/istio/ambient/resources/curl-pod.yaml
@@ -19,4 +19,4 @@ spec:
         image: ${CURL_IMAGE}
         command: ["/bin/sh", "-c"]
         args:
-        - while true; do echo "Calling echo-service..."; curl -s http://echo-service sleep 5; done;
+        - while true; do echo "Calling echo-service..."; curl -s http://echo-service; sleep 5; done;

--- a/hack/istio/ambient/resources/echo-server-waypoint-forworkload.yaml
+++ b/hack/istio/ambient/resources/echo-server-waypoint-forworkload.yaml
@@ -1,0 +1,37 @@
+# Echo workload for waypoint-forworkload only: enrollment is on the pod template so it survives
+# pod restarts (unlike kubectl label pod). For waypoint-for: workload, generators must call the pod
+# IP (not echo-service); see https://istio.io/latest/docs/ambient/usage/waypoint/
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: echo-server
+  name: echo-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-server
+  template:
+    metadata:
+      labels:
+        app: echo-server
+        istio.io/use-waypoint: bwaypoint
+    spec:
+      containers:
+      - name: echo-server
+        image: mirror.gcr.io/ealen/echo-server
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: echo-server


### PR DESCRIPTION
## Summary

Backports OSSMC Cypress test stability fixes from master/v2.27 to `v2.22`, addressing failures seen in Jenkins downstream-pipeline-3 #4919 (`kiali-ossmc-tests`).

Cherry-picked commits (with conflict resolution where v2.22 diverged):

- #9414 — OSSMC/kiosk waypoint link navigation
- #9421 — Waypoint tests for OSSMC
- #9408 — OSSMC CI rendering guards (waypoint.feature)
- #9451 — Waypoint install script flake fixes
- #9604 — Waypoint tracing filter fallback
- #9620 — Tracing reporting validation (`trace-details-tabs`, waypoint tracing config)
- #9831 — Waypoint Cypress selectors for OSSMC `data-label` attributes
- #9935 — Graph idle nodes race conditions in OSSMC
- #9959 — Namespace actions helpers + display menu hardening (Cypress-only portions; NamespaceDetails UI changes omitted on v2.22)

Additional hardening for Overview **Health for Services** offline scenario timing.

## Test failures addressed

| OSSMC test | Fix |
|------------|-----|
| Waypoint — ratings enrolled in waypoint | #9831, #9421, #9451, #9604 |
| Workload Details — trace/span info | #9620, #9604 |
| Service Details — graph traces / span info | #9620 |
| Overview — Health for Services | #9959 display-menu pattern + overview loading guards |
| Graph Display — idle nodes (show/disable) | #9935, #9959 |

## Test plan

- [ ] Re-run OSSMC Jenkins pipeline on `v2.22` with this branch (`KIALI_BRANCH=backport-v2.22-ossmc-tests`)
- [ ] Verify `kiali-ossmc-tests` core job passes: `graph_display`, `overview`, `workloads_details`, `service_details`
- [ ] Verify `kiali-ossmc-tests` ambient job passes: `waypoint`, `service_details`, `workloads_details`


Made with [Cursor](https://cursor.com)