### PR TITLE
CVE-2026-84375: Upgrade js-yaml to 4.3.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,7 +114,7 @@
     "eventemitter3": "5.0.4",
     "i18next": "^23.10.1",
     "i18next-http-backend": "^2.5.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.2",
     "lodash-es": "^4.18.0",
     "micro-memoize": "4.0.9",
     "moment": "^2.29.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1721,7 +1721,7 @@ __metadata:
     i18next: "npm:^23.10.1"
     i18next-http-backend: "npm:^2.5.0"
     i18next-parser: "npm:^9.4.0"
-    js-yaml: "npm:^4.3.0"
+    js-yaml: "npm:^4.3.2"
     jsdom: "npm:^29.1.1"
     junit-report-merger: "npm:^9.0.4"
     lodash-es: "npm:^4.18.0"
@@ -9069,14 +9069,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrades `js-yaml` from 4.3.0 to 4.3.2 to address CVE-2026-84375 (DoS in YAML merge-key parsing).

## Test plan

- [x] `make build-ui`
- [ ] CI passes


Made with [Cursor](https://cursor.com)