### PR TITLE
[v2.22] CVE-2026-75838: Upgrade dompurify to 3.4.14

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,7 +180,7 @@
     "typescript": "^5.9.0"
   },
   "resolutions": {
-    "dompurify": "^3.4.7",
+    "dompurify": "^3.4.13",
     "esbuild": "^0.25.2",
     "fflate": "^0.8.3",
     "js-cookie": "^3.0.8",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8334,15 +8334,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.7":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.13":
+  version: 3.4.14
+  resolution: "dompurify@npm:3.4.14"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/feca07ece3805d1d4e33e847c11196888dcdc97b2afe0bb8a2fd11de4e62bfdc434c2403ee3fb3c7771e903325041d062febec6c5518796391fdc0419a90a873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/10262 to v2.22.

Made with [Cursor](https://cursor.com)