### PR TITLE
[playwright] Port @core-2 services, workloads, mesh, and wizard tests

### DIFF
--- a/.github/workflows/integration-tests-frontend-playwright-core-2.yml
+++ b/.github/workflows/integration-tests-frontend-playwright-core-2.yml
@@ -1,0 +1,137 @@
+name: Integration Tests Frontend Playwright Core 2
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: true
+        type: string
+      build_branch:
+        required: true
+        type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
+      stern_logs:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  TARGET_BRANCH: ${{ inputs.target_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
+
+jobs:
+  integration_tests_frontend_playwright_core_2:
+    name: Playwright tests (core 2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CI: 1
+      TERM: xterm
+    steps:
+    - name: Check out code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.build_branch }}
+
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        docker system prune -af --volumes
+
+    - name: Start resource sampler
+      run: nohup nice -n 19 bash hack/ci-resource-sampler.sh start --csv /tmp/ci-telemetry-frontend-playwright-core-2.csv > /tmp/sampler.out 2>&1 &
+      continue-on-error: true
+
+    - name: Install Helm
+      uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      with:
+        version: 'v3.18.4'
+
+    - name: Enable corepack
+      run: corepack enable
+
+    - name: Setup node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: "24"
+        cache: yarn
+        cache-dependency-path: frontend/yarn.lock
+
+    - name: Download go binary
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: kiali
+        path: ~/go/bin/
+
+    - name: Ensure kiali binary is executable
+      run: chmod +x ~/go/bin/kiali
+
+    - name: Install frontend dependencies
+      working-directory: ./frontend
+      run: yarn install --immutable
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('frontend/yarn.lock') }}
+
+    - name: Run Playwright core 2 integration tests
+      run: hack/run-integration-tests.sh --test-suite playwright-core-2 --stern ${{ inputs.stern_logs }} $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: junit-frontend-playwright-core-2-report
+        path: frontend/playwright-results/combined-report.xml
+        if-no-files-found: warn
+
+    - name: Stop resource sampler
+      if: always()
+      run: bash hack/ci-resource-sampler.sh stop --csv /tmp/ci-telemetry-frontend-playwright-core-2.csv || true
+      continue-on-error: true
+
+    - name: Upload resource telemetry
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      continue-on-error: true
+      with:
+        name: resource-telemetry-frontend-playwright-core-2
+        path: /tmp/ci-telemetry-frontend-playwright-core-2.csv
+        retention-days: 14
+        if-no-files-found: ignore
+
+    - name: Get debug info when integration tests fail
+      if: failure()
+      run: |
+        mkdir debug-output
+        hack/ci-get-debug-info.sh --output-directory debug-output
+
+    - name: Upload debug info artifact
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: debug-info-frontend-playwright-core-2
+        path: debug-output
+
+    - name: Upload Playwright report on failure
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: playwright-report-core-2
+        path: |
+          frontend/playwright-report
+          frontend/test-results
+          frontend/playwright-results
+        if-no-files-found: ignore
+
+    - name: Upload stern logs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ inputs.stern_logs == true }}
+      with:
+        name: playwright-logs-frontend-core-2
+        path: hack/stern

--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -74,3 +74,11 @@ jobs:
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
+
+  integration_tests_frontend_playwright_core_2:
+    name: Run Playwright core 2 tests
+    uses: ./.github/workflows/integration-tests-frontend-playwright-core-2.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,9 @@ hack/run-integration-tests.sh --test-suite <suite> --tests-only true
 | `frontend-tempo` | Frontend tracing tests with Tempo |
 | `local` | Runs Kiali locally (not in-cluster) with smoke Cypress tests |
 | `offline` | Runs Kiali in offline mode with must-gather data |
+| `playwright-smoke` | Playwright smoke suite (KinD + local Kiali) |
+| `playwright-core-1` | Playwright core test group 1 (KinD + local Kiali) |
+| `playwright-core-2` | Playwright core test group 2 (KinD + local Kiali) |
 
 #### The `local` Suite (Recommended for Local Development)
 
@@ -473,8 +476,10 @@ cd frontend
 yarn playwright:install chromium
 yarn playwright:run:smoke
 yarn playwright:run:core1
+yarn playwright:run:core2
 hack/run-integration-tests.sh --test-suite playwright-smoke   # KinD + local Kiali
 hack/run-integration-tests.sh --test-suite playwright-core-1
+hack/run-integration-tests.sh --test-suite playwright-core-2
 ```
 
 **Layout:** `frontend/e2e/pages/`, `frontend/e2e/tests/`, `frontend/e2e/fixtures/kialiFixtures.ts`, `frontend/playwright.config.ts`. Cypress remains in `frontend/cypress/` until cutover.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -82,8 +82,9 @@ Use `isVisible()` / `isHidden()` for toggle guards — same semantics as `toBeVi
 
 ### CI and Jenkins
 
+- **GitHub** (`playwright-smoke`, `playwright-core-1`, `playwright-core-2`): KinD cluster + local `kiali` binary with `hack/ci-yaml/ci-test-config-no-cache.yaml`. One parallel job per suite.
+- **Jenkins** (`kiali-playwright-tests`): in-cluster OSSM Kiali via OpenShift route (downstream validation). Default `TEST_SET` is `playwright:run:junit` (crd-validation, core-1, core-2, core-caching). Error-rates health tests poll `/api/.../health`; empty `health_config.rate` on the OSSM CR is fine (Kiali uses built-in degraded thresholds).
 - **Do not run `playwright test --last-failed` before merge-reports** — the rerun overwrites `blob-report/` and Jenkins `combined-report.xml` only lists rerun tests (misleading failure counts).
-- GitHub **Playwright CI**: separate parallel jobs for smoke and core-1 (each with its own KinD cluster). Jenkins default `playwright:run:all` runs smoke + core-1 in one invocation.
 - **JUnit**: Playwright may record timeouts as `errors` not `failures` — check both in XML.
 - Local `kiali run --port-forward-grafana` without `external_services.grafana` in config: **WARN** on `/api/status` (`grafana URL is not set`) is expected and does not fail tests.
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -108,6 +108,7 @@ cd frontend
 yarn playwright:install chromium   # once, after yarn install
 yarn playwright:run:smoke
 yarn playwright:run:core1
+yarn playwright:run:core2
 yarn playwright:run:smoke --headed
 yarn playwright:ui --project=smoke
 ```
@@ -116,7 +117,7 @@ Use `yarn playwright:install` — not `yarn playwright install`.
 
 ## CI
 
-PRs targeting `epic/playwright-migration` run **Playwright CI** (`.github/workflows/playwright-ci.yml`): build + parallel `playwright-smoke` and `playwright-core-1` integration suites (`hack/run-integration-tests.sh`).
+PRs targeting `epic/playwright-migration` run **Playwright CI** (`.github/workflows/playwright-ci.yml`): build + parallel `playwright-smoke`, `playwright-core-1`, and `playwright-core-2` integration suites (`hack/run-integration-tests.sh`).
 
 Jenkins: `kiali/test-jobs/kiali-playwright-tests` — prefer `TEST_SET=playwright:run:smoke` or `playwright:run:all` with empty `TEST_TAGS` on OpenShift; use `playwright:run:core1` equivalent via `run:all` or future dedicated script.
 

--- a/frontend/e2e/fixtures/kialiFixtures.ts
+++ b/frontend/e2e/fixtures/kialiFixtures.ts
@@ -1,12 +1,17 @@
 import { test as base } from '@playwright/test';
-import { AppsPage } from '../pages/AppsPage';
 import { AppDetailsPage } from '../pages/AppDetailsPage';
-import { OverviewPage } from '../pages/OverviewPage';
-import { ServicesPage } from '../pages/ServicesPage';
+import { AppsPage } from '../pages/AppsPage';
 import { GraphPage } from '../pages/GraphPage';
-import { SidebarPage } from '../pages/SidebarPage';
 import { IstioConfigPage } from '../pages/IstioConfigPage';
+import { IstioConfigWizardPage } from '../pages/IstioConfigWizardPage';
+import { K8sRoutingWizardPage } from '../pages/K8sRoutingWizardPage';
 import { MeshPage } from '../pages/MeshPage';
+import { NamespaceDetailPage } from '../pages/NamespaceDetailPage';
+import { OverviewPage } from '../pages/OverviewPage';
+import { ServiceDetailsPage } from '../pages/ServiceDetailsPage';
+import { ServicesPage } from '../pages/ServicesPage';
+import { SidebarPage } from '../pages/SidebarPage';
+import { WorkloadDetailsPage } from '../pages/WorkloadDetailsPage';
 import { WorkloadsPage } from '../pages/WorkloadsPage';
 
 type KialiFixtures = {
@@ -14,10 +19,15 @@ type KialiFixtures = {
   appsPage: AppsPage;
   graphPage: GraphPage;
   istioConfigPage: IstioConfigPage;
+  istioConfigWizardPage: IstioConfigWizardPage;
+  k8sRoutingWizardPage: K8sRoutingWizardPage;
   meshPage: MeshPage;
+  namespaceDetailPage: NamespaceDetailPage;
   overviewPage: OverviewPage;
+  serviceDetailsPage: ServiceDetailsPage;
   servicesPage: ServicesPage;
   sidebarPage: SidebarPage;
+  workloadDetailsPage: WorkloadDetailsPage;
   workloadsPage: WorkloadsPage;
 };
 
@@ -31,23 +41,38 @@ export const test = base.extend<KialiFixtures>({
   appsPage: async ({ page }, use) => {
     await use(new AppsPage(page));
   },
-  overviewPage: async ({ page }, use) => {
-    await use(new OverviewPage(page));
-  },
-  servicesPage: async ({ page }, use) => {
-    await use(new ServicesPage(page));
-  },
   graphPage: async ({ page }, use) => {
     await use(new GraphPage(page));
-  },
-  sidebarPage: async ({ page }, use) => {
-    await use(new SidebarPage(page));
   },
   istioConfigPage: async ({ page }, use) => {
     await use(new IstioConfigPage(page));
   },
+  istioConfigWizardPage: async ({ page }, use) => {
+    await use(new IstioConfigWizardPage(page));
+  },
+  k8sRoutingWizardPage: async ({ page }, use) => {
+    await use(new K8sRoutingWizardPage(page));
+  },
   meshPage: async ({ page }, use) => {
     await use(new MeshPage(page));
+  },
+  namespaceDetailPage: async ({ page }, use) => {
+    await use(new NamespaceDetailPage(page));
+  },
+  overviewPage: async ({ page }, use) => {
+    await use(new OverviewPage(page));
+  },
+  serviceDetailsPage: async ({ page }, use) => {
+    await use(new ServiceDetailsPage(page));
+  },
+  servicesPage: async ({ page }, use) => {
+    await use(new ServicesPage(page));
+  },
+  sidebarPage: async ({ page }, use) => {
+    await use(new SidebarPage(page));
+  },
+  workloadDetailsPage: async ({ page }, use) => {
+    await use(new WorkloadDetailsPage(page));
   },
   workloadsPage: async ({ page }, use) => {
     await use(new WorkloadsPage(page));

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -1,4 +1,4 @@
-import { expect, type APIRequestContext, type Locator } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 import { gotoListPage } from '../utils/navigation';
 import { selectNamespace } from '../utils/namespace';
@@ -6,6 +6,7 @@ import { waitForLoadingComplete } from '../utils/transition';
 import { linkSelector } from '../utils/linkSelector';
 import { colExists, expectOnlyRow, expectRowCount, getColWithRowText } from '../utils/table';
 import { collectAmbientL7Warnings } from '../utils/ambientValidation';
+import { editIstioConfigYaml } from '../utils/monacoEditor';
 
 const TYPE_FILTERS = [
   'AuthorizationPolicy',
@@ -326,13 +327,86 @@ export class IstioConfigPage extends BasePage {
       await expect(row).toContainText(statusText);
     }).toPass({ intervals: [10_000], timeout: 60_000 });
   }
+
+  async openConfigByName(name: string): Promise<void> {
+    await waitForLoadingComplete(this.page);
+    await getColWithRowText(this.page, name, 'Name').locator(linkSelector()).first().click();
+  }
+
+  async expectEditorVisible(): Promise<void> {
+    await expect(this.page.locator('[data-test="istio-config-editor"] .monaco-editor')).toBeVisible();
+  }
+
+  async editYaml(): Promise<void> {
+    await editIstioConfigYaml(this.page);
+  }
+
+  async clickReload(): Promise<void> {
+    await this.getBySel('reload-istio-config').click();
+  }
+
+  async clickCancel(): Promise<void> {
+    await this.getBySel('cancel-istio-config').click();
+  }
+
+  async expectUnsavedModal(action: string): Promise<void> {
+    await expect(this.getBySel('unsaved-changes-modal')).toBeVisible();
+    await expect(this.getBySel('confirm-unsaved')).toContainText(action);
+  }
+
+  async cancelUnsavedModal(): Promise<void> {
+    await this.getBySel('cancel-unsaved').click();
+  }
+
+  async expectNoUnsavedModal(): Promise<void> {
+    await expect(this.getBySel('unsaved-changes-modal')).toHaveCount(0);
+  }
+
+  async clickCreateIstioConfigAction(type: string): Promise<void> {
+    await this.getBySel('istio-actions-toggle').click();
+    await waitForLoadingComplete(this.page);
+    await this.page.locator(`li[data-test="create_${type}"]`).locator('button').click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async expectConfigWizard(title: string): Promise<void> {
+    await expect(this.page.locator('h1')).toContainText(title);
+  }
+
+  async typesInInput(id: string, value: string): Promise<void> {
+    await this.page.locator(`input[id="${id}"]`).fill(value);
+  }
+
+  async chooseModeFromSelect(option: string, id: string): Promise<void> {
+    const select = this.page.locator(`select[id="${id}"]`);
+    if ((await select.count()) > 0) {
+      await select.selectOption(option);
+      return;
+    }
+    await this.page.locator(`button[id="${id}-toggle"]`).click();
+    const optionLocator = this.page.getByRole('option', { name: new RegExp(option, 'i') });
+    if ((await optionLocator.count()) > 0) {
+      await optionLocator.first().click();
+      return;
+    }
+    await this.page
+      .locator('.pf-v6-c-menu__list-item')
+      .filter({ hasText: new RegExp(option, 'i') })
+      .first()
+      .click();
+  }
+
+  async expectObjectListed(type: string, name: string, namespace: string): Promise<void> {
+    const row = this.getBySel(`VirtualItem_Ns${namespace}_${type}_${name}`);
+    await expect(async () => {
+      await this.refreshList();
+      await expect(row.locator('svg')).toBeVisible();
+    }).toPass({ intervals: [5_000], timeout: 60_000 });
+  }
+
+  async expectObjectNotListed(type: string, name: string, namespace: string): Promise<void> {
+    await expect(this.getBySel(`VirtualItem_Ns${namespace}_${type}_${name}`)).toHaveCount(0);
+  }
 }
 
-export async function expectGatewayApiEnabled(request: APIRequestContext): Promise<boolean> {
-  const response = await request.get('/api/config');
-  if (!response.ok()) {
-    return false;
-  }
-  const body = await response.json();
-  return Boolean(body.gatewayAPIEnabled);
-}
+export { isGatewayApiEnabled, isGatewayApiEnabled as expectGatewayApiEnabled } from '../utils/kialiConfig';

--- a/frontend/e2e/pages/IstioConfigWizardPage.ts
+++ b/frontend/e2e/pages/IstioConfigWizardPage.ts
@@ -1,0 +1,127 @@
+import { expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { waitForLoadingComplete } from '../utils/transition';
+
+export class IstioConfigWizardPage extends BasePage {
+  async expectConfigWizard(title: string): Promise<void> {
+    await expect(this.page.locator('h1')).toContainText(title);
+  }
+
+  async addListener(): Promise<void> {
+    await this.page.locator('button[name="addListener"]').click();
+  }
+
+  async addHostname(): Promise<void> {
+    await this.page.locator('button[name="addAddress"]').click();
+  }
+
+  async typesInInput(id: string, value: string): Promise<void> {
+    await this.page.locator(`input[id="${id}"]`).fill(value);
+  }
+
+  async checkHostnameValidation(id: string): Promise<void> {
+    const invalidValues = ['host', '1.1.1.1', 'namespace/host', '*.hostname.*.com', '*', 'HOST.com'];
+    for (const value of invalidValues) {
+      await this.page.locator(`input[id="${id}"]`).fill(value);
+      await expect(this.page.locator(`input[id="${id}"]`)).toHaveAttribute('aria-invalid', 'true');
+    }
+    await this.page.locator(`input[id="${id}"]`).fill('*.hostname.com');
+    await expect(this.page.locator(`input[id="${id}"]`)).toHaveAttribute('aria-invalid', 'false');
+  }
+
+  async addServerToServerList(): Promise<void> {
+    await this.page.locator('button[name="addServer"]').click();
+  }
+
+  async expectInputWarning(id: string, hasWarning: boolean): Promise<void> {
+    await expect(this.page.locator(`input[id="${id}"]`)).toHaveAttribute('aria-invalid', hasWarning ? 'true' : 'false');
+  }
+
+  async createIstioConfig(): Promise<void> {
+    const create = this.getBySel('create');
+    await expect(create).toBeVisible();
+    await expect(create).toBeEnabled();
+    await create.click();
+    await expect(this.page).not.toHaveURL(/\/istio\/new\//);
+    await waitForLoadingComplete(this.page);
+  }
+
+  async previewConfiguration(): Promise<void> {
+    const preview = this.getBySel('preview');
+    await expect(preview).toBeEnabled();
+    await preview.click();
+    await expect(this.getBySel('create')).toBeVisible();
+  }
+
+  async chooseModeFromSelect(option: string, id: string): Promise<void> {
+    const select = this.page.locator(`select[id="${id}"]`);
+    if ((await select.count()) > 0) {
+      await select.selectOption(option);
+      return;
+    }
+    await this.page.locator(`button[id="${id}-toggle"]`).click();
+    const menu = this.page.locator(`#${id}-menu, [aria-label="${id} Select"]`).first();
+    const optionLocator = menu.getByRole('option', { name: new RegExp(option, 'i') });
+    if ((await optionLocator.count()) > 0) {
+      await optionLocator.first().click();
+      return;
+    }
+    await this.page
+      .locator('.pf-v6-c-menu__list-item')
+      .filter({ hasText: new RegExp(option, 'i') })
+      .first()
+      .click();
+  }
+
+  async expectMessage(message: string): Promise<void> {
+    await expect(this.page.locator('main')).toContainText(message);
+  }
+
+  async openSubmenu(title: string): Promise<void> {
+    await this.page.getByRole('button', { name: title }).click();
+  }
+
+  async expectPreviewButtonDisabled(): Promise<void> {
+    await expect(this.getBySel('preview')).toBeDisabled();
+  }
+
+  async expectErrorMessage(message: string): Promise<void> {
+    await expect(this.page.locator('h4')).toContainText(message);
+  }
+
+  async expectInputEmpty(id: string): Promise<void> {
+    await expect(this.page.locator(`input[id="${id}"]`)).toBeEmpty();
+  }
+
+  async selectClusters(clusters: string): Promise<void> {
+    await this.getBySel('cluster-dropdown').click();
+    for (const cluster of clusters.split(',')) {
+      await this.page.locator(`input[type="checkbox"][value="${cluster.trim()}"]`).check();
+    }
+    await this.getBySel('cluster-dropdown').click();
+  }
+
+  async closeSuccessNotification(): Promise<void> {
+    await this.page
+      .locator('[aria-label^="Close Success alert: alert: Istio networking.istio.io/v1, Kind=Gateway created"]')
+      .click();
+  }
+
+  async expectPreviewContains(value: string): Promise<void> {
+    await expect(this.page.locator('[data-test="editor-preview"] .monaco-editor')).toBeVisible();
+    await expect
+      .poll(async () => {
+        return this.page.evaluate(expected => {
+          const win = window as Window & {
+            monaco?: { editor: { getEditors: () => Array<{ getValue: () => string }> } };
+          };
+          const monaco = win.monaco;
+          if (!monaco) {
+            return false;
+          }
+          return monaco.editor.getEditors().some(ed => ed.getValue().includes(expected));
+        }, value);
+      })
+      .toBe(true);
+  }
+}

--- a/frontend/e2e/pages/K8sRoutingWizardPage.ts
+++ b/frontend/e2e/pages/K8sRoutingWizardPage.ts
@@ -1,0 +1,131 @@
+import { expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { waitForLoadingComplete } from '../utils/transition';
+
+export class K8sRoutingWizardPage extends BasePage {
+  async expectWizard(title: string): Promise<void> {
+    await expect(this.page.locator(`div[aria-label="${title}"]`)).toBeVisible();
+  }
+
+  async clickTab(tab: string): Promise<void> {
+    await this.getBySel(tab).click();
+  }
+
+  async clickRequestMatchingDropdown(select: string): Promise<void> {
+    await this.getBySel('requestmatching-header-toggle').click();
+    await this.page.locator(`li[data-test="requestmatching-header-${select}"]`).locator('button').click();
+  }
+
+  async clickRequestFilteringDropdown(select: string): Promise<void> {
+    await this.getBySel('filtering-type-toggle').click();
+    await this.page.locator(`li[data-test="filtering-type-${select}"]`).locator('button').click();
+  }
+
+  async typeMatchingHeader(header: string): Promise<void> {
+    await this.page.locator('input#header-name-id').fill(header);
+  }
+
+  async typeFilteringHeader(header: string): Promise<void> {
+    await this.page.locator('input#filter-header-name-id').fill(header);
+  }
+
+  async clickMatchValueDropdown(value: string): Promise<void> {
+    await this.getBySel('requestmatching-match-toggle').click();
+    await this.page.locator(`li[data-test="requestmatching-match-${value}"]`).locator('button').click();
+  }
+
+  async typeMatchValue(value: string): Promise<void> {
+    await this.page.locator('input#match-value-id').fill(value);
+  }
+
+  async addMatch(): Promise<void> {
+    await this.getBySel('add-match').click();
+  }
+
+  async addFilter(): Promise<void> {
+    await this.getBySel('add-filter').click();
+  }
+
+  async typeTrafficWeight(weight: string, workload: string): Promise<void> {
+    await this.getBySel(`input-slider-${workload}`).fill(weight);
+  }
+
+  async addRoute(): Promise<void> {
+    await this.getBySel('add-route').click();
+  }
+
+  async clickMatchingSelected(match: string): Promise<void> {
+    await this.getBySel(match).locator('button').first().click();
+  }
+
+  async previewConfiguration(): Promise<void> {
+    const preview = this.getBySel('preview');
+    await expect(preview).toBeEnabled();
+    await preview.click();
+    await expect(this.getBySel('create').or(this.getBySel('update'))).toBeVisible();
+  }
+
+  async createConfiguration(): Promise<void> {
+    const create = this.getBySel('create');
+    await expect(create).toBeEnabled();
+    await create.click();
+    await this.getBySel('confirm-create').click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async updateConfiguration(): Promise<void> {
+    const update = this.getBySel('update');
+    await expect(update).toBeEnabled();
+    const responses = this.page.waitForResponse(
+      response =>
+        response.request().method() !== 'GET' &&
+        response.url().includes('/api/') &&
+        response.url().includes('/istio/') &&
+        response.ok(),
+      { timeout: 60_000 }
+    );
+    await update.click();
+    await expect(this.getBySel('confirm-update')).toBeVisible();
+    const confirm = this.getBySel('confirm-update');
+    await confirm.click();
+    await responses;
+    await expect(this.page.getByRole('dialog')).toHaveCount(0);
+    await waitForLoadingComplete(this.page);
+  }
+
+  async confirmDeleteConfiguration(): Promise<void> {
+    await this.getBySel('confirm-delete').click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async clickAdvancedOptions(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Show advanced options' }).click();
+  }
+
+  async clickAddGateway(): Promise<void> {
+    const gatewaySwitch = this.page.locator('input#advanced-gwSwitch');
+    if (!(await gatewaySwitch.isChecked())) {
+      await this.page.locator('input#advanced-gwSwitch + *').click();
+    }
+    await expect(gatewaySwitch).toBeChecked();
+  }
+
+  async selectCreateGateway(): Promise<void> {
+    await this.page.getByRole('radio', { name: /Create K8s API Gateway/i }).click();
+    await expect(this.page.locator('#createGateway')).toBeChecked();
+  }
+
+  async expectReference(namespace: string, name: string, type: string): Promise<void> {
+    await expect(this.getBySel(`${type}-${namespace}-${name}`)).toBeVisible();
+  }
+
+  async clickReference(namespace: string, name: string, type: string): Promise<void> {
+    await this.getBySel(`${type}-${namespace}-${name}`).click();
+    const pathByType: Record<string, string> = {
+      destinationrule: `/namespaces/${namespace}/istio/networking.istio.io/v1/DestinationRule/${name}`,
+      service: `/namespaces/${namespace}/services/${name}`,
+      virtualservice: `/namespaces/${namespace}/istio/networking.istio.io/v1/VirtualService/${name}`
+    };
+    await expect(this.page).toHaveURL(new RegExp(pathByType[type]));
+  }
+}

--- a/frontend/e2e/pages/ListPage.ts
+++ b/frontend/e2e/pages/ListPage.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 import { gotoListPage } from '../utils/navigation';
-import { selectNamespace } from '../utils/namespace';
 import { colExists, expectColumnHeaderVisible, expectColumnHeaderHidden } from '../utils/table';
 import { waitForLoadingComplete } from '../utils/transition';
 
@@ -28,8 +27,7 @@ export class ListPage extends BasePage {
   }
 
   async openListWithNamespace(namespace: string, query: Record<string, string> = {}): Promise<void> {
-    await this.openList(query);
-    await selectNamespace(this.page, namespace);
+    await this.openList({ namespaces: namespace, ...query });
   }
 
   async visitWithUrlParams(urlParams: string): Promise<void> {

--- a/frontend/e2e/pages/MeshPage.ts
+++ b/frontend/e2e/pages/MeshPage.ts
@@ -99,6 +99,15 @@ export class MeshPage extends BasePage {
     }).toPass({ intervals: [3_000], timeout: 60_000 });
   }
 
+  /**
+   * Poll /api/mesh/graph for health, then refresh the mesh page so cytoscape node data
+   * (and the side-panel health icon) match the API before selecting the node.
+   */
+  async syncInfraHealthToUi(infraName: string, predicate: (health: string) => boolean): Promise<void> {
+    await this.waitForInfraHealth(infraName, predicate);
+    await this.refreshPage();
+  }
+
   async expectSidePanelIcon(type: string): Promise<void> {
     const panel = this.page.locator('#target-panel-node');
     await expect(async () => {

--- a/frontend/e2e/pages/MeshPage.ts
+++ b/frontend/e2e/pages/MeshPage.ts
@@ -79,6 +79,7 @@ export class MeshPage extends BasePage {
     await expect(this.page.locator('#target-panel-node')).toContainText(name);
   }
 
+  /** True when Kiali reaches Grafana via local port-forward (KinD CI), not an in-cluster route (Jenkins/OSSM). */
   async usesLocalGrafanaPortForward(): Promise<boolean> {
     const panel = this.page.locator('#target-panel-node');
     await expect(panel).toBeVisible();
@@ -141,7 +142,7 @@ export class MeshPage extends BasePage {
       const body = await response.json();
       expect(body.process_resident_memory_bytes).toBeTruthy();
       expect(body.process_cpu_seconds_total).toBeTruthy();
-    }).toPass({ intervals: [3_000], timeout: 90_000 });
+    }).toPass({ intervals: [3_000], timeout: 120_000 });
 
     await expect(async () => {
       await this.refreshPage();
@@ -154,6 +155,6 @@ export class MeshPage extends BasePage {
       await expect(panel.getByTestId('cpu-chart')).toBeVisible();
       await expect(panel.getByTestId('control-plane-certificate')).toBeVisible();
       await expect(panel.getByTestId('label-TLS')).toContainText('TLSV1_2');
-    }).toPass({ intervals: [3_000], timeout: 90_000 });
+    }).toPass({ intervals: [3_000], timeout: 120_000 });
   }
 }

--- a/frontend/e2e/pages/MeshPage.ts
+++ b/frontend/e2e/pages/MeshPage.ts
@@ -1,10 +1,13 @@
 import { expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 import { gotoConsolePage } from '../utils/navigation';
+import { selectMeshNodeByLabel } from '../utils/meshTopology';
 
 type MeshGraphNode = {
   data?: {
+    healthData?: string;
     id?: string;
+    infraName?: string;
     infraType?: string;
   };
 };
@@ -62,5 +65,99 @@ export class MeshPage extends BasePage {
     });
 
     expect(connected.length, `Expected ${edgeCount} kiali↔istiod edge(s), got ${connected.length}`).toBe(edgeCount);
+  }
+
+  async selectMeshNodeByLabel(label: string): Promise<void> {
+    await this.waitForLoad();
+    await selectMeshNodeByLabel(this.page, label);
+    await this.waitForLoad();
+  }
+
+  async expectNodeSidePanel(name: string): Promise<void> {
+    await this.waitForLoad();
+    await expect(this.page.locator('#target-panel-node')).toBeVisible();
+    await expect(this.page.locator('#target-panel-node')).toContainText(name);
+  }
+
+  async usesLocalGrafanaPortForward(): Promise<boolean> {
+    const panel = this.page.locator('#target-panel-node');
+    await expect(panel).toBeVisible();
+    const text = await panel.textContent();
+    return Boolean(text?.includes('localhost:') || text?.includes('127.0.0.1'));
+  }
+
+  async waitForInfraHealth(infraName: string, predicate: (health: string) => boolean): Promise<void> {
+    await expect(async () => {
+      const response = await this.page.request.get('/api/mesh/graph');
+      expect(response.ok()).toBeTruthy();
+      const body = (await response.json()) as MeshGraphResponse;
+      const node = (body.elements?.nodes ?? []).find(n => n.data?.infraName?.toLowerCase() === infraName.toLowerCase());
+      const health = node?.data?.healthData;
+      expect(health, `Expected health data for ${infraName}`).toBeTruthy();
+      expect(predicate(health!)).toBe(true);
+    }).toPass({ intervals: [3_000], timeout: 60_000 });
+  }
+
+  async expectSidePanelIcon(type: string): Promise<void> {
+    const panel = this.page.locator('#target-panel-node');
+    await expect(async () => {
+      await expect(panel.getByTestId(`icon-${type}-validation`)).toBeVisible();
+    }).toPass({ intervals: [3_000], timeout: 60_000 });
+  }
+
+  async expectNoSidePanelIcon(type: string): Promise<void> {
+    await expect(this.page.locator('#target-panel-node').getByTestId(`icon-${type}-validation`)).toHaveCount(0);
+  }
+
+  async expectSidePanelContains(text: string): Promise<void> {
+    await expect(this.page.locator('#target-panel-node')).toContainText(text);
+  }
+
+  async expectConfigTabs(tabs: string): Promise<void> {
+    for (const tab of tabs.split(',')) {
+      await expect(this.getBySel(`config-tab-${tab.trim()}`)).toBeVisible();
+    }
+  }
+
+  async expectConfigTabContains(tab: string, text: string): Promise<void> {
+    await this.getBySel(`config-tab-${tab}`).click();
+    await expect(this.getBySel(`${tab}-config-editor`)).toContainText(text);
+  }
+
+  async expectConfigTabNotContains(tab: string, text: string): Promise<void> {
+    await this.getBySel(`config-tab-${tab}`).click();
+    await expect(this.getBySel(`${tab}-config-editor`)).not.toContainText(text);
+  }
+
+  async refreshPage(): Promise<void> {
+    await this.getBySel('refresh-button').click();
+    await this.waitForLoad();
+  }
+
+  async expectControlPlaneSidePanel(): Promise<void> {
+    const maxTries = 15;
+    for (let tries = 1; tries <= maxTries; tries++) {
+      const response = await this.page.request.get('/api/namespaces/istio-system/controlplanes/istiod/metrics');
+      if (response.ok()) {
+        const body = await response.json();
+        if (body.process_resident_memory_bytes != null) {
+          break;
+        }
+      }
+      if (tries === maxTries) {
+        throw new Error('Timed out waiting for istiod memory metrics');
+      }
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+
+    await this.refreshPage();
+    const panel = this.page.locator('#target-panel-control-plane');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText('istiod');
+    await expect(panel).toContainText('Outbound policy');
+    await expect(panel.getByTestId('memory-chart')).toBeVisible();
+    await expect(panel.getByTestId('cpu-chart')).toBeVisible();
+    await expect(panel.getByTestId('control-plane-certificate')).toBeVisible();
+    await expect(panel.getByTestId('label-TLS')).toContainText('TLSV1_2');
   }
 }

--- a/frontend/e2e/pages/MeshPage.ts
+++ b/frontend/e2e/pages/MeshPage.ts
@@ -135,29 +135,25 @@ export class MeshPage extends BasePage {
   }
 
   async expectControlPlaneSidePanel(): Promise<void> {
-    const maxTries = 15;
-    for (let tries = 1; tries <= maxTries; tries++) {
+    await expect(async () => {
       const response = await this.page.request.get('/api/namespaces/istio-system/controlplanes/istiod/metrics');
-      if (response.ok()) {
-        const body = await response.json();
-        if (body.process_resident_memory_bytes != null) {
-          break;
-        }
-      }
-      if (tries === maxTries) {
-        throw new Error('Timed out waiting for istiod memory metrics');
-      }
-      await new Promise(resolve => setTimeout(resolve, 3000));
-    }
+      expect(response.ok()).toBeTruthy();
+      const body = await response.json();
+      expect(body.process_resident_memory_bytes).toBeTruthy();
+      expect(body.process_cpu_seconds_total).toBeTruthy();
+    }).toPass({ intervals: [3_000], timeout: 90_000 });
 
-    await this.refreshPage();
-    const panel = this.page.locator('#target-panel-control-plane');
-    await expect(panel).toBeVisible();
-    await expect(panel).toContainText('istiod');
-    await expect(panel).toContainText('Outbound policy');
-    await expect(panel.getByTestId('memory-chart')).toBeVisible();
-    await expect(panel.getByTestId('cpu-chart')).toBeVisible();
-    await expect(panel.getByTestId('control-plane-certificate')).toBeVisible();
-    await expect(panel.getByTestId('label-TLS')).toContainText('TLSV1_2');
+    await expect(async () => {
+      await this.refreshPage();
+      await this.selectMeshNodeByLabel('istiod');
+      const panel = this.page.locator('#target-panel-control-plane');
+      await expect(panel).toBeVisible();
+      await expect(panel).toContainText('istiod');
+      await expect(panel).toContainText('Outbound policy');
+      await expect(panel.getByTestId('memory-chart')).toBeVisible();
+      await expect(panel.getByTestId('cpu-chart')).toBeVisible();
+      await expect(panel.getByTestId('control-plane-certificate')).toBeVisible();
+      await expect(panel.getByTestId('label-TLS')).toContainText('TLSV1_2');
+    }).toPass({ intervals: [3_000], timeout: 90_000 });
   }
 }

--- a/frontend/e2e/pages/NamespaceDetailPage.ts
+++ b/frontend/e2e/pages/NamespaceDetailPage.ts
@@ -1,0 +1,90 @@
+import { expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { gotoConsolePage } from '../utils/navigation';
+import { waitForLoadingComplete } from '../utils/transition';
+
+const isOssmc = (): boolean => process.env.PLAYWRIGHT_OSSMC === 'true';
+
+export class NamespaceDetailPage extends BasePage {
+  private targetNamespace = '';
+
+  async open(namespace: string): Promise<void> {
+    this.targetNamespace = namespace;
+    if (isOssmc()) {
+      await this.page.route('**/api/namespaces/graph*', route => route.continue());
+    }
+    await gotoConsolePage(this.page, `namespaces/${namespace}`);
+    if (isOssmc()) {
+      await this.page.waitForResponse(response => response.url().includes('/api/namespaces/graph'));
+    }
+    await waitForLoadingComplete(this.page);
+  }
+
+  async openActionsMenu(): Promise<void> {
+    await waitForLoadingComplete(this.page);
+    await expect(this.page.locator('[role="dialog"]')).toHaveCount(0);
+    if (isOssmc()) {
+      await this.page.locator('button#minigraph-toggle').click();
+    } else {
+      await this.getBySel('namespace-actions-toggle').click();
+    }
+    await expect(this.page.locator('[role="menu"]')).toBeVisible();
+  }
+
+  async hasSidecarInjectionAction(action: 'disable' | 'enable' | 'remove'): Promise<boolean> {
+    const selector = `${action}-${this.targetNamespace}-namespace-sidecar-injection`;
+    return (await this.getBySel(selector).count()) > 0;
+  }
+
+  private async clickSidecarInjectionAction(action: 'disable' | 'enable' | 'remove'): Promise<void> {
+    await this.openActionsMenu();
+    const selector = `${action}-${this.targetNamespace}-namespace-sidecar-injection`;
+    const menuItem = this.getBySel(selector);
+    if ((await menuItem.count()) === 0) {
+      throw new Error(
+        `Sidecar injection action "${action}" is not available for namespace ${this.targetNamespace}. ` +
+          'Ensure istioInjectionAction is enabled and the cluster is not in istio upgrade mode.'
+      );
+    }
+    await menuItem.click();
+    await this.confirmTrafficPolicyModal();
+  }
+
+  async confirmTrafficPolicyModal(): Promise<void> {
+    const patchPromise = this.page.waitForResponse(
+      response => response.request().method() === 'PATCH' && response.url().includes('/api/namespaces/')
+    );
+    const confirm = this.getBySel('confirm-create');
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toBeEnabled();
+    await confirm.click();
+    await patchPromise;
+    await expect(this.page.locator('[role="dialog"]')).toHaveCount(0);
+    await waitForLoadingComplete(this.page);
+  }
+
+  async enableNamespaceInjection(): Promise<void> {
+    await this.clickSidecarInjectionAction('enable');
+  }
+
+  async disableNamespaceInjection(): Promise<void> {
+    await this.clickSidecarInjectionAction('disable');
+  }
+
+  async removeNamespaceInjection(): Promise<void> {
+    await this.clickSidecarInjectionAction('remove');
+  }
+
+  async expectNamespaceInjectionLabel(state: 'absent' | 'disabled' | 'enabled'): Promise<void> {
+    const response = await this.page.request.get(`/api/namespaces/${this.targetNamespace}/info`);
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    if (state === 'enabled') {
+      expect(body.labels['istio-injection']).toBe('enabled');
+    } else if (state === 'disabled') {
+      expect(body.labels['istio-injection']).toBe('disabled');
+    } else {
+      expect(body.labels).not.toHaveProperty('istio-injection');
+    }
+  }
+}

--- a/frontend/e2e/pages/ServiceDetailsPage.ts
+++ b/frontend/e2e/pages/ServiceDetailsPage.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { gotoConsolePage } from '../utils/navigation';
+import { waitForLoadingComplete } from '../utils/transition';
+
+const isOssmc = (): boolean => process.env.PLAYWRIGHT_OSSMC === 'true';
+
+type ServiceAction = 'delete_traffic_routing' | 'k8s_grpc_request_routing' | 'k8s_request_routing' | 'request_routing';
+
+export class ServiceDetailsPage extends BasePage {
+  async open(namespace: string, service: string): Promise<void> {
+    await gotoConsolePage(this.page, `namespaces/${namespace}/services/${service}`);
+  }
+
+  async clickServiceAction(action: ServiceAction): Promise<void> {
+    await waitForLoadingComplete(this.page);
+
+    if (isOssmc()) {
+      await this.page.waitForResponse(
+        response =>
+          response.url().includes('/api/') && response.url().includes('/services/') && response.url().includes('/graph')
+      );
+      await this.page.locator('button#minigraph-toggle').click();
+    } else {
+      await this.getBySel('service-actions-toggle').click();
+      await waitForLoadingComplete(this.page);
+    }
+
+    await this.page.locator(`li[data-test="${action}"]`).locator('button').click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async expectIstioConfigTableRowCount(count: number): Promise<void> {
+    const table = this.page.locator('table[aria-label="Istio Config List"]');
+    await expect(async () => {
+      await this.page.reload();
+      await waitForLoadingComplete(this.page);
+      await expect(table.locator('tbody tr')).toHaveCount(count);
+    }).toPass({ intervals: [2_000], timeout: 60_000 });
+  }
+
+  async expectIstioConfigTableEmpty(): Promise<void> {
+    const table = this.page.locator('table[aria-label="Istio Config List"]');
+    await expect(table.getByTestId('istio-config-empty')).toBeVisible();
+  }
+
+  async clickIstioConfigBadgeLink(badge: string, name = 'reviews'): Promise<void> {
+    const table = this.page.locator('table[aria-label="Istio Config List"]');
+    const row = table.locator('tbody tr').filter({ hasText: name }).filter({ hasText: badge });
+    await row.getByRole('link', { name }).click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async expectServiceReference(namespace: string, name: string): Promise<void> {
+    await expect(this.getBySel(`service-${namespace}-${name}`)).toBeVisible();
+  }
+}

--- a/frontend/e2e/pages/ServicesPage.ts
+++ b/frontend/e2e/pages/ServicesPage.ts
@@ -1,4 +1,6 @@
 import { expect } from '@playwright/test';
+import { getClusterForSingleCluster } from '../utils/cluster';
+import { checkHealthIndicatorInTable, checkHealthStatusInTable } from '../utils/table';
 import { ListPage } from './ListPage';
 
 export class ServicesPage extends ListPage {
@@ -13,5 +15,19 @@ export class ServicesPage extends ListPage {
     await this.expectColumn('Configuration', true);
     await this.expectColumn('Health', true);
     await this.expectColumn('Details', true);
+  }
+
+  async expectServiceListedAs(
+    namespace: string,
+    service: string,
+    healthStatus: 'healthy' | 'na' | 'failure' | 'degraded'
+  ): Promise<void> {
+    const cluster = await getClusterForSingleCluster(this.page.request);
+    await checkHealthIndicatorInTable(this.page, cluster, namespace, null, service, healthStatus);
+  }
+
+  async expectServiceHealthStatus(namespace: string, service: string, healthStatus: string): Promise<void> {
+    const cluster = await getClusterForSingleCluster(this.page.request);
+    await checkHealthStatusInTable(this.page, cluster, namespace, null, service, healthStatus);
   }
 }

--- a/frontend/e2e/pages/WorkloadDetailsPage.ts
+++ b/frontend/e2e/pages/WorkloadDetailsPage.ts
@@ -1,0 +1,123 @@
+import { expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { gotoConsolePage } from '../utils/navigation';
+import { restartWorkload } from '../utils/sidecarInjection';
+import { waitForLoadingComplete } from '../utils/transition';
+
+const isOssmc = (): boolean => process.env.PLAYWRIGHT_OSSMC === 'true';
+
+type SidecarAction = 'disable_auto_injection' | 'enable_auto_injection' | 'remove_auto_injection';
+
+export class WorkloadDetailsPage extends BasePage {
+  async open(namespace: string, workload: string): Promise<void> {
+    await gotoConsolePage(this.page, `namespaces/${namespace}/workloads/${workload}`);
+  }
+
+  async openLogsTab(namespace: string, workload: string): Promise<void> {
+    await gotoConsolePage(this.page, `namespaces/${namespace}/workloads/${workload}`, { tab: 'logs' });
+
+    const changeIntervalDuration = async (): Promise<void> => {
+      await this.page.locator('#metrics_filter_interval_duration-toggle').click();
+      // IDs starting with a digit are invalid CSS selectors (#3600); use attribute selector.
+      await this.page.locator('[id="3600"]').click();
+    };
+
+    if (isOssmc()) {
+      await this.page.locator('#time_duration').click();
+      await changeIntervalDuration();
+      await this.page.locator('#time-duration-modal').getByRole('button', { name: 'Confirm' }).click();
+    } else {
+      await changeIntervalDuration();
+    }
+
+    await waitForLoadingComplete(this.page);
+    await expect(this.page.locator('#logsText p').first()).toBeVisible();
+  }
+
+  async setLogShow(text: string): Promise<void> {
+    await this.page.locator('#log_show').fill(text);
+    await this.page.locator('#log_show').press('Enter');
+  }
+
+  async setLogHide(text: string): Promise<void> {
+    await this.page.locator('#log_hide').fill(text);
+    await this.page.locator('#log_hide').press('Enter');
+  }
+
+  async expectLogLinesContain(text: string): Promise<void> {
+    const lines = this.page.locator('#logsText p');
+    const count = await lines.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(lines.nth(i)).toContainText(text);
+    }
+  }
+
+  async expectLogLinesNotContain(text: string): Promise<void> {
+    const lines = this.page.locator('#logsText p');
+    const count = await lines.count();
+    for (let i = 0; i < count; i++) {
+      await expect(lines.nth(i)).not.toContainText(text);
+    }
+  }
+
+  async expectJsonLogLines(): Promise<void> {
+    await expect(this.page.locator('#logsText').getByTestId('json-log-info-button').first()).toBeVisible();
+  }
+
+  async clickJsonLogLine(): Promise<void> {
+    await this.page.locator('#logsText').getByTestId('json-log-info-button').first().click();
+  }
+
+  async expectParsedJsonValues(): Promise<void> {
+    await this.getBySel('json-modal').getByTestId('json-table-tab').click();
+    const firstRow = this.getBySel('parsed-json-table').locator('tr').first();
+    await expect(firstRow.locator('td').nth(0)).toContainText('a');
+    await expect(firstRow.locator('td').nth(1)).toContainText('b');
+  }
+
+  async openWorkloadActions(): Promise<void> {
+    if (isOssmc()) {
+      await this.page.waitForResponse(
+        response =>
+          response.url().includes('/api/') &&
+          response.url().includes('/workloads/') &&
+          response.url().includes('/graph')
+      );
+      await this.page.locator('button#minigraph-toggle').click();
+    } else {
+      await this.getBySel('workload-actions-toggle').click();
+    }
+  }
+
+  async clickSidecarAction(action: SidecarAction): Promise<void> {
+    await this.openWorkloadActions();
+    await this.page.locator(`li[data-test=${action}]`).locator('button').click();
+    await expect(this.page.locator('div.pf-v6-c-alert.pf-m-success')).toBeVisible();
+  }
+
+  async clickSidecarActionAndRestart(action: SidecarAction, namespace: string, workload: string): Promise<void> {
+    await this.clickSidecarAction(action);
+    await restartWorkload(namespace, workload);
+    await this.open(namespace, workload);
+    await waitForLoadingComplete(this.page);
+  }
+
+  async expectMissingSidecarBadge(exists: boolean, namespace: string, workload: string): Promise<void> {
+    const badge = this.getBySel(`missing-sidecar-badge-for-${workload}-workload-in-${namespace}-namespace`);
+    if (exists) {
+      await expect(badge).toBeVisible();
+    } else {
+      await expect(badge).toHaveCount(0);
+    }
+  }
+
+  async expectNoWorkloadInjectionLabel(): Promise<void> {
+    const card = this.getBySel('workload-labels-card');
+    const overflow = card.locator('.pf-m-overflow');
+    if ((await overflow.count()) > 0) {
+      await overflow.click();
+    }
+    await expect(card.getByTestId('sidecar.istio.io/inject-label-container')).toHaveCount(0);
+  }
+}

--- a/frontend/e2e/pages/WorkloadsPage.ts
+++ b/frontend/e2e/pages/WorkloadsPage.ts
@@ -1,7 +1,23 @@
+import { getClusterForSingleCluster } from '../utils/cluster';
+import { checkHealthIndicatorInTable, checkHealthStatusInTable } from '../utils/table';
 import { ListPage } from './ListPage';
 
 export class WorkloadsPage extends ListPage {
   constructor(page: ListPage['page']) {
     super(page, 'workloads');
+  }
+
+  async expectWorkloadListedAs(
+    namespace: string,
+    workload: string,
+    healthStatus: 'healthy' | 'idle' | 'failure' | 'degraded'
+  ): Promise<void> {
+    const cluster = await getClusterForSingleCluster(this.page.request);
+    await checkHealthIndicatorInTable(this.page, cluster, namespace, 'Deployment', workload, healthStatus);
+  }
+
+  async expectWorkloadHealthStatus(namespace: string, workload: string, healthStatus: string): Promise<void> {
+    const cluster = await getClusterForSingleCluster(this.page.request);
+    await checkHealthStatusInTable(this.page, cluster, namespace, 'Deployment', workload, healthStatus);
   }
 }

--- a/frontend/e2e/tests/istio_config/istio_config_editor.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_editor.spec.ts
@@ -1,0 +1,40 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { selectNamespace } from '../../utils/namespace';
+import { core2 } from '../../utils/suite-tags';
+
+const isOssmc = (): boolean => process.env.PLAYWRIGHT_OSSMC === 'true';
+
+test.describe('Istio Config editor', () => {
+  test.beforeEach(async ({ istioConfigPage, page }) => {
+    ensureDemoApp('bookinfo');
+    await istioConfigPage.open();
+    await selectNamespace(page, 'bookinfo');
+  });
+
+  test('Unsaved YAML edits show reload confirmation', core2, async ({ istioConfigPage }) => {
+    test.skip(isOssmc(), 'Monaco editor unsaved-changes modal is skipped in OSSMC (Cypress @skip-ossmc)');
+
+    await istioConfigPage.openConfigByName('bookinfo');
+    await istioConfigPage.expectEditorVisible();
+    await istioConfigPage.editYaml();
+    await istioConfigPage.clickReload();
+    await istioConfigPage.expectUnsavedModal('Reload');
+    await istioConfigPage.cancelUnsavedModal();
+    await istioConfigPage.expectNoUnsavedModal();
+    await istioConfigPage.expectEditorVisible();
+  });
+
+  test('Unsaved YAML edits show leave confirmation on Cancel', core2, async ({ istioConfigPage }) => {
+    test.skip(isOssmc(), 'Monaco editor unsaved-changes modal is skipped in OSSMC (Cypress @skip-ossmc)');
+
+    await istioConfigPage.openConfigByName('bookinfo');
+    await istioConfigPage.expectEditorVisible();
+    await istioConfigPage.editYaml();
+    await istioConfigPage.clickCancel();
+    await istioConfigPage.expectUnsavedModal('Leave');
+    await istioConfigPage.cancelUnsavedModal();
+    await istioConfigPage.expectNoUnsavedModal();
+    await istioConfigPage.expectEditorVisible();
+  });
+});

--- a/frontend/e2e/tests/istio_config/istio_config_list.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_list.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/kialiFixtures';
 import { selectNamespace } from '../../utils/namespace';
-import { expectGatewayApiEnabled } from '../../pages/IstioConfigPage';
+import { isGatewayApiEnabled } from '../../utils/kialiConfig';
 import {
   applyMinimalK8sInferencePool,
   deleteK8sInferencePool,
@@ -61,7 +61,7 @@ test.describe('Istio Config list', () => {
   });
 
   test('Ability to create a K8sGateway object', core1, async ({ page, istioConfigPage }) => {
-    const enabled = await expectGatewayApiEnabled(page.request);
+    const enabled = await isGatewayApiEnabled(page.request);
     test.skip(!enabled, 'gateway API not enabled on cluster');
     await istioConfigPage.expectCanCreateK8sIstioObject('gateway.networking.k8s.io', 'v1', 'Gateway');
   });

--- a/frontend/e2e/tests/istio_config/wizard_istio_config_gateway.spec.ts
+++ b/frontend/e2e/tests/istio_config/wizard_istio_config_gateway.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/kialiFixtures';
 import { ensureDemoApp } from '../../utils/demoApps';
-import { acquireBookinfoRoutingLock } from '../../utils/bookinfoRoutingLock';
+import { useBookinfoRoutingLockPerTest } from '../../utils/bookinfoRoutingLock';
 import {
   deleteK8sGateway,
   deleteK8sReferenceGrant,
@@ -14,18 +14,9 @@ const gatewayName = 'k8sapigateway';
 const namespace = 'bookinfo';
 
 test.describe('Istio Config wizard: K8s Gateway API', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({ mode: 'serial', timeout: 180_000 });
 
-  let releaseGatewayLock: (() => void) | undefined;
-
-  test.beforeAll(async () => {
-    releaseGatewayLock = await acquireBookinfoRoutingLock();
-  });
-
-  test.afterAll(() => {
-    releaseGatewayLock?.();
-    releaseGatewayLock = undefined;
-  });
+  useBookinfoRoutingLockPerTest();
 
   test.beforeEach(async ({ istioConfigPage, request, page }) => {
     ensureDemoApp('bookinfo');

--- a/frontend/e2e/tests/istio_config/wizard_istio_config_gateway.spec.ts
+++ b/frontend/e2e/tests/istio_config/wizard_istio_config_gateway.spec.ts
@@ -1,0 +1,84 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { acquireBookinfoRoutingLock } from '../../utils/bookinfoRoutingLock';
+import {
+  deleteK8sGateway,
+  deleteK8sReferenceGrant,
+  ensureBookinfoTlsCertSecret
+} from '../../utils/istioConfigResources';
+import { isGatewayApiEnabled } from '../../utils/kialiConfig';
+import { selectNamespace } from '../../utils/namespace';
+import { core2 } from '../../utils/suite-tags';
+
+const gatewayName = 'k8sapigateway';
+const namespace = 'bookinfo';
+
+test.describe('Istio Config wizard: K8s Gateway API', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let releaseGatewayLock: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    releaseGatewayLock = await acquireBookinfoRoutingLock();
+  });
+
+  test.afterAll(() => {
+    releaseGatewayLock?.();
+    releaseGatewayLock = undefined;
+  });
+
+  test.beforeEach(async ({ istioConfigPage, request, page }) => {
+    ensureDemoApp('bookinfo');
+    test.skip(!(await isGatewayApiEnabled(request)), 'Gateway API is not enabled');
+    await istioConfigPage.open();
+    await selectNamespace(page, namespace);
+  });
+
+  test('Create a K8s Gateway scenario', core2, async ({ istioConfigPage, istioConfigWizardPage }) => {
+    deleteK8sGateway(gatewayName, namespace);
+    await istioConfigPage.clickCreateIstioConfigAction('K8sGateway');
+    await istioConfigWizardPage.expectConfigWizard('Create K8sGateway');
+    await istioConfigWizardPage.addListener();
+    await istioConfigWizardPage.typesInInput('name', gatewayName);
+    await istioConfigWizardPage.typesInInput('addName_0', 'listener');
+    await istioConfigWizardPage.checkHostnameValidation('addHostname_0');
+    await istioConfigWizardPage.typesInInput('addHostname_0', 'website.com');
+    await istioConfigWizardPage.typesInInput('addPort_0', '8080');
+    await istioConfigWizardPage.previewConfiguration();
+    await istioConfigWizardPage.createIstioConfig();
+    await istioConfigPage.expectObjectListed('K8sGateway', gatewayName, namespace);
+  });
+
+  test('Create a K8s Gateway HTTPS scenario', core2, async ({ istioConfigPage, istioConfigWizardPage }) => {
+    ensureBookinfoTlsCertSecret();
+    deleteK8sGateway(gatewayName, namespace);
+    await istioConfigPage.clickCreateIstioConfigAction('K8sGateway');
+    await istioConfigWizardPage.expectConfigWizard('Create K8sGateway');
+    await istioConfigWizardPage.addListener();
+    await istioConfigWizardPage.typesInInput('name', gatewayName);
+    await istioConfigWizardPage.typesInInput('addName_0', 'listener');
+    await istioConfigWizardPage.checkHostnameValidation('addHostname_0');
+    await istioConfigWizardPage.typesInInput('addHostname_0', 'website.com');
+    await istioConfigWizardPage.typesInInput('addPort_0', '443');
+    await istioConfigWizardPage.chooseModeFromSelect('HTTPS', 'addPortProtocol_0');
+    await istioConfigWizardPage.expectPreviewButtonDisabled();
+    await istioConfigWizardPage.typesInInput('tlsCert_0', 'cert');
+    await istioConfigWizardPage.previewConfiguration();
+    await istioConfigWizardPage.createIstioConfig();
+    await istioConfigPage.expectObjectListed('K8sGateway', gatewayName, namespace);
+  });
+
+  test('Create a K8s Reference Grant scenario', core2, async ({ istioConfigPage, istioConfigWizardPage }) => {
+    const refGrantName = 'k8srefgrant';
+    deleteK8sReferenceGrant(refGrantName, namespace);
+    await istioConfigPage.clickCreateIstioConfigAction('K8sReferenceGrant');
+    await istioConfigWizardPage.expectConfigWizard('Create K8sReferenceGrant');
+    await istioConfigWizardPage.typesInInput('name', refGrantName);
+    await istioConfigWizardPage.chooseModeFromSelect('Gateway', 'ReferenceGrantFromKind');
+    await istioConfigWizardPage.chooseModeFromSelect('Secret', 'ReferenceGrantToKind');
+    await istioConfigWizardPage.chooseModeFromSelect('istio-system', 'ReferenceGrantFromNamespace');
+    await istioConfigWizardPage.previewConfiguration();
+    await istioConfigWizardPage.createIstioConfig();
+    await istioConfigPage.expectObjectListed('K8sReferenceGrant', refGrantName, namespace);
+  });
+});

--- a/frontend/e2e/tests/mesh/mesh_core2.spec.ts
+++ b/frontend/e2e/tests/mesh/mesh_core2.spec.ts
@@ -4,7 +4,13 @@ import { kubectlScaleDeployment } from '../../utils/kubectl';
 import { applySharedMeshConfig, restoreSharedMeshConfig } from '../../utils/sharedMeshConfig';
 import { core2 } from '../../utils/suite-tags';
 
+/**
+ * Grafana scale and shared-mesh Sail patches both touch istio-system; run serially so
+ * parallel workers do not race on control-plane state (Jenkins OSSM).
+ */
 test.describe('Mesh page core-2', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test.afterEach(() => {
     try {
       kubectlScaleDeployment('istio-system', 'grafana', 1);
@@ -14,6 +20,7 @@ test.describe('Mesh page core-2', () => {
   });
 
   test('Grafana Infra unreachable', core2, async ({ meshPage }) => {
+    test.setTimeout(180_000);
     test.skip(!hasGrafanaDeployment(), 'Grafana deployment is not installed in istio-system');
 
     await meshPage.open();

--- a/frontend/e2e/tests/mesh/mesh_core2.spec.ts
+++ b/frontend/e2e/tests/mesh/mesh_core2.spec.ts
@@ -1,15 +1,15 @@
 import { test } from '../../fixtures/kialiFixtures';
 import { hasGrafanaDeployment, hasSailIstioCr } from '../../utils/kialiConfig';
-import { kubectlScale } from '../../utils/kubectl';
+import { kubectlScaleDeployment } from '../../utils/kubectl';
 import { applySharedMeshConfig, restoreSharedMeshConfig } from '../../utils/sharedMeshConfig';
 import { core2 } from '../../utils/suite-tags';
 
 test.describe('Mesh page core-2', () => {
   test.afterEach(() => {
     try {
-      kubectlScale('istio-system', 'grafana', 1);
+      kubectlScaleDeployment('istio-system', 'grafana', 1);
     } catch {
-      // Best-effort restore after Grafana upscale test.
+      // Best-effort restore after Grafana upscale test (matches Cypress @component-health-upscale).
     }
   });
 
@@ -24,7 +24,7 @@ test.describe('Mesh page core-2', () => {
       'Grafana uses a local port-forward URL; scaling the deployment does not make it unreachable locally'
     );
 
-    kubectlScale('istio-system', 'grafana', 0);
+    kubectlScaleDeployment('istio-system', 'grafana', 0);
     await meshPage.refreshPage();
     await meshPage.waitForInfraHealth('Grafana', health => health !== 'Healthy');
     await meshPage.selectMeshNodeByLabel('Grafana');
@@ -32,7 +32,7 @@ test.describe('Mesh page core-2', () => {
     await meshPage.expectSidePanelContains('Version: unknown');
     await meshPage.expectSidePanelIcon('error');
 
-    kubectlScale('istio-system', 'grafana', 1);
+    kubectlScaleDeployment('istio-system', 'grafana', 1);
     await meshPage.refreshPage();
     await meshPage.waitForInfraHealth('Grafana', health => health === 'Healthy');
     await meshPage.selectMeshNodeByLabel('Grafana');
@@ -44,7 +44,7 @@ test.describe('Mesh page core-2', () => {
 
   test('Shared mesh config is seen on istiod panel', core2, async ({ meshPage, request }) => {
     test.skip(!hasSailIstioCr(), 'Sail Istio CR is required for shared mesh config (@shared-mesh-config)');
-    test.setTimeout(180_000);
+    test.setTimeout(240_000);
 
     await applySharedMeshConfig(request);
     try {

--- a/frontend/e2e/tests/mesh/mesh_core2.spec.ts
+++ b/frontend/e2e/tests/mesh/mesh_core2.spec.ts
@@ -44,6 +44,7 @@ test.describe('Mesh page core-2', () => {
 
   test('Shared mesh config is seen on istiod panel', core2, async ({ meshPage, request }) => {
     test.skip(!hasSailIstioCr(), 'Sail Istio CR is required for shared mesh config (@shared-mesh-config)');
+    test.setTimeout(180_000);
 
     await applySharedMeshConfig(request);
     try {

--- a/frontend/e2e/tests/mesh/mesh_core2.spec.ts
+++ b/frontend/e2e/tests/mesh/mesh_core2.spec.ts
@@ -1,0 +1,61 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { hasGrafanaDeployment, hasSailIstioCr } from '../../utils/kialiConfig';
+import { kubectlScale } from '../../utils/kubectl';
+import { applySharedMeshConfig, restoreSharedMeshConfig } from '../../utils/sharedMeshConfig';
+import { core2 } from '../../utils/suite-tags';
+
+test.describe('Mesh page core-2', () => {
+  test.afterEach(() => {
+    try {
+      kubectlScale('istio-system', 'grafana', 1);
+    } catch {
+      // Best-effort restore after Grafana upscale test.
+    }
+  });
+
+  test('Grafana Infra unreachable', core2, async ({ meshPage }) => {
+    test.skip(!hasGrafanaDeployment(), 'Grafana deployment is not installed in istio-system');
+
+    await meshPage.open();
+    await meshPage.selectMeshNodeByLabel('Grafana');
+    await meshPage.expectNodeSidePanel('Grafana');
+    test.skip(
+      await meshPage.usesLocalGrafanaPortForward(),
+      'Grafana uses a local port-forward URL; scaling the deployment does not make it unreachable locally'
+    );
+
+    kubectlScale('istio-system', 'grafana', 0);
+    await meshPage.refreshPage();
+    await meshPage.waitForInfraHealth('Grafana', health => health !== 'Healthy');
+    await meshPage.selectMeshNodeByLabel('Grafana');
+    await meshPage.expectNodeSidePanel('Grafana');
+    await meshPage.expectSidePanelContains('Version: unknown');
+    await meshPage.expectSidePanelIcon('error');
+
+    kubectlScale('istio-system', 'grafana', 1);
+    await meshPage.refreshPage();
+    await meshPage.waitForInfraHealth('Grafana', health => health === 'Healthy');
+    await meshPage.selectMeshNodeByLabel('Grafana');
+    await meshPage.expectNodeSidePanel('Grafana');
+    await meshPage.expectSidePanelIcon('correct');
+    await meshPage.expectNoSidePanelIcon('error');
+    await meshPage.expectNoSidePanelIcon('warning');
+  });
+
+  test('Shared mesh config is seen on istiod panel', core2, async ({ meshPage, request }) => {
+    test.skip(!hasSailIstioCr(), 'Sail Istio CR is required for shared mesh config (@shared-mesh-config)');
+
+    await applySharedMeshConfig(request);
+    try {
+      await meshPage.open();
+      await meshPage.selectMeshNodeByLabel('istiod');
+      await meshPage.expectControlPlaneSidePanel();
+      await meshPage.expectConfigTabs('effective,standard,shared');
+      await meshPage.expectConfigTabContains('effective', 'mode: REGISTRY_ONLY');
+      await meshPage.expectConfigTabContains('shared', 'mode: REGISTRY_ONLY');
+      await meshPage.expectConfigTabNotContains('standard', 'mode: REGISTRY_ONLY');
+    } finally {
+      restoreSharedMeshConfig();
+    }
+  });
+});

--- a/frontend/e2e/tests/mesh/mesh_core2.spec.ts
+++ b/frontend/e2e/tests/mesh/mesh_core2.spec.ts
@@ -33,7 +33,7 @@ test.describe('Mesh page core-2', () => {
 
     kubectlScaleDeployment('istio-system', 'grafana', 0);
     await meshPage.refreshPage();
-    await meshPage.waitForInfraHealth('Grafana', health => health !== 'Healthy');
+    await meshPage.syncInfraHealthToUi('Grafana', health => health !== 'Healthy');
     await meshPage.selectMeshNodeByLabel('Grafana');
     await meshPage.expectNodeSidePanel('Grafana');
     await meshPage.expectSidePanelContains('Version: unknown');
@@ -41,7 +41,7 @@ test.describe('Mesh page core-2', () => {
 
     kubectlScaleDeployment('istio-system', 'grafana', 1);
     await meshPage.refreshPage();
-    await meshPage.waitForInfraHealth('Grafana', health => health === 'Healthy');
+    await meshPage.syncInfraHealthToUi('Grafana', health => health === 'Healthy');
     await meshPage.selectMeshNodeByLabel('Grafana');
     await meshPage.expectNodeSidePanel('Grafana');
     await meshPage.expectSidePanelIcon('correct');

--- a/frontend/e2e/tests/namespaces/sidecar_injection.spec.ts
+++ b/frontend/e2e/tests/namespaces/sidecar_injection.spec.ts
@@ -1,0 +1,146 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { isIstioInjectionUiEnabled } from '../../utils/kialiConfig';
+import {
+  clearNamespaceInjection,
+  ensureWorkloadHasInjectionOverride,
+  setNamespaceInjection,
+  setupWorkloadWithInjectionOverride,
+  setupWorkloadWithSidecar,
+  setupWorkloadWithoutSidecar
+} from '../../utils/sidecarInjection';
+import { core2 } from '../../utils/suite-tags';
+
+const namespace = 'sleep';
+const workload = 'sleep';
+
+test.describe('Namespace sidecar injection', () => {
+  test.beforeEach(async ({ page, request }) => {
+    ensureDemoApp('sleep');
+    test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
+    await clearNamespaceInjection(page, namespace);
+  });
+
+  test(
+    'Override the default policy for automatic sidecar injection by enabling it in a namespace',
+    core2,
+    async ({ namespaceDetailPage }) => {
+      await namespaceDetailPage.open(namespace);
+      test.skip(
+        !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
+        'Enable sidecar injection is not available (ambient-only cluster?)'
+      );
+      await namespaceDetailPage.enableNamespaceInjection();
+      await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
+    }
+  );
+
+  test(
+    'Switch the override configuration for automatic sidecar injection in a namespace to disabled',
+    core2,
+    async ({ namespaceDetailPage, page }) => {
+      await setNamespaceInjection(page, namespace, 'enabled');
+      await namespaceDetailPage.open(namespace);
+      test.skip(
+        !(await namespaceDetailPage.hasSidecarInjectionAction('disable')),
+        'Disable sidecar injection is not available (ambient-only cluster?)'
+      );
+      await namespaceDetailPage.disableNamespaceInjection();
+      await namespaceDetailPage.expectNamespaceInjectionLabel('disabled');
+    }
+  );
+
+  test(
+    'Switch the override configuration for automatic sidecar injection in a namespace to enabled',
+    core2,
+    async ({ namespaceDetailPage, page }) => {
+      await setNamespaceInjection(page, namespace, 'disabled');
+      await namespaceDetailPage.open(namespace);
+      test.skip(
+        !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
+        'Enable sidecar injection is not available (ambient-only cluster?)'
+      );
+      await namespaceDetailPage.enableNamespaceInjection();
+      await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
+    }
+  );
+
+  test(
+    'Switch to using the default policy for automatic sidecar injection in a namespace',
+    core2,
+    async ({ namespaceDetailPage, page }) => {
+      await setNamespaceInjection(page, namespace, 'enabled');
+      await namespaceDetailPage.open(namespace);
+      test.skip(
+        !(await namespaceDetailPage.hasSidecarInjectionAction('remove')),
+        'Remove sidecar injection is not available (ambient-only cluster?)'
+      );
+      await namespaceDetailPage.removeNamespaceInjection();
+      await namespaceDetailPage.expectNamespaceInjectionLabel('absent');
+    }
+  );
+});
+
+test.describe('Workload sidecar injection', () => {
+  test.beforeEach(async ({ request }) => {
+    ensureDemoApp('sleep');
+    test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
+  });
+
+  test(
+    'Override the default policy for automatic sidecar injection by enabling it in a workload',
+    core2,
+    async ({ workloadDetailsPage, page }) => {
+      await setupWorkloadWithoutSidecar(page, namespace, workload);
+      await workloadDetailsPage.open(namespace, workload);
+      await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
+      await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
+    }
+  );
+
+  test(
+    'Override the default policy for automatic sidecar injection by disabling it in a workload',
+    core2,
+    async ({ workloadDetailsPage, page }) => {
+      await setupWorkloadWithSidecar(page, namespace, workload);
+      await workloadDetailsPage.open(namespace, workload);
+      await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
+      await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
+    }
+  );
+
+  test(
+    'Switch the override configuration for automatic sidecar injection in a workload to disabled',
+    core2,
+    async ({ workloadDetailsPage, page }) => {
+      await setupWorkloadWithSidecar(page, namespace, workload);
+      await ensureWorkloadHasInjectionOverride(page, namespace, workload, true);
+      await workloadDetailsPage.open(namespace, workload);
+      await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
+      await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
+    }
+  );
+
+  test(
+    'Switch the override configuration for automatic sidecar injection in a workload to enabled',
+    core2,
+    async ({ workloadDetailsPage, page }) => {
+      await setupWorkloadWithoutSidecar(page, namespace, workload);
+      await ensureWorkloadHasInjectionOverride(page, namespace, workload, false);
+      await workloadDetailsPage.open(namespace, workload);
+      await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
+      await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
+    }
+  );
+
+  test(
+    'Remove override configuration for automatic sidecar injection in a workload',
+    core2,
+    async ({ workloadDetailsPage, page }) => {
+      await setupWorkloadWithInjectionOverride(page, namespace, workload);
+      await workloadDetailsPage.open(namespace, workload);
+      await workloadDetailsPage.clickSidecarActionAndRestart('remove_auto_injection', namespace, workload);
+      await workloadDetailsPage.expectNoWorkloadInjectionLabel();
+    }
+  );
+});

--- a/frontend/e2e/tests/namespaces/sidecar_injection.spec.ts
+++ b/frontend/e2e/tests/namespaces/sidecar_injection.spec.ts
@@ -14,133 +14,141 @@ import { core2 } from '../../utils/suite-tags';
 const namespace = 'sleep';
 const workload = 'sleep';
 
-test.describe('Namespace sidecar injection', () => {
-  test.beforeEach(async ({ page, request }) => {
-    ensureDemoApp('sleep');
-    test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
-    await clearNamespaceInjection(page, namespace);
+/**
+ * Namespace and workload scenarios share the sleep demo app; run serially so
+ * parallel workers do not race on the same deployment (Cypress runs in order).
+ */
+test.describe('Sidecar injection', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.describe('Namespace sidecar injection', () => {
+    test.beforeEach(async ({ page, request }) => {
+      ensureDemoApp('sleep');
+      test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
+      await clearNamespaceInjection(page, namespace);
+    });
+
+    test(
+      'Override the default policy for automatic sidecar injection by enabling it in a namespace',
+      core2,
+      async ({ namespaceDetailPage }) => {
+        await namespaceDetailPage.open(namespace);
+        test.skip(
+          !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
+          'Enable sidecar injection is not available (ambient-only cluster?)'
+        );
+        await namespaceDetailPage.enableNamespaceInjection();
+        await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
+      }
+    );
+
+    test(
+      'Switch the override configuration for automatic sidecar injection in a namespace to disabled',
+      core2,
+      async ({ namespaceDetailPage, page }) => {
+        await setNamespaceInjection(page, namespace, 'enabled');
+        await namespaceDetailPage.open(namespace);
+        test.skip(
+          !(await namespaceDetailPage.hasSidecarInjectionAction('disable')),
+          'Disable sidecar injection is not available (ambient-only cluster?)'
+        );
+        await namespaceDetailPage.disableNamespaceInjection();
+        await namespaceDetailPage.expectNamespaceInjectionLabel('disabled');
+      }
+    );
+
+    test(
+      'Switch the override configuration for automatic sidecar injection in a namespace to enabled',
+      core2,
+      async ({ namespaceDetailPage, page }) => {
+        await setNamespaceInjection(page, namespace, 'disabled');
+        await namespaceDetailPage.open(namespace);
+        test.skip(
+          !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
+          'Enable sidecar injection is not available (ambient-only cluster?)'
+        );
+        await namespaceDetailPage.enableNamespaceInjection();
+        await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
+      }
+    );
+
+    test(
+      'Switch to using the default policy for automatic sidecar injection in a namespace',
+      core2,
+      async ({ namespaceDetailPage, page }) => {
+        await setNamespaceInjection(page, namespace, 'enabled');
+        await namespaceDetailPage.open(namespace);
+        test.skip(
+          !(await namespaceDetailPage.hasSidecarInjectionAction('remove')),
+          'Remove sidecar injection is not available (ambient-only cluster?)'
+        );
+        await namespaceDetailPage.removeNamespaceInjection();
+        await namespaceDetailPage.expectNamespaceInjectionLabel('absent');
+      }
+    );
   });
 
-  test(
-    'Override the default policy for automatic sidecar injection by enabling it in a namespace',
-    core2,
-    async ({ namespaceDetailPage }) => {
-      await namespaceDetailPage.open(namespace);
-      test.skip(
-        !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
-        'Enable sidecar injection is not available (ambient-only cluster?)'
-      );
-      await namespaceDetailPage.enableNamespaceInjection();
-      await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
-    }
-  );
+  test.describe('Workload sidecar injection', () => {
+    test.beforeEach(async ({ request }) => {
+      ensureDemoApp('sleep');
+      test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
+    });
 
-  test(
-    'Switch the override configuration for automatic sidecar injection in a namespace to disabled',
-    core2,
-    async ({ namespaceDetailPage, page }) => {
-      await setNamespaceInjection(page, namespace, 'enabled');
-      await namespaceDetailPage.open(namespace);
-      test.skip(
-        !(await namespaceDetailPage.hasSidecarInjectionAction('disable')),
-        'Disable sidecar injection is not available (ambient-only cluster?)'
-      );
-      await namespaceDetailPage.disableNamespaceInjection();
-      await namespaceDetailPage.expectNamespaceInjectionLabel('disabled');
-    }
-  );
+    test(
+      'Override the default policy for automatic sidecar injection by enabling it in a workload',
+      core2,
+      async ({ workloadDetailsPage, page }) => {
+        await setupWorkloadWithoutSidecar(page, namespace, workload);
+        await workloadDetailsPage.open(namespace, workload);
+        await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
+        await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
+      }
+    );
 
-  test(
-    'Switch the override configuration for automatic sidecar injection in a namespace to enabled',
-    core2,
-    async ({ namespaceDetailPage, page }) => {
-      await setNamespaceInjection(page, namespace, 'disabled');
-      await namespaceDetailPage.open(namespace);
-      test.skip(
-        !(await namespaceDetailPage.hasSidecarInjectionAction('enable')),
-        'Enable sidecar injection is not available (ambient-only cluster?)'
-      );
-      await namespaceDetailPage.enableNamespaceInjection();
-      await namespaceDetailPage.expectNamespaceInjectionLabel('enabled');
-    }
-  );
+    test(
+      'Override the default policy for automatic sidecar injection by disabling it in a workload',
+      core2,
+      async ({ workloadDetailsPage, page }) => {
+        await setupWorkloadWithSidecar(page, namespace, workload);
+        await workloadDetailsPage.open(namespace, workload);
+        await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
+        await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
+      }
+    );
 
-  test(
-    'Switch to using the default policy for automatic sidecar injection in a namespace',
-    core2,
-    async ({ namespaceDetailPage, page }) => {
-      await setNamespaceInjection(page, namespace, 'enabled');
-      await namespaceDetailPage.open(namespace);
-      test.skip(
-        !(await namespaceDetailPage.hasSidecarInjectionAction('remove')),
-        'Remove sidecar injection is not available (ambient-only cluster?)'
-      );
-      await namespaceDetailPage.removeNamespaceInjection();
-      await namespaceDetailPage.expectNamespaceInjectionLabel('absent');
-    }
-  );
-});
+    test(
+      'Switch the override configuration for automatic sidecar injection in a workload to disabled',
+      core2,
+      async ({ workloadDetailsPage, page }) => {
+        await setupWorkloadWithSidecar(page, namespace, workload);
+        await ensureWorkloadHasInjectionOverride(page, namespace, workload, true);
+        await workloadDetailsPage.open(namespace, workload);
+        await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
+        await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
+      }
+    );
 
-test.describe('Workload sidecar injection', () => {
-  test.beforeEach(async ({ request }) => {
-    ensureDemoApp('sleep');
-    test.skip(!(await isIstioInjectionUiEnabled(request)), 'Sidecar injection UI is disabled in Kiali config');
+    test(
+      'Switch the override configuration for automatic sidecar injection in a workload to enabled',
+      core2,
+      async ({ workloadDetailsPage, page }) => {
+        await setupWorkloadWithoutSidecar(page, namespace, workload);
+        await ensureWorkloadHasInjectionOverride(page, namespace, workload, false);
+        await workloadDetailsPage.open(namespace, workload);
+        await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
+        await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
+      }
+    );
+
+    test(
+      'Remove override configuration for automatic sidecar injection in a workload',
+      core2,
+      async ({ workloadDetailsPage, page }) => {
+        await setupWorkloadWithInjectionOverride(page, namespace, workload);
+        await workloadDetailsPage.open(namespace, workload);
+        await workloadDetailsPage.clickSidecarActionAndRestart('remove_auto_injection', namespace, workload);
+        await workloadDetailsPage.expectNoWorkloadInjectionLabel();
+      }
+    );
   });
-
-  test(
-    'Override the default policy for automatic sidecar injection by enabling it in a workload',
-    core2,
-    async ({ workloadDetailsPage, page }) => {
-      await setupWorkloadWithoutSidecar(page, namespace, workload);
-      await workloadDetailsPage.open(namespace, workload);
-      await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
-      await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
-    }
-  );
-
-  test(
-    'Override the default policy for automatic sidecar injection by disabling it in a workload',
-    core2,
-    async ({ workloadDetailsPage, page }) => {
-      await setupWorkloadWithSidecar(page, namespace, workload);
-      await workloadDetailsPage.open(namespace, workload);
-      await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
-      await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
-    }
-  );
-
-  test(
-    'Switch the override configuration for automatic sidecar injection in a workload to disabled',
-    core2,
-    async ({ workloadDetailsPage, page }) => {
-      await setupWorkloadWithSidecar(page, namespace, workload);
-      await ensureWorkloadHasInjectionOverride(page, namespace, workload, true);
-      await workloadDetailsPage.open(namespace, workload);
-      await workloadDetailsPage.clickSidecarActionAndRestart('disable_auto_injection', namespace, workload);
-      await workloadDetailsPage.expectMissingSidecarBadge(true, namespace, workload);
-    }
-  );
-
-  test(
-    'Switch the override configuration for automatic sidecar injection in a workload to enabled',
-    core2,
-    async ({ workloadDetailsPage, page }) => {
-      await setupWorkloadWithoutSidecar(page, namespace, workload);
-      await ensureWorkloadHasInjectionOverride(page, namespace, workload, false);
-      await workloadDetailsPage.open(namespace, workload);
-      await workloadDetailsPage.clickSidecarActionAndRestart('enable_auto_injection', namespace, workload);
-      await workloadDetailsPage.expectMissingSidecarBadge(false, namespace, workload);
-    }
-  );
-
-  test(
-    'Remove override configuration for automatic sidecar injection in a workload',
-    core2,
-    async ({ workloadDetailsPage, page }) => {
-      await setupWorkloadWithInjectionOverride(page, namespace, workload);
-      await workloadDetailsPage.open(namespace, workload);
-      await workloadDetailsPage.clickSidecarActionAndRestart('remove_auto_injection', namespace, workload);
-      await workloadDetailsPage.expectNoWorkloadInjectionLabel();
-    }
-  );
 });

--- a/frontend/e2e/tests/services/services_health.spec.ts
+++ b/frontend/e2e/tests/services/services_health.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { waitForServiceHealthStatus } from '../../utils/health';
+import { hasYServerDegradedHealthConfig } from '../../utils/kialiConfig';
+import { core2 } from '../../utils/suite-tags';
+
+test.describe('Services list health statuses', () => {
+  test('The idle status of a service is reported in the list of services', core2, async ({ servicesPage }) => {
+    await servicesPage.openListWithNamespace('sleep');
+    await servicesPage.expectServiceListedAs('sleep', 'sleep', 'na');
+    await servicesPage.expectServiceHealthStatus('sleep', 'sleep', 'n/a');
+  });
+});
+
+test.describe('Services list error-rates health statuses', () => {
+  test(
+    'The failing status of a service is reported in the list of services',
+    core2,
+    async ({ servicesPage, request }) => {
+      await waitForServiceHealthStatus(request, 'alpha', 'w-server', 'Failure');
+      await servicesPage.openListWithNamespace('alpha');
+      await servicesPage.expectServiceListedAs('alpha', 'w-server', 'failure');
+      await servicesPage.expectServiceHealthStatus('alpha', 'w-server', 'Failure');
+    }
+  );
+
+  test(
+    'The degraded status of a service is reported in the list of services',
+    core2,
+    async ({ servicesPage, request }) => {
+      if (!(await hasYServerDegradedHealthConfig(request))) {
+        test.skip(
+          true,
+          'Requires health_config.rate for alpha/y-server (CI/Jenkins set this via Helm; default local config reports Failure)'
+        );
+      }
+      await waitForServiceHealthStatus(request, 'alpha', 'y-server', 'Degraded');
+      await servicesPage.openListWithNamespace('alpha');
+      await servicesPage.expectServiceListedAs('alpha', 'y-server', 'degraded');
+      await servicesPage.expectServiceHealthStatus('alpha', 'y-server', 'Degraded');
+    }
+  );
+});

--- a/frontend/e2e/tests/services/services_health.spec.ts
+++ b/frontend/e2e/tests/services/services_health.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '../../fixtures/kialiFixtures';
 import { waitForServiceHealthStatus } from '../../utils/health';
-import { hasYServerDegradedHealthConfig } from '../../utils/kialiConfig';
 import { core2 } from '../../utils/suite-tags';
 
 test.describe('Services list health statuses', () => {
@@ -27,12 +26,6 @@ test.describe('Services list error-rates health statuses', () => {
     'The degraded status of a service is reported in the list of services',
     core2,
     async ({ servicesPage, request }) => {
-      if (!(await hasYServerDegradedHealthConfig(request))) {
-        test.skip(
-          true,
-          'Requires health_config.rate for alpha/y-server (CI/Jenkins set this via Helm; default local config reports Failure)'
-        );
-      }
       await waitForServiceHealthStatus(request, 'alpha', 'y-server', 'Degraded');
       await servicesPage.openListWithNamespace('alpha');
       await servicesPage.expectServiceListedAs('alpha', 'y-server', 'degraded');

--- a/frontend/e2e/tests/services/wizard_k8s_routing.spec.ts
+++ b/frontend/e2e/tests/services/wizard_k8s_routing.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../fixtures/kialiFixtures';
 import { ensureDemoApp } from '../../utils/demoApps';
-import { acquireBookinfoRoutingLock } from '../../utils/bookinfoRoutingLock';
+import { useBookinfoRoutingLockPerTest } from '../../utils/bookinfoRoutingLock';
 import {
   deleteBookinfoReviewsGateway,
   deleteBookinfoReviewsTrafficRouting,
@@ -15,22 +15,16 @@ const service = 'reviews';
 
 /**
  * HTTP and GRPC routing wizards share bookinfo/reviews and must not run in parallel.
- * Keep them in this single serial file (one cross-process lock for the whole block).
+ * Keep them in this single serial file; lock is per-test via useBookinfoRoutingLockPerTest().
  */
 test.describe.serial('Service Details Wizard: K8s Routing', () => {
-  test.describe.configure({ timeout: 120_000 });
+  test.describe.configure({ timeout: 180_000 });
 
-  let releaseRoutingLock: (() => void) | undefined;
+  useBookinfoRoutingLockPerTest();
 
-  test.beforeAll(async () => {
-    releaseRoutingLock = await acquireBookinfoRoutingLock();
+  test.beforeAll(() => {
     deleteBookinfoReviewsTrafficRouting();
     ensureDemoApp('bookinfo');
-  });
-
-  test.afterAll(() => {
-    releaseRoutingLock?.();
-    releaseRoutingLock = undefined;
   });
 
   test.beforeEach(async ({ request }) => {

--- a/frontend/e2e/tests/services/wizard_k8s_routing.spec.ts
+++ b/frontend/e2e/tests/services/wizard_k8s_routing.spec.ts
@@ -1,0 +1,157 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { acquireBookinfoRoutingLock } from '../../utils/bookinfoRoutingLock';
+import {
+  deleteBookinfoReviewsGateway,
+  deleteBookinfoReviewsTrafficRouting,
+  waitForK8sGateway
+} from '../../utils/istioConfigResources';
+import { isGatewayApiEnabled } from '../../utils/kialiConfig';
+import { expectEditorMatchesRegex } from '../../utils/monacoEditor';
+import { core2 } from '../../utils/suite-tags';
+
+const namespace = 'bookinfo';
+const service = 'reviews';
+
+/**
+ * HTTP and GRPC routing wizards share bookinfo/reviews and must not run in parallel.
+ * Keep them in this single serial file (one cross-process lock for the whole block).
+ */
+test.describe.serial('Service Details Wizard: K8s Routing', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  let releaseRoutingLock: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    releaseRoutingLock = await acquireBookinfoRoutingLock();
+    deleteBookinfoReviewsTrafficRouting();
+    ensureDemoApp('bookinfo');
+  });
+
+  test.afterAll(() => {
+    releaseRoutingLock?.();
+    releaseRoutingLock = undefined;
+  });
+
+  test.beforeEach(async ({ request }) => {
+    test.skip(!(await isGatewayApiEnabled(request)), 'Gateway API is not enabled');
+  });
+
+  test('Create a K8s HTTP Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    deleteBookinfoReviewsTrafficRouting();
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('k8s_request_routing');
+    await k8sRoutingWizardPage.expectWizard('Create K8s HTTP routing');
+    await k8sRoutingWizardPage.clickTab('Request Matching');
+    await k8sRoutingWizardPage.clickRequestMatchingDropdown('headers');
+    await k8sRoutingWizardPage.typeMatchingHeader('end-user');
+    await k8sRoutingWizardPage.clickMatchValueDropdown('Exact');
+    await k8sRoutingWizardPage.typeMatchValue('jason');
+    await k8sRoutingWizardPage.addMatch();
+    await k8sRoutingWizardPage.clickTab('Route To');
+    await k8sRoutingWizardPage.typeTrafficWeight('100', 'reviews');
+    await k8sRoutingWizardPage.clickTab('Route Filtering');
+    await k8sRoutingWizardPage.clickRequestFilteringDropdown('requestMirror');
+    await k8sRoutingWizardPage.addFilter();
+    await k8sRoutingWizardPage.addRoute();
+    await k8sRoutingWizardPage.previewConfiguration();
+    await k8sRoutingWizardPage.createConfiguration();
+    await serviceDetailsPage.expectIstioConfigTableRowCount(1);
+  });
+
+  test('See a HTTPRoute generated', core2, async ({ serviceDetailsPage, page }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickIstioConfigBadgeLink('HTTP');
+    await expectEditorMatchesRegex(page, 'kind: HTTPRoute');
+    await serviceDetailsPage.expectServiceReference(namespace, service);
+  });
+
+  test('Update a K8s HTTP Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    deleteBookinfoReviewsGateway();
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('k8s_request_routing');
+    await k8sRoutingWizardPage.expectWizard('Update K8s HTTP routing');
+    await k8sRoutingWizardPage.clickAdvancedOptions();
+    await k8sRoutingWizardPage.clickTab('K8s Gateways');
+    await k8sRoutingWizardPage.clickAddGateway();
+    await k8sRoutingWizardPage.selectCreateGateway();
+    await k8sRoutingWizardPage.previewConfiguration();
+    await k8sRoutingWizardPage.updateConfiguration();
+    waitForK8sGateway('reviews-gateway', namespace);
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.expectIstioConfigTableRowCount(2);
+  });
+
+  test('See a K8s Gateway generated with warning (HTTP)', core2, async ({ serviceDetailsPage, page }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickIstioConfigBadgeLink('G', 'reviews-gateway');
+    await expectEditorMatchesRegex(page, 'kind: Gateway');
+  });
+
+  test('Delete the K8s HTTP Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('delete_traffic_routing');
+    await k8sRoutingWizardPage.confirmDeleteConfiguration();
+    await serviceDetailsPage.expectIstioConfigTableEmpty();
+    deleteBookinfoReviewsTrafficRouting();
+  });
+
+  test('Create a K8s GRPC Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    deleteBookinfoReviewsTrafficRouting();
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('k8s_grpc_request_routing');
+    await k8sRoutingWizardPage.expectWizard('Create K8s GRPC routing');
+    await k8sRoutingWizardPage.clickTab('Request Matching');
+    await k8sRoutingWizardPage.clickRequestMatchingDropdown('headers');
+    await k8sRoutingWizardPage.typeMatchingHeader('end-user');
+    await k8sRoutingWizardPage.clickMatchValueDropdown('Exact');
+    await k8sRoutingWizardPage.typeMatchValue('jason');
+    await k8sRoutingWizardPage.addMatch();
+    await k8sRoutingWizardPage.clickTab('Route To');
+    await k8sRoutingWizardPage.typeTrafficWeight('100', 'reviews');
+    await k8sRoutingWizardPage.clickTab('Route Filtering');
+    await k8sRoutingWizardPage.clickRequestFilteringDropdown('requestMirror');
+    await k8sRoutingWizardPage.addFilter();
+    await k8sRoutingWizardPage.addRoute();
+    await k8sRoutingWizardPage.previewConfiguration();
+    await k8sRoutingWizardPage.createConfiguration();
+    await serviceDetailsPage.expectIstioConfigTableRowCount(1);
+  });
+
+  test('See a GRPCRoute generated', core2, async ({ serviceDetailsPage, page }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickIstioConfigBadgeLink('gRPC');
+    await expectEditorMatchesRegex(page, 'kind: GRPCRoute');
+    await serviceDetailsPage.expectServiceReference(namespace, service);
+  });
+
+  test('Update a K8s GRPC Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    deleteBookinfoReviewsGateway();
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('k8s_grpc_request_routing');
+    await k8sRoutingWizardPage.expectWizard('Update K8s GRPC routing');
+    await k8sRoutingWizardPage.clickAdvancedOptions();
+    await k8sRoutingWizardPage.clickTab('K8s Gateways');
+    await k8sRoutingWizardPage.clickAddGateway();
+    await k8sRoutingWizardPage.selectCreateGateway();
+    await k8sRoutingWizardPage.previewConfiguration();
+    await k8sRoutingWizardPage.updateConfiguration();
+    waitForK8sGateway('reviews-gateway', namespace);
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.expectIstioConfigTableRowCount(2);
+  });
+
+  test('See a K8s Gateway generated with warning (GRPC)', core2, async ({ serviceDetailsPage, page }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickIstioConfigBadgeLink('G', 'reviews-gateway');
+    await expectEditorMatchesRegex(page, 'kind: Gateway');
+  });
+
+  test('Delete the K8s GRPC Routing scenario', core2, async ({ serviceDetailsPage, k8sRoutingWizardPage }) => {
+    await serviceDetailsPage.open(namespace, service);
+    await serviceDetailsPage.clickServiceAction('delete_traffic_routing');
+    await k8sRoutingWizardPage.confirmDeleteConfiguration();
+    await serviceDetailsPage.expectIstioConfigTableEmpty();
+    deleteBookinfoReviewsTrafficRouting();
+  });
+});

--- a/frontend/e2e/tests/workloads/workload_logs.spec.ts
+++ b/frontend/e2e/tests/workloads/workload_logs.spec.ts
@@ -1,0 +1,46 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { hasLoggersNamespace } from '../../utils/kialiConfig';
+import { core2 } from '../../utils/suite-tags';
+
+test.describe('Workload logs tab', () => {
+  test.beforeEach(() => {
+    test.skip(!hasLoggersNamespace(), 'loggers demo namespace is not installed (install via install-testing-demos.sh)');
+  });
+
+  test(
+    'The log pane of the logs tab should only show the lines with the requested text',
+    core2,
+    async ({ workloadDetailsPage }) => {
+      await workloadDetailsPage.openLogsTab('loggers', 'custom-logger');
+      await workloadDetailsPage.setLogShow('GET');
+      await workloadDetailsPage.expectLogLinesContain('GET');
+    }
+  );
+
+  test(
+    'The log pane of the logs tab should hide the lines with the requested text',
+    core2,
+    async ({ workloadDetailsPage }) => {
+      await workloadDetailsPage.openLogsTab('loggers', 'custom-logger');
+      await workloadDetailsPage.setLogHide('GET');
+      await workloadDetailsPage.expectLogLinesNotContain('GET');
+    }
+  );
+
+  test(
+    'The log pane of the logs tab should show json log lines with a json log indicator',
+    core2,
+    async ({ workloadDetailsPage }) => {
+      await workloadDetailsPage.openLogsTab('loggers', 'json-logger');
+      await workloadDetailsPage.setLogHide('text log format');
+      await workloadDetailsPage.expectJsonLogLines();
+    }
+  );
+
+  test('The json log should contain certain values on the parsed object', core2, async ({ workloadDetailsPage }) => {
+    await workloadDetailsPage.openLogsTab('loggers', 'json-logger');
+    await workloadDetailsPage.setLogHide('text log format');
+    await workloadDetailsPage.clickJsonLogLine();
+    await workloadDetailsPage.expectParsedJsonValues();
+  });
+});

--- a/frontend/e2e/tests/workloads/workloads_health.spec.ts
+++ b/frontend/e2e/tests/workloads/workloads_health.spec.ts
@@ -1,0 +1,54 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { kubectlNamespaceExists, kubectlScale } from '../../utils/kubectl';
+import { waitForWorkloadHealthStatus } from '../../utils/health';
+import { core2 } from '../../utils/suite-tags';
+
+test.describe('Workloads list idle health', () => {
+  test.afterEach(() => {
+    if (kubectlNamespaceExists('sleep')) {
+      try {
+        kubectlScale('sleep', 'sleep', 1);
+      } catch {
+        // Best-effort restore after scale-down; ignore if deployment is already scaled.
+      }
+    }
+  });
+
+  test(
+    'The idle status of a workload is reported in the list of workloads',
+    core2,
+    async ({ workloadsPage, request }) => {
+      ensureDemoApp('sleep');
+      kubectlScale('sleep', 'sleep', 0);
+      await waitForWorkloadHealthStatus(request, 'sleep', 'sleep', 'Not Ready');
+      await workloadsPage.openListWithNamespace('sleep');
+      await workloadsPage.expectWorkloadListedAs('sleep', 'sleep', 'idle');
+      await workloadsPage.expectWorkloadHealthStatus('sleep', 'sleep', 'Not Ready');
+    }
+  );
+});
+
+test.describe('Workloads list error-rates health statuses', () => {
+  test(
+    'The failing status of a workload is reported in the list of workloads',
+    core2,
+    async ({ workloadsPage, request }) => {
+      await waitForWorkloadHealthStatus(request, 'alpha', 'v-server', 'Failure');
+      await workloadsPage.openListWithNamespace('alpha');
+      await workloadsPage.expectWorkloadListedAs('alpha', 'v-server', 'failure');
+      await workloadsPage.expectWorkloadHealthStatus('alpha', 'v-server', 'Failure');
+    }
+  );
+
+  test(
+    'The degraded status of a workload is reported in the list of workloads',
+    core2,
+    async ({ workloadsPage, request }) => {
+      await waitForWorkloadHealthStatus(request, 'alpha', 'b-client', 'Degraded');
+      await workloadsPage.openListWithNamespace('alpha');
+      await workloadsPage.expectWorkloadListedAs('alpha', 'b-client', 'degraded');
+      await workloadsPage.expectWorkloadHealthStatus('alpha', 'b-client', 'Degraded');
+    }
+  );
+});

--- a/frontend/e2e/utils/bookinfoRoutingLock.ts
+++ b/frontend/e2e/utils/bookinfoRoutingLock.ts
@@ -1,3 +1,4 @@
+import { test } from '@playwright/test';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -73,4 +74,22 @@ export async function withBookinfoRoutingLock<T>(fn: () => Promise<T>): Promise<
   } finally {
     release();
   }
+}
+
+let activeBookinfoRoutingLockRelease: (() => void) | undefined;
+
+/**
+ * Hold the bookinfo routing lock per test (not for the whole describe).
+ * Lets gateway and routing spec files interleave across Playwright workers without
+ * one file blocking the other for minutes via beforeAll.
+ */
+export function useBookinfoRoutingLockPerTest(): void {
+  test.beforeEach(async () => {
+    activeBookinfoRoutingLockRelease = await acquireBookinfoRoutingLock();
+  });
+
+  test.afterEach(() => {
+    activeBookinfoRoutingLockRelease?.();
+    activeBookinfoRoutingLockRelease = undefined;
+  });
 }

--- a/frontend/e2e/utils/bookinfoRoutingLock.ts
+++ b/frontend/e2e/utils/bookinfoRoutingLock.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const LOCK_FILE = path.join(os.tmpdir(), 'kiali-playwright-bookinfo-routing.lock');
+const LOCK_STALE_MS = 5 * 60 * 1000;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isStaleLock(): boolean {
+  try {
+    const stat = fs.statSync(LOCK_FILE);
+    if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+      return true;
+    }
+
+    const content = fs.readFileSync(LOCK_FILE, 'utf8');
+    const pid = Number.parseInt(content.split(':')[0] ?? '', 10);
+    return !Number.isFinite(pid) || !isProcessAlive(pid);
+  } catch {
+    return false;
+  }
+}
+
+function tryAcquireLock(): (() => void) | undefined {
+  if (isStaleLock()) {
+    try {
+      fs.unlinkSync(LOCK_FILE);
+    } catch {
+      // ignore
+    }
+  }
+
+  try {
+    fs.writeFileSync(LOCK_FILE, `${process.pid}:${Date.now()}`, { flag: 'wx' });
+    return () => {
+      try {
+        fs.unlinkSync(LOCK_FILE);
+      } catch {
+        // ignore
+      }
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Acquire a cross-process lock for bookinfo Gateway API wizard tests (routing + istio config). */
+export async function acquireBookinfoRoutingLock(): Promise<() => void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const release = tryAcquireLock();
+    if (release) {
+      return release;
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  throw new Error('Timed out acquiring bookinfo routing lock');
+}
+
+/** Run a bookinfo/reviews routing wizard test under the shared lock. */
+export async function withBookinfoRoutingLock<T>(fn: () => Promise<T>): Promise<T> {
+  const release = await acquireBookinfoRoutingLock();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}

--- a/frontend/e2e/utils/demoApps.ts
+++ b/frontend/e2e/utils/demoApps.ts
@@ -67,6 +67,39 @@ function getNodeArchitecture(): string | undefined {
   }
 }
 
+function hasKialiCr(): boolean {
+  try {
+    execSync('kubectl get crd kialis.kiali.io', { stdio: 'ignore' });
+    const names = execSync('kubectl get kiali --all-namespaces -o name', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    return names.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function waitForDemoNamespaces(namespaces: string): void {
+  if (hasKialiCr()) {
+    execSync(path.join(HACK_ISTIO, 'wait-for-namespace.sh') + ` -n ${namespaces}`, {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+      timeout: 400000
+    });
+    return;
+  }
+
+  // Local Kiali (make run-backend): no Kiali CR / operator — wait for pods only.
+  for (const namespace of namespaces.split(/\s+/)) {
+    execSync(`kubectl wait pods -n ${namespace} --for condition=Ready --timeout=120s --all`, {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+      timeout: 130000
+    });
+  }
+}
+
 function installDemoApp(demoapp: DemoApp): void {
   const config = DEMO_APP_CONFIG[demoapp];
   const arch = getNodeArchitecture();
@@ -90,11 +123,7 @@ function installDemoApp(demoapp: DemoApp): void {
     stdio: 'inherit',
     timeout: 300000
   });
-  execSync(path.join(HACK_ISTIO, 'wait-for-namespace.sh') + ` -n ${config.namespaces}`, {
-    cwd: REPO_ROOT,
-    stdio: 'inherit',
-    timeout: 400000
-  });
+  waitForDemoNamespaces(config.namespaces);
 }
 
 /**

--- a/frontend/e2e/utils/health.ts
+++ b/frontend/e2e/utils/health.ts
@@ -1,11 +1,50 @@
 import type { APIRequestContext } from '@playwright/test';
 
-type AppHealthResponse = {
+type HealthResponse = {
   health?: {
     status?: {
       status?: string;
     };
   };
+};
+
+const waitForResourceHealthStatus = async (
+  request: APIRequestContext,
+  resourcePath: string,
+  expectedStatus: string,
+  timeoutMs = 90_000
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: string | undefined;
+  let lastHttpStatus: number | undefined;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await request.get(resourcePath);
+      lastHttpStatus = response.status();
+      if (response.ok()) {
+        const body = (await response.json()) as HealthResponse;
+        lastStatus = body.health?.status?.status;
+        if (lastStatus === expectedStatus) {
+          return;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('Target page, context or browser has been closed')) {
+        throw new Error(
+          `Health poll aborted for ${resourcePath} (expected ${expectedStatus}). Last status: ${lastStatus ?? 'unknown'}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 5_000));
+  }
+
+  throw new Error(
+    `Timeout waiting for ${resourcePath} to reach ${expectedStatus}. Last status: ${lastStatus ?? 'unknown'}, last HTTP: ${lastHttpStatus ?? 'unknown'}`
+  );
 };
 
 export const waitForAppHealthStatus = async (
@@ -15,22 +54,40 @@ export const waitForAppHealthStatus = async (
   expectedStatus: string,
   timeoutMs = 90_000
 ): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  let lastStatus: string | undefined;
+  await waitForResourceHealthStatus(
+    request,
+    `/api/namespaces/${namespace}/apps/${app}?health=true`,
+    expectedStatus,
+    timeoutMs
+  );
+};
 
-  while (Date.now() < deadline) {
-    const response = await request.get(`/api/namespaces/${namespace}/apps/${app}?health=true`);
-    if (response.ok()) {
-      const body = (await response.json()) as AppHealthResponse;
-      lastStatus = body.health?.status?.status;
-      if (lastStatus === expectedStatus) {
-        return;
-      }
-    }
-    await new Promise(resolve => setTimeout(resolve, 5_000));
-  }
+export const waitForServiceHealthStatus = async (
+  request: APIRequestContext,
+  namespace: string,
+  service: string,
+  expectedStatus: string,
+  timeoutMs = 90_000
+): Promise<void> => {
+  await waitForResourceHealthStatus(
+    request,
+    `/api/namespaces/${namespace}/services/${service}?health=true`,
+    expectedStatus,
+    timeoutMs
+  );
+};
 
-  throw new Error(
-    `Timeout waiting for app ${app} in ${namespace} to reach ${expectedStatus}. Last status: ${lastStatus ?? 'unknown'}`
+export const waitForWorkloadHealthStatus = async (
+  request: APIRequestContext,
+  namespace: string,
+  workload: string,
+  expectedStatus: string,
+  timeoutMs = 90_000
+): Promise<void> => {
+  await waitForResourceHealthStatus(
+    request,
+    `/api/namespaces/${namespace}/workloads/${workload}?health=true`,
+    expectedStatus,
+    timeoutMs
   );
 };

--- a/frontend/e2e/utils/istioConfigResources.ts
+++ b/frontend/e2e/utils/istioConfigResources.ts
@@ -1,0 +1,69 @@
+import { kubectlDelete, kubectlExec } from './kubectl';
+
+function waitForResourceDeleted(getCommand: string, timeoutMs = 30_000): void {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (kubectlExec(getCommand).exitCode !== 0) {
+      return;
+    }
+    kubectlExec('sleep 0.5');
+  }
+  throw new Error(`Timed out waiting for resource deletion: ${getCommand}`);
+}
+
+export function deleteK8sGateway(name: string, namespace = 'bookinfo'): void {
+  kubectlDelete(`gateways.gateway.networking.k8s.io ${name} -n ${namespace}`);
+  waitForResourceDeleted(`kubectl get gateways.gateway.networking.k8s.io ${name} -n ${namespace}`);
+}
+
+export function waitForK8sGateway(name: string, namespace = 'bookinfo', timeoutMs = 60_000): void {
+  const getCommand = `kubectl get gateways.gateway.networking.k8s.io ${name} -n ${namespace}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (kubectlExec(getCommand).exitCode === 0) {
+      return;
+    }
+    kubectlExec('sleep 1');
+  }
+  throw new Error(`Timed out waiting for gateway ${namespace}/${name}`);
+}
+
+/** TLS secret referenced by the K8s Gateway HTTPS wizard scenario. */
+export function ensureBookinfoTlsCertSecret(): void {
+  if (kubectlExec('kubectl get secret cert -n bookinfo').exitCode === 0) {
+    return;
+  }
+
+  kubectlExec(
+    'openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/kiali-e2e-cert.key -out /tmp/kiali-e2e-cert.crt -subj "/CN=website.com" 2>/dev/null',
+    true
+  );
+  kubectlExec(
+    'kubectl create secret tls cert --cert=/tmp/kiali-e2e-cert.crt --key=/tmp/kiali-e2e-cert.key -n bookinfo',
+    true
+  );
+}
+
+export function deleteK8sReferenceGrant(name: string, namespace = 'bookinfo'): void {
+  kubectlDelete(`referencegrants.gateway.networking.k8s.io ${name} -n ${namespace}`);
+}
+
+/** Remove orphaned reviews-gateway left when delete traffic routing does not remove gateways. */
+export function deleteBookinfoReviewsGateway(): void {
+  const list = kubectlExec(
+    'kubectl get gateways.gateway.networking.k8s.io -n bookinfo -o jsonpath=\'{range .items[*]}{.metadata.name}{"\\n"}{end}\''
+  );
+  if (list.exitCode === 0) {
+    for (const name of list.stdout.split('\n').filter(line => line.startsWith('reviews-gateway'))) {
+      kubectlDelete(`gateways.gateway.networking.k8s.io ${name} -n bookinfo`);
+      waitForResourceDeleted(`kubectl get gateways.gateway.networking.k8s.io ${name} -n bookinfo`);
+    }
+  }
+}
+
+/** Remove leftover Gateway API routing from prior wizard runs on bookinfo/reviews. */
+export function deleteBookinfoReviewsTrafficRouting(): void {
+  kubectlDelete('httproutes.gateway.networking.k8s.io reviews -n bookinfo');
+  kubectlDelete('grpcroutes.gateway.networking.k8s.io reviews -n bookinfo');
+  deleteBookinfoReviewsGateway();
+}

--- a/frontend/e2e/utils/kialiConfig.ts
+++ b/frontend/e2e/utils/kialiConfig.ts
@@ -1,25 +1,9 @@
 import type { APIRequestContext } from '@playwright/test';
 import { kubectlExec } from './kubectl';
 
-type HealthRateTolerance = {
-  code?: string;
-  degraded?: number;
-  failure?: number;
-};
-
-type HealthRate = {
-  kind?: string;
-  name?: string;
-  namespace?: string;
-  tolerance?: HealthRateTolerance[];
-};
-
 type KialiConfig = {
   ambientEnabled?: boolean;
   gatewayAPIEnabled?: boolean;
-  healthConfig?: {
-    rate?: HealthRate[];
-  };
   kialiFeatureFlags?: {
     istioInjectionAction?: boolean;
     istioUpgradeAction?: boolean;
@@ -43,27 +27,6 @@ export async function isIstioInjectionUiEnabled(request: APIRequestContext): Pro
   const config = await getKialiConfig(request);
   const flags = config.kialiFeatureFlags;
   return Boolean(flags?.istioInjectionAction) && !flags?.istioUpgradeAction;
-}
-
-/**
- * Cypress core-2 and CI set health_config.rate for alpha/y-server so error-rates traffic
- * classifies as Degraded (not Failure). Local Kiali without that override reports Failure.
- */
-export async function hasYServerDegradedHealthConfig(request: APIRequestContext): Promise<boolean> {
-  const config = await getKialiConfig(request);
-  return (
-    config.healthConfig?.rate?.some(
-      rate =>
-        rate.namespace === 'alpha' &&
-        rate.kind === 'service' &&
-        rate.name === 'y-server' &&
-        rate.tolerance?.some(
-          tolerance =>
-            tolerance.degraded !== undefined &&
-            (tolerance.failure === undefined || tolerance.degraded < tolerance.failure)
-        )
-    ) ?? false
-  );
 }
 
 export function hasGrafanaDeployment(): boolean {

--- a/frontend/e2e/utils/kialiConfig.ts
+++ b/frontend/e2e/utils/kialiConfig.ts
@@ -1,0 +1,79 @@
+import type { APIRequestContext } from '@playwright/test';
+import { kubectlExec } from './kubectl';
+
+type HealthRateTolerance = {
+  code?: string;
+  degraded?: number;
+  failure?: number;
+};
+
+type HealthRate = {
+  kind?: string;
+  name?: string;
+  namespace?: string;
+  tolerance?: HealthRateTolerance[];
+};
+
+type KialiConfig = {
+  ambientEnabled?: boolean;
+  gatewayAPIEnabled?: boolean;
+  healthConfig?: {
+    rate?: HealthRate[];
+  };
+  kialiFeatureFlags?: {
+    istioInjectionAction?: boolean;
+    istioUpgradeAction?: boolean;
+  };
+};
+
+export async function getKialiConfig(request: APIRequestContext): Promise<KialiConfig> {
+  const response = await request.get('/api/config');
+  if (!response.ok()) {
+    return {};
+  }
+  return (await response.json()) as KialiConfig;
+}
+
+export async function isGatewayApiEnabled(request: APIRequestContext): Promise<boolean> {
+  const config = await getKialiConfig(request);
+  return Boolean(config.gatewayAPIEnabled);
+}
+
+export async function isIstioInjectionUiEnabled(request: APIRequestContext): Promise<boolean> {
+  const config = await getKialiConfig(request);
+  const flags = config.kialiFeatureFlags;
+  return Boolean(flags?.istioInjectionAction) && !flags?.istioUpgradeAction;
+}
+
+/**
+ * Cypress core-2 and CI set health_config.rate for alpha/y-server so error-rates traffic
+ * classifies as Degraded (not Failure). Local Kiali without that override reports Failure.
+ */
+export async function hasYServerDegradedHealthConfig(request: APIRequestContext): Promise<boolean> {
+  const config = await getKialiConfig(request);
+  return (
+    config.healthConfig?.rate?.some(
+      rate =>
+        rate.namespace === 'alpha' &&
+        rate.kind === 'service' &&
+        rate.name === 'y-server' &&
+        rate.tolerance?.some(
+          tolerance =>
+            tolerance.degraded !== undefined &&
+            (tolerance.failure === undefined || tolerance.degraded < tolerance.failure)
+        )
+    ) ?? false
+  );
+}
+
+export function hasGrafanaDeployment(): boolean {
+  return kubectlExec('kubectl get deployment grafana -n istio-system').exitCode === 0;
+}
+
+export function hasSailIstioCr(): boolean {
+  return kubectlExec('kubectl get istio default -n istio-system').exitCode === 0;
+}
+
+export function hasLoggersNamespace(): boolean {
+  return kubectlExec('kubectl get namespace loggers').exitCode === 0;
+}

--- a/frontend/e2e/utils/kubectl.ts
+++ b/frontend/e2e/utils/kubectl.ts
@@ -33,6 +33,12 @@ export function kubectlScale(namespace: string, deployment: string, replicas: nu
   kubectlExec(`kubectl scale -n ${namespace} --replicas=${replicas} deployment/${deployment}`, true);
 }
 
+/** Matches Cypress `user scales to …` (scale + rollout status, no restart). */
+export function kubectlScaleDeployment(namespace: string, deployment: string, replicas: number): void {
+  kubectlScale(namespace, deployment, replicas);
+  kubectlExec(`kubectl rollout status deployment ${deployment} -n ${namespace} --timeout=120s`, true);
+}
+
 export function kubectlRolloutRestart(namespace: string, deployment: string): void {
   kubectlExec(`kubectl rollout restart deployment ${deployment} -n ${namespace}`, true);
 }

--- a/frontend/e2e/utils/kubectl.ts
+++ b/frontend/e2e/utils/kubectl.ts
@@ -1,14 +1,48 @@
 import { execSync } from 'child_process';
 
-export function kubectlNamespaceExists(namespace: string): boolean {
+type KubectlExecResult = {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+};
+
+export function kubectlExec(command: string, failOnNonZeroExit = false): KubectlExecResult {
   try {
-    execSync(`kubectl get namespace ${namespace}`, { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
+    const stdout = execSync(command, { encoding: 'utf8' });
+    return { exitCode: 0, stderr: '', stdout: stdout.trim() };
+  } catch (error) {
+    const execError = error as { status?: number; stderr?: Buffer | string; stdout?: Buffer | string };
+    const result: KubectlExecResult = {
+      exitCode: execError.status ?? 1,
+      stderr: (execError.stderr ?? '').toString().trim(),
+      stdout: (execError.stdout ?? '').toString().trim()
+    };
+    if (failOnNonZeroExit) {
+      throw error;
+    }
+    return result;
   }
 }
 
+export function kubectlNamespaceExists(namespace: string): boolean {
+  const { exitCode } = kubectlExec(`kubectl get namespace ${namespace}`);
+  return exitCode === 0;
+}
+
 export function kubectlScale(namespace: string, deployment: string, replicas: number): void {
-  execSync(`kubectl scale -n ${namespace} --replicas=${replicas} deployment/${deployment}`, { stdio: 'ignore' });
+  kubectlExec(`kubectl scale -n ${namespace} --replicas=${replicas} deployment/${deployment}`, true);
+}
+
+export function kubectlRolloutRestart(namespace: string, deployment: string): void {
+  kubectlExec(`kubectl rollout restart deployment ${deployment} -n ${namespace}`, true);
+}
+
+export function kubectlScaleAndWait(namespace: string, deployment: string, replicas = 1): void {
+  kubectlScale(namespace, deployment, replicas);
+  kubectlRolloutRestart(namespace, deployment);
+  kubectlExec(`kubectl rollout status deployment ${deployment} -n ${namespace}`, true);
+}
+
+export function kubectlDelete(resourceArgs: string): KubectlExecResult {
+  return kubectlExec(`kubectl delete ${resourceArgs}`, false);
 }

--- a/frontend/e2e/utils/meshTopology.ts
+++ b/frontend/e2e/utils/meshTopology.ts
@@ -1,0 +1,157 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Select a mesh topology node by label via MeshPageComponent React state.
+ * Mirrors Cypress mesh.ts getReact + setSelectedIds pattern.
+ */
+export async function selectMeshNodeByLabel(page: Page, label: string): Promise<void> {
+  await page.evaluate(nodeLabel => {
+    const getReactFiber = (el: Element): unknown => {
+      if ('_reactRootContainer' in el) {
+        const container = (el as { _reactRootContainer?: { _internalRoot?: { current?: unknown }; current?: unknown } })
+          ._reactRootContainer;
+        return container?._internalRoot?.current ?? container?.current;
+      }
+      const containerKey = Object.keys(el).find(k => k.startsWith('__reactContainer'));
+      if (containerKey) {
+        const container = (el as Record<string, unknown>)[containerKey] as {
+          stateNode?: { current?: unknown };
+        };
+        return container?.stateNode?.current ?? container;
+      }
+      const fiberKey = Object.keys(el).find(k => k.startsWith('__reactFiber'));
+      return fiberKey ? (el as Record<string, unknown>)[fiberKey] : null;
+    };
+
+    const getComponentName = (fiber: { type?: unknown }): string => {
+      const type = fiber.type as {
+        displayName?: string;
+        name?: string;
+        render?: { displayName?: string; name?: string };
+      };
+      if (!type) return '';
+      if (typeof type === 'string') return type;
+      if (typeof type === 'function') {
+        return type.displayName || type.name || '';
+      }
+      if (type.displayName) return type.displayName;
+      if (type.name) return type.name;
+      if (type.render) {
+        return type.render.displayName || type.render.name || '';
+      }
+      return '';
+    };
+
+    const getStateFromFiber = (fiber: { memoizedState?: unknown }): unknown => {
+      const memoizedState = fiber.memoizedState as
+        { next?: unknown; baseState?: unknown; memoizedState?: unknown } | Record<string, unknown> | null;
+      if (!memoizedState) return undefined;
+      if (typeof memoizedState === 'object' && memoizedState !== null) {
+        if (!('next' in memoizedState) && !('baseState' in memoizedState)) {
+          return memoizedState;
+        }
+        if ('baseState' in memoizedState && memoizedState.baseState !== undefined) {
+          return memoizedState.baseState;
+        }
+      }
+      let hook = memoizedState as { next?: unknown; baseState?: unknown; memoizedState?: unknown } | null;
+      while (hook) {
+        if (hook.memoizedState !== undefined && hook.memoizedState !== null) {
+          if (typeof hook.memoizedState !== 'object' || !('next' in (hook.memoizedState as object))) {
+            return hook.memoizedState;
+          }
+        }
+        if (hook.baseState !== undefined) {
+          return hook.baseState;
+        }
+        hook = hook.next as typeof hook;
+      }
+      return undefined;
+    };
+
+    type ReactTreeNode = {
+      children: ReactTreeNode[];
+      name: string;
+      state: unknown;
+    };
+
+    const buildNodeTree = (fiber: { child?: unknown; sibling?: unknown; type?: unknown }): ReactTreeNode => {
+      const name = getComponentName(fiber as { type?: unknown });
+      const state = getStateFromFiber(fiber as { memoizedState?: unknown });
+      const children: ReactTreeNode[] = [];
+      let child = fiber.child as { child?: unknown; sibling?: unknown } | null;
+      while (child) {
+        children.push(buildNodeTree(child));
+        child = child.sibling as typeof child;
+      }
+      return { name, state, children };
+    };
+
+    const findComponentsInTree = (
+      tree: ReactTreeNode,
+      selector: string,
+      stateFilter: Record<string, unknown>
+    ): ReactTreeNode[] => {
+      const results: ReactTreeNode[] = [];
+      const stack: ReactTreeNode[] = [tree];
+      while (stack.length) {
+        const current = stack.pop()!;
+        if (current.name === selector) {
+          const state = current.state as Record<string, unknown> | undefined;
+          const matches = Object.entries(stateFilter).every(([key, value]) => state?.[key] === value);
+          if (matches) {
+            results.push(current);
+          }
+        }
+        for (let i = current.children.length - 1; i >= 0; i--) {
+          stack.push(current.children[i]);
+        }
+      }
+      return results;
+    };
+
+    const rootEl = document.querySelector('#root') ?? document.querySelector('body');
+    if (!rootEl) {
+      throw new Error('React root element not found');
+    }
+    const fiber = getReactFiber(rootEl);
+    if (!fiber) {
+      throw new Error('React fiber root not found');
+    }
+    const tree = buildNodeTree(fiber as Parameters<typeof buildNodeTree>[0]);
+    const results = findComponentsInTree(tree, 'MeshPageComponent', { isReady: true });
+    if (results.length !== 1) {
+      throw new Error(`MeshPageComponent not ready (found ${results.length})`);
+    }
+
+    const state = results[0].state as {
+      meshRefs: {
+        getController: () => {
+          getElements: () => Array<{
+            getData: () => Record<string, unknown>;
+            getId: () => string;
+            getKind: () => string;
+            getLabel: () => string;
+          }>;
+          hasGraph: () => boolean;
+        };
+        setSelectedIds: (values: string[]) => void;
+      };
+    };
+
+    const controller = state.meshRefs.getController();
+    if (!controller.hasGraph()) {
+      throw new Error('Mesh controller has no graph');
+    }
+
+    const elements = controller.getElements();
+    const nodeKind = 'node';
+    const nodes = elements.filter(el => el.getKind?.() === nodeKind);
+    const node = nodes.find(n => n.getLabel().toLowerCase() === nodeLabel.toLowerCase());
+    if (!node) {
+      throw new Error(`Mesh node with label "${nodeLabel}" not found`);
+    }
+
+    state.meshRefs.setSelectedIds([node.getId()]);
+  }, label);
+}

--- a/frontend/e2e/utils/monacoEditor.ts
+++ b/frontend/e2e/utils/monacoEditor.ts
@@ -1,0 +1,64 @@
+import { expect, type Page } from '@playwright/test';
+import { getColWithRowText } from './table';
+import { linkSelector } from './linkSelector';
+
+export async function editIstioConfigYaml(page: Page): Promise<void> {
+  const editor = page.locator('[data-test="istio-config-editor"] .monaco-editor');
+  await expect(editor).toBeVisible();
+  await expect(page.locator('[data-test="istio-config-editor"] .view-lines')).not.toBeEmpty();
+
+  await page.evaluate(() => {
+    const win = window as Window & {
+      istioConfigEditor?: {
+        getModel: () => { getLineCount: () => number; getLineMaxColumn: (line: number) => number };
+        setPosition: (pos: { column: number; lineNumber: number }) => void;
+        trigger: (source: string, handler: string, payload: { text: string }) => void;
+      };
+    };
+    const ed = win.istioConfigEditor;
+    if (!ed) {
+      throw new Error('istioConfigEditor global not found');
+    }
+    const model = ed.getModel();
+    const lastLine = model.getLineCount();
+    const lastCol = model.getLineMaxColumn(lastLine);
+    ed.setPosition({ lineNumber: lastLine, column: lastCol });
+    ed.trigger('playwright-test', 'type', { text: '\n# playwright-unsaved-edit' });
+  });
+
+  await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
+}
+
+export async function expectEditorMatchesRegex(page: Page, regexContent: string): Promise<void> {
+  await expect(page.locator('[data-test="editor-preview"], [data-test="istio-config-editor"]')).toBeVisible({
+    timeout: 60_000
+  });
+
+  await expect
+    .poll(async () => {
+      return page.evaluate(pattern => {
+        const win = window as Window & {
+          monaco?: { editor: { getEditors: () => Array<{ getValue: () => string }> } };
+        };
+        const monaco = win.monaco;
+        if (!monaco) {
+          return false;
+        }
+        const editors = monaco.editor.getEditors();
+        const regex = new RegExp(pattern);
+        return editors.some(ed => {
+          try {
+            return regex.test(ed.getValue());
+          } catch {
+            return false;
+          }
+        });
+      }, regexContent);
+    })
+    .toBe(true);
+}
+
+export async function clickIstioConfigRowLink(page: Page, column: string, rowText: string): Promise<void> {
+  const cell = getColWithRowText(page, rowText, column);
+  await cell.locator(linkSelector()).first().click();
+}

--- a/frontend/e2e/utils/sharedMeshConfig.ts
+++ b/frontend/e2e/utils/sharedMeshConfig.ts
@@ -58,7 +58,7 @@ export async function applySharedMeshConfig(request: APIRequestContext): Promise
   kubectlExec(`echo "${istioSharedMeshConfigMap}" | kubectl apply -f -`, true);
   kubectlExec(`kubectl patch istio default --type='merge' -p '${applyPatch}'`, true);
   await waitForSharedMeshConfig(request);
-  kubectlExec(`kubectl wait --for=delete pod/${podName} -n istio-system --timeout=60s`, true);
+  kubectlExec(`kubectl wait --for=delete pod/${podName} -n istio-system --timeout=180s`, true);
 }
 
 export function restoreSharedMeshConfig(): void {

--- a/frontend/e2e/utils/sharedMeshConfig.ts
+++ b/frontend/e2e/utils/sharedMeshConfig.ts
@@ -22,8 +22,8 @@ function restoreSharedMeshConfigResources(): void {
   kubectlExec(`kubectl patch istio default --type='merge' -p '${restorePatch}'`, false);
 }
 
-async function waitForSharedMeshConfig(request: APIRequestContext): Promise<void> {
-  const maxTries = 20;
+async function waitForSharedMeshConfig(request: APIRequestContext, istiodPodName: string): Promise<void> {
+  const maxTries = 15;
   for (let tries = 1; tries <= maxTries; tries++) {
     const response = await request.get('/api/mesh/graph');
     if (!response.ok()) {
@@ -35,10 +35,17 @@ async function waitForSharedMeshConfig(request: APIRequestContext): Promise<void
       (node: { data?: { infraType?: string; infraData?: { config?: { sharedConfig?: unknown } } } }) =>
         node.data?.infraType === 'istiod'
     );
-    if (istiodNode?.data?.infraData?.config?.sharedConfig !== undefined) {
-      return;
+    if (istiodNode?.data?.infraData?.config?.sharedConfig === undefined) {
+      await new Promise(resolve => setTimeout(resolve, 3000));
+      continue;
     }
-    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Cypress @shared-mesh-config: only after Kiali sees sharedConfig, wait for the pre-patch pod to go away.
+    const podStillExists = kubectlExec(`kubectl get pod/${istiodPodName} -n istio-system`, false).exitCode === 0;
+    if (podStillExists) {
+      kubectlExec(`kubectl wait --for=delete pod/${istiodPodName} -n istio-system --timeout=60s`, true);
+    }
+    return;
   }
   restoreSharedMeshConfigResources();
   throw new Error('Timed out waiting for Kiali to see the Shared Mesh Config');
@@ -57,8 +64,7 @@ export async function applySharedMeshConfig(request: APIRequestContext): Promise
 
   kubectlExec(`echo "${istioSharedMeshConfigMap}" | kubectl apply -f -`, true);
   kubectlExec(`kubectl patch istio default --type='merge' -p '${applyPatch}'`, true);
-  await waitForSharedMeshConfig(request);
-  kubectlExec(`kubectl wait --for=delete pod/${podName} -n istio-system --timeout=180s`, true);
+  await waitForSharedMeshConfig(request, podName);
 }
 
 export function restoreSharedMeshConfig(): void {

--- a/frontend/e2e/utils/sharedMeshConfig.ts
+++ b/frontend/e2e/utils/sharedMeshConfig.ts
@@ -40,10 +40,11 @@ async function waitForSharedMeshConfig(request: APIRequestContext, istiodPodName
       continue;
     }
 
-    // Cypress @shared-mesh-config: only after Kiali sees sharedConfig, wait for the pre-patch pod to go away.
+    // Cypress @shared-mesh-config else branch: wait for pre-patch pod delete when possible.
+    // On OSSM/Sail the pod may keep running while Kiali already reports sharedConfig — do not fail setup.
     const podStillExists = kubectlExec(`kubectl get pod/${istiodPodName} -n istio-system`, false).exitCode === 0;
     if (podStillExists) {
-      kubectlExec(`kubectl wait --for=delete pod/${istiodPodName} -n istio-system --timeout=60s`, true);
+      kubectlExec(`kubectl wait --for=delete pod/${istiodPodName} -n istio-system --timeout=60s`, false);
     }
     return;
   }

--- a/frontend/e2e/utils/sharedMeshConfig.ts
+++ b/frontend/e2e/utils/sharedMeshConfig.ts
@@ -1,0 +1,66 @@
+import type { APIRequestContext } from '@playwright/test';
+import { kubectlExec } from './kubectl';
+import { hasSailIstioCr } from './kialiConfig';
+
+const istioSharedMeshConfigMap = `
+apiVersion: v1
+data:
+  mesh: |-
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
+kind: ConfigMap
+metadata:
+  name: istio-user
+  namespace: istio-system
+`;
+
+const restorePatch = '{"spec": {"values": {"pilot": {"env": {"SHARED_MESH_CONFIG": null}}}}}';
+const applyPatch = '{"spec": {"values": {"pilot": {"env": {"SHARED_MESH_CONFIG": "istio-user"}}}}}';
+
+function restoreSharedMeshConfigResources(): void {
+  kubectlExec(`echo "${istioSharedMeshConfigMap}" | kubectl delete -f -`, false);
+  kubectlExec(`kubectl patch istio default --type='merge' -p '${restorePatch}'`, false);
+}
+
+async function waitForSharedMeshConfig(request: APIRequestContext): Promise<void> {
+  const maxTries = 15;
+  for (let tries = 1; tries <= maxTries; tries++) {
+    const response = await request.get('/api/mesh/graph');
+    if (!response.ok()) {
+      restoreSharedMeshConfigResources();
+      throw new Error(`Expected 200 from /api/mesh/graph, got ${response.status()}`);
+    }
+    const body = await response.json();
+    const istiodNode = body.elements?.nodes?.find(
+      (node: { data?: { infraType?: string; infraData?: { config?: { sharedConfig?: unknown } } } }) =>
+        node.data?.infraType === 'istiod'
+    );
+    if (istiodNode?.data?.infraData?.config?.sharedConfig !== undefined) {
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, 3000));
+  }
+  restoreSharedMeshConfigResources();
+  throw new Error('Timed out waiting for Kiali to see the Shared Mesh Config');
+}
+
+export async function applySharedMeshConfig(request: APIRequestContext): Promise<void> {
+  if (!hasSailIstioCr()) {
+    throw new Error('Sail Istio CR (istio default) is not installed — shared mesh config test requires Sail operator');
+  }
+
+  const podResult = kubectlExec(
+    `kubectl get pods -l app=istiod -n istio-system -o jsonpath="{.items[0].metadata.name}"`,
+    true
+  );
+  const podName = podResult.stdout;
+
+  kubectlExec(`echo "${istioSharedMeshConfigMap}" | kubectl apply -f -`, true);
+  kubectlExec(`kubectl patch istio default --type='merge' -p '${applyPatch}'`, true);
+  await waitForSharedMeshConfig(request);
+  kubectlExec(`kubectl wait --for=delete pod/${podName} -n istio-system --timeout=60s`, true);
+}
+
+export function restoreSharedMeshConfig(): void {
+  restoreSharedMeshConfigResources();
+}

--- a/frontend/e2e/utils/sharedMeshConfig.ts
+++ b/frontend/e2e/utils/sharedMeshConfig.ts
@@ -23,7 +23,7 @@ function restoreSharedMeshConfigResources(): void {
 }
 
 async function waitForSharedMeshConfig(request: APIRequestContext): Promise<void> {
-  const maxTries = 15;
+  const maxTries = 20;
   for (let tries = 1; tries <= maxTries; tries++) {
     const response = await request.get('/api/mesh/graph');
     if (!response.ok()) {

--- a/frontend/e2e/utils/sidecarInjection.ts
+++ b/frontend/e2e/utils/sidecarInjection.ts
@@ -1,0 +1,93 @@
+import type { Page } from '@playwright/test';
+import { kubectlScaleAndWait } from './kubectl';
+
+const workloadGvk = 'apps/v1, Kind=Deployment';
+
+const patchNamespace = async (page: Page, namespace: string, labels: Record<string, string | null>): Promise<void> => {
+  const response = await page.request.patch(`/api/namespaces/${namespace}`, {
+    data: { metadata: { labels } }
+  });
+  if (!response.ok()) {
+    throw new Error(`Failed to patch namespace ${namespace}: ${response.status()}`);
+  }
+};
+
+const patchWorkloadInjection = async (
+  page: Page,
+  namespace: string,
+  workload: string,
+  injectLabel: string | null,
+  injectAnnotation: string | null = null
+): Promise<void> => {
+  const response = await page.request.patch(`/api/namespaces/${namespace}/workloads/${workload}?gvk="${workloadGvk}"`, {
+    data: {
+      spec: {
+        template: {
+          metadata: {
+            annotations: {
+              'sidecar.istio.io/inject': injectAnnotation
+            },
+            labels: {
+              'sidecar.istio.io/inject': injectLabel
+            }
+          }
+        }
+      }
+    }
+  });
+  if (!response.ok()) {
+    throw new Error(`Failed to patch workload ${namespace}/${workload}: ${response.status()}`);
+  }
+};
+
+export async function clearNamespaceInjection(page: Page, namespace: string): Promise<void> {
+  await patchNamespace(page, namespace, { 'istio-injection': null, 'istio.io/rev': null });
+}
+
+export async function setNamespaceInjection(page: Page, namespace: string, enabledOrDisabled: string): Promise<void> {
+  await patchNamespace(page, namespace, { 'istio-injection': enabledOrDisabled, 'istio.io/rev': null });
+}
+
+export async function setupWorkloadWithoutSidecar(page: Page, namespace: string, workload: string): Promise<void> {
+  await clearNamespaceInjection(page, namespace);
+  await patchWorkloadInjection(page, namespace, workload, null, null);
+  await restartWorkload(namespace, workload);
+}
+
+export async function setupWorkloadWithSidecar(page: Page, namespace: string, workload: string): Promise<void> {
+  await setNamespaceInjection(page, namespace, 'enabled');
+  await patchWorkloadInjection(page, namespace, workload, 'true', null);
+  await restartWorkload(namespace, workload);
+}
+
+export async function ensureWorkloadNoInjectionOverride(
+  page: Page,
+  namespace: string,
+  workload: string,
+  hasSidecar: boolean
+): Promise<void> {
+  await setNamespaceInjection(page, namespace, hasSidecar ? 'enabled' : 'disabled');
+  await patchWorkloadInjection(page, namespace, workload, null, null);
+  await restartWorkload(namespace, workload);
+}
+
+export async function ensureWorkloadHasInjectionOverride(
+  page: Page,
+  namespace: string,
+  workload: string,
+  hasSidecar: boolean
+): Promise<void> {
+  await patchWorkloadInjection(page, namespace, workload, hasSidecar ? 'true' : 'false', null);
+}
+
+export async function setupWorkloadWithInjectionOverride(
+  page: Page,
+  namespace: string,
+  workload: string
+): Promise<void> {
+  await patchWorkloadInjection(page, namespace, workload, 'true', null);
+}
+
+export async function restartWorkload(namespace: string, workload: string): Promise<void> {
+  kubectlScaleAndWait(namespace, workload);
+}

--- a/frontend/e2e/utils/suite-tags.ts
+++ b/frontend/e2e/utils/suite-tags.ts
@@ -15,5 +15,8 @@ export const coreCachingOnly = { tag: '@core-caching' as const };
 /** @core-1 — frontend-core-1 Playwright / Cypress suite */
 export const core1 = { tag: '@core-1' as const };
 
+/** @core-2 — frontend-core-2 Playwright / Cypress suite */
+export const core2 = { tag: '@core-2' as const };
+
 /** @smoke + @prometheus-disabled */
 export const smokeAndPrometheusDisabled = { tag: ['@smoke', '@prometheus-disabled'] as const };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,7 @@
     "playwright:combine:reports": "node scripts/playwright-combine-reports.mjs",
     "playwright:run:smoke": "playwright test --project=smoke --pass-with-no-tests",
     "playwright:run:core1": "playwright test --project=core-1 --pass-with-no-tests",
+    "playwright:run:core2": "playwright test --project=core-2 --pass-with-no-tests",
     "playwright:run:junit": "playwright test --project=crd-validation --project=core-1 --project=core-2 --project=core-caching --pass-with-no-tests",
     "playwright:run:all": "playwright test --project=smoke --project=core-1 --project=core-2 --project=core-caching --project=crd-validation --project=perses --project=ai-chatbot --pass-with-no-tests",
     "playwright:run:ambient:junit": "playwright test --project=ambient --project=waypoint --project=waypoint-tracing --pass-with-no-tests",

--- a/hack/ci-yaml/ci-test-config-no-cache.yaml
+++ b/hack/ci-yaml/ci-test-config-no-cache.yaml
@@ -1,3 +1,12 @@
+health_config:
+  rate:
+  - kind: service
+    name: y-server
+    namespace: alpha
+    tolerance:
+    - code: 5xx
+      degraded: 2
+      failure: 100
 kiali_internal:
   graph_cache:
     enabled: false

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -29,6 +29,7 @@ LOCAL="local"
 MCP_TOOLS="false"
 OFFLINE="offline"
 PLAYWRIGHT_CORE_1="playwright-core-1"
+PLAYWRIGHT_CORE_2="playwright-core-2"
 PLAYWRIGHT_SMOKE="playwright-smoke"
 HELM_CHARTS_DIR=""
 ISTIO_VERSION=""
@@ -176,8 +177,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     -ts|--test-suite)
       TEST_SUITE="${2}"
-      if [ "${TEST_SUITE}" != "${BACKEND}" ] && [ "${TEST_SUITE}" != "${BACKEND_EXTERNAL_CONTROLPLANE}" ] && [ "${TEST_SUITE}" != "${FRONTEND}" ] && [ "${TEST_SUITE}" != "${FRONTEND_AMBIENT}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_1}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_2}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_OPTIONAL}" ] && [ "${TEST_SUITE}" != "${FRONTEND_PRIMARY_REMOTE}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_PRIMARY}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_MESH}" ] && [ "${TEST_SUITE}" != "${FRONTEND_EXTERNAL_KIALI}" ] && [ "${TEST_SUITE}" != "${FRONTEND_TEMPO}" ] && [ "${TEST_SUITE}" != "${AI_CHATBOT}" ] && [ "${TEST_SUITE}" != "${LOCAL}" ] && [ "${TEST_SUITE}" != "${OFFLINE}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_1}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_SMOKE}" ]; then
-        echo "--test-suite option must be one of '${BACKEND}', '${BACKEND_EXTERNAL_CONTROLPLANE}', '${FRONTEND}', '${FRONTEND_AMBIENT}', '${FRONTEND_CORE_1}', '${FRONTEND_CORE_2}', '${FRONTEND_CORE_CACHING}', '${FRONTEND_CORE_OPTIONAL}', '${FRONTEND_PRIMARY_REMOTE}', '${FRONTEND_MULTI_PRIMARY}', '${FRONTEND_EXTERNAL_KIALI}', '${FRONTEND_TEMPO}', '${AI_CHATBOT}', '${LOCAL}', '${OFFLINE}', '${PLAYWRIGHT_CORE_1}' or '${PLAYWRIGHT_SMOKE}'"
+      if [ "${TEST_SUITE}" != "${BACKEND}" ] && [ "${TEST_SUITE}" != "${BACKEND_EXTERNAL_CONTROLPLANE}" ] && [ "${TEST_SUITE}" != "${FRONTEND}" ] && [ "${TEST_SUITE}" != "${FRONTEND_AMBIENT}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_1}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_2}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_OPTIONAL}" ] && [ "${TEST_SUITE}" != "${FRONTEND_PRIMARY_REMOTE}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_PRIMARY}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_MESH}" ] && [ "${TEST_SUITE}" != "${FRONTEND_EXTERNAL_KIALI}" ] && [ "${TEST_SUITE}" != "${FRONTEND_TEMPO}" ] && [ "${TEST_SUITE}" != "${AI_CHATBOT}" ] && [ "${TEST_SUITE}" != "${LOCAL}" ] && [ "${TEST_SUITE}" != "${OFFLINE}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_1}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_2}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_SMOKE}" ]; then
+        echo "--test-suite option must be one of '${BACKEND}', '${BACKEND_EXTERNAL_CONTROLPLANE}', '${FRONTEND}', '${FRONTEND_AMBIENT}', '${FRONTEND_CORE_1}', '${FRONTEND_CORE_2}', '${FRONTEND_CORE_CACHING}', '${FRONTEND_CORE_OPTIONAL}', '${FRONTEND_PRIMARY_REMOTE}', '${FRONTEND_MULTI_PRIMARY}', '${FRONTEND_EXTERNAL_KIALI}', '${FRONTEND_TEMPO}', '${AI_CHATBOT}', '${LOCAL}', '${OFFLINE}', '${PLAYWRIGHT_CORE_1}', '${PLAYWRIGHT_CORE_2}' or '${PLAYWRIGHT_SMOKE}'"
         exit 1
       fi
       shift;shift
@@ -259,7 +260,7 @@ Valid command line arguments:
   -to|--tests-only <true|false>
     If true, only run the tests and skip the setup.
     Default: false
-  -ts|--test-suite <${BACKEND}|${BACKEND_EXTERNAL_CONTROLPLANE}|${FRONTEND}|${FRONTEND_AMBIENT}|${FRONTEND_CORE_1}|${FRONTEND_CORE_2}|${FRONTEND_CORE_CACHING}|${FRONTEND_CORE_OPTIONAL}|${FRONTEND_PRIMARY_REMOTE}|${FRONTEND_MULTI_PRIMARY}|${FRONTEND_MULTI_MESH}|${FRONTEND_MULTIPLE_CONTROLPLANES}|${FRONTEND_EXTERNAL_KIALI}|${FRONTEND_TEMPO}|${AI_CHATBOT}|${LOCAL}|${OFFLINE}|${PLAYWRIGHT_CORE_1}|${PLAYWRIGHT_SMOKE}>
+  -ts|--test-suite <${BACKEND}|${BACKEND_EXTERNAL_CONTROLPLANE}|${FRONTEND}|${FRONTEND_AMBIENT}|${FRONTEND_CORE_1}|${FRONTEND_CORE_2}|${FRONTEND_CORE_CACHING}|${FRONTEND_CORE_OPTIONAL}|${FRONTEND_PRIMARY_REMOTE}|${FRONTEND_MULTI_PRIMARY}|${FRONTEND_MULTI_MESH}|${FRONTEND_MULTIPLE_CONTROLPLANES}|${FRONTEND_EXTERNAL_KIALI}|${FRONTEND_TEMPO}|${AI_CHATBOT}|${LOCAL}|${OFFLINE}|${PLAYWRIGHT_CORE_1}|${PLAYWRIGHT_CORE_2}|${PLAYWRIGHT_SMOKE}>
     Which test suite to run.
     Default: ${BACKEND}
   -w|--waypoint <true|false>
@@ -1252,6 +1253,72 @@ elif [ "${TEST_SUITE}" == "${PLAYWRIGHT_CORE_1}" ]; then
   cd "${SCRIPT_DIR}"/../frontend
   set +e
   yarn run playwright:run:core1
+  PLAYWRIGHT_EXIT=$?
+  set -e
+  yarn run playwright:combine:reports
+  exit ${PLAYWRIGHT_EXIT}
+elif [ "${TEST_SUITE}" == "${PLAYWRIGHT_CORE_2}" ]; then
+  ensurePlaywrightReady
+
+  GOPATH=$(go env GOPATH)
+
+  if [ -z "${GOPATH}" ]; then
+    echo "ERROR: Unable to determine GOPATH. Please ensure Go is properly installed."
+    exit 1
+  fi
+
+  KIALI_BINARY="${GOPATH}/bin/kiali"
+  if [ ! -f "${KIALI_BINARY}" ]; then
+    echo "ERROR: Kiali binary not found at ${KIALI_BINARY}. Please build the kiali binary first."
+    exit 1
+  fi
+
+  if [ "${TESTS_ONLY}" == "false" ]; then
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --auth-strategy anonymous --sail true --deploy-kiali false ${ISTIO_VERSION_ARG} ${HELM_CHARTS_DIR_ARG}
+
+    # Demo apps without error-rates beta namespace — same as Cypress frontend-core-2
+    "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" --install-errorrates-beta false
+  fi
+
+  infomsg "Setup complete."
+
+  if [ "${SETUP_ONLY}" == "true" ]; then
+    exit 0
+  fi
+
+  infomsg "Starting Kiali locally in the background using binary: ${KIALI_BINARY}"
+  "${KIALI_BINARY}" -c "${SCRIPT_DIR}/ci-yaml/ci-test-config-no-cache.yaml" run --cluster-name-overrides kind-ci=cluster-default --port-forward-tracing --enable-tracing --port-forward-prom --port-forward-grafana --no-browser &
+  KIALI_PID=$!
+
+  KIALI_URL="http://localhost:20001"
+
+  infomsg "Waiting for Kiali server to respond at ${KIALI_URL}"
+  WAIT_START=$(date +%s)
+  WAIT_END=$((WAIT_START + 60))
+  while true; do
+    if ! ps -p ${KIALI_PID} > /dev/null; then
+      echo "Kiali process is not running. An error must have occurred. Check the logs above."
+      exit 1
+    fi
+    if curl -s --fail "${KIALI_URL}/healthz" > /dev/null 2>&1; then
+      break
+    fi
+    WAIT_NOW=$(date +%s)
+    if [ "${WAIT_NOW}" -gt "${WAIT_END}" ]; then
+      echo "Timed out waiting for Kiali server to respond at ${KIALI_URL}/healthz"
+      exit 1
+    fi
+    sleep 2
+  done
+  infomsg "Kiali server is healthy"
+
+  export PLAYWRIGHT_BASE_URL="${KIALI_URL}"
+
+  trap cleanup_kiali EXIT
+
+  cd "${SCRIPT_DIR}"/../frontend
+  set +e
+  yarn run playwright:run:core2
   PLAYWRIGHT_EXIT=$?
   set -e
   yarn run playwright:combine:reports


### PR DESCRIPTION
### Describe the change

Ports the remaining Cypress `@core-2` scenarios to Playwright:

- Services/workloads health lists (error-rates + idle)
- K8s HTTP/GRPC routing wizard (merged serial spec)
- Istio config editor + K8s Gateway API wizard
- Mesh core-2 (Grafana localhost skip, shared mesh config)
- Namespace sidecar injection (ambient skips)
- Workload logs

Adds page objects, helpers (`bookinfoRoutingLock`, `istioConfigResources`, `kialiConfig`, etc.), and `yarn playwright:run:core2`.

The degraded `y-server` health test skips when Kiali lacks the CI `health_config` override (no local yaml change required). Bookinfo Gateway API wizard specs share a cross-process lock to avoid parallel flakes under full `core-2`.

### Steps to test the PR

```bash
cd frontend
yarn playwright:install chromium
yarn playwright:run:core2
```

With a local KinD cluster + Kiali:

```bash
hack/run-integration-tests.sh --test-suite playwright-core-2 --tests-only true
```

### Automation testing

Playwright `@core-2` specs added under `frontend/e2e/tests/` with suite tag via `core2` in `suite-tags.ts`.

### Issue reference

Part of #9712 (Cypress → Playwright migration).


Made with [Cursor](https://cursor.com)