### PR TITLE
[v2.27] Skip InferencePool Cypress test on OSSMC

### DIFF
--- a/frontend/cypress/integration/featureFiles/istio_config.feature
+++ b/frontend/cypress/integration/featureFiles/istio_config.feature
@@ -86,9 +86,13 @@ Feature: Kiali Istio Config page
   Scenario: Ability to create a K8sGateway object
     Then the user can create a "gateway.networking.k8s.io" "v1" "Gateway" K8s Istio object
 
+  # Skip on OSSMC: downstream OSSMC clusters do not have the InferencePool CRD.
+  # Istio is installed via Sail/OLM, which does not apply Gateway API Inference
+  # Extension CRDs, and OSSMC does not run the Cypress hook that would install them.
   @bookinfo-app
   @gateway-api-ie
   @core-1
+  @skip-ossmc
   Scenario: K8s Inference Pool list
     Given user deletes k8sinferencepool named "foo" and the resource is no longer available
     When there is a "foo" K8sInferencePool in the "bookinfo" namespace with "details-v1" selector


### PR DESCRIPTION
## Summary
- Backport of #10251 to `v2.27`.
- Skip the `K8s Inference Pool list` Cypress scenario on OSSMC (`@skip-ossmc`).
- Downstream OSSMC clusters install Istio via Sail/OLM and do not apply Gateway API Inference Extension CRDs, so creating an `InferencePool` fails.

## Test plan
- [ ] Confirm Kiali Cypress on `v2.27` still runs this scenario.
- [ ] After OSSMC `v2.27` frontend sync, confirm OSSMC Cypress excludes this scenario.


Made with [Cursor](https://cursor.com)