### PR TITLE
[AI] Use cached health status in mesh traffic graph AI tool

### DIFF
--- a/ai/mcp/get_mesh_traffic_graph/health_calculation.go
+++ b/ai/mcp/get_mesh_traffic_graph/health_calculation.go
@@ -120,11 +120,11 @@ func computeHealthSummary(
 						Name:      appName,
 						Status:    status,
 						Issue:     issue,
-						ErrorRate: calculateErrorRate(app.Requests),
+						ErrorRate: entityErrorRate(app.Status),
 					})
 				}
 
-				nsSummary.ErrorRate += calculateErrorRate(app.Requests)
+				nsSummary.ErrorRate += entityErrorRate(app.Status)
 			}
 		}
 
@@ -157,11 +157,11 @@ func computeHealthSummary(
 						Name:      svcName,
 						Status:    status,
 						Issue:     issue,
-						ErrorRate: calculateErrorRate(svc.Requests),
+						ErrorRate: entityErrorRate(svc.Status),
 					})
 				}
 
-				nsSummary.ErrorRate += calculateErrorRate(svc.Requests)
+				nsSummary.ErrorRate += entityErrorRate(svc.Status)
 			}
 		}
 
@@ -194,11 +194,11 @@ func computeHealthSummary(
 						Name:      wlName,
 						Status:    status,
 						Issue:     issue,
-						ErrorRate: calculateErrorRate(wl.Requests),
+						ErrorRate: entityErrorRate(wl.Status),
 					})
 				}
 
-				nsSummary.ErrorRate += calculateErrorRate(wl.Requests)
+				nsSummary.ErrorRate += entityErrorRate(wl.Status)
 			}
 		}
 
@@ -222,312 +222,83 @@ func computeHealthSummary(
 	return summary
 }
 
-// evaluateAppHealth determines app health status
+// evaluateAppHealth uses the backend-calculated status, same as Kiali list pages.
 func evaluateAppHealth(app *models.AppHealth) (status string, issue string) {
-	// Check workload statuses
-	totalWorkloads := len(app.WorkloadStatuses)
-	if totalWorkloads == 0 {
-		return "UNKNOWN", "no workloads found"
+	return statusFromCachedHealth(app.Status, app.WorkloadStatuses)
+}
+
+// evaluateServiceHealth uses the backend-calculated status, same as Kiali list pages.
+func evaluateServiceHealth(svc *models.ServiceHealth) (status string, issue string) {
+	return statusFromCachedHealth(svc.Status, nil)
+}
+
+// evaluateWorkloadHealth uses the backend-calculated status, same as Kiali list pages.
+func evaluateWorkloadHealth(wl *models.WorkloadHealth) (status string, issue string) {
+	if wl == nil {
+		return "UNKNOWN", ""
 	}
 
-	workloadStatus := "HEALTHY"
-	unhealthyCount := 0
-	for _, ws := range app.WorkloadStatuses {
-		// User has scaled down a workload, then desired replicas will be 0 and it's not an error condition
-		// This matches Kiali frontend logic: return NOT_READY when desiredReplicas === 0
-		if ws.DesiredReplicas == 0 {
-			workloadStatus = "NOT_READY"
-			issue = "scaled to 0 replicas"
+	var workloadStatuses []*models.WorkloadStatus
+	if wl.WorkloadStatus != nil {
+		workloadStatuses = []*models.WorkloadStatus{wl.WorkloadStatus}
+	}
+	return statusFromCachedHealth(wl.Status, workloadStatuses)
+}
+
+// statusFromCachedHealth maps backend CalculatedHealthStatus to mesh summary strings.
+// Health is computed once in business.HealthCalculator; this only aggregates for AI output.
+func statusFromCachedHealth(cached *models.CalculatedHealthStatus, workloadStatuses []*models.WorkloadStatus) (status string, issue string) {
+	if cached == nil {
+		return "UNKNOWN", ""
+	}
+
+	return modelsHealthStatusToSummary(cached.Status), issueFromCachedStatus(cached, workloadStatuses)
+}
+
+// modelsHealthStatusToSummary maps backend health status to mesh summary strings.
+func modelsHealthStatusToSummary(status models.HealthStatus) string {
+	switch status {
+	case models.HealthStatusHealthy:
+		return "HEALTHY"
+	case models.HealthStatusDegraded:
+		return "DEGRADED"
+	case models.HealthStatusFailure:
+		return "UNHEALTHY"
+	case models.HealthStatusNotReady:
+		return "NOT_READY"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func issueFromCachedStatus(cached *models.CalculatedHealthStatus, workloadStatuses []*models.WorkloadStatus) string {
+	for _, ws := range workloadStatuses {
+		if ws == nil {
 			continue
 		}
-
-		if ws.AvailableReplicas < ws.DesiredReplicas {
-			unhealthyCount++
-			issue = fmt.Sprintf("%d/%d replicas available", ws.AvailableReplicas, ws.DesiredReplicas)
-			if ws.AvailableReplicas == 0 {
-				workloadStatus = "UNHEALTHY"
-			} else if workloadStatus != "UNHEALTHY" {
-				workloadStatus = "DEGRADED"
-			}
-		}
-		if ws.SyncedProxies >= 0 && ws.SyncedProxies < ws.AvailableReplicas {
-			if issue == "" {
-				issue = fmt.Sprintf("%d/%d proxies synced", ws.SyncedProxies, ws.AvailableReplicas)
-			}
-			if workloadStatus == "HEALTHY" {
-				workloadStatus = "DEGRADED"
-			}
-		}
-	}
-
-	// Evaluate request health using tolerance-based logic (Kiali tolerances)
-	requestStatus, errorRate := evaluateRequestHealth(app.Requests)
-	if errorRate > 0 && issue == "" {
-		issue = fmt.Sprintf("error rate: %.2f%%", errorRate*100)
-	}
-
-	// Merge workload and request statuses (worst wins)
-	finalStatus := mergeHealthStatus(workloadStatus, requestStatus)
-	return finalStatus, issue
-}
-
-// evaluateServiceHealth determines service health status
-func evaluateServiceHealth(svc *models.ServiceHealth) (status string, issue string) {
-	// If there is no inbound or outbound traffic data, service health is UNKNOWN
-	if !hasAnyRequests(svc.Requests) {
-		return "UNKNOWN", ""
-	}
-
-	// Evaluate request health using tolerance-based logic (Kiali tolerances)
-	status, errorRate := evaluateRequestHealth(svc.Requests)
-
-	if errorRate > 0 && issue == "" {
-		issue = fmt.Sprintf("error rate: %.2f%%", errorRate*100)
-	}
-	return status, issue
-}
-
-// hasAnyRequests returns true if there is any non-zero request count in inbound or outbound
-func hasAnyRequests(req models.RequestHealth) bool {
-	// Check inbound
-	for _, codes := range req.Inbound {
-		for _, count := range codes {
-			if count > 0 {
-				return true
-			}
-		}
-	}
-	// Check outbound
-	for _, codes := range req.Outbound {
-		for _, count := range codes {
-			if count > 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// evaluateWorkloadHealth determines workload health status
-func evaluateWorkloadHealth(wl *models.WorkloadHealth) (status string, issue string) {
-	workloadStatus := "HEALTHY"
-
-	if wl.WorkloadStatus != nil {
-		ws := wl.WorkloadStatus
-		// User has scaled down a workload, then desired replicas will be 0 and it's not an error condition
-		// This matches Kiali frontend logic: return NOT_READY when desiredReplicas === 0
 		if ws.DesiredReplicas == 0 {
-			workloadStatus = "NOT_READY"
-			issue = "scaled to 0 replicas"
-		} else if ws.AvailableReplicas < ws.DesiredReplicas {
-			issue = fmt.Sprintf("%d/%d replicas available", ws.AvailableReplicas, ws.DesiredReplicas)
-			if ws.AvailableReplicas == 0 {
-				workloadStatus = "UNHEALTHY"
-			} else {
-				workloadStatus = "DEGRADED"
-			}
+			return "scaled to 0 replicas"
+		}
+		if ws.AvailableReplicas < ws.DesiredReplicas {
+			return fmt.Sprintf("%d/%d replicas available", ws.AvailableReplicas, ws.DesiredReplicas)
 		}
 		if ws.SyncedProxies >= 0 && ws.SyncedProxies < ws.AvailableReplicas {
-			if issue == "" {
-				issue = fmt.Sprintf("%d/%d proxies synced", ws.SyncedProxies, ws.AvailableReplicas)
-			}
-			if workloadStatus == "HEALTHY" {
-				workloadStatus = "DEGRADED"
-			}
+			return fmt.Sprintf("%d/%d proxies synced", ws.SyncedProxies, ws.AvailableReplicas)
 		}
 	}
 
-	// Evaluate request health using tolerance-based logic (Kiali tolerances)
-	requestStatus, errorRate := evaluateRequestHealth(wl.Requests)
-
-	// If there is no inbound or outbound traffic data and no workload status info, mark UNKNOWN
-	if !hasAnyRequests(wl.Requests) && wl.WorkloadStatus == nil {
-		return "UNKNOWN", ""
+	if cached != nil && cached.ErrorRatio > 0 {
+		return fmt.Sprintf("error rate: %.2f%%", cached.ErrorRatio)
 	}
-	if errorRate > 0 && issue == "" {
-		issue = fmt.Sprintf("error rate: %.2f%%", errorRate*100)
-	}
-
-	// Merge workload and request statuses (worst wins)
-	finalStatus := mergeHealthStatus(workloadStatus, requestStatus)
-	return finalStatus, issue
+	return ""
 }
 
-// mergeHealthStatus returns the worst of two health statuses
-// Priority matches Kiali frontend: UNHEALTHY(4) > DEGRADED(3) > NOT_READY(2) > HEALTHY(1) > UNKNOWN(0)
-func mergeHealthStatus(s1, s2 string) string {
-	priority := map[string]int{
-		"UNHEALTHY": 4,
-		"DEGRADED":  3,
-		"NOT_READY": 2,
-		"HEALTHY":   1,
-		"UNKNOWN":   0,
-	}
-
-	if priority[s1] > priority[s2] {
-		return s1
-	}
-	return s2
-}
-
-// calculateErrorRate computes error percentage from request health
-// This uses a simplified approach - for each protocol/code combination,
-// it checks against tolerance thresholds to determine if it's an error
-func calculateErrorRate(req models.RequestHealth) float64 {
-	totalRequests := 0.0
-	errorRequests := 0.0
-
-	// Count inbound
-	for protocol, codes := range req.Inbound {
-		for code, count := range codes {
-			totalRequests += count
-			if isErrorCode(protocol, code) {
-				errorRequests += count
-			}
-		}
-	}
-
-	// Count outbound
-	for protocol, codes := range req.Outbound {
-		for code, count := range codes {
-			totalRequests += count
-			if isErrorCode(protocol, code) {
-				errorRequests += count
-			}
-		}
-	}
-
-	if totalRequests == 0 {
+// entityErrorRate returns the error ratio (0-1) from backend-calculated status.
+func entityErrorRate(cached *models.CalculatedHealthStatus) float64 {
+	if cached == nil || cached.ErrorRatio < 0 {
 		return 0.0
 	}
-	return errorRequests / totalRequests
-}
-
-// isErrorCode checks if a status code represents an error
-// Based on Kiali's default tolerance configuration
-func isErrorCode(protocol, code string) bool {
-	switch protocol {
-	case "http":
-		// "-" represents aborted/fault-injected requests (always an error)
-		if code == "-" {
-			return true
-		}
-		// 4xx client errors
-		if len(code) == 3 && code[0] == '4' {
-			return true
-		}
-		// 5xx server errors
-		if len(code) == 3 && code[0] == '5' {
-			return true
-		}
-	case "grpc":
-		// "-" represents aborted requests
-		if code == "-" {
-			return true
-		}
-		// gRPC error codes (1-16, non-zero)
-		if code != "0" {
-			return true
-		}
-	}
-	return false
-}
-
-// evaluateRequestHealth evaluates health status based on request metrics
-// Returns status and worst error ratio found
-func evaluateRequestHealth(req models.RequestHealth) (status string, worstRatio float64) {
-	status = "HEALTHY"
-	worstRatio = 0.0
-
-	// Helper to process requests (inbound or outbound)
-	processRequests := func(requests map[string]map[string]float64) {
-		for protocol, codes := range requests {
-			totalForProtocol := 0.0
-
-			// Calculate totals
-			for _, count := range codes {
-				totalForProtocol += count
-			}
-
-			if totalForProtocol == 0 {
-				continue
-			}
-
-			// Calculate error ratios for each code
-			for code, count := range codes {
-				if isErrorCode(protocol, code) {
-					ratio := count / totalForProtocol
-
-					// Track worst ratio
-					if ratio > worstRatio {
-						worstRatio = ratio
-					}
-
-					// Evaluate against tolerance thresholds
-					// Based on Kiali defaults:
-					// - Code "-": degraded=0%, failure=10%
-					// - 5xx: degraded=0%, failure=10%
-					// - 4xx: degraded=10%, failure=20%
-					// - grpc errors: degraded=0%, failure=10%
-
-					codeStatus := getStatusForCodeRatio(protocol, code, ratio)
-					if codeStatus == "UNHEALTHY" {
-						status = "UNHEALTHY"
-					} else if codeStatus == "DEGRADED" && status == "HEALTHY" {
-						status = "DEGRADED"
-					}
-				}
-			}
-		}
-	}
-
-	processRequests(req.Inbound)
-	processRequests(req.Outbound)
-
-	return status, worstRatio
-}
-
-// getStatusForCodeRatio determines health status based on error code and ratio
-// Implements Kiali's default tolerance configuration
-func getStatusForCodeRatio(protocol, code string, ratio float64) string {
-	percentage := ratio * 100
-
-	switch protocol {
-	case "http":
-		if code == "-" {
-			// Aborted/fault-injected: degraded=0%, failure=10%
-			if percentage >= 10 {
-				return "UNHEALTHY"
-			} else if percentage > 0 {
-				return "DEGRADED"
-			}
-		} else if len(code) == 3 && code[0] == '5' {
-			// 5xx errors: degraded=0%, failure=10%
-			if percentage >= 10 {
-				return "UNHEALTHY"
-			} else if percentage > 0 {
-				return "DEGRADED"
-			}
-		} else if len(code) == 3 && code[0] == '4' {
-			// 4xx errors: degraded=10%, failure=20%
-			if percentage >= 20 {
-				return "UNHEALTHY"
-			} else if percentage >= 10 {
-				return "DEGRADED"
-			}
-		}
-	case "grpc":
-		// gRPC errors (including "-"): degraded=0%, failure=10%
-		if code != "0" {
-			if percentage >= 10 {
-				return "UNHEALTHY"
-			} else if percentage > 0 {
-				return "DEGRADED"
-			}
-		}
-	}
-
-	return "HEALTHY"
+	return cached.ErrorRatio / 100.0
 }
 
 // computeNamespaceStatus determines namespace overall status

--- a/ai/mcp/get_mesh_traffic_graph/health_calculation.go
+++ b/ai/mcp/get_mesh_traffic_graph/health_calculation.go
@@ -2,6 +2,7 @@ package get_mesh_traffic_graph
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -272,7 +273,21 @@ func modelsHealthStatusToSummary(status models.HealthStatus) string {
 }
 
 func issueFromCachedStatus(cached *models.CalculatedHealthStatus, workloadStatuses []*models.WorkloadStatus) string {
-	for _, ws := range workloadStatuses {
+	sorted := slices.Clone(workloadStatuses)
+	slices.SortFunc(sorted, func(a, b *models.WorkloadStatus) int {
+		if a == nil && b == nil {
+			return 0
+		}
+		if a == nil {
+			return 1
+		}
+		if b == nil {
+			return -1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	for _, ws := range sorted {
 		if ws == nil {
 			continue
 		}

--- a/ai/mcp/get_mesh_traffic_graph/health_calculation_test.go
+++ b/ai/mcp/get_mesh_traffic_graph/health_calculation_test.go
@@ -1,0 +1,128 @@
+package get_mesh_traffic_graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiali/kiali/models"
+)
+
+func TestModelsHealthStatusToSummary(t *testing.T) {
+	tests := []struct {
+		status   models.HealthStatus
+		expected string
+	}{
+		{models.HealthStatusHealthy, "HEALTHY"},
+		{models.HealthStatusDegraded, "DEGRADED"},
+		{models.HealthStatusFailure, "UNHEALTHY"},
+		{models.HealthStatusNotReady, "NOT_READY"},
+		{models.HealthStatusNA, "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			assert.Equal(t, tt.expected, modelsHealthStatusToSummary(tt.status))
+		})
+	}
+}
+
+func TestEvaluateAppHealth_UsesCachedStatus(t *testing.T) {
+	app := &models.AppHealth{
+		Status: &models.CalculatedHealthStatus{
+			ErrorRatio: 5,
+			Status:     models.HealthStatusDegraded,
+		},
+	}
+
+	status, issue := evaluateAppHealth(app)
+
+	assert.Equal(t, "DEGRADED", status)
+	assert.Contains(t, issue, "error rate: 5.00%")
+}
+
+func TestEvaluateAppHealth_UsesCachedStatusNotLocalThresholds(t *testing.T) {
+	app := &models.AppHealth{
+		Status: &models.CalculatedHealthStatus{
+			ErrorRatio: 5,
+			Status:     models.HealthStatusFailure,
+		},
+		Requests: models.RequestHealth{
+			Inbound: map[string]map[string]float64{
+				"http": {"500": 5, "200": 95},
+			},
+		},
+	}
+
+	status, _ := evaluateAppHealth(app)
+
+	assert.Equal(t, "UNHEALTHY", status)
+}
+
+func TestEvaluateServiceHealth_UsesCachedStatus(t *testing.T) {
+	svc := &models.ServiceHealth{
+		Status: &models.CalculatedHealthStatus{
+			ErrorRatio: 12,
+			Status:     models.HealthStatusFailure,
+		},
+	}
+
+	status, issue := evaluateServiceHealth(svc)
+
+	assert.Equal(t, "UNHEALTHY", status)
+	assert.Contains(t, issue, "error rate: 12.00%")
+}
+
+func TestStatusFromCachedHealth_MissingStatus(t *testing.T) {
+	status, issue := statusFromCachedHealth(nil, nil)
+
+	assert.Equal(t, "UNKNOWN", status)
+	assert.Empty(t, issue)
+}
+
+func TestEvaluateWorkloadHealth_UsesCachedStatus(t *testing.T) {
+	wl := &models.WorkloadHealth{
+		Status: &models.CalculatedHealthStatus{
+			Status: models.HealthStatusNotReady,
+		},
+		WorkloadStatus: &models.WorkloadStatus{
+			AvailableReplicas: 0,
+			DesiredReplicas:   0,
+		},
+	}
+
+	status, issue := evaluateWorkloadHealth(wl)
+
+	assert.Equal(t, "NOT_READY", status)
+	assert.Contains(t, issue, "scaled to 0 replicas")
+}
+
+func TestIssueFromCachedStatus_PrefersWorkloadIssueOverErrorRate(t *testing.T) {
+	cached := &models.CalculatedHealthStatus{
+		ErrorRatio: 12,
+		Status:     models.HealthStatusFailure,
+	}
+	workloadStatuses := []*models.WorkloadStatus{
+		{
+			AvailableReplicas: 1,
+			DesiredReplicas:   3,
+		},
+	}
+
+	issue := issueFromCachedStatus(cached, workloadStatuses)
+
+	assert.Equal(t, "1/3 replicas available", issue)
+}
+
+func TestEvaluateWorkloadHealth_NilWorkload(t *testing.T) {
+	status, issue := evaluateWorkloadHealth(nil)
+
+	assert.Equal(t, "UNKNOWN", status)
+	assert.Empty(t, issue)
+}
+
+func TestEntityErrorRate_UsesCachedStatus(t *testing.T) {
+	status := &models.CalculatedHealthStatus{ErrorRatio: 25}
+
+	assert.InDelta(t, 0.25, entityErrorRate(status), 0.001)
+}

--- a/ai/mcp/get_mesh_traffic_graph/health_calculation_test.go
+++ b/ai/mcp/get_mesh_traffic_graph/health_calculation_test.go
@@ -104,6 +104,7 @@ func TestIssueFromCachedStatus_PrefersWorkloadIssueOverErrorRate(t *testing.T) {
 	}
 	workloadStatuses := []*models.WorkloadStatus{
 		{
+			Name:              "reviews-v1",
 			AvailableReplicas: 1,
 			DesiredReplicas:   3,
 		},
@@ -112,6 +113,28 @@ func TestIssueFromCachedStatus_PrefersWorkloadIssueOverErrorRate(t *testing.T) {
 	issue := issueFromCachedStatus(cached, workloadStatuses)
 
 	assert.Equal(t, "1/3 replicas available", issue)
+}
+
+func TestIssueFromCachedStatus_SortsWorkloadsByName(t *testing.T) {
+	workloads := []*models.WorkloadStatus{
+		{
+			Name:              "reviews-v2",
+			AvailableReplicas: 0,
+			DesiredReplicas:   2,
+		},
+		{
+			Name:              "productpage-v1",
+			AvailableReplicas: 1,
+			DesiredReplicas:   3,
+		},
+	}
+	reversed := []*models.WorkloadStatus{workloads[1], workloads[0]}
+
+	issue := issueFromCachedStatus(nil, workloads)
+	reversedIssue := issueFromCachedStatus(nil, reversed)
+
+	assert.Equal(t, "1/3 replicas available", issue)
+	assert.Equal(t, issue, reversedIssue)
 }
 
 func TestEvaluateWorkloadHealth_NilWorkload(t *testing.T) {


### PR DESCRIPTION
### Describe the change

The `get_mesh_traffic_graph` MCP tool used to recompute traffic health with hardcoded default thresholds, ignoring `health_config.rate` and rate annotations. That caused AI summaries to disagree with Kiali list pages and `kiali_health_status`.

This change consumes the backend `CalculatedHealthStatus` already returned by `GetNamespaceAppHealth` / `GetNamespaceServiceHealth` / `GetNamespaceWorkloadHealth` — the same cached status the UI uses — and only maps it into the compact AI summary format.

### Steps to test the PR

#### Prerequisites

1. KinD cluster with Istio and demo apps (bookinfo + error rates recommended):

```bash
make build-ui build
hack/run-integration-tests.sh --test-suite local --setup-only true
```

2. Start Kiali locally with AI enabled (add your provider API key):

```bash
# Example: extend ci-test-config-no-cache.yaml with chat_ai.enabled: true and a provider key
$(go env GOPATH)/bin/kiali \
  -c hack/ci-yaml/ci-test-config-no-cache.yaml run \
  --cluster-name-overrides kind-ci=cluster-default \
  --port-forward-prom --no-browser
```

3. Open Kiali at http://localhost:20001 and open the **AI Assistant** panel.

#### Optional: custom health thresholds (best way to see the fix)

Apply a custom tolerance so UI health differs from the old hardcoded AI defaults (failure at 10% for 5xx):

```yaml
health_config:
  rate:
    - kind: app
      name: reviews
      namespace: bookinfo
      tolerance:
        - code: "5xx"
          degraded: 0
          failure: 50
```

Restart Kiali after changing config. With ~15% 5xx traffic from the error-rates demo, the **Applications** list should show **Healthy**, while the old AI path would have reported **Degraded/Unhealthy**.

#### Kiali AI queries to run

Ask the AI Assistant these prompts (one at a time is fine):

1. **"Show me the traffic graph for the bookinfo namespace and summarize the mesh health."**

2. **"Get the mesh traffic graph for bookinfo. Which apps or services are unhealthy or degraded?"**

3. **"What is the overall health of the bookinfo namespace? Include entity counts from the traffic graph health summary."**

4. **(If custom health_config is applied)** **"Is the reviews app in bookinfo healthy? Compare its health with what you see in the mesh traffic graph summary."**

#### Expected results

- AI health summary (`health.overallStatus`, per-namespace counts, `topUnhealthy`) matches the **Applications/Services/Workloads** list health icons for the same entities.
- With custom `health_config`, AI follows the UI/backend status (e.g. reviews stays **Healthy** at 15% 5xx when failure threshold is 50%), not the old hardcoded 10% failure default.
- Issue text in `topUnhealthy` prefers actionable workload problems (replicas/proxies) over error-rate percentage when both exist.

#### Compare with UI

1. Go to **Applications** → select namespace **bookinfo**.
2. Note health for apps with traffic errors (e.g. reviews, ratings).
3. Confirm the AI answers from the queries above report the same status.

#### Unit tests

```bash
go test ./ai/mcp/get_mesh_traffic_graph/... -run 'Health|Cached|Issue|Entity|Workload'
```

### Automation testing

Added unit tests in `health_calculation_test.go` covering:
- Mapping of backend `HealthStatus` to summary strings
- Use of cached status instead of local threshold logic
- Workload issue priority over error rate in issue text
- Nil workload guard

### Issue reference

Fixes #10097

Made with [Cursor](https://cursor.com)