### PR TITLE
[v2.17] Backport OSSMC frontend sync workflow

### DIFF
--- a/.github/workflows/notify-ossmc-sync.yml
+++ b/.github/workflows/notify-ossmc-sync.yml
@@ -1,0 +1,28 @@
+name: Notify OSSMC Frontend Sync
+
+on:
+  push:
+    branches:
+    - 'v*.*'
+    paths:
+    - 'frontend/src/**'
+    - 'frontend/public/locales/**'
+    - 'frontend/cypress/integration/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dispatch to OSSMC
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ secrets.KIALI_BOT_TOKEN }}
+        script: |
+          await github.rest.repos.createDispatchEvent({
+            owner: 'kiali',
+            repo: 'openshift-servicemesh-plugin',
+            event_type: 'kiali-frontend-updated',
+            client_payload: {
+              branch: '${{ github.ref_name }}'
+            }
+          });

--- a/hack/fix_imports.sh
+++ b/hack/fix_imports.sh
@@ -6,7 +6,7 @@ if ! which goimports &> /dev/null; then
     echo "You do not have 'go' in your PATH - please install it. Aborting."
     exit 1
   fi
-  go install golang.org/x/tools/cmd/goimports@latest
+  go install golang.org/x/tools/cmd/goimports@v0.47.0
 fi
 
 FILES=`find . -path './vendor' -prune -o -path './frontend' -prune -o -type f -iname '*.go' -print`


### PR DESCRIPTION
## Summary
- Backport `notify-ossmc-sync.yml` to `v2.17` so frontend merges on this branch dispatch OSSMC sync events
- Use the `v*.*` release-branch glob consistent with Kiali CI workflows
- Pin `goimports` to `v0.47.0` in `hack/fix_imports.sh` (and `hack/hooks/pre-commit.sh` where present) so CI works with Go 1.25 (`goimports@latest` now requires Go >= 1.26)

## Context
The workflow previously existed only on `master`, so merges like #10282 into `v2.17` did not notify `openshift-servicemesh-plugin`.

Release-branch CI also failed on `make format` because `goimports@latest` resolves to `golang.org/x/tools@v0.50.0`, which requires Go >= 1.26 while `v2.17` uses Go 1.25.x with `GOTOOLCHAIN=local`.

## Test plan
- [ ] Merge this PR
- [ ] Verify backend CI passes (`make format` / goimports install)
- [ ] Merge a frontend PR into `v2.17` and verify the `Notify OSSMC Frontend Sync` workflow runs
- [ ] Confirm OSSMC receives the `kiali-frontend-updated` dispatch for branch `v2.17`