### PR TITLE
[playwright] Port @crd-validation istio config validation tests

### DIFF
--- a/.github/workflows/integration-tests-frontend-playwright-core-optional.yml
+++ b/.github/workflows/integration-tests-frontend-playwright-core-optional.yml
@@ -1,0 +1,137 @@
+name: Integration Tests Frontend Playwright Core Optional
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: true
+        type: string
+      build_branch:
+        required: true
+        type: string
+      istio_version:
+        required: false
+        type: string
+        default: ""
+      stern_logs:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  TARGET_BRANCH: ${{ inputs.target_branch }}
+  BUILD_BRANCH: ${{ inputs.build_branch || inputs.target_branch }}
+
+jobs:
+  integration_tests_frontend_playwright_core_optional:
+    name: Playwright tests (core optional)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CI: 1
+      TERM: xterm
+    steps:
+    - name: Check out code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.build_branch }}
+
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        docker system prune -af --volumes
+
+    - name: Start resource sampler
+      run: nohup nice -n 19 bash hack/ci-resource-sampler.sh start --csv /tmp/ci-telemetry-frontend-playwright-core-optional.csv > /tmp/sampler.out 2>&1 &
+      continue-on-error: true
+
+    - name: Install Helm
+      uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      with:
+        version: 'v3.18.4'
+
+    - name: Enable corepack
+      run: corepack enable
+
+    - name: Setup node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: "24"
+        cache: yarn
+        cache-dependency-path: frontend/yarn.lock
+
+    - name: Download go binary
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: kiali
+        path: ~/go/bin/
+
+    - name: Ensure kiali binary is executable
+      run: chmod +x ~/go/bin/kiali
+
+    - name: Install frontend dependencies
+      working-directory: ./frontend
+      run: yarn install --immutable
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('frontend/yarn.lock') }}
+
+    - name: Run Playwright core optional integration tests
+      run: hack/run-integration-tests.sh --test-suite playwright-core-optional --stern ${{ inputs.stern_logs }} $(if [ -n "${{ inputs.istio_version }}" ]; then echo "--istio-version ${{ inputs.istio_version }}"; fi)
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: junit-frontend-playwright-core-optional-report
+        path: frontend/playwright-results/combined-report.xml
+        if-no-files-found: warn
+
+    - name: Stop resource sampler
+      if: always()
+      run: bash hack/ci-resource-sampler.sh stop --csv /tmp/ci-telemetry-frontend-playwright-core-optional.csv || true
+      continue-on-error: true
+
+    - name: Upload resource telemetry
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      continue-on-error: true
+      with:
+        name: resource-telemetry-frontend-playwright-core-optional
+        path: /tmp/ci-telemetry-frontend-playwright-core-optional.csv
+        retention-days: 14
+        if-no-files-found: ignore
+
+    - name: Get debug info when integration tests fail
+      if: failure()
+      run: |
+        mkdir debug-output
+        hack/ci-get-debug-info.sh --output-directory debug-output
+
+    - name: Upload debug info artifact
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: debug-info-frontend-playwright-core-optional
+        path: debug-output
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: playwright-report-core-optional
+        path: |
+          frontend/playwright-report
+          frontend/test-results
+          frontend/playwright-results
+        if-no-files-found: ignore
+
+    - name: Upload stern logs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ inputs.stern_logs == true }}
+      with:
+        name: playwright-logs-frontend-core-optional
+        path: hack/stern

--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -90,3 +90,11 @@ jobs:
     with:
       target_branch: ${{ needs.initialize.outputs.target-branch }}
       build_branch: ${{ needs.initialize.outputs.build-branch }}
+
+  integration_tests_frontend_playwright_core_optional:
+    name: Run Playwright core optional tests
+    uses: ./.github/workflows/integration-tests-frontend-playwright-core-optional.yml
+    needs: [initialize, build_backend]
+    with:
+      target_branch: ${{ needs.initialize.outputs.target-branch }}
+      build_branch: ${{ needs.initialize.outputs.build-branch }}

--- a/frontend/e2e/MIGRATION-PLAN.md
+++ b/frontend/e2e/MIGRATION-PLAN.md
@@ -85,7 +85,7 @@
 - [x] `@core-1` suite passes (145 tests, PR #10195 + #10220)
 - [x] `@core-2` suite passes (PR #10269)
 - [x] `@core-caching` suite ported (playwright-core-caching CI; health/graph cache enabled locally)
-- [ ] `@crd-validation` suite passes (Playwright spec ported; run `yarn playwright:run:crd-validation`)
+- [ ] `@crd-validation` suite passes (Playwright spec + `playwright-core-optional` CI; run `yarn playwright:run:core-optional`)
 - [ ] `@perses` suite passes
 - [ ] `@ambient` suite passes
 - [ ] `@waypoint` suite passes
@@ -105,7 +105,8 @@
 - [x] During migration: Playwright runs **alongside** Cypress in GitHub Actions for migrated suites
   (coexistence) (PR #10195 — `integration-tests-frontend-playwright-core-1.yml`)
 - [x] `hack/run-integration-tests.sh` updated for `playwright-smoke`, `playwright-core-1`,
-  `playwright-core-2`, and `playwright-core-caching` suites (PR #10174, #10195, #10220, #10269)
+  `playwright-core-2`, `playwright-core-caching`, and `playwright-core-optional` suites
+  (PR #10174, #10195, #10220, #10269, #10292)
 - [ ] `hack/run-integration-tests.sh` updated for all remaining Playwright projects
 - [x] GitHub Actions workflows updated for Playwright (JUnit artifacts, screenshots/traces on failure)
   (PR #10174, #10220; core-caching workflow on epic branch)

--- a/frontend/e2e/MIGRATION-PLAN.md
+++ b/frontend/e2e/MIGRATION-PLAN.md
@@ -85,7 +85,7 @@
 - [x] `@core-1` suite passes (145 tests, PR #10195 + #10220)
 - [x] `@core-2` suite passes (PR #10269)
 - [x] `@core-caching` suite ported (playwright-core-caching CI; health/graph cache enabled locally)
-- [ ] `@crd-validation` suite passes
+- [ ] `@crd-validation` suite passes (Playwright spec ported; run `yarn playwright:run:crd-validation`)
 - [ ] `@perses` suite passes
 - [ ] `@ambient` suite passes
 - [ ] `@waypoint` suite passes

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -86,7 +86,7 @@ Use `isVisible()` / `isHidden()` for toggle guards — same semantics as `toBeVi
 
 ### CI and Jenkins
 
-- **GitHub** (`playwright-smoke`, `playwright-core-1`, `playwright-core-2`, `playwright-core-caching`): KinD cluster + local `kiali` binary. Smoke/core-1/core-2 use `hack/ci-yaml/ci-test-config-no-cache.yaml`; **core-caching** uses `ci-test-config-cache.yaml` (graph + health cache enabled) and installs **bookinfo only** before Kiali starts. One parallel job per suite.
+- **GitHub** (`playwright-smoke`, `playwright-core-1`, `playwright-core-2`, `playwright-core-caching`, `playwright-core-optional`): KinD cluster + local `kiali` binary. Smoke/core-1/core-2/core-optional use `hack/ci-yaml/ci-test-config-no-cache.yaml`; **core-caching** uses `ci-test-config-cache.yaml` (graph + health cache enabled) and installs **bookinfo only** before Kiali starts. **core-optional** installs bookinfo + sleep + Perses (same cluster setup as Cypress `frontend-core-optional`). One parallel job per suite.
 - **Jenkins** (`kiali-playwright-tests`): in-cluster OSSM Kiali via OpenShift route (downstream validation). Default `TEST_SET` is `playwright:run:junit` (crd-validation, core-1, core-2, core-caching). Error-rates health tests poll `/api/.../health`; empty `health_config.rate` on the OSSM CR is fine (Kiali uses built-in degraded thresholds).
 - **Do not run `playwright test --last-failed` before merge-reports** — the rerun overwrites `blob-report/` and Jenkins `combined-report.xml` only lists rerun tests (misleading failure counts).
 - **JUnit**: Playwright may record timeouts as `errors` not `failures` — check both in XML.
@@ -128,6 +128,14 @@ $(go env GOPATH)/bin/kiali \
 
 Full KinD setup: `hack/run-integration-tests.sh --test-suite playwright-core-caching`.
 
+### Core-optional (`yarn playwright:run:core-optional`)
+
+Ports Cypress `frontend-core-optional` scope: `@crd-validation` and `@perses` Playwright projects. KinD setup matches Cypress (bookinfo + sleep, Perses Helm chart in `istio-system`).
+
+```bash
+hack/run-integration-tests.sh --test-suite playwright-core-optional
+```
+
 ## Local run
 
 Kiali UI at `http://localhost:3001` (override with `PLAYWRIGHT_BASE_URL`):
@@ -139,6 +147,7 @@ yarn playwright:run:smoke
 yarn playwright:run:core1
 yarn playwright:run:core2
 yarn playwright:run:core-caching
+yarn playwright:run:core-optional
 yarn playwright:run:smoke --headed
 yarn playwright:ui --project=smoke
 ```
@@ -147,7 +156,7 @@ Use `yarn playwright:install` — not `yarn playwright install`.
 
 ## CI
 
-PRs targeting `epic/playwright-migration` run **Playwright CI** (`.github/workflows/playwright-ci.yml`): build + parallel `playwright-smoke`, `playwright-core-1`, `playwright-core-2`, and `playwright-core-caching` integration suites (`hack/run-integration-tests.sh`).
+PRs targeting `epic/playwright-migration` run **Playwright CI** (`.github/workflows/playwright-ci.yml`): build + parallel `playwright-smoke`, `playwright-core-1`, `playwright-core-2`, `playwright-core-caching`, and `playwright-core-optional` integration suites (`hack/run-integration-tests.sh`).
 
 Jenkins: `kiali/test-jobs/kiali-playwright-tests` — prefer `TEST_SET=playwright:run:smoke` or `playwright:run:all` with empty `TEST_TAGS` on OpenShift; use `playwright:run:core1` equivalent via `run:all` or future dedicated script.
 

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -29,6 +29,17 @@ const VALIDATION_FILTERS = ['Valid', 'Not Valid', 'Not Validated', 'Warning'] as
 
 const GATEWAY_GVK = 'networking.istio.io/v1, Kind=Gateway';
 
+const ISTIO_TYPE_GVK: Record<string, string> = {
+  AuthorizationPolicy: 'security.istio.io/v1, Kind=AuthorizationPolicy',
+  DestinationRule: 'networking.istio.io/v1, Kind=DestinationRule',
+  Gateway: GATEWAY_GVK,
+  K8sGateway: 'gateway.networking.k8s.io/v1, Kind=Gateway',
+  K8sReferenceGrant: 'gateway.networking.k8s.io/v1beta1, Kind=ReferenceGrant',
+  PeerAuthentication: 'security.istio.io/v1, Kind=PeerAuthentication',
+  Sidecar: 'networking.istio.io/v1, Kind=Sidecar',
+  VirtualService: 'networking.istio.io/v1, Kind=VirtualService'
+};
+
 const VALIDATION_ICON: Record<string, string> = {
   danger: 'icon-error-validation',
   error: 'icon-error-validation',
@@ -329,6 +340,38 @@ export class IstioConfigPage extends BasePage {
     }
   }
 
+  private async hasApiValidationStatus(
+    namespace: string,
+    typeName: string,
+    instanceName: string,
+    healthStatus: string
+  ): Promise<boolean> {
+    const gvk = ISTIO_TYPE_GVK[typeName];
+    if (!gvk) {
+      return true;
+    }
+
+    const response = await this.page.request.get(`/api/namespaces/${namespace}/istio?validate=true&_=${Date.now()}`);
+    if (!response.ok()) {
+      return false;
+    }
+
+    const body = (await response.json()) as {
+      validations?: Record<string, Record<string, { checks?: Array<{ severity?: string }>; valid?: boolean }>>;
+    };
+    const entry = body.validations?.[gvk]?.[`${instanceName}.${namespace}`];
+    if (!entry) {
+      return false;
+    }
+
+    if (healthStatus === 'success') {
+      return entry.valid === true;
+    }
+
+    const expectedSeverity = healthStatus === 'warning' ? 'warning' : 'error';
+    return (entry.checks ?? []).some(check => check.severity === expectedSeverity);
+  }
+
   async expectValidationStatus(
     namespace: string,
     typeName: string,
@@ -341,11 +384,14 @@ export class IstioConfigPage extends BasePage {
     const expectedIcon = VALIDATION_ICON[healthStatus];
 
     await expect(async () => {
+      if (!(await this.hasApiValidationStatus(namespace, typeName, instanceName, healthStatus))) {
+        throw new Error(`API validation not ready for ${typeName}/${instanceName} (${healthStatus})`);
+      }
       await this.page.request.get(`/api/istio/config?validate=true&_=${Date.now()}`);
       await this.refreshList();
       await expect(row).toBeVisible({ timeout: 5_000 });
       await expect(row.locator(`[data-test="${expectedIcon}"]`)).toBeVisible({ timeout: 5_000 });
-    }).toPass({ intervals: [3_000], timeout: 90_000 });
+    }).toPass({ intervals: [3_000], timeout: 120_000 });
   }
 
   async openConfigByName(name: string): Promise<void> {

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -40,6 +40,10 @@ const ISTIO_TYPE_GVK: Record<string, string> = {
   VirtualService: 'networking.istio.io/v1, Kind=VirtualService'
 };
 
+const ISTIO_DETAIL_API_PATH: Record<string, string> = {
+  PeerAuthentication: 'security.istio.io/v1/PeerAuthentication'
+};
+
 const VALIDATION_ICON: Record<string, string> = {
   danger: 'icon-error-validation',
   error: 'icon-error-validation',
@@ -498,11 +502,61 @@ export class IstioConfigPage extends BasePage {
     await waitForLoadingComplete(this.page);
   }
 
+  private configurationAnalysisSection(): Locator {
+    return this.page.getByRole('heading', { name: 'Configuration Analysis' }).locator('../..');
+  }
+
+  private async hasDetailsApiValidationCode(
+    namespace: string,
+    typeName: string,
+    instanceName: string,
+    validationCode: string
+  ): Promise<boolean> {
+    const detailPath = ISTIO_DETAIL_API_PATH[typeName];
+    if (!detailPath) {
+      return true;
+    }
+
+    const response = await this.page.request.get(
+      `/api/namespaces/${namespace}/istio/${detailPath}/${instanceName}?validate=true&_=${Date.now()}`
+    );
+    if (!response.ok()) {
+      return false;
+    }
+
+    const body = (await response.json()) as { validation?: { checks?: Array<{ code?: string }> } };
+    return (body.validation?.checks ?? []).some(check => check.code === validationCode);
+  }
+
+  /** PeerAuthentication list rows show N/A until the details page is loaded with validate=true. */
+  async expectValidationOnDetailsPage(
+    namespace: string,
+    typeName: string,
+    instanceName: string,
+    validationCode: string
+  ): Promise<void> {
+    await this.ensureConfigurationValidationEnabled();
+    await this.openConfigByRow(namespace, typeName, instanceName);
+
+    const analysisSection = this.configurationAnalysisSection();
+    await expect(async () => {
+      if (!(await this.hasDetailsApiValidationCode(namespace, typeName, instanceName, validationCode))) {
+        throw new Error(`Detail API validation missing ${validationCode} for ${typeName}/${instanceName}`);
+      }
+      await waitForLoadingComplete(this.page);
+      await expect(analysisSection.getByText(validationCode)).toBeVisible({ timeout: 5_000 });
+      await expect(analysisSection.locator('[data-test="icon-error-validation"]')).toBeVisible({ timeout: 5_000 });
+    }).toPass({ intervals: [3_000], timeout: 120_000 });
+  }
+
   async expectGroupedValidationMessage(code: string, count: number): Promise<void> {
-    await waitForLoadingComplete(this.page);
-    // Heading sits in a StackItem; validation rows are sibling StackItems in the same Stack.
-    const analysisSection = this.page.getByRole('heading', { name: 'Configuration Analysis' }).locator('../..');
-    await expect(analysisSection.getByText(new RegExp(`${code}.*\\(${count}\\)`))).toBeVisible();
+    const messagePattern = count > 1 ? new RegExp(`${code}.*\\(${count}\\)`) : new RegExp(code);
+    const analysisSection = this.configurationAnalysisSection();
+
+    await expect(async () => {
+      await waitForLoadingComplete(this.page);
+      await expect(analysisSection.getByText(messagePattern)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ intervals: [3_000], timeout: 120_000 });
   }
 }
 

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -29,21 +29,6 @@ const VALIDATION_FILTERS = ['Valid', 'Not Valid', 'Not Validated', 'Warning'] as
 
 const GATEWAY_GVK = 'networking.istio.io/v1, Kind=Gateway';
 
-const ISTIO_TYPE_GVK: Record<string, string> = {
-  AuthorizationPolicy: 'security.istio.io/v1, Kind=AuthorizationPolicy',
-  DestinationRule: 'networking.istio.io/v1, Kind=DestinationRule',
-  Gateway: GATEWAY_GVK,
-  K8sGateway: 'gateway.networking.k8s.io/v1, Kind=Gateway',
-  K8sReferenceGrant: 'gateway.networking.k8s.io/v1beta1, Kind=ReferenceGrant',
-  PeerAuthentication: 'security.istio.io/v1, Kind=PeerAuthentication',
-  Sidecar: 'networking.istio.io/v1, Kind=Sidecar',
-  VirtualService: 'networking.istio.io/v1, Kind=VirtualService'
-};
-
-const ISTIO_DETAIL_API_PATH: Record<string, string> = {
-  PeerAuthentication: 'security.istio.io/v1/PeerAuthentication'
-};
-
 const VALIDATION_ICON: Record<string, string> = {
   danger: 'icon-error-validation',
   error: 'icon-error-validation',
@@ -344,38 +329,6 @@ export class IstioConfigPage extends BasePage {
     }
   }
 
-  private async hasApiValidationStatus(
-    namespace: string,
-    typeName: string,
-    instanceName: string,
-    healthStatus: string
-  ): Promise<boolean> {
-    const gvk = ISTIO_TYPE_GVK[typeName];
-    if (!gvk) {
-      return true;
-    }
-
-    const response = await this.page.request.get(`/api/namespaces/${namespace}/istio?validate=true&_=${Date.now()}`);
-    if (!response.ok()) {
-      return false;
-    }
-
-    const body = (await response.json()) as {
-      validations?: Record<string, Record<string, { checks?: Array<{ severity?: string }>; valid?: boolean }>>;
-    };
-    const entry = body.validations?.[gvk]?.[`${instanceName}.${namespace}`];
-    if (!entry) {
-      return false;
-    }
-
-    if (healthStatus === 'success') {
-      return entry.valid === true;
-    }
-
-    const expectedSeverity = healthStatus === 'warning' ? 'warning' : 'error';
-    return (entry.checks ?? []).some(check => check.severity === expectedSeverity);
-  }
-
   async expectValidationStatus(
     namespace: string,
     typeName: string,
@@ -388,14 +341,10 @@ export class IstioConfigPage extends BasePage {
     const expectedIcon = VALIDATION_ICON[healthStatus];
 
     await expect(async () => {
-      if (!(await this.hasApiValidationStatus(namespace, typeName, instanceName, healthStatus))) {
-        throw new Error(`API validation not ready for ${typeName}/${instanceName} (${healthStatus})`);
-      }
-      await this.page.request.get(`/api/istio/config?validate=true&_=${Date.now()}`);
       await this.refreshList();
       await expect(row).toBeVisible({ timeout: 5_000 });
       await expect(row.locator(`[data-test="${expectedIcon}"]`)).toBeVisible({ timeout: 5_000 });
-    }).toPass({ intervals: [3_000], timeout: 120_000 });
+    }).toPass({ intervals: [3_000], timeout: 90_000 });
   }
 
   async openConfigByName(name: string): Promise<void> {
@@ -506,28 +455,6 @@ export class IstioConfigPage extends BasePage {
     return this.page.getByRole('heading', { name: 'Configuration Analysis' }).locator('../..');
   }
 
-  private async hasDetailsApiValidationCode(
-    namespace: string,
-    typeName: string,
-    instanceName: string,
-    validationCode: string
-  ): Promise<boolean> {
-    const detailPath = ISTIO_DETAIL_API_PATH[typeName];
-    if (!detailPath) {
-      return true;
-    }
-
-    const response = await this.page.request.get(
-      `/api/namespaces/${namespace}/istio/${detailPath}/${instanceName}?validate=true&_=${Date.now()}`
-    );
-    if (!response.ok()) {
-      return false;
-    }
-
-    const body = (await response.json()) as { validation?: { checks?: Array<{ code?: string }> } };
-    return (body.validation?.checks ?? []).some(check => check.code === validationCode);
-  }
-
   /** PeerAuthentication list rows show N/A until the details page is loaded with validate=true. */
   async expectValidationOnDetailsPage(
     namespace: string,
@@ -536,27 +463,42 @@ export class IstioConfigPage extends BasePage {
     validationCode: string
   ): Promise<void> {
     await this.ensureConfigurationValidationEnabled();
-    await this.openConfigByRow(namespace, typeName, instanceName);
+    await waitForLoadingComplete(this.page);
 
-    const analysisSection = this.configurationAnalysisSection();
-    await expect(async () => {
-      if (!(await this.hasDetailsApiValidationCode(namespace, typeName, instanceName, validationCode))) {
-        throw new Error(`Detail API validation missing ${validationCode} for ${typeName}/${instanceName}`);
-      }
-      await waitForLoadingComplete(this.page);
-      await expect(analysisSection.getByText(validationCode)).toBeVisible({ timeout: 5_000 });
-      await expect(analysisSection.locator('[data-test="icon-error-validation"]')).toBeVisible({ timeout: 5_000 });
-    }).toPass({ intervals: [3_000], timeout: 120_000 });
+    const validateResponse = this.page.waitForResponse(
+      response =>
+        response.request().method() === 'GET' &&
+        response.url().includes('/istio/') &&
+        response.url().includes(`/${instanceName}`) &&
+        response.url().includes('validate=true') &&
+        response.ok(),
+      { timeout: 60_000 }
+    );
+
+    await this.getBySel(`VirtualItem_Ns${namespace}_${typeName}_${instanceName}`)
+      .locator(linkSelector())
+      .first()
+      .click();
+    await validateResponse;
+    await waitForLoadingComplete(this.page);
+    await this.expectGroupedValidationMessage(validationCode, 1, 'danger');
   }
 
-  async expectGroupedValidationMessage(code: string, count: number): Promise<void> {
+  async expectGroupedValidationMessage(
+    code: string,
+    count: number,
+    severity: 'danger' | 'warning' = 'warning'
+  ): Promise<void> {
     const messagePattern = count > 1 ? new RegExp(`${code}.*\\(${count}\\)`) : new RegExp(code);
+    const iconTestId = severity === 'danger' ? 'icon-error-validation' : 'icon-warning-validation';
     const analysisSection = this.configurationAnalysisSection();
 
     await expect(async () => {
       await waitForLoadingComplete(this.page);
-      await expect(analysisSection.getByText(messagePattern)).toBeVisible({ timeout: 5_000 });
-    }).toPass({ intervals: [3_000], timeout: 120_000 });
+      const validationRow = analysisSection.locator('div').filter({ hasText: messagePattern });
+      await expect(validationRow.first()).toBeVisible({ timeout: 5_000 });
+      await expect(validationRow.first().getByTestId(iconTestId)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ intervals: [3_000], timeout: 90_000 });
   }
 }
 

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -29,6 +29,13 @@ const VALIDATION_FILTERS = ['Valid', 'Not Valid', 'Not Validated', 'Warning'] as
 
 const GATEWAY_GVK = 'networking.istio.io/v1, Kind=Gateway';
 
+const VALIDATION_ICON: Record<string, string> = {
+  danger: 'icon-error-validation',
+  error: 'icon-error-validation',
+  success: 'icon-correct-validation',
+  warning: 'icon-warning-validation'
+};
+
 export class IstioConfigPage extends BasePage {
   private filterOption(name: string) {
     // Exact match avoids Gateway⊂K8sGateway and Valid⊂Not Valid / Not Validated.
@@ -314,6 +321,38 @@ export class IstioConfigPage extends BasePage {
     await waitForLoadingComplete(this.page);
   }
 
+  async ensureConfigurationValidationEnabled(): Promise<void> {
+    const toggle = this.getBySel('toggle-configuration');
+    if (!(await toggle.isChecked())) {
+      await toggle.check();
+      await waitForLoadingComplete(this.page);
+    }
+  }
+
+  async expectValidationStatus(
+    namespace: string,
+    typeName: string,
+    instanceName: string,
+    healthStatus: string
+  ): Promise<void> {
+    await this.ensureConfigurationValidationEnabled();
+
+    const row = this.getBySel(`VirtualItem_Ns${namespace}_${typeName}_${instanceName}`);
+    const expectedIcon = VALIDATION_ICON[healthStatus];
+
+    await expect(async () => {
+      await this.page.request.get(`/api/istio/config?validate=true&_=${Date.now()}`);
+      await this.refreshList();
+      await expect(row).toBeVisible({ timeout: 5_000 });
+      await expect(row.locator(`[data-test="${expectedIcon}"]`)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ intervals: [3_000], timeout: 90_000 });
+  }
+
+  async openConfigByName(name: string): Promise<void> {
+    await waitForLoadingComplete(this.page);
+    await getColWithRowText(this.page, name, 'Name').locator(linkSelector()).first().click();
+  }
+
   async expectObjectConfigurationStatus(
     namespace: string,
     typeName: string,
@@ -326,11 +365,6 @@ export class IstioConfigPage extends BasePage {
       await this.refreshList();
       await expect(row).toContainText(statusText);
     }).toPass({ intervals: [10_000], timeout: 60_000 });
-  }
-
-  async openConfigByName(name: string): Promise<void> {
-    await waitForLoadingComplete(this.page);
-    await getColWithRowText(this.page, name, 'Name').locator(linkSelector()).first().click();
   }
 
   async expectEditorVisible(): Promise<void> {
@@ -410,6 +444,19 @@ export class IstioConfigPage extends BasePage {
 
   async expectObjectNotListed(type: string, name: string, namespace: string): Promise<void> {
     await expect(this.getBySel(`VirtualItem_Ns${namespace}_${type}_${name}`)).toHaveCount(0);
+  }
+
+  async openConfigByRow(namespace: string, typeName: string, name: string): Promise<void> {
+    await waitForLoadingComplete(this.page);
+    await this.getBySel(`VirtualItem_Ns${namespace}_${typeName}_${name}`).locator(linkSelector()).first().click();
+    await waitForLoadingComplete(this.page);
+  }
+
+  async expectGroupedValidationMessage(code: string, count: number): Promise<void> {
+    await waitForLoadingComplete(this.page);
+    // Heading sits in a StackItem; validation rows are sibling StackItems in the same Stack.
+    const analysisSection = this.page.getByRole('heading', { name: 'Configuration Analysis' }).locator('../..');
+    await expect(analysisSection.getByText(new RegExp(`${code}.*\\(${count}\\)`))).toBeVisible();
   }
 }
 

--- a/frontend/e2e/pages/IstioConfigPage.ts
+++ b/frontend/e2e/pages/IstioConfigPage.ts
@@ -455,16 +455,39 @@ export class IstioConfigPage extends BasePage {
     return this.page.getByRole('heading', { name: 'Configuration Analysis' }).locator('../..');
   }
 
-  /** PeerAuthentication list rows show N/A until the details page is loaded with validate=true. */
+  /**
+   * List rows for some types (notably PeerAuthentication) show N/A until the details API runs with
+   * validate=true. Open details and wait for that response so downstream validations are computed.
+   */
+  async primeValidationFromDetails(namespace: string, typeName: string, instanceName: string): Promise<void> {
+    await this.ensureConfigurationValidationEnabled();
+    await this.refreshList();
+    await waitForLoadingComplete(this.page);
+    await this.openConfigDetailsAndWaitForValidation(namespace, typeName, instanceName);
+    await this.open();
+    await waitForLoadingComplete(this.page);
+  }
+
+  /** Assert a validation code on the config details page (list icon may stay N/A on OSSMC). */
   async expectValidationOnDetailsPage(
     namespace: string,
     typeName: string,
     instanceName: string,
-    validationCode: string
+    validationCode: string,
+    severity: 'danger' | 'warning' = 'danger'
   ): Promise<void> {
     await this.ensureConfigurationValidationEnabled();
+    await this.refreshList();
     await waitForLoadingComplete(this.page);
+    await this.openConfigDetailsAndWaitForValidation(namespace, typeName, instanceName);
+    await this.expectGroupedValidationMessage(validationCode, 1, severity);
+  }
 
+  private async openConfigDetailsAndWaitForValidation(
+    namespace: string,
+    typeName: string,
+    instanceName: string
+  ): Promise<void> {
     const validateResponse = this.page.waitForResponse(
       response =>
         response.request().method() === 'GET' &&
@@ -481,7 +504,6 @@ export class IstioConfigPage extends BasePage {
       .click();
     await validateResponse;
     await waitForLoadingComplete(this.page);
-    await this.expectGroupedValidationMessage(validationCode, 1, 'danger');
   }
 
   async expectGroupedValidationMessage(

--- a/frontend/e2e/tests/apps/app_details_graph.spec.ts
+++ b/frontend/e2e/tests/apps/app_details_graph.spec.ts
@@ -1,13 +1,16 @@
 import { test } from '../../fixtures/kialiFixtures';
+import { ensureDemoApp } from '../../utils/demoApps';
 import { core1 } from '../../utils/suite-tags';
 
 test.describe('App details graph', () => {
   test('See app minigraph for details app', core1, async ({ appDetailsPage }) => {
+    ensureDemoApp('bookinfo');
     await appDetailsPage.openApp('bookinfo', 'details');
     await appDetailsPage.expectMinigraphVisible();
   });
 
   test('Application detail URL stays under applications after mini graph loads', core1, async ({ appDetailsPage }) => {
+    ensureDemoApp('error-rates');
     await appDetailsPage.openApp('alpha', 'a-client');
     await appDetailsPage.expectMinigraphVisible();
     await appDetailsPage.expectUrlIncludes('a-client');

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -488,7 +488,14 @@ test.describe('Istio Config CRD validation', () => {
   test.describe('istio-system', () => {
     test.describe.configure({ mode: 'serial' });
 
+    test.beforeEach(() => {
+      // KIA0505 leaves PeerAuthentication/default DISABLE in sleep, which suppresses KIA0208 mesh checks.
+      cleanSleepMtlsTestResources();
+      cleanIstioSystemTestResources();
+    });
+
     test.afterEach(() => {
+      cleanSleepMtlsTestResources();
       cleanIstioSystemTestResources();
     });
 
@@ -507,7 +514,6 @@ test.describe('Istio Config CRD validation', () => {
       await selectNamespace(page, 'sleep');
       await istioConfigPage.expectValidationOnDetailsPage('sleep', 'DestinationRule', drName, 'KIA0208');
       deleteIstioConfig('DestinationRule', drName, 'sleep');
-      cleanIstioSystemTestResources();
     });
 
     test('KIA0506 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -449,7 +449,7 @@ test.describe('Istio Config CRD validation', () => {
 
       await istioConfigPage.open();
       await selectNamespace(page, 'sleep');
-      await istioConfigPage.expectValidationStatus('sleep', 'PeerAuthentication', 'default', 'danger');
+      await istioConfigPage.expectValidationOnDetailsPage('sleep', 'PeerAuthentication', 'default', 'KIA0505');
     });
   });
 
@@ -504,7 +504,7 @@ test.describe('Istio Config CRD validation', () => {
 
       await istioConfigPage.open();
       await selectNamespace(page, 'istio-system');
-      await istioConfigPage.expectValidationStatus('istio-system', 'PeerAuthentication', 'default', 'danger');
+      await istioConfigPage.expectValidationOnDetailsPage('istio-system', 'PeerAuthentication', 'default', 'KIA0506');
       deleteIstioConfig('DestinationRule', drName, 'sleep');
       cleanIstioSystemTestResources();
     });

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -14,6 +14,7 @@ import {
   applyVirtualService,
   applyVirtualServiceWithSubset,
   cleanIstioSystemTestResources,
+  cleanSleepMtlsTestResources,
   deleteIstioConfig,
   deleteIstioGateway,
   patchAuthorizationPolicyFromSourceNamespace,
@@ -418,6 +419,14 @@ test.describe('Istio Config CRD validation', () => {
   test.describe('sleep mTLS', () => {
     test.describe.configure({ mode: 'serial' });
 
+    test.beforeEach(() => {
+      cleanSleepMtlsTestResources();
+    });
+
+    test.afterEach(() => {
+      cleanSleepMtlsTestResources();
+    });
+
     test('KIA0207 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'disable-mtls');
       ensureDemoApp('bookinfo');
@@ -431,15 +440,12 @@ test.describe('Istio Config CRD validation', () => {
       await istioConfigPage.open();
       await selectNamespace(page, 'sleep');
       await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
-      deleteIstioConfig('DestinationRule', drName, 'sleep');
-      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
     });
 
     test('KIA0505 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'enable-mtls');
       ensureDemoApp('bookinfo');
       ensureDemoApp('sleep');
-      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
       applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
       patchDestinationRuleEnableMtls(drName, 'sleep');
       applyPeerAuthentication('default', 'sleep');
@@ -448,8 +454,6 @@ test.describe('Istio Config CRD validation', () => {
       await istioConfigPage.open();
       await selectNamespace(page, 'sleep');
       await istioConfigPage.expectValidationStatus('sleep', 'PeerAuthentication', 'default', 'danger');
-      deleteIstioConfig('DestinationRule', drName, 'sleep');
-      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
     });
   });
 

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -420,8 +420,8 @@ test.describe('Istio Config CRD validation', () => {
     });
   });
 
-  // Contend for sleep default PeerAuthentication — run one at a time.
-  test.describe('sleep mTLS', () => {
+  // sleep + istio-system mTLS tests contend on PeerAuthentication/default — one worker, in order.
+  test.describe('mTLS contention', () => {
     test.describe.configure({ mode: 'serial' });
 
     test.beforeAll(() => {
@@ -431,10 +431,12 @@ test.describe('Istio Config CRD validation', () => {
 
     test.beforeEach(() => {
       cleanSleepMtlsTestResources();
+      cleanIstioSystemTestResources();
     });
 
     test.afterEach(() => {
       cleanSleepMtlsTestResources();
+      cleanIstioSystemTestResources();
     });
 
     test('KIA0207 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
@@ -462,6 +464,42 @@ test.describe('Istio Config CRD validation', () => {
       await selectNamespace(page, 'sleep');
       await istioConfigPage.expectValidationOnDetailsPage('sleep', 'PeerAuthentication', 'default', 'KIA0505');
     });
+
+    test('KIA0208 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'disable-mtls');
+      applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
+      patchDestinationRuleDisableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'istio-system');
+      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'STRICT');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+    });
+
+    test('KIA0506 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'enable-mtls');
+      applyDestinationRule(drName, 'sleep', '*.local');
+      patchDestinationRuleEnableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'istio-system');
+      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'DISABLE');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'istio-system');
+      await istioConfigPage.expectValidationOnDetailsPage('istio-system', 'PeerAuthentication', 'default', 'KIA0506');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+    });
+
+    test('KIA1006 validation', crdValidationOnly, async ({ istioConfigPage, page }) => {
+      applySidecar('default', 'istio-system', 'default/sleep.sleep.svc.cluster.local');
+      patchSidecarWorkloadSelector('default', 'istio-system', 'app=grafana');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'istio-system');
+      await istioConfigPage.expectValidationStatus('istio-system', 'Sidecar', 'default', 'warning');
+      deleteIstioConfig('Sidecar', 'default', 'istio-system');
+    });
   });
 
   // Deletes the bookinfo demo VirtualService — must not run concurrently with other bookinfo tests.
@@ -481,67 +519,6 @@ test.describe('Istio Config CRD validation', () => {
       await istioConfigPage.expectValidationStatus('bookinfo', 'AuthorizationPolicy', name, 'warning');
       deleteIstioConfig('AuthorizationPolicy', name, 'bookinfo');
       restoreBookinfoNetworking();
-    });
-  });
-
-  // Contend for istio-system default PeerAuthentication / Sidecar — run one at a time.
-  test.describe('istio-system', () => {
-    test.describe.configure({ mode: 'serial' });
-
-    test.beforeEach(() => {
-      // KIA0505 leaves PeerAuthentication/default DISABLE in sleep, which suppresses KIA0208 mesh checks.
-      cleanSleepMtlsTestResources();
-      cleanIstioSystemTestResources();
-    });
-
-    test.afterEach(() => {
-      cleanSleepMtlsTestResources();
-      cleanIstioSystemTestResources();
-    });
-
-    test('KIA0208 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
-      const drName = crdResourceName(testInfo, 'disable-mtls');
-      ensureDemoApp('bookinfo');
-      ensureDemoApp('sleep');
-      applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
-      patchDestinationRuleDisableMtls(drName, 'sleep');
-      applyPeerAuthentication('default', 'istio-system');
-      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'STRICT');
-
-      await istioConfigPage.open();
-      await selectNamespace(page, 'istio-system');
-      await istioConfigPage.primeValidationFromDetails('istio-system', 'PeerAuthentication', 'default');
-      await selectNamespace(page, 'sleep');
-      await istioConfigPage.expectValidationOnDetailsPage('sleep', 'DestinationRule', drName, 'KIA0208');
-      deleteIstioConfig('DestinationRule', drName, 'sleep');
-    });
-
-    test('KIA0506 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
-      const drName = crdResourceName(testInfo, 'enable-mtls');
-      ensureDemoApp('bookinfo');
-      ensureDemoApp('sleep');
-      applyDestinationRule(drName, 'sleep', '*.local');
-      patchDestinationRuleEnableMtls(drName, 'sleep');
-      applyPeerAuthentication('default', 'istio-system');
-      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'DISABLE');
-
-      await istioConfigPage.open();
-      await selectNamespace(page, 'istio-system');
-      await istioConfigPage.expectValidationOnDetailsPage('istio-system', 'PeerAuthentication', 'default', 'KIA0506');
-      deleteIstioConfig('DestinationRule', drName, 'sleep');
-      cleanIstioSystemTestResources();
-    });
-
-    test('KIA1006 validation', crdValidationOnly, async ({ istioConfigPage, page }) => {
-      ensureDemoApp('bookinfo');
-      applySidecar('default', 'istio-system', 'default/sleep.sleep.svc.cluster.local');
-      patchSidecarWorkloadSelector('default', 'istio-system', 'app=grafana');
-
-      await istioConfigPage.open();
-      await selectNamespace(page, 'istio-system');
-      await istioConfigPage.expectValidationStatus('istio-system', 'Sidecar', 'default', 'warning');
-      deleteIstioConfig('Sidecar', 'default', 'istio-system');
-      cleanIstioSystemTestResources();
     });
   });
 });

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -38,7 +38,7 @@ import { selectNamespace, selectNamespaces } from '../../utils/namespace';
 import { crdValidationOnly } from '../../utils/suite-tags';
 
 test.describe('Istio Config CRD validation', () => {
-  test.describe.configure({ mode: 'serial', timeout: 180_000 });
+  test.describe.configure({ timeout: 180_000 });
 
   test.afterAll(() => {
     cleanSleepMtlsTestResources();

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -417,21 +417,19 @@ test.describe('Istio Config CRD validation', () => {
 
   // Contend for sleep default PeerAuthentication — run one at a time.
   test.describe('sleep mTLS', () => {
-    test.describe.configure({ mode: 'serial' });
+    test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+    test.beforeAll(() => {
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+    });
 
     test.beforeEach(() => {
       cleanSleepMtlsTestResources();
     });
 
-    test.afterEach(() => {
-      cleanSleepMtlsTestResources();
-    });
-
     test('KIA0207 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'disable-mtls');
-      ensureDemoApp('bookinfo');
-      ensureDemoApp('sleep');
-      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
       applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
       patchDestinationRuleDisableMtls(drName, 'sleep');
       applyPeerAuthentication('default', 'sleep');
@@ -444,8 +442,6 @@ test.describe('Istio Config CRD validation', () => {
 
     test('KIA0505 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'enable-mtls');
-      ensureDemoApp('bookinfo');
-      ensureDemoApp('sleep');
       applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
       patchDestinationRuleEnableMtls(drName, 'sleep');
       applyPeerAuthentication('default', 'sleep');

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -417,7 +417,7 @@ test.describe('Istio Config CRD validation', () => {
 
   // Contend for sleep default PeerAuthentication — run one at a time.
   test.describe('sleep mTLS', () => {
-    test.describe.configure({ mode: 'serial', timeout: 300_000 });
+    test.describe.configure({ mode: 'serial' });
 
     test.beforeAll(() => {
       ensureDemoApp('bookinfo');

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -446,7 +446,9 @@ test.describe('Istio Config CRD validation', () => {
 
       await istioConfigPage.open();
       await selectNamespace(page, 'sleep');
-      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      await istioConfigPage.primeValidationFromDetails('sleep', 'PeerAuthentication', 'default');
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationOnDetailsPage('sleep', 'DestinationRule', drName, 'KIA0207');
     });
 
     test('KIA0505 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
@@ -500,8 +502,10 @@ test.describe('Istio Config CRD validation', () => {
       patchPeerAuthenticationMtlsMode('default', 'istio-system', 'STRICT');
 
       await istioConfigPage.open();
+      await selectNamespace(page, 'istio-system');
+      await istioConfigPage.primeValidationFromDetails('istio-system', 'PeerAuthentication', 'default');
       await selectNamespace(page, 'sleep');
-      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      await istioConfigPage.expectValidationOnDetailsPage('sleep', 'DestinationRule', drName, 'KIA0208');
       deleteIstioConfig('DestinationRule', drName, 'sleep');
       cleanIstioSystemTestResources();
     });

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -38,7 +38,12 @@ import { selectNamespace, selectNamespaces } from '../../utils/namespace';
 import { crdValidationOnly } from '../../utils/suite-tags';
 
 test.describe('Istio Config CRD validation', () => {
-  test.describe.configure({ timeout: 180_000 });
+  test.describe.configure({ mode: 'serial', timeout: 180_000 });
+
+  test.afterAll(() => {
+    cleanSleepMtlsTestResources();
+    cleanIstioSystemTestResources();
+  });
 
   test.describe('parallel', () => {
     test.describe.configure({ mode: 'parallel' });
@@ -428,6 +433,10 @@ test.describe('Istio Config CRD validation', () => {
       cleanSleepMtlsTestResources();
     });
 
+    test.afterEach(() => {
+      cleanSleepMtlsTestResources();
+    });
+
     test('KIA0207 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'disable-mtls');
       applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
@@ -476,6 +485,10 @@ test.describe('Istio Config CRD validation', () => {
   // Contend for istio-system default PeerAuthentication / Sidecar — run one at a time.
   test.describe('istio-system', () => {
     test.describe.configure({ mode: 'serial' });
+
+    test.afterEach(() => {
+      cleanIstioSystemTestResources();
+    });
 
     test('KIA0208 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
       const drName = crdResourceName(testInfo, 'disable-mtls');

--- a/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
+++ b/frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts
@@ -1,0 +1,524 @@
+import { test } from '../../fixtures/kialiFixtures';
+import { crdResourceName } from '../../utils/crdValidationTest';
+import { ensureDemoApp } from '../../utils/demoApps';
+import { ensureGatewayApiCrds, isGatewayApiCrdInstalled } from '../../utils/gatewayApi';
+import { isGatewayApiEnabled } from '../../utils/kialiConfig';
+import {
+  applyAuthorizationPolicy,
+  applyDestinationRule,
+  applyIstioGateway,
+  applyK8sGateway,
+  applyK8sReferenceGrant,
+  applyPeerAuthentication,
+  applySidecar,
+  applyVirtualService,
+  applyVirtualServiceWithSubset,
+  cleanIstioSystemTestResources,
+  deleteIstioConfig,
+  deleteIstioGateway,
+  patchAuthorizationPolicyFromSourceNamespace,
+  patchAuthorizationPolicyFromSourcePrincipal,
+  patchAuthorizationPolicyToOperationHost,
+  patchAuthorizationPolicyToOperationMethod,
+  patchDestinationRuleDisableMtls,
+  patchDestinationRuleEnableMtls,
+  patchDestinationRuleSubset,
+  patchK8sGatewayAddress,
+  patchPeerAuthenticationMtlsMode,
+  patchSidecarWorkloadSelector,
+  patchVirtualServiceAdditionalDestination,
+  patchVirtualServiceGateways,
+  patchVirtualServiceHosts,
+  patchVirtualServiceRouteWeight,
+  restoreBookinfoNetworking
+} from '../../utils/istioCrdValidation';
+import { deleteK8sGateway, deleteK8sReferenceGrant } from '../../utils/istioConfigResources';
+import { selectNamespace, selectNamespaces } from '../../utils/namespace';
+import { crdValidationOnly } from '../../utils/suite-tags';
+
+test.describe('Istio Config CRD validation', () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  test.describe('parallel', () => {
+    test.describe.configure({ mode: 'parallel' });
+
+    test('KIA0101 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      applyAuthorizationPolicy(name, 'bookinfo');
+      patchAuthorizationPolicyFromSourceNamespace(name, 'bookinfo', 'bar');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'AuthorizationPolicy', name, 'warning');
+      deleteIstioConfig('AuthorizationPolicy', name, 'bookinfo');
+    });
+
+    test('KIA0102 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const apName = crdResourceName(testInfo, 'foo');
+      const drName = crdResourceName(testInfo, 'enable-mtls');
+      ensureDemoApp('bookinfo');
+      applyDestinationRule(drName, 'bookinfo', '*.bookinfo.svc.cluster.local');
+      applyAuthorizationPolicy(apName, 'bookinfo');
+      patchAuthorizationPolicyToOperationMethod(apName, 'bookinfo', 'non-fully-qualified-grpc');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'AuthorizationPolicy', apName, 'warning');
+      deleteIstioConfig('AuthorizationPolicy', apName, 'bookinfo');
+      deleteIstioConfig('DestinationRule', drName, 'bookinfo');
+    });
+
+    test('KIA0106 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      applyAuthorizationPolicy(name, 'bookinfo');
+      patchAuthorizationPolicyFromSourcePrincipal(name, 'bookinfo', 'cluster.local/ns/bookinfo/sa/sleep');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'AuthorizationPolicy', name, 'danger');
+      deleteIstioConfig('AuthorizationPolicy', name, 'bookinfo');
+    });
+
+    test('KIA0201 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const foo = crdResourceName(testInfo, 'foo');
+      const bar = crdResourceName(testInfo, 'bar');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(foo, 'sleep', 'sleep');
+      patchDestinationRuleSubset(foo, 'sleep', 'mysubset', 'version=v1');
+      applyDestinationRule(bar, 'sleep', 'sleep');
+      patchDestinationRuleSubset(bar, 'sleep', 'mysubset', 'version=v1');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', foo, 'warning');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', bar, 'warning');
+      deleteIstioConfig('DestinationRule', foo, 'sleep');
+      deleteIstioConfig('DestinationRule', bar, 'sleep');
+    });
+
+    test('KIA0202 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(name, 'sleep', 'nonexistent');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', name, 'warning');
+      deleteIstioConfig('DestinationRule', name, 'sleep');
+    });
+
+    test('KIA0203 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'foo');
+      const vsName = crdResourceName(testInfo, 'foo-route');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(drName, 'sleep', 'sleep');
+      patchDestinationRuleSubset(drName, 'sleep', 'v1', 'version=v1');
+      applyVirtualServiceWithSubset(vsName, 'sleep', 'foo-route', 'sleep', 'v1');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      deleteIstioConfig('VirtualService', vsName, 'sleep');
+    });
+
+    test('KIA0209 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(name, 'sleep', '*.sleep.svc.cluster.local');
+      patchDestinationRuleSubset(name, 'sleep', 'v1', '');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', name, 'warning');
+      deleteIstioConfig('DestinationRule', name, 'sleep');
+    });
+
+    test('KIA0301 wildcard validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyIstioGateway(name, 'bookinfo', 'productpage.local', 80, 'app=productpage');
+      applyIstioGateway(name, 'sleep', '*', 80, 'app=productpage');
+
+      await istioConfigPage.open();
+      await selectNamespaces(page, ['bookinfo', 'sleep']);
+      await istioConfigPage.expectValidationStatus('bookinfo', 'Gateway', name, 'warning');
+      await istioConfigPage.expectValidationStatus('sleep', 'Gateway', name, 'warning');
+      deleteIstioGateway(name, 'sleep');
+      deleteIstioGateway(name, 'bookinfo');
+    });
+
+    test('KIA0301 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyIstioGateway(name, 'bookinfo', 'productpage.local', 80, 'app=productpage');
+      applyIstioGateway(name, 'sleep', 'productpage.local', 80, 'app=productpage');
+
+      await istioConfigPage.open();
+      await selectNamespaces(page, ['bookinfo', 'sleep']);
+      await istioConfigPage.expectValidationStatus('bookinfo', 'Gateway', name, 'warning');
+      await istioConfigPage.expectValidationStatus('sleep', 'Gateway', name, 'warning');
+      deleteIstioGateway(name, 'sleep');
+      deleteIstioGateway(name, 'bookinfo');
+    });
+
+    test('KIA0302 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyIstioGateway(name, 'sleep', 'foo.local', 80, 'app=foo');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'Gateway', name, 'warning');
+      deleteIstioGateway(name, 'sleep');
+    });
+
+    test('KIA1004 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applySidecar(name, 'sleep', 'sleep/foo.sleep.svc.cluster.local');
+      patchSidecarWorkloadSelector(name, 'sleep', 'app=sleep');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'Sidecar', name, 'warning');
+      deleteIstioConfig('Sidecar', name, 'sleep');
+    });
+
+    test('KIA1101 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyVirtualService(name, 'sleep', 'foo-route', 'foo');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', name, 'warning');
+      deleteIstioConfig('VirtualService', name, 'sleep');
+    });
+
+    test('KIA1102 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      deleteIstioGateway(name, 'sleep');
+      deleteIstioConfig('DestinationRule', name, 'sleep');
+      applyVirtualService(name, 'sleep', 'foo-route', 'sleep');
+      patchVirtualServiceHosts(name, 'sleep', 'sleep');
+      patchVirtualServiceGateways(name, 'sleep', 'foo');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', name, 'danger');
+      deleteIstioConfig('VirtualService', name, 'sleep');
+    });
+
+    test('VirtualService references to Gateway', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const gwName = crdResourceName(testInfo, 'foo');
+      const vsName = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyIstioGateway(gwName, 'bookinfo', 'productpage.local', 80, 'app=productpage');
+      applyVirtualService(vsName, 'sleep', 'foo-route', 'sleep');
+      patchVirtualServiceHosts(vsName, 'sleep', 'sleep');
+      patchVirtualServiceGateways(vsName, 'sleep', `bookinfo/${gwName}`);
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', vsName, 'success');
+      deleteIstioConfig('VirtualService', vsName, 'sleep');
+      deleteIstioGateway(gwName, 'bookinfo');
+    });
+
+    test('KIA1104 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyVirtualService(name, 'sleep', 'foo-route', 'sleep');
+      patchVirtualServiceRouteWeight(name, 'sleep', 10);
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', name, 'warning');
+      deleteIstioConfig('VirtualService', name, 'sleep');
+    });
+
+    test('KIA1105 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const vsName = crdResourceName(testInfo, 'foo');
+      const drName = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyVirtualServiceWithSubset(vsName, 'sleep', 'foo-route', 'sleep', 'v1');
+      patchVirtualServiceRouteWeight(vsName, 'sleep', 50);
+      patchVirtualServiceAdditionalDestination(vsName, 'sleep', 'sleep', 'v1', 50);
+      applyDestinationRule(drName, 'sleep', 'sleep');
+      patchDestinationRuleSubset(drName, 'sleep', 'v1', 'version=v1');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', vsName, 'warning');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      deleteIstioConfig('VirtualService', vsName, 'sleep');
+    });
+
+    test(
+      'Duplicate validation codes are grouped on the detail page',
+      crdValidationOnly,
+      async ({ istioConfigPage, page }, testInfo) => {
+        const vsName = crdResourceName(testInfo, 'bar');
+        const drName = crdResourceName(testInfo, 'bar');
+        ensureDemoApp('bookinfo');
+        ensureDemoApp('sleep');
+        applyVirtualServiceWithSubset(vsName, 'sleep', 'bar-route', 'sleep', 'v1');
+        patchVirtualServiceRouteWeight(vsName, 'sleep', 50);
+        patchVirtualServiceAdditionalDestination(vsName, 'sleep', 'sleep', 'v1', 50);
+        applyDestinationRule(drName, 'sleep', 'sleep');
+        patchDestinationRuleSubset(drName, 'sleep', 'v1', 'version=v1');
+
+        await istioConfigPage.open();
+        await istioConfigPage.refreshList();
+        await selectNamespace(page, 'sleep');
+        await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', vsName, 'warning');
+        await istioConfigPage.openConfigByRow('sleep', 'VirtualService', vsName);
+        await istioConfigPage.expectGroupedValidationMessage('KIA1105', 2);
+        deleteIstioConfig('DestinationRule', drName, 'sleep');
+        deleteIstioConfig('VirtualService', vsName, 'sleep');
+      }
+    );
+
+    test('KIA1106 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const foo = crdResourceName(testInfo, 'foo');
+      const bar = crdResourceName(testInfo, 'bar');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyVirtualService(foo, 'sleep', 'foo-route', 'sleep');
+      patchVirtualServiceHosts(foo, 'sleep', 'sleep');
+      applyVirtualService(bar, 'sleep', 'bar-route', 'sleep');
+      patchVirtualServiceHosts(bar, 'sleep', 'sleep');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', foo, 'warning');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', bar, 'warning');
+      deleteIstioConfig('VirtualService', foo, 'sleep');
+      deleteIstioConfig('VirtualService', bar, 'sleep');
+    });
+
+    test('KIA1107 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      // Unique host avoids false "success" when parallel tests create a DR with subset v1 for "sleep".
+      const routeHost = crdResourceName(testInfo, 'missing-host');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyVirtualServiceWithSubset(name, 'sleep', 'foo-route', routeHost, 'v1');
+      deleteIstioConfig('DestinationRule', name, 'sleep');
+      deleteIstioGateway(name, 'sleep');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'VirtualService', name, 'warning');
+      deleteIstioConfig('VirtualService', name, 'sleep');
+    });
+
+    test('KIA1502 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const gatewayApiEnabled = await isGatewayApiEnabled(page.request);
+      test.skip(!gatewayApiEnabled, 'gateway API not enabled on cluster');
+
+      const crdInstalledBeforeEnsure = isGatewayApiCrdInstalled();
+      if (!crdInstalledBeforeEnsure) {
+        ensureGatewayApiCrds();
+        test.skip(!isGatewayApiCrdInstalled(), 'Gateway API CRDs not available on cluster');
+        test.skip(true, 'Gateway API CRDs were installed during this run; restart Kiali and re-run');
+      }
+
+      const foo = crdResourceName(testInfo, 'foo');
+      const bar = crdResourceName(testInfo, 'bar');
+      ensureDemoApp('bookinfo');
+      deleteK8sGateway(foo, 'bookinfo');
+      deleteK8sGateway(bar, 'bookinfo');
+      applyK8sGateway(foo, 'bookinfo', 'google.com', 'HTTP', '80', 'istio');
+      applyK8sGateway(bar, 'bookinfo', 'secondary.com', 'HTTP', '9080', 'istio');
+      patchK8sGatewayAddress(foo, 'bookinfo', 'Hostname', 'example.com');
+      patchK8sGatewayAddress(bar, 'bookinfo', 'Hostname', 'example.com');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'K8sGateway', foo, 'warning');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'K8sGateway', bar, 'warning');
+      deleteK8sGateway(foo, 'bookinfo');
+      deleteK8sGateway(bar, 'bookinfo');
+    });
+
+    test('KIA1504 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const gatewayApiEnabled = await isGatewayApiEnabled(page.request);
+      test.skip(!gatewayApiEnabled, 'gateway API not enabled on cluster');
+
+      const crdInstalledBeforeEnsure = isGatewayApiCrdInstalled();
+      if (!crdInstalledBeforeEnsure) {
+        ensureGatewayApiCrds();
+        test.skip(!isGatewayApiCrdInstalled(), 'Gateway API CRDs not available on cluster');
+        test.skip(true, 'Gateway API CRDs were installed during this run; restart Kiali and re-run');
+      }
+
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      deleteK8sGateway(name, 'bookinfo');
+      applyK8sGateway(name, 'bookinfo', 'google.com', 'HTTP', '80', 'nonexistentname');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'K8sGateway', name, 'danger');
+      deleteK8sGateway(name, 'bookinfo');
+    });
+
+    test('KIA1601 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const gatewayApiEnabled = await isGatewayApiEnabled(page.request);
+      test.skip(!gatewayApiEnabled, 'gateway API not enabled on cluster');
+
+      const crdInstalledBeforeEnsure = isGatewayApiCrdInstalled();
+      if (!crdInstalledBeforeEnsure) {
+        ensureGatewayApiCrds();
+        test.skip(!isGatewayApiCrdInstalled(), 'Gateway API CRDs not available on cluster');
+        test.skip(true, 'Gateway API CRDs were installed during this run; restart Kiali and re-run');
+      }
+
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      deleteK8sReferenceGrant(name, 'bookinfo');
+      applyK8sReferenceGrant(name, 'bookinfo', 'nonexistent');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'K8sReferenceGrant', name, 'danger');
+      deleteK8sReferenceGrant(name, 'bookinfo');
+    });
+  });
+
+  // Contend for sleep default PeerAuthentication — run one at a time.
+  test.describe('sleep mTLS', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test('KIA0207 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'disable-mtls');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
+      applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
+      patchDestinationRuleDisableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'sleep');
+      patchPeerAuthenticationMtlsMode('default', 'sleep', 'STRICT');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
+    });
+
+    test('KIA0505 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'enable-mtls');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
+      applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
+      patchDestinationRuleEnableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'sleep');
+      patchPeerAuthenticationMtlsMode('default', 'sleep', 'DISABLE');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'PeerAuthentication', 'default', 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      deleteIstioConfig('PeerAuthentication', 'default', 'sleep');
+    });
+  });
+
+  // Deletes the bookinfo demo VirtualService — must not run concurrently with other bookinfo tests.
+  test.describe('bookinfo networking', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test('KIA0104 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const name = crdResourceName(testInfo, 'foo');
+      ensureDemoApp('bookinfo');
+      deleteIstioConfig('VirtualService', 'bookinfo', 'bookinfo');
+      applyAuthorizationPolicy(name, 'bookinfo');
+      patchAuthorizationPolicyToOperationHost(name, 'bookinfo', 'missing.hostname');
+
+      await istioConfigPage.open();
+      await istioConfigPage.refreshList();
+      await selectNamespace(page, 'bookinfo');
+      await istioConfigPage.expectValidationStatus('bookinfo', 'AuthorizationPolicy', name, 'warning');
+      deleteIstioConfig('AuthorizationPolicy', name, 'bookinfo');
+      restoreBookinfoNetworking();
+    });
+  });
+
+  // Contend for istio-system default PeerAuthentication / Sidecar — run one at a time.
+  test.describe('istio-system', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test('KIA0208 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'disable-mtls');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(drName, 'sleep', '*.sleep.svc.cluster.local');
+      patchDestinationRuleDisableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'istio-system');
+      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'STRICT');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'sleep');
+      await istioConfigPage.expectValidationStatus('sleep', 'DestinationRule', drName, 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      cleanIstioSystemTestResources();
+    });
+
+    test('KIA0506 validation', crdValidationOnly, async ({ istioConfigPage, page }, testInfo) => {
+      const drName = crdResourceName(testInfo, 'enable-mtls');
+      ensureDemoApp('bookinfo');
+      ensureDemoApp('sleep');
+      applyDestinationRule(drName, 'sleep', '*.local');
+      patchDestinationRuleEnableMtls(drName, 'sleep');
+      applyPeerAuthentication('default', 'istio-system');
+      patchPeerAuthenticationMtlsMode('default', 'istio-system', 'DISABLE');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'istio-system');
+      await istioConfigPage.expectValidationStatus('istio-system', 'PeerAuthentication', 'default', 'danger');
+      deleteIstioConfig('DestinationRule', drName, 'sleep');
+      cleanIstioSystemTestResources();
+    });
+
+    test('KIA1006 validation', crdValidationOnly, async ({ istioConfigPage, page }) => {
+      ensureDemoApp('bookinfo');
+      applySidecar('default', 'istio-system', 'default/sleep.sleep.svc.cluster.local');
+      patchSidecarWorkloadSelector('default', 'istio-system', 'app=grafana');
+
+      await istioConfigPage.open();
+      await selectNamespace(page, 'istio-system');
+      await istioConfigPage.expectValidationStatus('istio-system', 'Sidecar', 'default', 'warning');
+      deleteIstioConfig('Sidecar', 'default', 'istio-system');
+      cleanIstioSystemTestResources();
+    });
+  });
+});

--- a/frontend/e2e/utils/crdValidationTest.ts
+++ b/frontend/e2e/utils/crdValidationTest.ts
@@ -1,0 +1,17 @@
+import type { TestInfo } from '@playwright/test';
+
+/** Unique kubectl object name per test so CRD validation specs can run in parallel. */
+export function crdResourceName(testInfo: TestInfo, base: string): string {
+  const kia = testInfo.title.match(/\bKIA\d+\b/)?.[0]?.toLowerCase();
+  if (kia) {
+    const variant = testInfo.title.toLowerCase().includes('wildcard') ? '-wildcard' : '';
+    return `${base}-${kia}${variant}`;
+  }
+  if (testInfo.title.includes('grouped')) {
+    return `${base}-grouped`;
+  }
+  if (testInfo.title.includes('references to Gateway')) {
+    return `${base}-gwref`;
+  }
+  return `${base}-${testInfo.testId.replace(/-/g, '').slice(0, 8)}`;
+}

--- a/frontend/e2e/utils/gatewayApi.ts
+++ b/frontend/e2e/utils/gatewayApi.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+
+import { kubectlExec } from './kubectl';
+
+const GATEWAY_API_CRD = 'gateways.gateway.networking.k8s.io';
+const GATEWAY_API_CRD_REF = 'v1.6.0';
+
+export function isGatewayApiCrdInstalled(): boolean {
+  return kubectlExec(`kubectl get crd ${GATEWAY_API_CRD}`).exitCode === 0;
+}
+
+/** Mirrors Cypress `@gateway-api` hook — KinD CI usually has CRDs from Sail install. */
+export function ensureGatewayApiCrds(): void {
+  if (isGatewayApiCrdInstalled()) {
+    return;
+  }
+
+  execSync(
+    `kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_CRD_REF}" | kubectl apply -f -`,
+    { shell: true, stdio: 'inherit' }
+  );
+  kubectlExec('kubectl rollout restart deployment/kiali -n istio-system', true);
+  kubectlExec('kubectl rollout status deployment/kiali -n istio-system --timeout=120s', true);
+}

--- a/frontend/e2e/utils/graphTopology.ts
+++ b/frontend/e2e/utils/graphTopology.ts
@@ -290,7 +290,15 @@ export async function readMiniGraphTopology(page: Page): Promise<GraphTopology> 
 }
 
 export async function expectMiniGraphReady(page: Page): Promise<void> {
-  await expect(page.locator('#MiniGraphCard[data-ready="true"]')).toBeVisible();
+  const miniGraph = page.locator('#MiniGraphCard');
+  await expect(miniGraph).toBeVisible();
+
+  // Cypress assertMiniGraphReady polls until MiniGraphCardComponent is ready and has nodes.
+  await expect(async () => {
+    await expect(page.locator('#MiniGraphCard[data-ready="true"]')).toBeVisible({ timeout: 5_000 });
+    const topology = await readMiniGraphTopology(page);
+    expect(topology.nodes.length).toBeGreaterThan(0);
+  }).toPass({ intervals: [3_000], timeout: 120_000 });
 }
 
 export async function expectGraphTopology(page: Page, assertFn: (topology: GraphTopology) => void): Promise<void> {

--- a/frontend/e2e/utils/istioCrdValidation.ts
+++ b/frontend/e2e/utils/istioCrdValidation.ts
@@ -1,0 +1,397 @@
+import { execSync } from 'child_process';
+
+import { kubectlDelete, kubectlExec } from './kubectl';
+
+function labelsStringToJson(labelsString: string): string {
+  if (labelsString.length === 0) {
+    return '{}';
+  }
+
+  const labelsJson = labelsString
+    .split(',')
+    .map(lbl => {
+      const [key, value] = lbl.split('=');
+      return `"${key}": "${value}"`;
+    })
+    .join(',');
+
+  return `{${labelsJson}}`;
+}
+
+function kubectlApplyManifest(manifest: string): void {
+  execSync('kubectl apply -f -', { input: manifest, encoding: 'utf-8' });
+}
+
+function waitForResourceDeleted(getCommand: string, timeoutMs = 30_000): void {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (kubectlExec(getCommand).exitCode !== 0) {
+      return;
+    }
+    kubectlExec('sleep 0.5');
+  }
+  throw new Error(`Timed out waiting for resource deletion: ${getCommand}`);
+}
+
+function waitForIstioConfig(kind: string, name: string, namespace: string, timeoutMs = 30_000): void {
+  const getCommand = `kubectl get ${kind} ${name} -n ${namespace}`;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (kubectlExec(getCommand).exitCode === 0) {
+      return;
+    }
+    kubectlExec('sleep 0.5');
+  }
+  throw new Error(`Timed out waiting for ${kind} ${namespace}/${name}`);
+}
+
+export function deleteIstioConfig(kind: string, name: string, namespace: string): void {
+  kubectlDelete(`${kind} ${name} -n ${namespace}`);
+}
+
+export function deleteIstioGateway(name: string, namespace: string): void {
+  kubectlDelete(`gateway.networking.istio.io ${name} -n ${namespace}`);
+}
+
+export function applyAuthorizationPolicy(name: string, namespace: string): void {
+  deleteIstioConfig('AuthorizationPolicy', name, namespace);
+  kubectlApplyManifest(`{
+    "apiVersion": "security.istio.io/v1",
+    "kind": "AuthorizationPolicy",
+    "metadata": {
+        "name": "${name}",
+        "namespace": "${namespace}"
+    }
+}`);
+}
+
+export function patchAuthorizationPolicyFromSourceNamespace(
+  name: string,
+  namespace: string,
+  sourceNamespace: string
+): void {
+  kubectlExec(
+    `kubectl patch AuthorizationPolicy ${name} -n ${namespace} --type=merge -p '{"spec":{"rules":[{"from":[{"source": {"namespaces":["${sourceNamespace}"]}}]}]}}'`,
+    true
+  );
+  waitForIstioConfig('AuthorizationPolicy', name, namespace);
+}
+
+export function patchAuthorizationPolicyFromSourcePrincipal(name: string, namespace: string, principal: string): void {
+  kubectlExec(
+    `kubectl patch AuthorizationPolicy ${name} -n ${namespace} --type=merge -p '{"spec":{"rules":[{"from":[{"source": {"principals":["${principal}"]}}]}]}}'`,
+    true
+  );
+}
+
+export function patchAuthorizationPolicyToOperationMethod(name: string, namespace: string, method: string): void {
+  kubectlExec(
+    `kubectl patch AuthorizationPolicy ${name} -n ${namespace} --type=merge -p '{"spec":{"rules":[{"to":[{"operation": {"methods":["${method}"]}}]}]}}'`,
+    true
+  );
+}
+
+export function patchAuthorizationPolicyToOperationHost(name: string, namespace: string, host: string): void {
+  kubectlExec(
+    `kubectl patch AuthorizationPolicy ${name} -n ${namespace} --type=merge -p '{"spec":{"rules":[{"to":[{"operation": {"hosts":["${host}"]}}]}]}}'`,
+    true
+  );
+}
+
+export function applyDestinationRule(name: string, namespace: string, host: string): void {
+  deleteIstioConfig('DestinationRule', name, namespace);
+  kubectlApplyManifest(`{
+    "apiVersion": "networking.istio.io/v1",
+    "kind": "DestinationRule",
+    "metadata": {
+        "name": "${name}",
+        "namespace": "${namespace}"
+    },
+    "spec": {
+      "host": "${host}"
+    }
+}`);
+}
+
+export function patchDestinationRuleSubset(name: string, namespace: string, subset: string, labels: string): void {
+  kubectlExec(
+    `kubectl patch DestinationRule ${name} -n ${namespace} --type=merge -p '{"spec":{"subsets":[ {"name":"${subset}", "labels": ${labelsStringToJson(labels)} }]}}'`,
+    true
+  );
+}
+
+export function patchDestinationRuleEnableMtls(name: string, namespace: string): void {
+  kubectlExec(
+    `kubectl patch DestinationRule ${name} -n ${namespace} --type=merge -p '{"spec":{"trafficPolicy":{"tls": {"mode": "ISTIO_MUTUAL"}} }}'`,
+    true
+  );
+}
+
+export function patchDestinationRuleDisableMtls(name: string, namespace: string): void {
+  kubectlExec(
+    `kubectl patch DestinationRule ${name} -n ${namespace} --type=merge -p '{"spec":{"trafficPolicy":{"tls": {"mode": "DISABLE"}} }}'`,
+    true
+  );
+}
+
+export function applyVirtualService(name: string, namespace: string, routeName: string, routeHost: string): void {
+  deleteIstioConfig('VirtualService', name, namespace);
+  kubectlApplyManifest(`{
+    "apiVersion": "networking.istio.io/v1",
+    "kind": "VirtualService",
+    "metadata": {
+      "name": "${name}",
+      "namespace": "${namespace}"
+    },
+    "spec": {
+      "http": [
+        {
+          "name": "${routeName}",
+          "route": [
+            {
+              "destination": {
+                "host": "${routeHost}"
+              }
+            }
+         ]
+        }
+      ]
+    }
+}`);
+}
+
+export function applyVirtualServiceWithSubset(
+  name: string,
+  namespace: string,
+  routeName: string,
+  routeHost: string,
+  subset: string
+): void {
+  applyVirtualService(name, namespace, routeName, routeHost);
+  kubectlExec(
+    `kubectl patch VirtualService ${name} -n ${namespace} --type=json -p '[{"op": "add", "path": "/spec/http/0/route/0/destination/subset", "value": "${subset}"}]'`,
+    true
+  );
+}
+
+export function patchVirtualServiceHosts(name: string, namespace: string, hosts: string): void {
+  const hostsJson = hosts
+    .split(',')
+    .map(h => `"${h}"`)
+    .join(',');
+  kubectlExec(
+    `kubectl patch VirtualService ${name} -n ${namespace} --type=merge -p '{"spec":{"hosts": [${hostsJson}]}}'`,
+    true
+  );
+}
+
+export function patchVirtualServiceGateways(name: string, namespace: string, gateway: string): void {
+  kubectlExec(
+    `kubectl patch VirtualService ${name} -n ${namespace} --type=json -p '[{"op": "add", "path": "/spec/gateways", "value": ["${gateway}"]}]'`,
+    true
+  );
+}
+
+export function patchVirtualServiceRouteWeight(name: string, namespace: string, weight: number): void {
+  kubectlExec(
+    `kubectl patch VirtualService ${name} -n ${namespace} --type=json -p '[{"op": "add", "path": "/spec/http/0/route/0/weight", "value": ${weight}}]'`,
+    true
+  );
+}
+
+export function patchVirtualServiceAdditionalDestination(
+  name: string,
+  namespace: string,
+  host: string,
+  subset: string,
+  weight: number
+): void {
+  kubectlExec(
+    `kubectl patch VirtualService ${name} -n ${namespace} --type=json -p '[{"op": "add", "path": "/spec/http/0/route/-", "value": {"weight": ${weight}, "destination":{"host": "${host}", "subset": "${subset}"}} }]'`,
+    true
+  );
+}
+
+export function applyPeerAuthentication(name: string, namespace: string): void {
+  deleteIstioConfig('PeerAuthentication', name, namespace);
+  kubectlApplyManifest(`{
+    "apiVersion": "security.istio.io/v1",
+    "kind": "PeerAuthentication",
+    "metadata": {
+        "name": "${name}",
+        "namespace": "${namespace}"
+    }
+}`);
+}
+
+export function patchPeerAuthenticationMtlsMode(name: string, namespace: string, mtlsMode: string): void {
+  kubectlExec(
+    `kubectl patch PeerAuthentication ${name} -n ${namespace} --type=merge -p '{"spec":{"mtls":{"mode": "${mtlsMode}"}}}'`,
+    true
+  );
+}
+
+export function applyIstioGateway(
+  name: string,
+  namespace: string,
+  hosts: string,
+  port: number,
+  labelsString: string
+): void {
+  deleteIstioGateway(name, namespace);
+  const hostsJson = hosts
+    .split(',')
+    .map(h => `"${h}"`)
+    .join(',');
+  kubectlApplyManifest(`{
+      "apiVersion": "networking.istio.io/v1",
+      "kind": "Gateway",
+      "metadata": {
+        "name": "${name}",
+        "namespace": "${namespace}"
+      },
+      "spec": {
+        "selector": ${labelsStringToJson(labelsString)},
+        "servers": [
+          {
+            "port": {
+              "number": ${port},
+              "protocol": "HTTP",
+              "name": "HTTP"
+            },
+            "hosts": [${hostsJson}]
+          }
+        ]
+      }
+}`);
+  waitForIstioConfig('gateway.networking.istio.io', name, namespace);
+}
+
+export function applySidecar(name: string, namespace: string, hosts: string): void {
+  deleteIstioConfig('Sidecar', name, namespace);
+  const hostsJson = hosts
+    .split(',')
+    .map(h => `"${h}"`)
+    .join(',');
+  kubectlApplyManifest(`{
+      "apiVersion": "networking.istio.io/v1",
+      "kind": "Sidecar",
+      "metadata": {
+        "name": "${name}",
+        "namespace": "${namespace}"
+      },
+      "spec": {
+        "egress": [
+          { "hosts": [${hostsJson}] }
+        ]
+      }
+}`);
+}
+
+export function patchSidecarWorkloadSelector(name: string, namespace: string, labelsString: string): void {
+  kubectlExec(
+    `kubectl patch Sidecar ${name} -n ${namespace} --type=merge -p '{"spec":{"workloadSelector":{"labels": ${labelsStringToJson(labelsString)}}}}'`,
+    true
+  );
+}
+
+export function applyK8sGateway(
+  name: string,
+  namespace: string,
+  hostname: string,
+  protocol: string,
+  port: string,
+  gatewayClassName: string
+): void {
+  kubectlApplyManifest(`{
+        "kind": "Gateway",
+        "apiVersion": "gateway.networking.k8s.io/v1",
+        "metadata": {
+          "name": "${name}",
+          "namespace": "${namespace}",
+          "labels": {},
+          "annotations": {}
+        },
+        "spec": {
+          "gatewayClassName": "${gatewayClassName}",
+          "listeners": [
+            {
+              "name": "foo",
+              "port": ${port},
+              "protocol": "${protocol}",
+              "hostname": "${hostname}",
+              "allowedRoutes": {
+                "namespaces": {
+                  "from": "All",
+                  "selector": {
+                    "matchLabels": {}
+                  }
+                }
+              }
+            }
+          ],
+          "addresses": []
+        }
+      }`);
+}
+
+export function patchK8sGatewayAddress(name: string, namespace: string, type: string, value: string): void {
+  kubectlExec(
+    `kubectl patch Gateway ${name} -n ${namespace} --type=merge -p '{"spec":{"addresses":[{"type": "${type}","value":"${value}"}]}}'`,
+    true
+  );
+}
+
+export function applyK8sReferenceGrant(name: string, namespace: string, fromNamespace: string): void {
+  kubectlApplyManifest(`{
+  "kind": "ReferenceGrant",
+  "apiVersion": "gateway.networking.k8s.io/v1beta1",
+  "metadata": {
+    "name": "${name}",
+    "namespace": "${namespace}",
+    "labels": {},
+    "annotations": {}
+  },
+  "spec": {
+    "from": [
+      {
+        "kind": "HTTPRoute",
+        "group": "gateway.networking.k8s.io",
+        "namespace": "${fromNamespace}"
+      }
+    ],
+    "to": [
+      {
+        "kind": "Service",
+        "group": ""
+      }
+    ]
+  }
+}`);
+}
+
+/** Mirrors Cypress `@clean-istio-namespace-resources-after` hook. */
+export function cleanIstioSystemTestResources(): void {
+  kubectlDelete('PeerAuthentication default -n istio-system');
+  kubectlDelete('Sidecar default -n istio-system');
+  waitForResourceDeleted('kubectl get PeerAuthentication default -n istio-system');
+  waitForResourceDeleted('kubectl get Sidecar default -n istio-system');
+  kubectlExec('kubectl rollout restart deployment -n alpha', false);
+  kubectlExec('kubectl rollout restart deployment -n beta', false);
+  kubectlExec('kubectl rollout status deployment -n alpha --timeout=60s', false);
+  kubectlExec('kubectl rollout status deployment -n beta --timeout=60s', false);
+}
+
+/** KIA0104 and similar scenarios delete VirtualService/bookinfo; restore sample networking once. */
+export function restoreBookinfoNetworking(): void {
+  kubectlExec(
+    'sh -c \'ISTIO_DIR=$(ls -dt1 ../_output/istio-* 2>/dev/null | head -n1); [ -z "$ISTIO_DIR" ] && exit 0; NET="$ISTIO_DIR/samples/bookinfo/networking/bookinfo-gateway.yaml"; [ -f "$NET" ] || exit 0; kubectl apply -n bookinfo -f "$NET"\'',
+    false
+  );
+  waitForResourceDeleted('kubectl get PeerAuthentication default -n istio-system');
+  waitForResourceDeleted('kubectl get Sidecar default -n istio-system');
+  kubectlExec('kubectl rollout restart deployment -n alpha', false);
+  kubectlExec('kubectl rollout restart deployment -n beta', false);
+  kubectlExec('kubectl rollout status deployment -n alpha --timeout=60s', false);
+  kubectlExec('kubectl rollout status deployment -n beta --timeout=60s', false);
+}

--- a/frontend/e2e/utils/istioCrdValidation.ts
+++ b/frontend/e2e/utils/istioCrdValidation.ts
@@ -376,11 +376,12 @@ export function applyK8sReferenceGrant(name: string, namespace: string, fromName
 }
 
 const SLEEP_MTLS_TEST_DR_NAMES = ['disable-mtls-kia0207', 'enable-mtls-kia0505'];
+const ISTIO_SYSTEM_MTLS_TEST_DR_NAMES = ['disable-mtls-kia0208', 'enable-mtls-kia0506'];
 
 /** KIA0207 and KIA0505 share PeerAuthentication/default and ns-wide DRs on sleep — clean between serial runs. */
 export function cleanSleepMtlsTestResources(): void {
   const cleanupTimeoutMs = 10_000;
-  for (const drName of SLEEP_MTLS_TEST_DR_NAMES) {
+  for (const drName of [...SLEEP_MTLS_TEST_DR_NAMES, ...ISTIO_SYSTEM_MTLS_TEST_DR_NAMES]) {
     kubectlDelete(`DestinationRule ${drName} -n sleep`);
     waitForResourceDeleted(`kubectl get DestinationRule ${drName} -n sleep`, cleanupTimeoutMs);
   }

--- a/frontend/e2e/utils/istioCrdValidation.ts
+++ b/frontend/e2e/utils/istioCrdValidation.ts
@@ -111,6 +111,7 @@ export function applyDestinationRule(name: string, namespace: string, host: stri
       "host": "${host}"
     }
 }`);
+  waitForIstioConfig('DestinationRule', name, namespace);
 }
 
 export function patchDestinationRuleSubset(name: string, namespace: string, subset: string, labels: string): void {
@@ -125,6 +126,7 @@ export function patchDestinationRuleEnableMtls(name: string, namespace: string):
     `kubectl patch DestinationRule ${name} -n ${namespace} --type=merge -p '{"spec":{"trafficPolicy":{"tls": {"mode": "ISTIO_MUTUAL"}} }}'`,
     true
   );
+  waitForIstioConfig('DestinationRule', name, namespace);
 }
 
 export function patchDestinationRuleDisableMtls(name: string, namespace: string): void {
@@ -132,6 +134,7 @@ export function patchDestinationRuleDisableMtls(name: string, namespace: string)
     `kubectl patch DestinationRule ${name} -n ${namespace} --type=merge -p '{"spec":{"trafficPolicy":{"tls": {"mode": "DISABLE"}} }}'`,
     true
   );
+  waitForIstioConfig('DestinationRule', name, namespace);
 }
 
 export function applyVirtualService(name: string, namespace: string, routeName: string, routeHost: string): void {
@@ -222,6 +225,7 @@ export function applyPeerAuthentication(name: string, namespace: string): void {
         "namespace": "${namespace}"
     }
 }`);
+  waitForIstioConfig('PeerAuthentication', name, namespace);
 }
 
 export function patchPeerAuthenticationMtlsMode(name: string, namespace: string, mtlsMode: string): void {
@@ -229,6 +233,7 @@ export function patchPeerAuthenticationMtlsMode(name: string, namespace: string,
     `kubectl patch PeerAuthentication ${name} -n ${namespace} --type=merge -p '{"spec":{"mtls":{"mode": "${mtlsMode}"}}}'`,
     true
   );
+  waitForIstioConfig('PeerAuthentication', name, namespace);
 }
 
 export function applyIstioGateway(
@@ -368,6 +373,18 @@ export function applyK8sReferenceGrant(name: string, namespace: string, fromName
     ]
   }
 }`);
+}
+
+const SLEEP_MTLS_TEST_DR_NAMES = ['disable-mtls-kia0207', 'enable-mtls-kia0505'];
+
+/** KIA0207 and KIA0505 share PeerAuthentication/default and ns-wide DRs on sleep — clean between serial runs. */
+export function cleanSleepMtlsTestResources(): void {
+  for (const drName of SLEEP_MTLS_TEST_DR_NAMES) {
+    kubectlDelete(`DestinationRule ${drName} -n sleep`);
+    waitForResourceDeleted(`kubectl get DestinationRule ${drName} -n sleep`);
+  }
+  kubectlDelete('PeerAuthentication default -n sleep');
+  waitForResourceDeleted('kubectl get PeerAuthentication default -n sleep');
 }
 
 /** Mirrors Cypress `@clean-istio-namespace-resources-after` hook. */

--- a/frontend/e2e/utils/istioCrdValidation.ts
+++ b/frontend/e2e/utils/istioCrdValidation.ts
@@ -406,10 +406,5 @@ export function restoreBookinfoNetworking(): void {
     'sh -c \'ISTIO_DIR=$(ls -dt1 ../_output/istio-* 2>/dev/null | head -n1); [ -z "$ISTIO_DIR" ] && exit 0; NET="$ISTIO_DIR/samples/bookinfo/networking/bookinfo-gateway.yaml"; [ -f "$NET" ] || exit 0; kubectl apply -n bookinfo -f "$NET"\'',
     false
   );
-  waitForResourceDeleted('kubectl get PeerAuthentication default -n istio-system');
-  waitForResourceDeleted('kubectl get Sidecar default -n istio-system');
-  kubectlExec('kubectl rollout restart deployment -n alpha', false);
-  kubectlExec('kubectl rollout restart deployment -n beta', false);
-  kubectlExec('kubectl rollout status deployment -n alpha --timeout=60s', false);
-  kubectlExec('kubectl rollout status deployment -n beta --timeout=60s', false);
+  cleanIstioSystemTestResources();
 }

--- a/frontend/e2e/utils/istioCrdValidation.ts
+++ b/frontend/e2e/utils/istioCrdValidation.ts
@@ -379,12 +379,13 @@ const SLEEP_MTLS_TEST_DR_NAMES = ['disable-mtls-kia0207', 'enable-mtls-kia0505']
 
 /** KIA0207 and KIA0505 share PeerAuthentication/default and ns-wide DRs on sleep — clean between serial runs. */
 export function cleanSleepMtlsTestResources(): void {
+  const cleanupTimeoutMs = 10_000;
   for (const drName of SLEEP_MTLS_TEST_DR_NAMES) {
     kubectlDelete(`DestinationRule ${drName} -n sleep`);
-    waitForResourceDeleted(`kubectl get DestinationRule ${drName} -n sleep`);
+    waitForResourceDeleted(`kubectl get DestinationRule ${drName} -n sleep`, cleanupTimeoutMs);
   }
   kubectlDelete('PeerAuthentication default -n sleep');
-  waitForResourceDeleted('kubectl get PeerAuthentication default -n sleep');
+  waitForResourceDeleted('kubectl get PeerAuthentication default -n sleep', cleanupTimeoutMs);
 }
 
 /** Mirrors Cypress `@clean-istio-namespace-resources-after` hook. */

--- a/frontend/e2e/utils/namespace.ts
+++ b/frontend/e2e/utils/namespace.ts
@@ -1,10 +1,17 @@
 import type { Page } from '@playwright/test';
 import { waitForLoadingComplete } from './transition';
 
-/** Select a namespace in the Kiali namespace dropdown (PatternFly checkbox list). */
-export const selectNamespace = async (page: Page, namespace: string): Promise<void> => {
+/** Select one or more namespaces in the Kiali namespace dropdown (additive — does not clear others). */
+export const selectNamespaces = async (page: Page, namespaces: string[]): Promise<void> => {
   await page.getByTestId('namespace-dropdown').click();
-  await page.getByTestId('namespace-dropdown-list').getByRole('checkbox', { name: namespace, exact: true }).check();
+  for (const namespace of namespaces) {
+    await page.getByTestId('namespace-dropdown-list').getByRole('checkbox', { name: namespace, exact: true }).check();
+  }
   await page.getByTestId('namespace-dropdown').click();
   await waitForLoadingComplete(page);
+};
+
+/** Select a namespace in the Kiali namespace dropdown (PatternFly checkbox list). */
+export const selectNamespace = async (page: Page, namespace: string): Promise<void> => {
+  await selectNamespaces(page, [namespace]);
 };

--- a/frontend/e2e/utils/suite-tags.ts
+++ b/frontend/e2e/utils/suite-tags.ts
@@ -20,3 +20,6 @@ export const core2 = { tag: '@core-2' as const };
 
 /** @smoke + @prometheus-disabled */
 export const smokeAndPrometheusDisabled = { tag: ['@smoke', '@prometheus-disabled'] as const };
+
+/** @crd-validation — frontend-core-optional Playwright / Cypress suite */
+export const crdValidationOnly = { tag: '@crd-validation' as const };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,6 +90,7 @@
     "playwright:run:core2": "playwright test --project=core-2 --pass-with-no-tests",
     "playwright:run:core-caching": "playwright test --project=core-caching --pass-with-no-tests",
     "playwright:run:crd-validation": "playwright test --project=crd-validation --pass-with-no-tests",
+    "playwright:run:core-optional": "playwright test --project=crd-validation --project=perses --pass-with-no-tests",
     "playwright:run:junit": "playwright test --project=crd-validation --project=core-1 --project=core-2 --project=core-caching --pass-with-no-tests",
     "playwright:run:all": "playwright test --project=smoke --project=core-1 --project=core-2 --project=core-caching --project=crd-validation --project=perses --project=ai-chatbot --pass-with-no-tests",
     "playwright:run:ambient:junit": "playwright test --project=ambient --project=waypoint --project=waypoint-tracing --pass-with-no-tests",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "playwright:run:core1": "playwright test --project=core-1 --pass-with-no-tests",
     "playwright:run:core2": "playwright test --project=core-2 --pass-with-no-tests",
     "playwright:run:core-caching": "playwright test --project=core-caching --pass-with-no-tests",
+    "playwright:run:crd-validation": "playwright test --project=crd-validation --pass-with-no-tests",
     "playwright:run:junit": "playwright test --project=crd-validation --project=core-1 --project=core-2 --project=core-caching --pass-with-no-tests",
     "playwright:run:all": "playwright test --project=smoke --project=core-1 --project=core-2 --project=core-caching --project=crd-validation --project=perses --project=ai-chatbot --pass-with-no-tests",
     "playwright:run:ambient:junit": "playwright test --project=ambient --project=waypoint --project=waypoint-tracing --pass-with-no-tests",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -99,7 +99,6 @@ export default defineConfig({
       name: 'crd-validation',
       grep: /@crd-validation/,
       dependencies: ['setup'],
-      fullyParallel: false,
       timeout: 180_000,
       use: { ...devices['Desktop Chrome'], storageState: AUTH_FILE }
     },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
       name: 'crd-validation',
       grep: /@crd-validation/,
       dependencies: ['setup'],
+      timeout: 180_000,
       use: { ...devices['Desktop Chrome'], storageState: AUTH_FILE }
     },
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
       name: 'crd-validation',
       grep: /@crd-validation/,
       dependencies: ['setup'],
+      fullyParallel: false,
       timeout: 180_000,
       use: { ...devices['Desktop Chrome'], storageState: AUTH_FILE }
     },

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -31,6 +31,7 @@ OFFLINE="offline"
 PLAYWRIGHT_CORE_1="playwright-core-1"
 PLAYWRIGHT_CORE_2="playwright-core-2"
 PLAYWRIGHT_CORE_CACHING="playwright-core-caching"
+PLAYWRIGHT_CORE_OPTIONAL="playwright-core-optional"
 PLAYWRIGHT_SMOKE="playwright-smoke"
 HELM_CHARTS_DIR=""
 ISTIO_VERSION=""
@@ -178,8 +179,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     -ts|--test-suite)
       TEST_SUITE="${2}"
-      if [ "${TEST_SUITE}" != "${BACKEND}" ] && [ "${TEST_SUITE}" != "${BACKEND_EXTERNAL_CONTROLPLANE}" ] && [ "${TEST_SUITE}" != "${FRONTEND}" ] && [ "${TEST_SUITE}" != "${FRONTEND_AMBIENT}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_1}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_2}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_OPTIONAL}" ] && [ "${TEST_SUITE}" != "${FRONTEND_PRIMARY_REMOTE}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_PRIMARY}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_MESH}" ] && [ "${TEST_SUITE}" != "${FRONTEND_EXTERNAL_KIALI}" ] && [ "${TEST_SUITE}" != "${FRONTEND_TEMPO}" ] && [ "${TEST_SUITE}" != "${AI_CHATBOT}" ] && [ "${TEST_SUITE}" != "${LOCAL}" ] && [ "${TEST_SUITE}" != "${OFFLINE}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_1}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_2}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_SMOKE}" ]; then
-        echo "--test-suite option must be one of '${BACKEND}', '${BACKEND_EXTERNAL_CONTROLPLANE}', '${FRONTEND}', '${FRONTEND_AMBIENT}', '${FRONTEND_CORE_1}', '${FRONTEND_CORE_2}', '${FRONTEND_CORE_CACHING}', '${FRONTEND_CORE_OPTIONAL}', '${FRONTEND_PRIMARY_REMOTE}', '${FRONTEND_MULTI_PRIMARY}', '${FRONTEND_EXTERNAL_KIALI}', '${FRONTEND_TEMPO}', '${AI_CHATBOT}', '${LOCAL}', '${OFFLINE}', '${PLAYWRIGHT_CORE_1}', '${PLAYWRIGHT_CORE_2}', '${PLAYWRIGHT_CORE_CACHING}' or '${PLAYWRIGHT_SMOKE}'"
+      if [ "${TEST_SUITE}" != "${BACKEND}" ] && [ "${TEST_SUITE}" != "${BACKEND_EXTERNAL_CONTROLPLANE}" ] && [ "${TEST_SUITE}" != "${FRONTEND}" ] && [ "${TEST_SUITE}" != "${FRONTEND_AMBIENT}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_1}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_2}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${FRONTEND_CORE_OPTIONAL}" ] && [ "${TEST_SUITE}" != "${FRONTEND_PRIMARY_REMOTE}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_PRIMARY}" ] && [ "${TEST_SUITE}" != "${FRONTEND_MULTI_MESH}" ] && [ "${TEST_SUITE}" != "${FRONTEND_EXTERNAL_KIALI}" ] && [ "${TEST_SUITE}" != "${FRONTEND_TEMPO}" ] && [ "${TEST_SUITE}" != "${AI_CHATBOT}" ] && [ "${TEST_SUITE}" != "${LOCAL}" ] && [ "${TEST_SUITE}" != "${OFFLINE}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_1}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_2}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_CACHING}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_CORE_OPTIONAL}" ] && [ "${TEST_SUITE}" != "${PLAYWRIGHT_SMOKE}" ]; then
+        echo "--test-suite option must be one of '${BACKEND}', '${BACKEND_EXTERNAL_CONTROLPLANE}', '${FRONTEND}', '${FRONTEND_AMBIENT}', '${FRONTEND_CORE_1}', '${FRONTEND_CORE_2}', '${FRONTEND_CORE_CACHING}', '${FRONTEND_CORE_OPTIONAL}', '${FRONTEND_PRIMARY_REMOTE}', '${FRONTEND_MULTI_PRIMARY}', '${FRONTEND_EXTERNAL_KIALI}', '${FRONTEND_TEMPO}', '${AI_CHATBOT}', '${LOCAL}', '${OFFLINE}', '${PLAYWRIGHT_CORE_1}', '${PLAYWRIGHT_CORE_2}', '${PLAYWRIGHT_CORE_CACHING}', '${PLAYWRIGHT_CORE_OPTIONAL}' or '${PLAYWRIGHT_SMOKE}'"
         exit 1
       fi
       shift;shift
@@ -261,7 +262,7 @@ Valid command line arguments:
   -to|--tests-only <true|false>
     If true, only run the tests and skip the setup.
     Default: false
-  -ts|--test-suite <${BACKEND}|${BACKEND_EXTERNAL_CONTROLPLANE}|${FRONTEND}|${FRONTEND_AMBIENT}|${FRONTEND_CORE_1}|${FRONTEND_CORE_2}|${FRONTEND_CORE_CACHING}|${FRONTEND_CORE_OPTIONAL}|${FRONTEND_PRIMARY_REMOTE}|${FRONTEND_MULTI_PRIMARY}|${FRONTEND_MULTI_MESH}|${FRONTEND_MULTIPLE_CONTROLPLANES}|${FRONTEND_EXTERNAL_KIALI}|${FRONTEND_TEMPO}|${AI_CHATBOT}|${LOCAL}|${OFFLINE}|${PLAYWRIGHT_CORE_1}|${PLAYWRIGHT_CORE_2}|${PLAYWRIGHT_CORE_CACHING}|${PLAYWRIGHT_SMOKE}>
+  -ts|--test-suite <${BACKEND}|${BACKEND_EXTERNAL_CONTROLPLANE}|${FRONTEND}|${FRONTEND_AMBIENT}|${FRONTEND_CORE_1}|${FRONTEND_CORE_2}|${FRONTEND_CORE_CACHING}|${FRONTEND_CORE_OPTIONAL}|${FRONTEND_PRIMARY_REMOTE}|${FRONTEND_MULTI_PRIMARY}|${FRONTEND_MULTI_MESH}|${FRONTEND_MULTIPLE_CONTROLPLANES}|${FRONTEND_EXTERNAL_KIALI}|${FRONTEND_TEMPO}|${AI_CHATBOT}|${LOCAL}|${OFFLINE}|${PLAYWRIGHT_CORE_1}|${PLAYWRIGHT_CORE_2}|${PLAYWRIGHT_CORE_CACHING}|${PLAYWRIGHT_CORE_OPTIONAL}|${PLAYWRIGHT_SMOKE}>
     Which test suite to run.
     Default: ${BACKEND}
   -w|--waypoint <true|false>
@@ -1386,6 +1387,74 @@ elif [ "${TEST_SUITE}" == "${PLAYWRIGHT_CORE_CACHING}" ]; then
   cd "${SCRIPT_DIR}"/../frontend
   set +e
   yarn run playwright:run:core-caching
+  PLAYWRIGHT_EXIT=$?
+  set -e
+  yarn run playwright:combine:reports
+  exit ${PLAYWRIGHT_EXIT}
+elif [ "${TEST_SUITE}" == "${PLAYWRIGHT_CORE_OPTIONAL}" ]; then
+  ensurePlaywrightReady
+
+  GOPATH=$(go env GOPATH)
+
+  if [ -z "${GOPATH}" ]; then
+    echo "ERROR: Unable to determine GOPATH. Please ensure Go is properly installed."
+    exit 1
+  fi
+
+  KIALI_BINARY="${GOPATH}/bin/kiali"
+  if [ ! -f "${KIALI_BINARY}" ]; then
+    echo "ERROR: Kiali binary not found at ${KIALI_BINARY}. Please build the kiali binary first."
+    exit 1
+  fi
+
+  if [ "${TESTS_ONLY}" == "false" ]; then
+    "${SCRIPT_DIR}"/setup-kind-in-ci.sh --auth-strategy anonymous --sail true --deploy-kiali false --install-perses "true" ${ISTIO_VERSION_ARG} ${HELM_CHARTS_DIR_ARG}
+
+    # Same demos as Cypress frontend-core-optional (crd-validation/perses; skip error-rates/loggers).
+    "${SCRIPT_DIR}"/istio/install-testing-demos.sh -c "kubectl" --bookinfo-only true
+    "${SCRIPT_DIR}"/istio/install-sleep-demo.sh -c kubectl
+    kubectl rollout status deployment/sleep -n sleep --timeout=120s
+  fi
+
+  infomsg "Setup complete."
+
+  if [ "${SETUP_ONLY}" == "true" ]; then
+    exit 0
+  fi
+
+  infomsg "Starting Kiali locally in the background using binary: ${KIALI_BINARY}"
+  "${KIALI_BINARY}" -c "${SCRIPT_DIR}/ci-yaml/ci-test-config-no-cache.yaml" run --cluster-name-overrides kind-ci=cluster-default --port-forward-tracing --enable-tracing --port-forward-prom --port-forward-grafana --no-browser &
+  KIALI_PID=$!
+
+  KIALI_URL="http://localhost:20001"
+
+  infomsg "Waiting for Kiali server to respond at ${KIALI_URL}"
+  WAIT_START=$(date +%s)
+  WAIT_END=$((WAIT_START + 60))
+  while true; do
+    if ! ps -p ${KIALI_PID} > /dev/null; then
+      echo "Kiali process is not running. An error must have occurred. Check the logs above."
+      exit 1
+    fi
+    if curl -s --fail "${KIALI_URL}/healthz" > /dev/null 2>&1; then
+      break
+    fi
+    WAIT_NOW=$(date +%s)
+    if [ "${WAIT_NOW}" -gt "${WAIT_END}" ]; then
+      echo "Timed out waiting for Kiali server to respond at ${KIALI_URL}/healthz"
+      exit 1
+    fi
+    sleep 2
+  done
+  infomsg "Kiali server is healthy"
+
+  export PLAYWRIGHT_BASE_URL="${KIALI_URL}"
+
+  trap cleanup_kiali EXIT
+
+  cd "${SCRIPT_DIR}"/../frontend
+  set +e
+  yarn run playwright:run:core-optional
   PLAYWRIGHT_EXIT=$?
   set -e
   yarn run playwright:combine:reports


### PR DESCRIPTION
### Describe the change

Ports all Cypress `@crd-validation` scenarios from `istio_config.feature` to Playwright (`frontend/e2e/tests/istio_config/istio_config_crd_validation.spec.ts`).

- Adds kubectl helpers for creating/patching Istio and Gateway API test resources (`istioCrdValidation.ts`, `gatewayApi.ts`).
- Adds parallel-safe resource naming via `crdResourceName()` so the suite runs in ~5m instead of ~28m serial.
- Uses targeted serial groups only where tests contend for shared resources (`bookinfo` demo VS, `sleep` default PeerAuthentication, `istio-system` default PA/Sidecar).
- Extends `IstioConfigPage` with validation-status assertions, grouped validation message checks, and configuration-validation toggle handling.
- Adds `crdValidationOnly` suite tag, `yarn playwright:run:crd-validation`, and 180s per-test timeout for the `crd-validation` project.

Part of #9712.

### Steps to test the PR

```bash
# KinD + local Kiali (or existing cluster with bookinfo/sleep demos)
make build-ui build
hack/run-integration-tests.sh --test-suite local --setup-only true

# Start Kiali locally
$(go env GOPATH)/bin/kiali \
  -c hack/ci-yaml/ci-test-config-no-cache.yaml run \
  --cluster-name-overrides kind-ci=cluster-default \
  --port-forward-prom --port-forward-grafana --no-browser

# Run the suite
cd frontend
yarn playwright:install chromium
yarn playwright:run:crd-validation
```

Expected: **26 passed, 3 skipped** (Gateway API scenarios skip when GW API is disabled on cluster). Runtime ~5m with parallel workers.

### Automation testing

- **E2E:** 28 Playwright scenarios covering KIA0101–KIA1601 validation codes (parity with Cypress `@crd-validation`).
- **CI:** Included in existing `playwright:run:junit` / Jenkins `TEST_SET` via the `crd-validation` project.

### Issue reference

Part of #9712 (CRD validation slice of the Playwright migration epic).