### PR TITLE
[v2.27] CVE-2026-45820: upgrade fflate to 0.8.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -188,6 +188,7 @@
   "resolutions": {
     "dompurify": "^3.4.7",
     "esbuild": "^0.25.2",
+    "fflate": "^0.8.3",
     "js-cookie": "^3.0.8",
     "js-yaml@npm:3.14.0": "npm:3.15.0",
     "lodash": "^4.18.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9877,10 +9877,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.4.8":
-  version: 0.4.8
-  resolution: "fflate@npm:0.4.8"
-  checksum: 10c0/29d1eddaaa5deab61b1c6b0d21282adacadbc4d2c01e94d8b1ee784398151673b9c563e53f97a801bc410a1ae55e8de5378114a743430e643e7a0644ba8e5a42
+"fflate@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `fflate` `^0.8.3` yarn resolution to address CVE-2026-45820 (Denial of Service via crafted ZIP archives)
- Backport of https://github.com/kiali/kiali/pull/10253
- `fflate` is a transitive dependency of `posthog-js` (via `@patternfly/chatbot`)

## Test plan

- [x] `make build-ui`
- [ ] CI passes


Made with [Cursor](https://cursor.com)