### PR TITLE
Only trigger CI on ci-full labeled events

### DIFF
--- a/.github/workflows/kiali-ci.yml
+++ b/.github/workflows/kiali-ci.yml
@@ -13,12 +13,16 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Non-CI labels (e.g. backport needed) must not cancel an in-progress run.
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'ci-full' }}
 
 permissions: read-all
 
 jobs:
   initialize:
+    # Only the ci-full label should trigger CI on labeled events; process labels
+    # (e.g. backport needed) are ignored without cancelling an in-progress run.
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci-full'
     permissions:
       contents: read
     name: Initialize
@@ -258,7 +262,9 @@ jobs:
         retention-days: 1
 
   codecov_upload_pr_base:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci-full')
     name: Upload PR base coverage to Codecov
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- Gate `labeled` pull_request events so only the `ci-full` label runs CI jobs
- Prevent non-CI labels (e.g. `backport needed`) from cancelling an in-progress CI run via concurrency

Fixes the regression introduced in #10167, where every label re-ran full CI to avoid a cancel-and-skip deadlock. Process labels now produce a no-op workflow run (all jobs skipped) without interrupting active CI.

## Test plan

- [ ] Open a test PR and confirm CI runs on `opened`/`synchronize` as before
- [ ] Add `backport needed` while CI is running — in-progress CI should complete, new run should skip all jobs
- [ ] Add `ci-full` to an open PR — CI should run and Wave 2 jobs should execute after Wave 1

Made with [Cursor](https://cursor.com)