### PR TITLE
Skip InferencePool Cypress test on OSSMC

### DIFF
--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -92,9 +92,13 @@ Feature: Kiali Istio Config page
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "gateway.networking.k8s.io" "v1" "Gateway" K8s Istio object
 
+  # Skip on OSSMC: downstream OSSMC clusters do not have the InferencePool CRD.
+  # Istio is installed via Sail/OLM, which does not apply Gateway API Inference
+  # Extension CRDs, and OSSMC does not run the Cypress hook that would install them.
   @bookinfo-app
   @gateway-api-ie
   @core-1
+  @skip-ossmc
   Scenario: K8s Inference Pool list
     Given user deletes k8sinferencepool named "foo" and the resource is no longer available
     When there is a "foo" K8sInferencePool in the "bookinfo" namespace with "details-v1" selector


### PR DESCRIPTION
## Summary
- Skip the `K8s Inference Pool list` Cypress scenario on OSSMC (`@skip-ossmc`).
- Downstream OSSMC clusters install Istio via Sail/OLM and do not apply Gateway API Inference Extension CRDs, so creating an `InferencePool` fails. OSSMC also does not run the Kiali Cypress hook that would install those CRDs.

cc @hhovsepy , just letting you know about this change. We are 95% sure this is necessary but just in case you know something we don't...

## Test plan
- [ ] Confirm Kiali Cypress still runs this scenario (no `@skip-ossmc` exclusion in the core suite).
- [ ] After OSSMC frontend sync, confirm OSSMC Cypress excludes this scenario (`not @skip-ossmc`).


Made with [Cursor](https://cursor.com)