### PR TITLE
[CI] Update workload for traces verification

### DIFF
--- a/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
+++ b/frontend/cypress/integration/featureFiles/waypoint_multicluster.feature
@@ -52,9 +52,9 @@ Feature: Kiali Waypoint in Ambient Multi-Primary (multi-cluster)
     Then the user sees the L7 "waypoint" link
     And the waypoint link points to the "west" cluster
 
-  Scenario: [Tracing] Verify traces for productpage-v1 in east cluster
-    Given the "productpage-v1" tracing data is ready in the "bookinfo-waypoints" namespace for the "east" cluster
-    And user is at the details page for the "workload" "bookinfo-waypoints/productpage-v1" located in the "east" cluster
+  Scenario: [Tracing] Verify traces for reviews-v1 in east cluster
+    Given the "reviews-v1" tracing data is ready in the "bookinfo-waypoints" namespace for the "east" cluster
+    And user is at the details page for the "workload" "bookinfo-waypoints/reviews-v1" located in the "east" cluster
     Then user sees trace information
     When user selects a trace
     Then user sees trace details


### PR DESCRIPTION
### Describe the change
Previous version of Istio doesn't have traces in productpage: 
<img width="1887" height="959" alt="image" src="https://github.com/user-attachments/assets/c59d7d83-87c5-4067-85d0-b0efcff166ef" />

<img width="482" height="639" alt="image" src="https://github.com/user-attachments/assets/420bc97a-2474-4fa5-bfcc-596953236634" />

<img width="1898" height="729" alt="image" src="https://github.com/user-attachments/assets/5e7e6bde-0c82-48a1-8ae2-d0d13a49a8ed" />

<img width="1897" height="985" alt="image" src="https://github.com/user-attachments/assets/256343c2-c0c3-4e3f-9272-eede91615713" />


### Steps to test the PR

Tested with Istio 1.29.2: https://github.com/josunect/kiali/actions/runs/34233649523/job/102089207062 

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference
Fixes https://github.com/kiali/kiali/issues/10290 
