### PR TITLE
Fix duplicate istiod→ztunnel edges on Mesh page

### DIFF
--- a/mesh/generator/generator.go
+++ b/mesh/generator/generator.go
@@ -179,69 +179,6 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 			}
 		}
 
-		// if ambient, add ztunnel
-		if gi.KialiCache.IsAmbientEnabled(cp.Cluster.Name) {
-			ztunnels, err := gi.Business.Workload.GetAllWorkloads(ctx, cp.Cluster.Name, fmt.Sprintf("%s=%s", config.IstioAppLabel, config.Ztunnel))
-			mesh.CheckError(err)
-
-			for _, ztunnel := range ztunnels {
-				var infraData interface{}
-
-				if len(ztunnel.Pods) > 0 {
-					dump := gi.Business.Workload.GetZtunnelConfig(ztunnel.Cluster, ztunnel.Namespace, ztunnel.Pods[0].Name)
-					// The dump can be huge, just return the config part and defer to the ztunnel workload tab for the other stuff
-					if dump != nil {
-						infraData = dump.Config
-					}
-				}
-
-				// if we couldn't fetch a ztunnel config, just return labels and annotation
-				if infraData == nil {
-					infraData = struct {
-						Annotations         map[string]string
-						Labels              map[string]string
-						TemplateAnnotations map[string]string
-						TemplateLabels      map[string]string
-					}{
-						Annotations:         ztunnel.Annotations,
-						Labels:              ztunnel.Labels,
-						TemplateAnnotations: ztunnel.TemplateAnnotations,
-						TemplateLabels:      ztunnel.TemplateLabels,
-					}
-				}
-
-				version := models.DefaultRevisionLabel
-				if rev, ok := ztunnel.Labels[config.IstioRevisionLabel]; ok {
-					version = rev
-				}
-
-				ztunnelNode, _, err := addInfra(meshMap, mesh.InfraTypeZtunnel, ztunnel.Cluster, ztunnel.Namespace, ztunnel.Name, infraData, version, false, "")
-				mesh.CheckError(err)
-
-				// add edge to the managing control plane
-				// Use revision/tag as primary match, version label as tie-breaker for multi-mesh
-				for _, infraNode := range meshMap {
-					if infraNode.InfraType == mesh.InfraTypeIstiod && infraNode.Cluster == ztunnel.Cluster {
-						cp := infraNode.Metadata[mesh.InfraData].(models.ControlPlane)
-						tag := "default"
-						if cp.Tag != nil {
-							tag = cp.Tag.Name
-						}
-						if tag != ztunnelNode.Metadata[mesh.Version] {
-							continue
-						}
-						// Revision/tag matches; use app.kubernetes.io/version as tie-breaker
-						ztunnelVersion := ztunnel.Labels[config.KubernetesVersionLabel]
-						if ztunnelVersion != "" && cp.Version != nil && cp.Version.Version != "" && ztunnelVersion != cp.Version.Version {
-							continue
-						}
-						infraNode.AddEdge(ztunnelNode)
-						break
-					}
-				}
-			}
-		}
-
 		// if included, add any waypoints
 		if o.IncludeWaypoints {
 			for _, wp := range gi.Business.Workload.GetWaypoints(ctx) {
@@ -339,6 +276,60 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 						}
 					}
 				}
+			}
+		}
+	}
+
+	// Process ztunnels once per cluster after all control planes are added.
+	clusters := make([]string, 0, len(clusterMap))
+	for cluster := range clusterMap {
+		clusters = append(clusters, cluster)
+	}
+	slices.Sort(clusters)
+	for _, cluster := range clusters {
+		if !gi.KialiCache.IsAmbientEnabled(cluster) {
+			continue
+		}
+
+		ztunnels, err := gi.Business.Workload.GetAllWorkloads(ctx, cluster, fmt.Sprintf("%s=%s", config.IstioAppLabel, config.Ztunnel))
+		mesh.CheckError(err)
+
+		for _, ztunnel := range ztunnels {
+			var infraData interface{}
+
+			if len(ztunnel.Pods) > 0 {
+				dump := gi.Business.Workload.GetZtunnelConfig(ztunnel.Cluster, ztunnel.Namespace, ztunnel.Pods[0].Name)
+				// The dump can be huge, just return the config part and defer to the ztunnel workload tab for the other stuff
+				if dump != nil {
+					infraData = dump.Config
+				}
+			}
+
+			// if we couldn't fetch a ztunnel config, just return labels and annotation
+			if infraData == nil {
+				infraData = struct {
+					Annotations         map[string]string
+					Labels              map[string]string
+					TemplateAnnotations map[string]string
+					TemplateLabels      map[string]string
+				}{
+					Annotations:         ztunnel.Annotations,
+					Labels:              ztunnel.Labels,
+					TemplateAnnotations: ztunnel.TemplateAnnotations,
+					TemplateLabels:      ztunnel.TemplateLabels,
+				}
+			}
+
+			version := models.DefaultRevisionLabel
+			if rev, ok := ztunnel.Labels[config.IstioRevisionLabel]; ok {
+				version = rev
+			}
+
+			ztunnelNode, _, err := addInfra(meshMap, mesh.InfraTypeZtunnel, ztunnel.Cluster, ztunnel.Namespace, ztunnel.Name, infraData, version, false, "")
+			mesh.CheckError(err)
+
+			if istiod := findManagingIstiod(meshMap, ztunnel.Cluster, version, ztunnel.Labels[config.KubernetesVersionLabel]); istiod != nil {
+				istiod.AddEdge(ztunnelNode)
 			}
 		}
 	}
@@ -445,6 +436,40 @@ func BuildMeshMap(ctx context.Context, o mesh.Options, gi *mesh.GlobalInfo) (mes
 	}
 
 	return meshMap, nil
+}
+
+// findManagingIstiod returns the istiod node that manages the given ztunnel workload.
+// Revision/tag is the primary match; app.kubernetes.io/version is used as a tie-breaker.
+// When multiple control planes match, the result is deterministic (namespace, then name).
+func findManagingIstiod(meshMap mesh.MeshMap, ztunnelCluster, ztunnelRevision, ztunnelVersion string) *mesh.Node {
+	var candidates []*mesh.Node
+	for _, infraNode := range meshMap {
+		if infraNode.InfraType != mesh.InfraTypeIstiod || infraNode.Cluster != ztunnelCluster {
+			continue
+		}
+		cp := infraNode.Metadata[mesh.InfraData].(models.ControlPlane)
+		tag := models.DefaultRevisionLabel
+		if cp.Tag != nil {
+			tag = cp.Tag.Name
+		}
+		if tag != ztunnelRevision {
+			continue
+		}
+		if ztunnelVersion != "" && cp.Version != nil && cp.Version.Version != "" && ztunnelVersion != cp.Version.Version {
+			continue
+		}
+		candidates = append(candidates, infraNode)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	slices.SortFunc(candidates, func(a, b *mesh.Node) int {
+		if cmp := strings.Compare(a.Namespace, b.Namespace); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.InfraName, b.InfraName)
+	})
+	return candidates[0]
 }
 
 func addInfra(meshMap mesh.MeshMap, infraType, cluster, namespace, name string, infraData interface{}, version string, isExternal bool, healthData string) (*mesh.Node, bool, error) {

--- a/mesh/generator/generator_test.go
+++ b/mesh/generator/generator_test.go
@@ -1,0 +1,69 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiali/kiali/mesh"
+	"github.com/kiali/kiali/models"
+)
+
+func TestFindManagingIstiod(t *testing.T) {
+	cluster := "cluster-primary"
+	ztunnelRevision := models.DefaultRevisionLabel
+
+	newIstiod := func(namespace, name, tag, version string) *mesh.Node {
+		cp := models.ControlPlane{
+			IstiodName:      name,
+			IstiodNamespace: namespace,
+		}
+		if tag != "" {
+			cp.Tag = &models.Tag{Name: tag}
+		}
+		if version != "" {
+			cp.Version = &models.ExternalServiceInfo{Version: version}
+		}
+		node := mesh.NewNode("id", mesh.NodeTypeInfra, mesh.InfraTypeIstiod, cluster, namespace, name)
+		node.Metadata[mesh.InfraData] = cp
+		return node
+	}
+
+	t.Run("returns nil when no istiod matches revision", func(t *testing.T) {
+		meshMap := mesh.NewMeshMap()
+		meshMap["a"] = newIstiod("istio-system", "istiod-canary", "canary", "1.24.0")
+
+		assert.Nil(t, findManagingIstiod(meshMap, cluster, ztunnelRevision, "1.24.0"))
+	})
+
+	t.Run("returns single matching istiod", func(t *testing.T) {
+		meshMap := mesh.NewMeshMap()
+		istiod := newIstiod("istio-system", "istiod", models.DefaultRevisionLabel, "1.24.0")
+		meshMap["a"] = istiod
+
+		assert.Same(t, istiod, findManagingIstiod(meshMap, cluster, ztunnelRevision, "1.24.0"))
+	})
+
+	t.Run("filters by app.kubernetes.io/version tie-breaker", func(t *testing.T) {
+		meshMap := mesh.NewMeshMap()
+		istiod124 := newIstiod("istio-system", "istiod", models.DefaultRevisionLabel, "1.24.0")
+		meshMap["a"] = istiod124
+		meshMap["b"] = newIstiod("istio-system", "istiod-canary", models.DefaultRevisionLabel, "1.25.0")
+
+		assert.Same(t, istiod124, findManagingIstiod(meshMap, cluster, ztunnelRevision, "1.24.0"))
+	})
+
+	t.Run("returns deterministic result when multiple istiods match", func(t *testing.T) {
+		meshMap := mesh.NewMeshMap()
+		istiodA := newIstiod("istio-a", "istiod", models.DefaultRevisionLabel, "")
+		istiodB := newIstiod("istio-b", "istiod", models.DefaultRevisionLabel, "")
+		meshMap["b"] = istiodB
+		meshMap["a"] = istiodA
+
+		result := findManagingIstiod(meshMap, cluster, ztunnelRevision, "")
+		require.NotNil(t, result)
+		assert.Equal(t, "istio-a", result.Namespace)
+		assert.Same(t, istiodA, result)
+	})
+}


### PR DESCRIPTION
## Summary

- Process ztunnel workloads **once per cluster** after all control planes are added, instead of inside the per-control-plane loop (which caused duplicate edges when multiple istiod deployments exist in the same cluster).
- Add `findManagingIstiod` helper that deterministically selects a single managing istiod by revision/tag match, `app.kubernetes.io/version` tie-breaker, and sorted namespace/name fallback.
  - Root cause is in `mesh/generator/generator.go`: ztunnel discovery and edge creation runs **inside** the `for _, cp := range meshDef.ControlPlanes` loop. When both control planes are in the same cluster, the same ztunnel workload is processed once per control plane iteration, and each pass can add another istiod→ztunnel edge.
- Add unit tests for the istiod matching logic.

Fixes #10286

## Test plan

- [x] `go test -race ./mesh/generator/... ./mesh/api/...`
- [ ] Deploy cluster with ambient mode and two control planes; verify Mesh page shows exactly one istiod→ztunnel edge per ztunnel node across multiple refreshes
- [ ] Verify single-control-plane ambient deployments still show the ztunnel connection (regression for #9714)

Made with [Cursor](https://cursor.com)