### PR TITLE
[v2.27] Pin Istio 1.29.1 for CI integration tests

### DIFF
--- a/hack/setup-kind-in-ci.sh
+++ b/hack/setup-kind-in-ci.sh
@@ -215,6 +215,8 @@ if [ -z "${ISTIO_VERSION}" ]; then
     ISTIO_VERSION="1.27.5"
   elif [ "${TARGET_BRANCH}" == "v2.22" ]; then
     ISTIO_VERSION="1.28.3"
+  elif [ "${TARGET_BRANCH}" == "v2.27" ]; then
+    ISTIO_VERSION="1.29.1"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Add the missing `v2.27 → 1.29.1` `ISTIO_VERSION` mapping in `hack/setup-kind-in-ci.sh`
- Fixes v2.27 CI jobs (notably multi-mesh integration tests) downloading the latest Istio release instead of the pinned version for this branch
- Backport of the v2.27 entry from master (#10020)

## Context

PRs targeting `v2.27` set `TARGET_BRANCH=v2.27`, but the branch mapping only went up to `v2.22`. With no match, `ISTIO_VERSION` stayed empty and `download-istio.sh` fetched the latest release from GitHub. This caused the multi-mesh Cypress job to hang or fail (e.g. #10263).

## Test plan

- [ ] CI passes on this PR, especially "Run frontend multi mesh integration tests"
- [ ] Verify CI logs show `ISTIO_VERSION=1.29.1` in the setup-kind settings output


Made with [Cursor](https://cursor.com)