### PR TITLE
CVE-2026-75838: Upgrade dompurify to 3.4.14

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -190,7 +190,7 @@
     "typescript-eslint": "^8.65.0"
   },
   "resolutions": {
-    "dompurify": "^3.4.7",
+    "dompurify": "^3.4.13",
     "fflate": "^0.8.3",
     "js-cookie": "^3.0.8",
     "lodash": "^4.18.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6394,15 +6394,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.7":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.13":
+  version: 3.4.14
+  resolution: "dompurify@npm:3.4.14"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/feca07ece3805d1d4e33e847c11196888dcdc97b2afe0bb8a2fd11de4e62bfdc434c2403ee3fb3c7771e903325041d062febec6c5518796391fdc0419a90a873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

DOMPurify before 3.4.13 has an XSS vulnerability in IN_PLACE sanitization where element-removal hooks fail to neutralize detached subtrees.

Bump the `dompurify` resolution to `^3.4.13`, consolidating transitive dependencies (monaco-editor, posthog-js) to dompurify 3.4.14.

## Test plan

- [x] `yarn install --no-immutable` and `yarn dedupe dompurify`
- [x] Verified all dompurify instances resolve to 3.4.14 via `yarn why dompurify`
- [x] `make build-ui`

Made with [Cursor](https://cursor.com)