### PR TITLE
Use v*.* branch filter for OSSMC frontend sync workflow

### DIFF
--- a/.github/workflows/notify-ossmc-sync.yml
+++ b/.github/workflows/notify-ossmc-sync.yml
@@ -2,7 +2,8 @@ name: Notify OSSMC Frontend Sync
 
 on:
   push:
-    branches: [v2.27, v2.22, v2.17, v2.11, v2.4]
+    branches:
+    - 'v*.*'
     paths:
     - 'frontend/src/**'
     - 'frontend/public/locales/**'


### PR DESCRIPTION
## Summary
- Replace the explicit release-branch list in `notify-ossmc-sync.yml` with the `v*.*` glob used by `kiali-ci.yml` and `mcp-contract-tests.yml`
- Keeps OSSMC sync notifications scoped to release branches without maintaining a manual branch list on master

## Test plan
- [ ] Merge a frontend change to a release branch after the corresponding backport PR lands and verify `Notify OSSMC Frontend Sync` runs
- [ ] Confirm pushes to `master` do not trigger the workflow

Made with [Cursor](https://cursor.com)