### PR TITLE
Fix AI chatbot Cypress tests Redux state path

### DIFF
--- a/frontend/cypress/integration/common/ai_chatbot.ts
+++ b/frontend/cypress/integration/common/ai_chatbot.ts
@@ -415,7 +415,7 @@ When('the user clicks the {string} header button', (label: string) => {
 
 /**
  * Verifies the Chatbot component class, which is driven by the displayMode value
- * stored in Redux (state.aiChat.displayMode). Pattern: pf-chatbot--{mode}.
+ * stored in Redux (state.ai.chat.displayMode). Pattern: pf-chatbot--{mode}.
  */
 Then('the chatbot should be in {string} display mode', (mode: string) => {
   cy.get(`.pf-chatbot.pf-chatbot--${mode}`).should('exist');
@@ -562,7 +562,7 @@ Given('two AI providers are configured', () => {
       );
     }
 
-    const aiState = store.getState().ai.chatAI;
+    const aiState = store.getState().ai.chat;
     const realProviders: any[] = (aiState.providers ?? []).filter((p: any) => p.name !== SECOND_PROVIDER_NAME);
 
     if (realProviders.length === 0) {
@@ -619,7 +619,7 @@ Given('the user is not allowed to use the AI chatbot', () => {
       );
     }
 
-    const aiState = store.getState().ai.chatAI;
+    const aiState = store.getState().ai.chat;
     store.dispatch({
       type: 'CHAT_AI_SET_CHAT_AI',
       payload: {


### PR DESCRIPTION
## Summary

Fixes failing `@ai-chatbot` Cypress scenarios introduced by the AI config refactor in #10256.

Cypress steps that inject or override chat state via the Redux fiber tree were reading `store.getState().ai.chatAI`, but the store path after #10256 is `ai.chat`. That caused `TypeError: Cannot read properties of undefined (reading 'providers'|'enabled')` in:

- The AI chatbot toggle is disabled and warns the user when they are not allowed to use it
- The new chat modal shows the provider change message when opened by selecting a different provider
- Confirming a provider change updates the selected provider and clears the chat

## Test plan

- [ ] CI `@ai-chatbot` Cypress suite passes
- [x] Change is limited to Cypress step definitions (no app code changes)


Made with [Cursor](https://cursor.com)