### PR TITLE
[v2.11] CVE-2026-84375: Upgrade js-yaml and immutable JS dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,7 @@
     "eventemitter3": "4.0.7",
     "i18next": "^23.10.1",
     "i18next-http-backend": "^2.5.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.2",
     "lodash-es": "^4.18.0",
     "micro-memoize": "4.0.9",
     "moment": "^2.29.4",
@@ -155,7 +155,8 @@
   },
   "resolutions": {
     "esbuild": "^0.25.2",
-    "js-yaml@npm:3.14.0": "npm:3.15.0",
+    "immutable": "^4.3.9",
+    "js-yaml@npm:3.14.0": "npm:3.15.2",
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",
     "workbox-webpack-plugin": "^7.1.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2705,7 +2705,7 @@ __metadata:
     i18next-http-backend: "npm:^2.5.0"
     i18next-parser: "npm:^9.4.0"
     jest-canvas-mock: "npm:2.2.0"
-    js-yaml: "npm:^4.3.0"
+    js-yaml: "npm:^4.3.2"
     junit-report-merger: "npm:^3.0.5"
     lodash-es: "npm:^4.18.0"
     micro-memoize: "npm:4.0.9"
@@ -10226,10 +10226,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^4.0.0":
-  version: 4.3.8
-  resolution: "immutable@npm:4.3.8"
-  checksum: 10c0/3de58996305a0faf6ef3fc0685f996c42653ad757760214f5aec7d4a6b59ea7abb882522c5f9a61776fae88c0b45e08eb77cbded5a4f57745ec7c63f9642e44b
+"immutable@npm:^4.3.9":
+  version: 4.3.9
+  resolution: "immutable@npm:4.3.9"
+  checksum: 10c0/394faa90ac8f2f62824e6c639705efdb8313787d6bc7864e28a48ee36aa2ba4b724eaf54a701ad991c278967a412b09143dd24fd19e3e2b0204eb481a5afa6ef
   languageName: node
   linkType: hard
 
@@ -11421,26 +11421,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.15.0, js-yaml@npm:^3.13.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+"js-yaml@npm:3.15.2, js-yaml@npm:^3.13.1":
+  version: 3.15.2
+  resolution: "js-yaml@npm:3.15.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/e341df211dece9d4b784849647ad7568b5b6a58a9ee58ead750482316d83276387343649fe4b71522705dc6c76acf97718588f23dc19443833ef3e75033af967
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/pull/10276 to v2.11.

- Upgrades js-yaml to 4.3.2 (CVE-2026-84375)
- Upgrades transitive js-yaml 3.x to 3.15.2 via resolution
- Upgrades immutable to 4.3.9 via resolution (CVE-2026-59879)

Made with [Cursor](https://cursor.com)